### PR TITLE
Fix #141: prevent the timer directive call digest loop every second

### DIFF
--- a/rd_ui/app/scripts/directives.js
+++ b/rd_ui/app/scripts/directives.js
@@ -302,31 +302,26 @@
         };
     });
 
-    directives.directive('rdTimer', ['$timeout', function ($timeout) {
+    directives.directive('rdTimer', [function () {
         return {
             restrict: 'E',
             scope: { timestamp: '=' },
             template: '{{currentTime}}',
             controller: ['$scope' ,function ($scope) {
                 $scope.currentTime = "00:00:00";
-                var currentTimeout = null;
 
-                var updateTime = function() {
-                    $scope.currentTime = moment(moment() - moment($scope.timestamp)).utc().format("HH:mm:ss")
-                    currentTimeout = $timeout(updateTime, 1000);
-                }
-
-                var cancelTimer = function() {
-                    if (currentTimeout) {
-                        $timeout.cancel(currentTimeout);
-                        currentTimeout = null;
-                    }
-                }
-
-                updateTime();
+                // We're using setInterval directly instead of $timeout, to avoid using $apply, to
+                // prevent the digest loop being run every second.
+                var currentTimer = setInterval(function() {
+                    $scope.currentTime = moment(moment() - moment($scope.timestamp)).utc().format("HH:mm:ss");
+                    $scope.$digest();
+                }, 1000);
 
                 $scope.$on('$destroy', function () {
-                    cancelTimer();
+                    if (currentTimer) {
+                        cancelInterval(currentTimer);
+                        currentTimer = null;
+                    }
                 });
             }]
         };


### PR DESCRIPTION
By using setInterval & $scope.$digest instead of $timeout which uses $scope.$apply, which in turn calls $rootScope.$digest.
