### PR TITLE
List only dashboards available to current user based on user's groups

### DIFF
--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -11,18 +11,18 @@ from redash.handlers.base import BaseResource, get_object_or_404
 
 class DashboardRecentAPI(BaseResource):
     def get(self):
-        recent = [d.to_dict() for d in models.Dashboard.recent(self.current_org, self.current_user.id)]
+        recent = [d.to_dict() for d in models.Dashboard.recent(self.current_user.groups, self.current_user.id)]
 
         global_recent = []
         if len(recent) < 10:
-            global_recent = [d.to_dict() for d in models.Dashboard.recent(self.current_org)]
+            global_recent = [d.to_dict() for d in models.Dashboard.recent(self.current_user.groups)]
 
         return take(20, distinct(chain(recent, global_recent), key=lambda d: d['id']))
 
 
 class DashboardListAPI(BaseResource):
     def get(self):
-        dashboards = [d.to_dict() for d in models.Dashboard.all(self.current_org)]
+        dashboards = [d.to_dict() for d in models.Dashboard.all(self.current_user.groups)]
 
         return dashboards
 

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -11,18 +11,18 @@ from redash.handlers.base import BaseResource, get_object_or_404
 
 class DashboardRecentAPI(BaseResource):
     def get(self):
-        recent = [d.to_dict() for d in models.Dashboard.recent(self.current_user.groups, self.current_user.id)]
+        recent = [d.to_dict() for d in models.Dashboard.recent(self.current_user.groups, self.current_user.id, for_user=True)]
 
         global_recent = []
         if len(recent) < 10:
-            global_recent = [d.to_dict() for d in models.Dashboard.recent(self.current_user.groups)]
+            global_recent = [d.to_dict() for d in models.Dashboard.recent(self.current_user.groups, self.current_user.id)]
 
         return take(20, distinct(chain(recent, global_recent), key=lambda d: d['id']))
 
 
 class DashboardListAPI(BaseResource):
     def get(self):
-        dashboards = [d.to_dict() for d in models.Dashboard.all(self.current_user.groups)]
+        dashboards = [d.to_dict() for d in models.Dashboard.all(self.current_user.groups, self.current_user.id)]
 
         return dashboards
 


### PR DESCRIPTION
User can only see dashboards that he has access to in lists on the main page and in header. Whether user has access is determined by the data sources available to him through his groups. If a dashboard contains widgets accessing different data sources, user will be able to see this dashboard in list, however, inside dashboard he will only be able to view widgets that he has access to, others will be locked. Dashboards with no widgets or with text-only widgets do not have data sources but may contain private information that should not be shared across groups, therefore they are only visible to their creator.