### PR TITLE
Feature: dimension support for charts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# For more information about the properties used in
+# this file, please see the EditorConfig documentation:
+# http://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{.travis.yml,package.json}]
+# The indent size used in the `package.json` file cannot be changed
+# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+indent_size = 2
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.js]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -195,6 +195,9 @@
         }).join(',');
     };
 
+    /**
+     * Sum up all y values of those points within the same dimension and also have the same x value
+     */
     QueryResult.prototype._combinePoints = function (data) {
       var newDataMapIndexedByX = {};
 

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -295,6 +295,7 @@
             });
           });
         } else {
+          point.dimensions = dimensions;
           addPointToSeries(seriesName, point);
         }
       });

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -188,14 +188,47 @@
       return this.filteredData;
     }
 
-    QueryResult.prototype.getChartData = function (mapping) {
+    QueryResult.prototype._serializeDimensions = function (dimensions, enabledDimensionNames) {
+      return _.sortBy(_.intersection(_.keys(dimensions), enabledDimensionNames))
+        .map(function (key) {
+          return [key, dimensions[key]].join(':')
+        }).join(',');
+    };
+
+    QueryResult.prototype._combinePoints = function (_data) {
+      var data = angular.copy(_data);
+      var newDataMapIndexedByX = {};
+
+      data.map(function (point) {
+        if (!newDataMapIndexedByX[point.x]) {
+          newDataMapIndexedByX[point.x] = angular.copy(point);
+        }
+        else {
+          newDataMapIndexedByX[point.x].y += point.y;
+        }
+      })
+
+      return _.values(newDataMapIndexedByX);
+    };
+
+    QueryResult.prototype.getChartData = function (mapping, dimensions) {
       var series = {};
+      var dimensions = dimensions || {};
+      var that = this;
+
+      var enabledDimensionNames = _.filter(dimensions, function (dimension) {
+          return dimension.enabled
+        })
+        .map(function (dimension) {
+          return dimension.name;
+        });
 
       _.each(this.getData(), function (row) {
         var point = {};
         var seriesName = undefined;
         var xValue = 0;
         var yValues = {};
+        var dimensions = {};
 
         _.each(row, function (value, definition) {
           var name = definition.split("::")[0] || definition.split("__")[0];
@@ -224,12 +257,22 @@
             seriesName = String(value);
           }
 
+          if (type == 'dimension') {
+            dimensions[name] = value === null ? 'NULL' : value;
+          }
+
           if (type == 'multiFilter' || type == 'multi-filter') {
             seriesName = String(value);
           }
         });
 
         var addPointToSeries = function (seriesName, point) {
+          // Append dimension string to seriesName
+          seriesName = [seriesName,
+            '(',
+            that._serializeDimensions(point.dimensions, enabledDimensionNames),
+            ')'].join('');
+
           if (series[seriesName] == undefined) {
             series[seriesName] = {
               name: seriesName,
@@ -243,14 +286,24 @@
 
         if (seriesName === undefined) {
           _.each(yValues, function (yValue, seriesName) {
-            addPointToSeries(seriesName, {'x': xValue, 'y': yValue});
+            addPointToSeries(seriesName, {
+              'x': xValue,
+              'y': yValue,
+              'dimensions': dimensions
+            });
           });
         } else {
           addPointToSeries(seriesName, point);
         }
       });
 
-      return _.values(series);
+      var result = _.values(series);
+
+      result.forEach(function (seriesItem) {
+        seriesItem.data = that._combinePoints(seriesItem.data)
+      });
+
+      return result;
     };
 
     QueryResult.prototype.getColumns = function () {

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -195,13 +195,12 @@
         }).join(',');
     };
 
-    QueryResult.prototype._combinePoints = function (_data) {
-      var data = angular.copy(_data);
+    QueryResult.prototype._combinePoints = function (data) {
       var newDataMapIndexedByX = {};
 
       data.map(function (point) {
         if (!newDataMapIndexedByX[point.x]) {
-          newDataMapIndexedByX[point.x] = angular.copy(point);
+          newDataMapIndexedByX[point.x] = _.clone(point);
         }
         else {
           newDataMapIndexedByX[point.x].y += point.y;

--- a/rd_ui/app/scripts/visualizations/chart.js
+++ b/rd_ui/app/scripts/visualizations/chart.js
@@ -43,7 +43,10 @@
          */
         $scope.dimensions = [];
 
-        var reloadDimensions = function () {
+        /**
+         * Extract all dimensions set by user
+         */
+        $scope.setAvailableDimensions = function () {
           $scope.dimensions = _.pairs($scope.options.columnMapping)
             .filter(function (pair) {
               return pair[1] === 'dimension';
@@ -97,7 +100,7 @@
         }, true);
 
         $scope.$watchCollection('options.columnMapping', function (chartOptions) {
-          reloadDimensions();
+          $scope.setAvailableDimensions();
           reloadData(true);
         });
 
@@ -145,8 +148,8 @@
           "X": "x",
           "Y": "y",
           "Series": "series",
-          "Unused": "unused",
-          "Dimension": "dimension"
+          "Dimension": "dimension",
+          "Unused": "unused"
         };
 
         scope.series = [];

--- a/rd_ui/app/scripts/visualizations/chart.js
+++ b/rd_ui/app/scripts/visualizations/chart.js
@@ -27,11 +27,34 @@
         queryResult: '=',
         options: '=?'
       },
-      template: "<chart options='chartOptions' series='chartSeries' class='graph'></chart>",
+      templateUrl: "/views/visualizations/chart.html",
       replace: false,
       controller: ['$scope', function ($scope) {
         $scope.chartSeries = [];
         $scope.chartOptions = {};
+        /**
+         * Dimension objects array. An example of this would be:
+         * [{
+         *   name: 'name of dimension',
+         *   enabled: true // whether we want to show this dimension in chart
+         * }]
+         *
+         * @type {Array}
+         */
+        $scope.dimensions = [];
+
+        var reloadDimensions = function () {
+          $scope.dimensions = _.pairs($scope.options.columnMapping)
+            .filter(function (pair) {
+              return pair[1] === 'dimension';
+            })
+            .map(function (pair) {
+              return {
+                name: pair[0],
+                enabled: false
+              }
+            });
+        };
 
         var reloadData = function(data) {
           if (!data || ($scope.queryResult && $scope.queryResult.getData()) == null) {
@@ -39,7 +62,11 @@
           } else {
             $scope.chartSeries.splice(0, $scope.chartSeries.length);
 
-            _.each($scope.queryResult.getChartData($scope.options.columnMapping), function (s) {
+            series = $scope.queryResult.getChartData(
+              $scope.options.columnMapping,
+              $scope.dimensions);
+
+            _.each(series, function (s) {
               var additional = {'stacking': 'normal'};
               if ('globalSeriesType' in $scope.options) {
                 additional['type'] = $scope.options.globalSeriesType;
@@ -65,8 +92,12 @@
           reloadData(true);
         }, true);
 
+        $scope.$watch('dimensions', function (dimensions) {
+          reloadData(true);
+        }, true);
 
         $scope.$watchCollection('options.columnMapping', function (chartOptions) {
+          reloadDimensions();
           reloadData(true);
         });
 
@@ -114,7 +145,8 @@
           "X": "x",
           "Y": "y",
           "Series": "series",
-          "Unused": "unused"
+          "Unused": "unused",
+          "Dimension": "dimension"
         };
 
         scope.series = [];

--- a/rd_ui/app/views/visualizations/chart.html
+++ b/rd_ui/app/views/visualizations/chart.html
@@ -1,0 +1,13 @@
+<div>
+  <chart options='chartOptions' series='chartSeries' class='graph'></chart>
+  <section ng-if="dimensions.length > 0">
+    <header><h5>Dimensions</h5></header>
+    <form>
+      <div class="checkbox" ng-repeat="dimension in dimensions">
+        <label>
+          <input type="checkbox" ng-model="dimension.enabled"> {{dimension.name}}
+        </label>
+      </div>
+    </form>
+  </section>
+</div>


### PR DESCRIPTION
So just as discussed with @arikfr via email ...

Dimensions is a set of features that data has. For example, let's say we have a query pulling UV of yelp.com from database.

```
SELECT time, COUNT(*) FROM uv_records
GROUP BY time
```

Often times the data should have many other properties. For example, for a single UV, let's say we magically know the user's gender. So now we have a query like this.

```
SELECT time, gender, COUNT(*) FROM uv_records
GROUP BY time, gender
```

The result cannot be shown as a chart in re:dash since, for every single date, we have multiple rows (points) corresponding to it. So the idea of dimension is here to help. A dimension is a certain property of data that can re-group current data into several groups. In our data, we can have two values (M, F) for gender, so if we use gender as a dimension, then we can have two groups of data. 

Here is a screenshot of how dimensions are set (not from the UV example though).

Once you have dimensions set up, you can view your data from different dimensions. So here is an example of the chart without applying any dimension.

![image](https://cloud.githubusercontent.com/assets/5257816/10466184/b39a0ef8-71a7-11e5-9bac-d4b01ebbc655.png)

Here we have two dimensions, has_canonical and is_indexable. Because we don't have any dimension enabled yet, the chart will still contain one series.

Now here is the fun part, we can turn on one of the dimensions and see the data being split into multiple series.

![image](https://cloud.githubusercontent.com/assets/5257816/10466189/bd6c1962-71a7-11e5-9b46-f3cffd3ab633.png)

BTW I also added **.editorconfig** for the sake of making code more consistent. If you don't think it's a good idea to have it here, feel free to tell me so I can pull it out.
