### PR TITLE
Add hide_schema option to data sources to disable schema sidebar

### DIFF
--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -102,7 +102,10 @@ class DataSourceSchemaResource(BaseResource):
     def get(self, data_source_id):
         data_source = get_object_or_404(models.DataSource.get_by_id_and_org, data_source_id, self.current_org)
         require_access(data_source.groups, self.current_user, view_only)
-        schema = data_source.get_schema()
+        if data_source.configuration.get('hide_schema', False):
+            schema = []
+        else:
+            schema = data_source.get_schema()
 
         return schema
 


### PR DESCRIPTION
I'm not sure if this is the best place to put this, but it worked for me as a test of the feature.

One of the database servers I am testing Re:dash has several thousand tables with many columns each. When using the query editor, the schema tool in the right side slows down the page considerably and consumes a bunch of RAM.

This adds the ability to update a data source and add the `hide_schema` setting (`False` by default) to return an empty array from the schema API call.