### PR TITLE
Force the use of JSON in Celery

### DIFF
--- a/redash/worker.py
+++ b/redash/worker.py
@@ -8,6 +8,8 @@ celery = Celery('redash',
                 include='redash.tasks')
 
 celery.conf.update(CELERY_RESULT_BACKEND=settings.CELERY_BACKEND,
+                   CELERY_TASK_SERIALIZER='json',
+                   CELERY_ACCEPT_CONTENT = ['json'],
                    CELERYBEAT_SCHEDULE={
                        'refresh_queries': {
                            'task': 'redash.tasks.refresh_queries',


### PR DESCRIPTION
Pickle support is going to be deprecated soon and instead of getting an error when running celery just use JSON (which is also a lot safer as Pickle can accidentally run arbitrary code).
