### PR TITLE
Fix: strings that start with a date wrongly treated as date fields

### DIFF
--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -45,7 +45,7 @@
             } else if (_.isString(v) && v.match(/^\d{4}-\d{2}-\d{2}T/)) {
               row[k] = moment.utc(v);
               columnTypes[k] = 'datetime';
-            } else if (_.isString(v) && v.match(/^\d{4}-\d{2}-\d{2}/)) {
+            } else if (_.isString(v) && v.match(/^\d{4}-\d{2}-\d{2}$/)) {
               row[k] = moment.utc(v);
               columnTypes[k] = 'date';
             } else if (typeof(v) == 'object' && v !== null) {


### PR DESCRIPTION
Tiny fix to avoid displaying a result that starts with a date string as only a date string.