### PR TITLE
Feature: add API to trigger query refresh and support for parameters.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ raven==5.9.2
 semver==2.2.1
 python-simple-hipchat==0.4.0
 xlsxwriter==0.8.4
+pystache==0.5.4

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -51,7 +51,6 @@ class BaseTestCase(TestCase):
 
         return make_request(method, path, user, data, is_json)
 
-
     def assertResponseEqual(self, expected, actual):
         for k, v in expected.iteritems():
             if isinstance(v, datetime.datetime) or isinstance(actual[k], datetime.datetime):

--- a/tests/handlers/test_queries.py
+++ b/tests/handlers/test_queries.py
@@ -1,0 +1,110 @@
+from redash import models
+from tests import BaseTestCase
+from tests.test_handlers import AuthenticationTestMixin
+
+
+class QueryAPITest(BaseTestCase, AuthenticationTestMixin):
+    def setUp(self):
+        self.paths = ['/api/queries']
+        super(QueryAPITest, self).setUp()
+
+    def test_update_query(self):
+        admin = self.factory.create_admin()
+        query = self.factory.create_query()
+
+        rv = self.make_request('post', '/api/queries/{0}'.format(query.id), data={'name': 'Testing'}, user=admin)
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json['name'], 'Testing')
+        self.assertEqual(rv.json['last_modified_by']['id'], admin.id)
+
+    def test_create_query(self):
+        query_data = {
+            'name': 'Testing',
+            'query': 'SELECT 1',
+            'schedule': "3600",
+            'data_source_id': self.factory.data_source.id
+        }
+
+        rv = self.make_request('post', '/api/queries', data=query_data)
+
+        self.assertEquals(rv.status_code, 200)
+        self.assertDictContainsSubset(query_data, rv.json)
+        self.assertEquals(rv.json['user']['id'], self.factory.user.id)
+        self.assertIsNotNone(rv.json['api_key'])
+        self.assertIsNotNone(rv.json['query_hash'])
+
+        query = models.Query.get_by_id(rv.json['id'])
+        self.assertEquals(len(list(query.visualizations)), 1)
+
+    def test_get_query(self):
+        query = self.factory.create_query()
+
+        rv = self.make_request('get', '/api/queries/{0}'.format(query.id))
+
+        self.assertEquals(rv.status_code, 200)
+        self.assertResponseEqual(rv.json, query.to_dict(with_visualizations=True))
+
+    def test_get_all_queries(self):
+        queries = [self.factory.create_query() for _ in range(10)]
+
+        rv = self.make_request('get', '/api/queries')
+
+        self.assertEquals(rv.status_code, 200)
+        self.assertEquals(len(rv.json), 10)
+
+    def test_query_without_data_source_should_be_available_only_by_admin(self):
+        query = self.factory.create_query()
+        query.data_source = None
+        query.save()
+
+        rv = self.make_request('get', '/api/queries/{}'.format(query.id))
+        self.assertEquals(rv.status_code, 403)
+
+        rv = self.make_request('get', '/api/queries/{}'.format(query.id), user=self.factory.create_admin())
+        self.assertEquals(rv.status_code, 200)
+
+    def test_query_only_accessible_to_users_from_its_organization(self):
+        second_org = self.factory.create_org()
+        second_org_admin = self.factory.create_admin(org=second_org)
+
+        query = self.factory.create_query()
+        query.data_source = None
+        query.save()
+
+        rv = self.make_request('get', '/api/queries/{}'.format(query.id), user=second_org_admin)
+        self.assertEquals(rv.status_code, 404)
+
+        rv = self.make_request('get', '/api/queries/{}'.format(query.id), user=self.factory.create_admin())
+        self.assertEquals(rv.status_code, 200)
+
+
+class QueryRefreshTest(BaseTestCase):
+    def setUp(self):
+        super(QueryRefreshTest, self).setUp()
+
+        self.query = self.factory.create_query()
+        self.path = '/api/queries/{}/refresh'.format(self.query.id)
+
+    def test_refresh_regular_query(self):
+        response = self.make_request('post', self.path)
+        self.assertEqual(200, response.status_code)
+
+    def test_refresh_of_query_with_parameters(self):
+        self.query.query = "SELECT {{param}}"
+        self.query.save()
+
+        response = self.make_request('post', "{}?p_param=1".format(self.path))
+        self.assertEqual(200, response.status_code)
+
+    def test_refresh_of_query_with_parameters_without_parameters(self):
+        self.query.query = "SELECT {{param}}"
+        self.query.save()
+
+        response = self.make_request('post', "{}".format(self.path))
+        self.assertEqual(400, response.status_code)
+
+    def test_refresh_query_you_dont_have_access_to(self):
+        group = self.factory.create_group()
+        user = self.factory.create_user(groups=[group.id])
+        response = self.make_request('post', self.path, user=user)
+        self.assertEqual(403, response.status_code)

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -16,3 +16,59 @@ class TestQueryResultsCacheHeaders(BaseTestCase):
         rv = self.make_request('get', '/api/queries/{}/results.json'.format(query.id))
         self.assertNotIn('Cache-Control', rv.headers)
 
