### PR TITLE
Switch to a better redis image for docker compose

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -13,7 +13,7 @@ redash:
     REDASH_COOKIE_SECRET:veryverysecret
     REDASH_GOOGLE_APPS_DOMAIN:
 redis:
-  image: redis:2.8
+  image: redis:latest
 postgres:
   image: postgres:9.3
   volumes:


### PR DESCRIPTION
I don't think we need to be back on Redis 2. 

When I went to update, I noticed there's also an optimal slimmed-down build using Alpine linux. See info here: https://hub.docker.com/_/redis/
I stuck with `latest` for simplicity, plus it's not clear in the how well maintained Alpine is: https://news.ycombinator.com/item?id=10782897
But switching to the alpine image might be an optional improvement here.