### PR TITLE
Feature: BigQuery: limit amount of MB processed per query

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -96,9 +96,9 @@ class BigQuery(BaseQueryRunner):
                     "type": "string",
                     'title': 'JSON Key File'
                 },
-                'maximumTotalMBytesProcessed': {
+                'totalMBytesProcessedLimit': {
                     "type": "number",
-                    'title': 'Maximum Total MByte Processed'
+                    'title': 'Total MByte Processed Limit'
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
@@ -177,11 +177,11 @@ class BigQuery(BaseQueryRunner):
         jobs = bigquery_service.jobs()
 
         try:
-            if "maximumTotalMBytesProcessed" in self.configuration:
-                maximumMB = self.configuration["maximumTotalMBytesProcessed"]
+            if "totalMBytesProcessedLimit" in self.configuration:
+                limitMB = self.configuration["totalMBytesProcessedLimit"]
                 processedMB = self._get_total_bytes_processed(jobs, query) / 1000.0 / 1000.0
-                if maximumMB < processedMB:
-                    return None, "Too large data will be processed (%f MBytes; maximum: %d MBytes)" % (processedMB, maximumMB)
+                if limitMB < processedMB:
+                    return None, "Larger than %d MBytes will be processed (%f MBytes)" % (limitMB, processedMB)
 
             data = self._get_query_result(jobs, query)
             error = None


### PR DESCRIPTION
Sometimes, a query executed on BigQuery highly costs. To prevent that, I added `totalMBytesProcessedLimit` parameter to BigQuery runner.
If `totalMBytesProcessedLimit` is set, the runner will dry-run a query and check data size which will be processed, and if the data is larger than `totalMBytesProcessedLimit`, an error occur like the following image.

![re dash new query 2015-12-16 20-31-56](https://cloud.githubusercontent.com/assets/706434/11839828/2866549e-a434-11e5-9f2f-2b9f38865a5b.png)

This PR contains indent changes, so compare view ignoring whitespace is more understandable: https://github.com/getredash/redash/compare/master...ryotarai:bq-max-mb-processed?w=