### PR TITLE
Fix date range selector does not show data of last day when user timezone is not UTC

### DIFF
--- a/rd_ui/app/scripts/visualizations/date_range_selector.js
+++ b/rd_ui/app/scripts/visualizations/date_range_selector.js
@@ -34,8 +34,8 @@
             scope.dateRangeHuman = oldDateRangeHuman;
             return;
           }
-          scope.dateRange.min = newDateRangeMin;
-          scope.dateRange.max = newDateRangeMax;
+          scope.dateRange.min = newDateRangeMin.startOf('day');
+          scope.dateRange.max = newDateRangeMax.endOf('day');
         }, true);
       }]
     }

--- a/rd_ui/app/scripts/visualizations/date_range_selector.js
+++ b/rd_ui/app/scripts/visualizations/date_range_selector.js
@@ -21,8 +21,8 @@
         });
 
         $scope.$watch('dateRangeHuman', function (dateRangeHuman, oldDateRangeHuman, scope) {
-          var newDateRangeMin = moment(dateRangeHuman.min);
-          var newDateRangeMax = moment(dateRangeHuman.max);
+          var newDateRangeMin = moment.utc(dateRangeHuman.min);
+          var newDateRangeMax = moment.utc(dateRangeHuman.max);
           if (!newDateRangeMin ||
               !newDateRangeMax ||
               !newDateRangeMin.isValid() ||
@@ -34,8 +34,8 @@
             scope.dateRangeHuman = oldDateRangeHuman;
             return;
           }
-          scope.dateRange.min = newDateRangeMin.startOf('day');
-          scope.dateRange.max = newDateRangeMax.endOf('day');
+          scope.dateRange.min = newDateRangeMin;
+          scope.dateRange.max = newDateRangeMax;
         }, true);
       }]
     }


### PR DESCRIPTION
Related to #594 and #617.
In following conditions, re:dash does not show the data of last day.

- some timestamp value group by day
- user in non UTC timezone

Like this:

```
SELECT
  to_char(created_at, 'YYYY-MM-DD') as day,
  COUNT(*) AS cnt
FROM
  queries
GROUP BY
  day
ORDER BY
  day
```

I think this is caused `dateRange` is treated as local timezone, but `point.x` is treated as UTC.
Following screenshot is a result of `console.log(dateRange, point.x);` before https://github.com/EverythingMe/redash/blob/master/rd_ui/app/scripts/services/resources.js#L197

<img width="697" alt="2015-11-14 13 07 52" src="https://cloud.githubusercontent.com/assets/346598/11161979/c25dfdcc-8ad0-11e5-9279-4a5da281c00f.png">

This pull request fix this issue, but I'm not sure that this change is OK for timezone handling in re:dash.
@arikfr What do you think?