### PR TITLE
Feature: Button toggle to display dashboard in at full screen width

### DIFF
--- a/rd_ui/app/scripts/controllers/dashboard.js
+++ b/rd_ui/app/scripts/controllers/dashboard.js
@@ -1,6 +1,7 @@
 (function() {
   var DashboardCtrl = function($scope, Events, Widget, $routeParams, $location, $http, $timeout, $q, Dashboard) {
     $scope.refreshEnabled = false;
+    $scope.isFullscreen = false;
     $scope.refreshRate = 60;
 
     var renderDashboard = function (dashboard) {
@@ -102,6 +103,10 @@
         });
       }
     }
+
+    $scope.toggleFullscreen = function() {
+      $scope.isFullscreen = !$scope.isFullscreen;
+    };
 
     $scope.triggerRefresh = function() {
       $scope.refreshEnabled = !$scope.refreshEnabled;

--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -8,6 +8,7 @@
 
         <span ng-if="!dashboard.is_archived">
             <button type="button" class="btn btn-default btn-xs" ng-class="{active: refreshEnabled}" tooltip="Enable/Disable Auto Refresh" ng-click="triggerRefresh()"><span class="glyphicon glyphicon-refresh"></span></button>
+            <button type="button" class="btn btn-default btn-xs" ng-class="{active: isFullscreen}" tooltip="Enable/Disable Fullscreen display" ng-click="toggleFullscreen()"><span class="glyphicon glyphicon-picture"></span></button>
             <div class="btn-group" role="group" ng-show="dashboard.canEdit()">
                 <button type="button" class="btn btn-default btn-xs" data-toggle="modal" href="#edit_dashboard_dialog" tooltip="Edit Dashboard (Name/Layout)"><span
                         class="glyphicon glyphicon-cog"></span></button>
@@ -20,8 +21,7 @@
     </h2>
     <filters ng-if="dashboard.dashboard_filters_enabled"></filters>
 </div>
-
-<div class="container" id="dashboard">
+<div ng-class="isFullscreen ? 'container-fluid' : 'container'" id="dashboard">
     <div ng-repeat="row in dashboard.widgets" class="row">
         <div ng-repeat="widget in row" class="col-lg-{{widget.width | colWidth}}"
              ng-controller='WidgetCtrl'>


### PR DESCRIPTION
We display dashboards on televisions and would like to better utilize the screen space.  This pull request adds a simple toggle button to the dashboard that allows the user to switch between `container` and `container-fluid` in the dashboard section that displays widgets.

By default the toggle is set to `false`