### PR TITLE
Endless loop query.

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -487,7 +487,7 @@ class QueryResult(BaseModel, BelongsToOrgMixin):
         return query.first()
 
     @classmethod
-    def store_result(cls, org_id, data_source_id, query_hash, query, data, run_time, retrieved_at):
+    def store_result(cls, org_id, data_source_id, query_hash, query, data, run_time, retrieved_at, query_id = 'adhoc'):
         query_result = cls.create(org=org_id,
                                   query_hash=query_hash,
                                   query=query,
@@ -500,6 +500,10 @@ class QueryResult(BaseModel, BelongsToOrgMixin):
 
         sql = "UPDATE queries SET latest_query_data_id = %s WHERE query_hash = %s AND data_source_id = %s RETURNING id"
         query_ids = [row[0] for row in db.database.execute_sql(sql, params=(query_result.id, query_hash, data_source_id))]
+
+        if (not query_ids) and query_id.__class__ == int:
+            sql = "UPDATE queries SET latest_query_data_id = %s WHERE id = %s RETURNING id"
+            query_ids = [row[0] for row in db.database.execute_sql(sql, params=(query_result.id, query_id))]
 
         # TODO: when peewee with update & returning support is released, we can get back to using this code:
         # updated_count = Query.update(latest_query_data=query_result).\

--- a/redash/tasks.py
+++ b/redash/tasks.py
@@ -305,7 +305,7 @@ def execute_query(self, query, data_source_id, metadata):
     redis_connection.delete(QueryTask._job_lock_id(query_hash, data_source.id))
 
     if not error:
-        query_result, updated_query_ids = models.QueryResult.store_result(data_source.org_id, data_source.id, query_hash, query, data, run_time, utils.utcnow())
+        query_result, updated_query_ids = models.QueryResult.store_result(data_source.org_id, data_source.id, query_hash, query, data, run_time, utils.utcnow(), metadata.get('Query ID', 'unknown'))
         logger.info("task=execute_query state=after_store query_hash=%s type=%s ds_id=%d task_id=%s queue=%s query_id=%s username=%s",
                     query_hash, data_source.type, data_source.id, self.request.id, self.request.delivery_info['routing_key'],
                     metadata.get('Query ID', 'unknown'), metadata.get('Username', 'unknown'))


### PR DESCRIPTION
Do not update query_result.retrieved_at.
if not exists query by query_hash and data_source_id, query.latest_query_data_id update by query_id.

We exists wrong query_hash and query.

If exists Another solution, please help me.

ps.
We has 600 query, these query modify GUI for very tired.
We want query.query update for sql.
