### PR TITLE
fix starting of celery in Heroku

### DIFF
--- a/Procfile.heroku
+++ b/Procfile.heroku
@@ -1,2 +1,2 @@
 web: ./manage.py runserver -p $PORT --host 0.0.0.0 -d -r
-worker: ./manage.py runworkers
+worker: ./bin/run celery worker --app=redash.worker --beat -Qqueries,celery,scheduled_queries


### PR DESCRIPTION
It was using the deprecated command. Switching to using celery as recommended.
