### PR TITLE
Fix: Specifying field type in the field name using __ didn't work

### DIFF
--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -228,7 +228,7 @@
 
         _.each(row, function (value, definition) {
           var name = definition.split("::")[0] || definition.split("__")[0];
-          var type = definition.split("::")[1] || definition.split("__")[0];
+          var type = definition.split("::")[1] || definition.split("__")[1];
           if (mapping) {
             type = mapping[definition];
           }


### PR DESCRIPTION
It works for '::' but probably didn't work for '__' due to a a copy-paste