### PR TITLE
Feature: add an option to update a query every 30 days

### DIFF
--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -265,6 +265,10 @@
             value: String(7 * 24 * 3600),
             name: 'Once a week'
         });
+        $scope.refreshOptions.push({
+            value: String(30 * 24 * 3600),
+            name: 'Every 30d'
+        });
 
         $scope.$watch('refreshType', function() {
           if ($scope.refreshType == 'periodic') {


### PR DESCRIPTION
Add an option to update a query every 30 days for use with things like monthly reports and month-over-month comparisons.

I use this in my Redash deployment and thought it might be useful for others.