### PR TITLE
Use redash's docker-hub redash image

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -1,5 +1,5 @@
 redash:
-  image: redash
+  image: redash/redash:latest
   ports:
     - "5000:5000"
   links:


### PR DESCRIPTION
I wasn't sure whether to add this as an inline comment or a change, but decided to use the remote image for two reasons:

1. People who are new to docker and just trying to get up and running quickly won't realize that they need to build the docker image locally. Conversely, anyone comfortable with docker will already know how to switch this to a local image built using the Dockerfile.

2. This is more consistent with #894

