### PR TITLE
Ubuntu bootstrap script - move update before upgrade

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -16,8 +16,8 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # Base packages
-apt-get dist-upgrade
 apt-get update
+apt-get dist-upgrade
 apt-get install -y python-pip python-dev nginx curl build-essential pwgen
 pip install -U setuptools
 


### PR DESCRIPTION
Running update before upgrade will fetch the latest sources, so we
can be sure that the upgrades will bring the box to the latest
versions of everything. Otherwise, this is often a no-op because
the box's sources will be cached at time of generation, meaning
there is nothing to upgrade.