### PR TITLE
Handle empty data returned by queries

### DIFF
--- a/redash/data/query_runner_mysql.py
+++ b/redash/data/query_runner_mysql.py
@@ -28,18 +28,24 @@ def mysql(connection_string):
             
             data = cursor.fetchall()
             
-            num_fields = len(cursor.description)
-            column_names = [i[0] for i in cursor.description]
+            cursor_desc = cursor.description
+            if (cursor_desc != None):
+                num_fields = len(cursor_desc)
+                column_names = [i[0] for i in cursor.description]
             
-            rows = [dict(zip(column_names, row)) for row in data]
+                rows = [dict(zip(column_names, row)) for row in data]
 
-            columns = [{'name': col_name,
-                        'friendly_name': col_name,
-                        'type': None} for col_name in column_names]
+                columns = [{'name': col_name,
+                            'friendly_name': col_name,
+                            'type': None} for col_name in column_names]
             
-            data = {'columns': columns, 'rows': rows}
-            json_data = json.dumps(data, cls=JSONEncoder)
-            error = None
+                data = {'columns': columns, 'rows': rows}
+                json_data = json.dumps(data, cls=JSONEncoder)
+                error = None
+            else:
+                json_data = None
+                error = "No data was returned."
+                
             cursor.close()
         except MySQLdb.Error, e:
             json_data = None


### PR DESCRIPTION
When someone enters a query that comprises from several statements, we get an empty result...
Example query:
  SET @eran=1;
  SELECT ...

I dont know how to handle such queries. Can't find anything in the doc.

However, its better to handle this properly rather than have len(cursor.description) throw an exception we dont handle (None doesnt have len function) - causing the user to see a stuck query he cant cancel.
