### PR TITLE
Fix cancelling queries for Redshift/Postgres

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import signal
 
 import jsonschema
 from jsonschema import ValidationError
@@ -38,11 +39,18 @@ SUPPORTED_COLUMN_TYPES = set([
     TYPE_DATE
 ])
 
+class InterruptException(Exception):
+    pass
+
+def signal_handler(*args):
+    raise InterruptException
+
 class BaseQueryRunner(object):
     def __init__(self, configuration):
         jsonschema.validate(configuration, self.configuration_schema())
         self.syntax = 'sql'
         self.configuration = configuration
+        signal.signal(signal.SIGINT, signal_handler)
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import json
-import signal
 
 import jsonschema
 from jsonschema import ValidationError
@@ -43,15 +42,11 @@ SUPPORTED_COLUMN_TYPES = set([
 class InterruptException(Exception):
     pass
 
-def signal_handler(*args):
-    raise InterruptException
-
 class BaseQueryRunner(object):
     def __init__(self, configuration):
         jsonschema.validate(configuration, self.configuration_schema())
         self.syntax = 'sql'
         self.configuration = configuration
-        signal.signal(signal.SIGINT, signal_handler)
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     'ValidationError',
     'BaseQueryRunner',
+    'InterruptException',
     'TYPE_DATETIME',
     'TYPE_BOOLEAN',
     'TYPE_INTEGER',

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -142,7 +142,7 @@ class PostgreSQL(BaseQueryRunner):
             logging.exception(e)
             error = e.message
             json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, InterruptException):
             connection.cancel()
             error = "Query cancelled by user."
             json_data = None

--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -132,7 +132,7 @@ class QueryTask(object):
         return self._async_result.ready()
 
     def cancel(self):
-        return self._async_result.revoke(terminate=True)
+        return self._async_result.revoke(terminate=True, signal='SIGINT')
 
     @staticmethod
     def _job_lock_id(query_hash, data_source_id):

--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -1,5 +1,6 @@
 import time
 import logging
+import signal
 from flask.ext.mail import Message
 import redis
 from celery import Task
@@ -8,7 +9,7 @@ from celery.utils.log import get_task_logger
 from redash import redis_connection, models, statsd_client, settings, utils, mail
 from redash.utils import gen_query_hash
 from redash.worker import celery
-from redash.query_runner import get_query_runner
+from redash.query_runner import get_query_runner, InterruptException
 
 logger = get_task_logger(__name__)
 
@@ -263,9 +264,12 @@ def check_alerts_for_query(self, query_id):
 
                 mail.send(message)
 
+def signal_handler(*args):
+    raise InterruptException
 
 @celery.task(bind=True, base=BaseTask, track_started=True)
 def execute_query(self, query, data_source_id, metadata):
+    signal.signal(signal.SIGINT, signal_handler)
     start_time = time.time()
 
     logger.info("Loading data source (%d)...", data_source_id)


### PR DESCRIPTION
Fixes #598.

I tested this on our stage machine and it worked. I've only actually implemented a handler for Postgres, but any query_runner can catch the `InterruptException` and handle it as desired.

I'm open to any and all comments. We don't have any other datasources hooked up, so not sure how this affects the other query runners.