### PR TITLE
Support for REMOTE_USER authentication

### DIFF
--- a/rd_ui/app/login.html
+++ b/rd_ui/app/login.html
@@ -37,6 +37,19 @@
 
     {% endif %}
 
+    {% if show_remote_user_login %}
+
+    <div class="row">
+      <a href="/remote_user/login">Remote User Login</a>
+    </div>
+
+    <div class="login-or">
+      <hr class="hr-or">
+      <span class="span-or">or</span>
+    </div>
+
+    {% endif %}
+
     <form role="form" method="post" name="login">
       <div class="form-group">
         <label for="inputEmail">Email</label>

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -8,7 +8,7 @@ from flask import redirect, request, jsonify, url_for
 
 from redash import models, settings
 from redash.authentication.org_resolving import current_org
-from redash.authentication import google_oauth, saml_auth
+from redash.authentication import google_oauth, saml_auth, remote_user_auth
 from redash.tasks import record_event
 
 login_manager = LoginManager()
@@ -143,6 +143,7 @@ def setup_authentication(app):
     app.secret_key = settings.COOKIE_SECRET
     app.register_blueprint(google_oauth.blueprint)
     app.register_blueprint(saml_auth.blueprint)
+    app.register_blueprint(remote_user_auth.blueprint)
 
     user_logged_in.connect(log_user_logged_in)
 

--- a/redash/authentication/remote_user_auth.py
+++ b/redash/authentication/remote_user_auth.py
@@ -1,0 +1,34 @@
+import logging
+from flask import redirect, url_for, Blueprint, request
+from redash.authentication.google_oauth import create_and_login_user
+from redash.authentication.org_resolving import current_org
+from redash import settings
+
+logger = logging.getLogger('remote_user_auth')
+
+blueprint = Blueprint('remote_user_auth', __name__)
+
+@blueprint.route("/remote_user/login")
+def login():
+    next_path = request.args.get('next')
+
+    if not settings.REMOTE_USER_LOGIN_ENABLED:
+        logger.error("Cannot use remote user for login without being enabled in settings")
+        return redirect(url_for('redash.index', next=next_path))
+
+    email = request.headers.get(settings.REMOTE_USER_HEADER)
+
+    # Some Apache auth configurations will, stupidly, set (null) instead of a
+    # falsey value.  Special case that here so it Just Works for more installs.
+    # '(null)' should never really be a value that anyone wants to legitimately
+    # use as a redash user email.
+    if email == '(null)':
+        email = None
+
+    if not email:
+        logger.error("Cannot use remote user for login when it's not provided in the request (looked in headers['" + settings.REMOTE_USER_HEADER + "'])")
+        return redirect(url_for('redash.index', next=next_path))
+
+    logger.info("Logging in " + email + " via remote user")
+    create_and_login_user(current_org, email, email)
+    return redirect(next_path or url_for('redash.index'), code=302)

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -89,7 +89,9 @@ def login(org_slug=None):
         return redirect(next_path)
 
     if not settings.PASSWORD_LOGIN_ENABLED:
-        if settings.SAML_LOGIN_ENABLED:
+        if settings.REMOTE_USER_LOGIN_ENABLED:
+            return redirect(url_for("remote_user_auth.login", next=next_path))
+        elif settings.SAML_LOGIN_ENABLED:
             return redirect(url_for("saml_auth.sp_initiated", next=next_path))
         else:
             return redirect(url_for("google_oauth.authorize", next=next_path))
@@ -115,7 +117,8 @@ def login(org_slug=None):
                            username=request.form.get('username', ''),
                            show_google_openid=settings.GOOGLE_OAUTH_ENABLED,
                            google_auth_url=google_auth_url,
-                           show_saml_login=settings.SAML_LOGIN_ENABLED)
+                           show_saml_login=settings.SAML_LOGIN_ENABLED,
+                           show_remote_user_login=settings.REMOTE_USER_LOGIN_ENABLED)
 
 
 @routes.route(org_scoped_rule('/logout'))

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -90,6 +90,32 @@ SAML_METADATA_URL = os.environ.get("REDASH_SAML_METADATA_URL", "")
 SAML_LOGIN_ENABLED = SAML_METADATA_URL != ""
 SAML_CALLBACK_SERVER_NAME = os.environ.get("REDASH_SAML_CALLBACK_SERVER_NAME", "")
 
+# Enables the use of an externally-provided and trusted remote user via an HTTP
+# header.  The "user" must be an email address.
+#
+# By default the trusted header is X-Forwarded-Remote-User.  You can change
+# this by setting REDASH_REMOTE_USER_HEADER.
+#
+# Enabling this authentication method is *potentially dangerous*, and it is
+# your responsibility to ensure that only a trusted frontend (usually on the
+# same server) can talk to the redash backend server, otherwise people will be
+# able to login as anyone they want by directly talking to the redash backend.
+# You must *also* ensure that any special header in the original request is
+# removed or always overwritten by your frontend, otherwise your frontend may
+# pass it through to the backend unchanged.
+#
+# Note that redash will only check the remote user once, upon the first need
+# for a login, and then set a cookie which keeps the user logged in.  Dropping
+# the remote user header after subsequent requests won't automatically log the
+# user out.  Doing so could be done with further work, but usually it's
+# unnecessary.
+#
+# If you also set REDASH_PASSWORD_LOGIN_ENABLED to false, then your
+# authentication will be seamless.  Otherwise a link will be presented on the
+# login page to trigger remote user auth.
+REMOTE_USER_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_REMOTE_USER_LOGIN_ENABLED", "false"))
+REMOTE_USER_HEADER = os.environ.get("REDASH_REMOTE_USER_HEADER", "X-Forwarded-Remote-User")
+
 # Usually it will be a single path, but we allow to specify additional ones to override the default assets. Only the
 # last one will be used for Flask templates.
 STATIC_ASSETS_PATHS = [fix_assets_path(path) for path in os.environ.get("REDASH_STATIC_ASSETS_PATH", "../rd_ui/app/").split(',')]


### PR DESCRIPTION
Via the environment or a proxy-added request header.  This allows
redash to use nearly any custom authentication setup.

Note that, like existing authentication providers, if you disable
password authentication and the remote user auth is unsuccessful
(probably due to a misconfiguration), then you'll get a redirect
loop of /login ⇄  /remote_user/login.