### PR TITLE
Replace deprecated flask.ext.* with flask_*

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ CLI to manage redash.
 """
 import json
 
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from redash import settings, models, __version__
 from redash.wsgi import app

--- a/redash/admin.py
+++ b/redash/admin.py
@@ -1,7 +1,7 @@
 import json
+from flask_admin import Admin
+from flask_admin.base import MenuLink
 from flask_admin.contrib.peewee import ModelView
-from flask.ext.admin import Admin
-from flask.ext.admin.base import MenuLink
 from flask_admin.contrib.peewee.form import CustomModelConverter
 from flask_admin.form.widgets import DateTimePickerWidget
 from playhouse.postgres_ext import ArrayField, DateTimeTZField

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -1,11 +1,10 @@
+from flask_login import LoginManager, user_logged_in
 import hashlib
 import hmac
 import time
 import logging
 
 from flask import redirect, request, jsonify
-from flask.ext.login import LoginManager
-from flask.ext.login import user_logged_in
 
 from redash import models, settings
 from redash.authentication import google_oauth, saml_auth

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -1,7 +1,7 @@
 import logging
-from flask.ext.login import login_user
 import requests
 from flask import redirect, url_for, Blueprint, flash, request, session
+from flask_login import login_user
 from flask_oauthlib.client import OAuth
 from redash import models, settings
 from redash.authentication.org_resolving import current_org

--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -1,6 +1,6 @@
 import json
 import click
-from flask.ext.script import Manager
+from flask_script import Manager
 from redash import models
 from redash.query_runner import query_runners, get_configuration_schema_for_type
 from redash.utils.configuration import ConfigurationContainer

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 
 manager = Manager(help="Manages the database (create/drop tables).")
 

--- a/redash/cli/organization.py
+++ b/redash/cli/organization.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 from redash import models
 
 manager = Manager(help="Organization management commands.")

--- a/redash/cli/users.py
+++ b/redash/cli/users.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager, prompt_pass
+from flask_script import Manager, prompt_pass
 from redash import models
 
 manager = Manager(help="Users management commands. This commands assume single organization operation.")

--- a/redash/handlers/base.py
+++ b/redash/handlers/base.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import Resource, abort
+from flask_restful import Resource, abort
 from flask_login import current_user, login_required
 from peewee import DoesNotExist
 

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -1,5 +1,5 @@
 from flask import make_response, request
-from flask.ext.restful import abort
+from flask_restful import abort
 from funcy import project
 
 from redash import models

--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -1,7 +1,7 @@
 from funcy import project
 from flask import render_template, url_for
-from flask.ext.restful import abort
 from flask_login import login_required
+from flask_restful import abort
 
 from redash import models, settings
 from redash.wsgi import app

--- a/redash/handlers/groups.py
+++ b/redash/handlers/groups.py
@@ -1,6 +1,6 @@
 import time
 from flask import request
-from flask.ext.restful import abort
+from flask_restful import abort
 from redash import models
 from redash.wsgi import api
 from redash.permissions import require_admin, require_permission

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask.ext.restful import abort
+from flask_restful import abort
 from flask_login import login_required
 import sqlparse
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -5,8 +5,8 @@ import time
 
 import pystache
 from flask import make_response, request
-from flask.ext.login import current_user
-from flask.ext.restful import abort
+from flask_login import current_user
+from flask_restful import abort
 import xlsxwriter
 from redash import models, settings, utils
 from redash.wsgi import api

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -1,6 +1,6 @@
 import time
 from flask import request
-from flask.ext.restful import abort
+from flask_restful import abort
 from funcy import project
 from peewee import IntegrityError
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -1,4 +1,5 @@
 import json
+from flask_login import UserMixin, AnonymousUserMixin
 import hashlib
 import logging
 import os
@@ -11,7 +12,6 @@ from funcy import project
 import peewee
 from passlib.apps import custom_app_context as pwd_context
 from playhouse.postgres_ext import ArrayField, DateTimeTZField
-from flask.ext.login import UserMixin, AnonymousUserMixin
 from permissions import has_access, view_only
 
 from redash import utils, settings, redis_connection

--- a/redash/permissions.py
+++ b/redash/permissions.py
@@ -1,6 +1,6 @@
+from flask_login import current_user
+from flask_restful import abort
 import functools
-from flask.ext.login import current_user
-from flask.ext.restful import abort
 from funcy import any, flatten
 
 view_only = True

--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -2,7 +2,7 @@ import datetime
 import time
 import logging
 import signal
-from flask.ext.mail import Message
+from flask_mail import Message
 import redis
 import hipchat
 import requests

--- a/redash/wsgi.py
+++ b/redash/wsgi.py
@@ -1,9 +1,9 @@
 import json
 from flask import Flask, make_response
-from flask.ext.sslify import SSLify
 from werkzeug.wrappers import Response
+from flask_restful import Api
+from flask_sslify import SSLify
 from werkzeug.contrib.fixers import ProxyFix
-from flask.ext.restful import Api
 
 from redash import settings, utils, mail, __version__
 from redash.models import db

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,7 @@
 import json
 from unittest import TestCase
 from flask import url_for
-from flask.ext.login import current_user
+from flask_login import current_user
 from mock import patch
 from tests import BaseTestCase
 from tests.handlers import authenticated_user, json_request


### PR DESCRIPTION
Importing flask extensions using flask.ext.* is deprecated in favor of flask_*
For background, see: https://github.com/mitsuhiko/flask/issues/1135