### PR TITLE
Minors fixes for MongoDB and Python query runners

### DIFF
--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 try:
     import pymongo
     from bson.objectid import ObjectId
+    from bson.timestamp import Timestamp
     from bson.son import SON
     enabled = True
 
@@ -34,6 +35,8 @@ class MongoDBJSONEncoder(JSONEncoder):
     def default(self, o):
         if isinstance(o, ObjectId):
             return str(o)
+        elif isinstance(o, Timestamp):
+            return super(MongoDBJSONEncoder, self).default(o.as_datetime())
 
         return super(MongoDBJSONEncoder, self).default(o)
 
@@ -116,13 +119,13 @@ class MongoDB(BaseQueryRunner):
                   columns.append(property)
 
     def _get_collection_fields(self, db, collection_name):
-        # Since MongoDB is a document based database and each document doesn't have 
+        # Since MongoDB is a document based database and each document doesn't have
         # to have the same fields as another documet in the collection its a bit hard to
         # show these attributes as fields in the schema.
         #
         # For now, the logic is to take the first and last documents (last is determined
         # by the Natural Order (http://www.mongodb.org/display/DOCS/Sorting+and+Natural+Order)
-        # as we don't know the correct order. In most single server installations it would be 
+        # as we don't know the correct order. In most single server installations it would be
         # find. In replicaset when reading from non master it might not return the really last
         # document written.
         first_document = None

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -77,7 +77,7 @@ class Python(BaseQueryRunner):
         if self.configuration.get("additionalModulesPaths", None):
             for p in self.configuration["additionalModulesPaths"].split(","):
                 if p not in sys.path:
-                    sys.path.append(p) 
+                    sys.path.append(p)
 
     def custom_import(self, name, globals=None, locals=None, fromlist=(), level=0):
         if name in self._allowed_modules:
@@ -153,9 +153,7 @@ class Python(BaseQueryRunner):
         except models.DataSource.DoesNotExist:
             raise Exception("Wrong data source name/id: %s." % data_source_name_or_id)
 
-        query_runner = get_query_runner(data_source.type, data_source.options)
-
-        data, error = query_runner.run_query(query)
+        data, error = data_source.query_runner.run_query(query)
         if error is not None:
             raise Exception(error)
 

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -60,8 +60,8 @@ class Python(BaseQueryRunner):
     def annotate_query(cls):
         return False
 
-    def __init__(self, configuration_json):
-        super(Python, self).__init__(configuration_json)
+    def __init__(self, configuration):
+        super(Python, self).__init__(configuration)
 
         self.syntax = "python"
 


### PR DESCRIPTION
- Python: added 'additionalModulesPaths' config key to add additional paths (comma separated) from which an import can occur. It still requires white listing the module in 'allowedImportModules'

- MongoDB - Added support for bson.timestamp.Timestamp JSON serialization as it sometimes gets returned in newer PyMongo versions.