### PR TITLE
Small fixes for new ConfigurationContainer use

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -15,7 +15,7 @@ from flask.ext.login import UserMixin, AnonymousUserMixin
 from permissions import has_access, view_only
 
 from redash import utils, settings, redis_connection
-from redash.query_runner import get_query_runner
+from redash.query_runner import get_query_runner, get_configuration_schema_for_type
 from redash.metrics.database import MeteredPostgresqlExtDatabase, MeteredModel
 from redash.utils import generate_token
 from redash.utils.configuration import ConfigurationContainer
@@ -350,6 +350,8 @@ class DataSource(BelongsToOrgMixin, BaseModel):
         }
 
         if all:
+            schema = get_configuration_schema_for_type(self.type)
+            self.options.set_schema(schema)
             d['options'] = self.options.to_dict(mask_secrets=True)
             d['queue_name'] = self.queue_name
             d['scheduled_queue_name'] = self.scheduled_queue_name

--- a/redash/utils/configuration.py
+++ b/redash/utils/configuration.py
@@ -38,7 +38,7 @@ class ConfigurationContainer(object):
         return self._config.iteritems()
 
     def to_dict(self, mask_secrets=False):
-        if mask_secrets is False:
+        if (mask_secrets is False or 'secret' not in self.schema):
             return self._config
 
         config = self._config.copy()


### PR DESCRIPTION
This contains two small fixes related to the new ConfigurationContainer from #844. 

TL;DR:
* Set the schema type before retrieving the options on a saved data source
* Don't require a `'secrets'` key on schemas.

The first was discussed in Slack -- basically retrieving an existing `DataSource` model with `options` failed because it didn't have a schema set. This gets the schema from the `type` attribute, passes it to the `ConfigurationContainer`, then grabs the config.

The second fix applies to converting `options` to a dict in the `ConfigurationContainer` class. If the schema doesn't have a `secrets` key, it just returns the options immediately without attempting to mask. This way we don't need to include an empty `'secrets'` key on every configuration schema.