### PR TITLE
Make sure qr serialization will always be in JSON

### DIFF
--- a/redash/data/manager.py
+++ b/redash/data/manager.py
@@ -6,9 +6,17 @@ import logging
 import peewee
 import qr
 import redis
+import json
 from redash import models
 from redash.data import worker
 from redash.utils import gen_query_hash
+
+
+class JSONPriorityQueue(qr.PriorityQueue):
+    """ Use a JSON serializer to help with cross language support """
+    def __init__(self, key, **kwargs):
+        super(qr.PriorityQueue, self).__init__(key, **kwargs)
+        self.serializer = json
 
 
 class Manager(object):
@@ -16,7 +24,7 @@ class Manager(object):
         self.statsd_client = statsd_client
         self.redis_connection = redis_connection
         self.workers = []
-        self.queue = qr.PriorityQueue("jobs", **self.redis_connection.connection_pool.connection_kwargs)
+        self.queue = JSONPriorityQueue("jobs", **self.redis_connection.connection_pool.connection_kwargs)
         self.max_retries = 5
         self.status = {
             'last_refresh_at': 0,


### PR DESCRIPTION
For the sake of future proofing parts of that systems that can be implemented in other languages (like the query runner), make sure that qr will only serialize complex structures using JSON instead of Pickle.
