### PR TITLE
QueryFiddle: reset sorting when executing query. fixes #33

### DIFF
--- a/rd_ui/app/scripts/query_fiddle/renderers.js
+++ b/rd_ui/app/scripts/query_fiddle/renderers.js
@@ -123,7 +123,7 @@ renderers.directive('gridRenderer', function () {
                 isPaginationEnabled: true,
                 itemsByPage: $scope.itemsPerPage || 15,
                 maxSize: 8
-            }
+            };
 
             $scope.$watch('queryResult && queryResult.getData()', function (data) {
                 if (!data) {

--- a/rd_ui/app/scripts/smart-table.js
+++ b/rd_ui/app/scripts/smart-table.js
@@ -113,8 +113,10 @@
 
                     //if item are added or removed into the data model from outside the grid
                     scope.$watch('dataCollection', function (oldValue, newValue) {
-                        if (oldValue !== newValue) {
-                            ctrl.sortBy();//it will trigger the refresh... some hack ?
+                        // evme:
+                        // reset sorting when data updates (executing query again)
+                        if (newValue) {
+                            ctrl.resetSort();
                         }
                     });
 
@@ -494,6 +496,12 @@
                 output = sortDataRow(arrayUtility.filter(array, filterAlgo, predicate), lastColumnSort);
                 scope.numberOfPages = calculateNumberOfPages(output);
                 return scope.isPaginationEnabled ? arrayUtility.fromTo(output, (scope.currentPage - 1) * scope.itemsByPage, scope.itemsByPage) : output;
+            };
+
+            this.resetSort = function() {
+                lastColumnSort = null;
+                predicate = {};
+                this.sortBy();
             };
 
             /*////////////


### PR DESCRIPTION
not the greatest piece of code ever written, but gets the job done.
I had to change `smart-table.js` because it does not expose any API.
