### PR TITLE
Feature: MongoDB - add support for $date and relative dates.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ dependencies:
   pre:
     - pip install -r requirements_dev.txt
     - pip install -r requirements.txt
+    - pip install pymongo==3.2.1
     - if [ "$CIRCLE_BRANCH" = "master" ]; then make deps; fi
   cache_directories:
     - rd_ui/node_modules/

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -52,8 +52,8 @@ def datetime_parser(dct):
             if len(m) > 0:
                 dct[k] = parse(m[0], yearfirst=True)
 
-    if '$relative_ts' in dct:
-        return parse_human_time(dct['$relative_ts'])
+    if '$humanTime' in dct:
+        return parse_human_time(dct['$humanTime'])
 
     return bson_object_hook(dct)
 

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -4,7 +4,7 @@ import logging
 import re
 from dateutil.parser import parse
 
-from redash.utils import JSONEncoder
+from redash.utils import JSONEncoder, parse_human_time
 from redash.query_runner import *
 
 logger = logging.getLogger(__name__)
@@ -14,6 +14,7 @@ try:
     from bson.objectid import ObjectId
     from bson.timestamp import Timestamp
     from bson.son import SON
+    from bson.json_util import object_hook as bson_object_hook
     enabled = True
 
 except ImportError:
@@ -51,7 +52,10 @@ def datetime_parser(dct):
             if len(m) > 0:
                 dct[k] = parse(m[0], yearfirst=True)
 
-    return dct
+    if '$relative_ts' in dct:
+        return parse_human_time(dct['$relative_ts'])
+
+    return bson_object_hook(dct)
 
 
 def parse_query_json(query):

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -12,6 +12,8 @@ import pystache
 
 from funcy import distinct
 
+from .human_time import parse_human_time
+
 COMMENTS_REGEX = re.compile("/\*.*?\*/")
 
 

--- a/redash/utils/human_time.py
+++ b/redash/utils/human_time.py
@@ -1,0 +1,12 @@
+import parsedatetime
+from time import mktime
+from datetime import datetime
+
+cal = parsedatetime.Calendar()
+
+
+def parse_human_time(s):
+    time_struct, _ = cal.parse(s)
+    return datetime.fromtimestamp(mktime(time_struct))
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ semver==2.2.1
 python-simple-hipchat==0.4.0
 xlsxwriter==0.8.4
 pystache==0.5.4
+parsedatetime==2.1

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -2,6 +2,9 @@ import datetime
 import json
 from unittest import TestCase
 from redash.query_runner.mongodb import parse_query_json
+from bson.tz_util import utc
+
+from redash.utils import parse_human_time
 
 
 class TestParseQueryJson(TestCase):
@@ -71,3 +74,35 @@ class TestParseQueryJson(TestCase):
         query_data = parse_query_json(json.dumps(query))
 
         self.assertDictEqual(query, query_data)
+
+    def test_supports_extended_json_types(self):
+        query = {
+            'test': 1,
+            'test_list': ['a', 'b', 'c'],
+            'test_dict': {
+                'a': 1,
+                'b': 2
+            },
+            'testIsoDate': "ISODate(\"2014-10-03T00:00\")",
+            'test$date': {
+                '$date': '2014-10-03T00:00:00.0'
+            },
+            'test$undefined': {
+                '$undefined': None
+            }
+        }
+        query_data = parse_query_json(json.dumps(query))
+        self.assertEqual(query_data['test$undefined'], None)
+        self.assertEqual(query_data['test$date'], datetime.datetime(2014, 10, 3, 0, 0).replace(tzinfo=utc))
+
+    def test_supports_relative_timestamps(self):
+        query = {
+            'ts': { '$relative_ts': '1 hour ago' }
+        }
+
+        one_hour_ago = parse_human_time("1 hour ago")
+        query_data = parse_query_json(json.dumps(query))
+        self.assertEqual(query_data['ts'], one_hour_ago)
+
+
+

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -97,7 +97,7 @@ class TestParseQueryJson(TestCase):
 
     def test_supports_relative_timestamps(self):
         query = {
-            'ts': { '$relative_ts': '1 hour ago' }
+            'ts': {'$humanTime': '1 hour ago'}
         }
 
         one_hour_ago = parse_human_time("1 hour ago")

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 from unittest import TestCase
+from pytz import utc
 from redash.query_runner.mongodb import parse_query_json
-from bson.tz_util import utc
 
 from redash.utils import parse_human_time
 


### PR DESCRIPTION
This pull request adds two imporvements to our MongoDB query parsing:

* Full support for [MongoDB Extended JSON](https://docs.mongodb.org/manual/reference/mongodb-extended-json/), which has [`$date`](https://docs.mongodb.org/manual/reference/mongodb-extended-json/#data_date) that can replace our `ISODate` implementation.
* Relative dates support:  passing an object of the form: `{"$relative_ts": "one hour ago"}` will result in a `datetime.datetime` object that represents one hour ago at the time of the query execution.