### PR TITLE
Fix: Empty cells in google sheets displayed as datetime values #768

### DIFF
--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -22,6 +22,8 @@ def _load_key(filename):
 
 
 def _guess_type(value):
+    if value == '':
+        return TYPE_STRING
     try:
         val = int(value)
         return TYPE_INTEGER
@@ -45,6 +47,10 @@ def _guess_type(value):
 def _value_eval_list(value):
     value_list = []
     for member in value:
+        if member == '' or member == None:
+            val = None
+            value_list.append(val)
+            continue
         try:
             val = int(member)
             value_list.append(val)


### PR DESCRIPTION
A bug fix for #768  ; where empty cells in Google spreadsheet of type TYPE_STRING and TYPE_DATETIME were getting replaced by current timestamp. 