### PR TITLE
Fix: data source loaded without properties

### DIFF
--- a/rd_ui/app/scripts/directives/data_source_directives.js
+++ b/rd_ui/app/scripts/directives/data_source_directives.js
@@ -4,7 +4,7 @@
   var directives = angular.module('redash.directives');
 
   // Angular strips data- from the directive, so data-source-form becomes sourceForm...
-  directives.directive('sourceForm', ['$http', 'growl', function ($http, growl) {
+  directives.directive('sourceForm', ['$http', 'growl', '$q', function ($http, growl, $q) {
     return {
       restrict: 'E',
       replace: true,
@@ -34,7 +34,10 @@
           });
         });
 
-        $http.get('api/data_sources/types').success(function (types) {
+        var typesPromise = $http.get('api/data_sources/types');
+
+        $q.all([typesPromise, $scope.dataSource.$promise]).then(function(responses) {
+          var types = responses[0].data;
           setType(types);
 
           $scope.dataSourceTypes = types;


### PR DESCRIPTION
If types loaded before the datasource, the UI will reset the type of the data source and clear the already set properties.