### PR TITLE
Correct Ubuntu Bootstrap.sh to a working Base URL

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -2,7 +2,7 @@
 set -eu
 
 REDASH_BASE_PATH=/opt/redash
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/docker/setup/ubuntu/files/
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/master/setup/ubuntu/files/
 
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
The redash/docker/setup/... path is returning 404, but redash/master/setup/... works.
