### PR TITLE
Treat all psycopg2.DatabaseError the same.

### DIFF
--- a/redash/data/query_runner_pg.py
+++ b/redash/data/query_runner_pg.py
@@ -88,11 +88,12 @@ def pg(connection_string):
             json_data = json.dumps(data, cls=JSONEncoder)
             error = None
             cursor.close()
-        except (select.error, OSError, psycopg2.OperationalError) as e:
+        except (select.error, OSError) as e:
             logging.exception(e)
             error = "Query interrupted. Please retry."
             json_data = None
         except psycopg2.DatabaseError as e:
+            logging.exception(e)
             json_data = None
             error = e.message
         except KeyboardInterrupt:


### PR DESCRIPTION
Sometimes division by zero are reported as OperationalError rather than
DataError.
