### PR TITLE
Fix: Alert: when Alert.name is multibyte character, occur UnicodeEncodeError

### DIFF
--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -350,7 +350,7 @@ def notify_hipchat(alert, html, new_state):
     try:
         hipchat_client = hipchat.HipChat(token=settings.HIPCHAT_API_TOKEN)
         message = '[' + new_state.upper() + '] ' + alert.name + '<br />' + html
-        hipchat_client.message_room(settings.HIPCHAT_ROOM_ID, settings.NAME, message, message_format='html')
+        hipchat_client.message_room(settings.HIPCHAT_ROOM_ID, settings.NAME, message.encode('utf-8', 'ignore'), message_format='html')
     except Exception:
         logger.exception("hipchat send ERROR.")
 
@@ -361,7 +361,7 @@ def notify_mail(alert, html, new_state, app):
     try:
         with app.app_context():
             message = Message(recipients=recipients,
-                              subject="[{1}] {0}".format(alert.name, new_state.upper()),
+                              subject="[{1}] {0}".format(alert.name.encode('utf-8', 'ignore'), new_state.upper()),
                               html=html)
             mail.send(message)
     except Exception:


### PR DESCRIPTION
Hello.

When Alert.name is multibyte character(Japanese), occur UnicodeEncodeError.
This behavior confirmed mail and hipchat.

thanks.

### Error trace
```
01:01:02 worker.1 | [2016-01-07 01:01:02,983: ERROR/Worker-2] redash.tasks.check_alerts_for_query[607a60c9-4ab9-4953-980c-f1b59fe71026]: mail send ERROR.
01:01:02 worker.1 | Traceback (most recent call last):
01:01:02 worker.1 |   File "/opt/redash/current/redash/tasks.py", line 362, in notify_mail
01:01:02 worker.1 |     subject="[{1}] {0}".format(alert.name, new_state.upper()),
01:01:02 worker.1 | UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)
01:01:02 worker.1 | [2016-01-07 01:01:02,986: ERROR/Worker-2] redash.tasks.check_alerts_for_query[607a60c9-4ab9-4953-980c-f1b59fe71026]: hipchat send ERROR.
01:01:02 worker.1 | Traceback (most recent call last):
01:01:02 worker.1 |   File "/opt/redash/current/redash/tasks.py", line 351, in notify_hipchat
01:01:02 worker.1 |     hipchat_client.message_room(settings.HIPCHAT_ROOM_ID, settings.NAME, message, message_format='html')
01:01:02 worker.1 |   File "/usr/local/lib/python2.7/dist-packages/hipchat/__init__.py", line 96, in message_room
01:01:02 worker.1 |     return self.method('rooms/message', 'POST', parameters)
01:01:02 worker.1 |   File "/usr/local/lib/python2.7/dist-packages/hipchat/__init__.py", line 53, in method
01:01:02 worker.1 |     request_data = urlencode(parameters).encode('utf-8')
01:01:02 worker.1 |   File "/usr/lib/python2.7/urllib.py", line 1332, in urlencode
01:01:02 worker.1 |     v = quote_plus(str(v))
01:01:02 worker.1 | UnicodeEncodeError: 'ascii' codec can't encode characters in position 12-17: ordinal not in range(128)
```