+
+class QueryResultListAPITest(BaseTestCase):
+    def test_get_existing_result(self):
+        query_result = self.factory.create_query_result()
+        query = self.factory.create_query()
+
+        rv = self.make_request('post', '/api/query_results',
+                               data={'data_source_id': self.factory.data_source.id,
+                                     'query': query.query})
+        self.assertEquals(rv.status_code, 200)
+        self.assertEquals(query_result.id, rv.json['query_result']['id'])
+
+    def test_execute_new_query(self):
+        query_result = self.factory.create_query_result()
+        query = self.factory.create_query()
+
+        rv = self.make_request('post', '/api/query_results',
+                               data={'data_source_id': self.factory.data_source.id,
+                                     'query': query.query,
+                                     'max_age': 0})
+
+        self.assertEquals(rv.status_code, 200)
+        self.assertNotIn('query_result', rv.json)
+        self.assertIn('job', rv.json)
+
+    def test_execute_query_without_access(self):
+        user = self.factory.create_user(groups=[self.factory.create_group().id])
+        query = self.factory.create_query()
+
+        rv = self.make_request('post', '/api/query_results',
+                               data={'data_source_id': self.factory.data_source.id,
+                                     'query': query.query,
+                                     'max_age': 0},
+                               user=user)
+
+        self.assertEquals(rv.status_code, 403)
+        self.assertIn('job', rv.json)
+
+    def test_execute_query_with_params(self):
+        query = "SELECT {{param}}"
+
+        rv = self.make_request('post', '/api/query_results',
+                               data={'data_source_id': self.factory.data_source.id,
+                                     'query': query,
+                                     'max_age': 0})
+
+        self.assertEquals(rv.status_code, 400)
+        self.assertIn('job', rv.json)
+
+        rv = self.make_request('post', '/api/query_results?p_param=1',
+                               data={'data_source_id': self.factory.data_source.id,
+                                     'query': query,
+                                     'max_age': 0})
+
+        self.assertEquals(rv.status_code, 200)
+        self.assertIn('job', rv.json)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from redash.utils import build_url
+from redash.utils import build_url, collect_query_parameters, collect_parameters_from_request
 from collections import namedtuple
 from unittest import TestCase
 
@@ -21,4 +21,31 @@ class TestBuildUrl(TestCase):
         self.assertEqual("https://example.com:80/test", build_url(DummyRequest("example.com:80", "https"), "example.com", "/test"))
         self.assertEqual("http://example.com:443/test", build_url(DummyRequest("example.com:443", "http"), "example.com", "/test"))
 
-    # CALL LIOR!!!
+
+class TestCollectParametersFromQuery(TestCase):
+    def test_returns_empty_list_for_regular_query(self):
+        query = u"SELECT 1"
+        self.assertEqual([], collect_query_parameters(query))
+
+    def test_finds_all_params(self):
+        query = u"SELECT {{param}} FROM {{table}}"
+        params = ['param', 'table']
+        self.assertEqual(params, collect_query_parameters(query))
+
+    def test_deduplicates_params(self):
+        query = u"SELECT {{param}}, {{param}} FROM {{table}}"
+        params = ['param', 'table']
+        self.assertEqual(params, collect_query_parameters(query))
+
+    def test_handles_nested_params(self):
+        query = u"SELECT {{param}}, {{param}} FROM {{table}} -- {{#test}} {{nested_param}} {{/test}}"
+        params = ['param', 'table', 'test', 'nested_param']
+        self.assertEqual(params, collect_query_parameters(query))
+
+
+class TestCollectParametersFromRequest(TestCase):
+    def test_ignores_non_prefixed_values(self):
+        self.assertEqual({}, collect_parameters_from_request({'test': 1}))
+
+    def test_takes_prefixed_values(self):
+        self.assertDictEqual({'test': 1, 'something_else': 'test'}, collect_parameters_from_request({'p_test': 1, 'p_something_else': 'test'}))


### PR DESCRIPTION
This pull request adds support for the query parameters logic in the backend and a new API method to trigger refresh of a query (`POST /api/queries/<query id>/refresh`).