### PR TITLE
Update psycopg2 to 2.5.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ aniso8601==0.82
 blinker==1.3
 itsdangerous==0.23
 peewee==2.2.2
-psycopg2==2.5.1
+psycopg2==2.5.2
 python-dateutil==2.1
 pytz==2013.9
 redis==2.7.5


### PR DESCRIPTION
In 2.5.1 they had an issue, where OperationalError exception was causing SEGFAULT
when being pickled. This was crashing the Celery worker, causing the jobs to be lost.
