### PR TITLE
Build dependencies during building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,7 @@ RUN mkdir -p /opt/redash/supervisord && \
 EXPOSE 5000
 EXPOSE 9001
 
+USER root
+
 # Startup script
 CMD ["supervisord", "-c", "/opt/redash/supervisord/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ RUN apt-get update && \
   # Postgres client
   libpq-dev \
   # Additional packages required for data sources:
-  libssl-dev libmysqlclient-dev
-
-RUN curl https://deb.nodesource.com/setup_4.x | bash - && \
-  apt-get install -y nodejs
+  libssl-dev libmysqlclient-dev && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # Users creation
 RUN useradd --system --comment " " --create-home redash

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && \
   # Additional packages required for data sources:
   libssl-dev libmysqlclient-dev
 
+RUN curl https://deb.nodesource.com/setup_4.x | bash - && \
+  apt-get install -y nodejs
+
 # Users creation
 RUN useradd --system --comment " " --create-home redash
 
@@ -25,13 +28,17 @@ WORKDIR /opt/redash/current
 RUN pip install -r requirements_all_ds.txt && \
   pip install -r requirements.txt
 
+# Fix permissions
+RUN chown -R redash /opt/redash
+
+USER redash
+
+RUN make deps && rm -rf rd_ui/node_modules
+
 # Setup supervisord
 RUN mkdir -p /opt/redash/supervisord && \
     mkdir -p /opt/redash/logs && \
     cp /opt/redash/current/setup/docker/supervisord/supervisord.conf /opt/redash/supervisord/supervisord.conf
-
-# Fix permissions
-RUN chown -R redash /opt/redash
 
 # Expose ports
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN pip install -U setuptools && \
   pip install supervisor==3.1.2
 
 COPY . /opt/redash/current
+RUN chown -R redash /opt/redash/current
 
 # Setting working directory
 WORKDIR /opt/redash/current
@@ -28,23 +29,25 @@ WORKDIR /opt/redash/current
 RUN pip install -r requirements_all_ds.txt && \
   pip install -r requirements.txt
 
-# Fix permissions
-RUN chown -R redash /opt/redash
-
-USER redash
-
-RUN make deps && rm -rf rd_ui/node_modules
+RUN curl https://deb.nodesource.com/setup_4.x | bash - && \
+  apt-get install -y nodejs && \
+  sudo -u redash -H make deps && \
+  rm -rf rd_ui/node_modules /home/redash/.npm /home/redash/.cache && \
+  apt-get purge -y nodejs && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # Setup supervisord
 RUN mkdir -p /opt/redash/supervisord && \
     mkdir -p /opt/redash/logs && \
     cp /opt/redash/current/setup/docker/supervisord/supervisord.conf /opt/redash/supervisord/supervisord.conf
 
+# Fix permissions
+RUN chown -R redash /opt/redash
+
 # Expose ports
 EXPOSE 5000
 EXPOSE 9001
-
-USER root
 
 # Startup script
 CMD ["supervisord", "-c", "/opt/redash/supervisord/supervisord.conf"]

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,8 @@ FILENAME=$(CIRCLE_ARTIFACTS)/$(NAME).$(VERSION).tar.gz
 
 deps:
 	cd rd_ui && npm install
-	cd rd_ui && npm install -g bower grunt-cli
-	cd rd_ui && bower install
-	cd rd_ui && grunt build
+	cd rd_ui && npm run bower install
+	cd rd_ui && npm run build
 
 pack:
 	sed -ri "s/^__version__ = '([0-9.]*)'/__version__ = '$(FULL_VERSION)'/" redash/__init__.py

--- a/rd_ui/package.json
+++ b/rd_ui/package.json
@@ -29,13 +29,16 @@
     "grunt-karma": "~0.8.3",
     "karma-phantomjs-launcher": "~0.1.4",
     "karma": "~0.12.19",
-    "karma-ng-html2js-preprocessor": "~0.1.0"
+    "karma-ng-html2js-preprocessor": "~0.1.0",
+    "bower": "~1.7.1",
+    "grunt-cli": "~0.1.13"
   },
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
     "test": "grunt test",
+    "build": "grunt build",
     "bower": "bower"
   }
 }


### PR DESCRIPTION
Currently, `make deps` is required before `docker build` and node and npm must be installed in build server for `make deps`. After merging this PR, `make deps` will run in a Docker container during building an image.

In addition, bower and grunt-cli are development dependencies and they should not be installed system-globally, so I added them into devDependencies and run them via `npm run`.