### PR TITLE
CLI: Restore ability to pass JSON options string for a new data source

### DIFF
--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -43,10 +43,10 @@ def new(name=None, type=None, options=None):
     else:
         validate_data_source_type(type)
 
-    if options is None:
-        query_runner = query_runners[type]
-        schema = query_runner.configuration_schema()
+    query_runner = query_runners[type]
+    schema = query_runner.configuration_schema()
 
+    if options is None:
         types = {
             'string': unicode,
             'number': int,
@@ -72,11 +72,14 @@ def new(name=None, type=None, options=None):
                 options_obj[k] = value
 
         options = ConfigurationContainer(options_obj, schema)
-        if not options.is_valid():
-            print "Error: invalid configuration."
-            exit()
+    else:
+        options = ConfigurationContainer(json.loads(options), schema)
 
-    print "Creating {} data source ({}) with options:\n{}".format(type, name, options)
+    if not options.is_valid():
+        print "Error: invalid configuration."
+        exit()
+
+    print "Creating {} data source ({}) with options:\n{}".format(type, name, options.to_json())
 
     data_source = models.DataSource.create(name=name,
                                            type=type,


### PR DESCRIPTION
Commit "Encapsulate data source/query runner configuration in an
object." (ed99b84) accidentally removed that functionality by not
inflating the passed in JSON into a ConfigurationContainer object.

This led to errors of the form if you passed -o:

    Traceback (most recent call last):
      ...
      File "/opt/redash/redash-git/redash/models.py", line 321, in db_value
	return value.to_json()
    AttributeError: 'unicode' object has no attribute 'to_json'