### PR TITLE
Fix: AlertSubscription missing in all_models

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -875,7 +875,7 @@ class Event(BaseModel):
         return event
 
 
-all_models = (DataSource, User, QueryResult, Query, Alert, Dashboard, Visualization, Widget, ActivityLog, Group, Event)
+all_models = (DataSource, User, QueryResult, Query, Alert, AlertSubscription, Dashboard, Visualization, Widget, ActivityLog, Group, Event)
 
 
 def init_db():


### PR DESCRIPTION
Hi.

I think `AlertSubscription` need to be included in `all_models`. Does this make sense?