### PR TITLE
Add Emacs (The One True Editor(TM)) backup files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 rd_ui/dist
 .DS_Store
 celerybeat-schedule
+.#*
+\#*#
+*~
 
 # Vagrant related
 .vagrant
@@ -13,3 +16,4 @@ redash/dump.rdb
 .env
 .ruby-version
 venv
+


### PR DESCRIPTION
Trivial, yet important: don't let Emacs backup file get into the repository.
