### PR TITLE
when the value is false, display false instead of empty cell

### DIFF
--- a/rd_ui/app/scripts/visualizations/table.js
+++ b/rd_ui/app/scripts/visualizations/table.js
@@ -86,6 +86,13 @@
               } else if (columnType === 'float') {
                 columnDefinition.formatFunction = 'number';
                 columnDefinition.formatParameter = 2;
+              } else if (columnType === 'boolean') {
+                columnDefinition.formatFunction = function (value) {
+                  if (value !== undefined) {
+                    return "" + value;
+                  }
+                  return value;
+                };
               } else if (columnType === 'date') {
                 columnDefinition.formatFunction = function (value) {
                   if (value) {


### PR DESCRIPTION
the column type boolean was not handled before, and false values was creating an empty cell instead of display "false"
