### PR TITLE
Feature: support HipChat Server

### DIFF
--- a/redash/settings.py
+++ b/redash/settings.py
@@ -110,6 +110,7 @@ MAIL_ASCII_ATTACHMENTS = parse_boolean(os.environ.get('REDASH_MAIL_ASCII_ATTACHM
 HOST = os.environ.get('REDASH_HOST', '')
 
 HIPCHAT_API_TOKEN = os.environ.get('REDASH_HIPCHAT_API_TOKEN', None)
+HIPCHAT_API_URL = os.environ.get('REDASH_HIPCHAT_API_URL', None)
 HIPCHAT_ROOM_ID = os.environ.get('REDASH_HIPCHAT_ROOM_ID', None)
 
 WEBHOOK_ENDPOINT = os.environ.get('REDASH_WEBHOOK_ENDPOINT', None)

--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -349,7 +349,10 @@ def check_alerts_for_query(self, query_id):
 
 def notify_hipchat(alert, html, new_state):
     try:
-        hipchat_client = hipchat.HipChat(token=settings.HIPCHAT_API_TOKEN)
+        if settings.HIPCHAT_API_URL:
+            hipchat_client = hipchat.HipChat(token=settings.HIPCHAT_API_TOKEN, url=settings.HIPCHAT_API_URL)
+        else:
+            hipchat_client = hipchat.HipChat(token=settings.HIPCHAT_API_TOKEN)
         message = '[' + new_state.upper() + '] ' + alert.name + '<br />' + html
         hipchat_client.message_room(settings.HIPCHAT_ROOM_ID, settings.NAME, message.encode('utf-8', 'ignore'), message_format='html')
     except Exception:


### PR DESCRIPTION
Failed to send alert for Hipchat Server(on-premise), because api's url is different.
So, added support for Hipchat Server.

#### Setting environment variables
- HIPCHAT_API_URL