### PR TITLE
Fix YAML syntax error due to missing spaces

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -6,11 +6,11 @@ redash:
     - redis
     - postgres
   environment:
-    REDASH_STATIC_ASSETS_PATH:"../rd_ui/app/"
-    REDASH_LOG_LEVEL:"INFO"
-    REDASH_REDIS_URL:redis://localhost:6379/0
-    REDASH_DATABASE_URL:"postgresql://redash"
-    REDASH_COOKIE_SECRET:veryverysecret
+    REDASH_STATIC_ASSETS_PATH: "../rd_ui/app/"
+    REDASH_LOG_LEVEL: "INFO"
+    REDASH_REDIS_URL: redis://localhost:6379/0
+    REDASH_DATABASE_URL: "postgresql://redash"
+    REDASH_COOKIE_SECRET: veryverysecret
     REDASH_GOOGLE_APPS_DOMAIN:
 redis:
   image: redis:2.8


### PR DESCRIPTION
Environment variables weren't being parsed properly due to missing spaces.