### PR TITLE
WIP: Use 'latest' tag on postgresql docker image

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -15,7 +15,7 @@ redash:
 redis:
   image: redis:2.8
 postgres:
-  image: postgres:9.3
+  image: postgres:latest
   volumes:
    - /opt/postgres-data:/var/lib/postgresql/data
 redash-nginx:


### PR DESCRIPTION
This is an example file, so no need to pin to an old Postgresql version