### PR TITLE
Dockerfile: use redash's docker-hub nginx image

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -22,7 +22,5 @@ redash-nginx:
   image: redash/nginx:latest
   ports:
     - "80:80"
-  volumes:
-    - "../redash-nginx/nginx.conf:/etc/nginx/nginx.conf"
   links:
     - redash

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -19,7 +19,7 @@ postgres:
   volumes:
    - /opt/postgres-data:/var/lib/postgresql/data
 redash-nginx:
-  image: redash-nginx:1.0
+  image: redash/nginx:latest
   ports:
     - "80:80"
   volumes:


### PR DESCRIPTION
This is not fully workable yet, as running `docker-compose up` throws:

    ~/C/redash ❯❯❯ docker-compose up
    redash_redis_1 is up-to-date
    redash_postgres_1 is up-to-date
    redash_redash_1 is up-to-date
    Starting redash_redash-nginx_1
    ERROR: Cannot start container e3577332ca4ea334daa78012fbc14d1331fec966c1bb621b4a131faf7aea3373: [9] System error: not a directory

@arikfr any idea what's going on here? My redash image was created locally with `docker build -t redash .` using the default `Dockerfile` in the repo...