### PR TITLE
Fix: permissions migration was changing default's group type

### DIFF
--- a/migrations/0022_add_new_permissions.py
+++ b/migrations/0022_add_new_permissions.py
@@ -7,4 +7,4 @@ if __name__ == '__main__':
             group.permissions.append('list_dashboards')
             group.permissions.append('list_alerts')
             group.permissions.append('list_data_sources')
-            group.save(only=group.dirty_fields)
+            group.save(only=[models.Group.permissions])

--- a/migrations/0023_make_sure_correct_group_type.py
+++ b/migrations/0023_make_sure_correct_group_type.py
@@ -1,0 +1,8 @@
+from redash import models
+
+if __name__ == '__main__':
+    with models.db.database.transaction():
+        groups = models.Group.select(models.Group.id, models.Group.type).where(models.Group.name=='default')
+        for group in groups:
+            group.type = models.Group.BUILTIN_GROUP
+            group.save(only=[models.Group.type])


### PR DESCRIPTION
This fixes the 0022 migration not to change the group types & added migration 0023 to make sure the `default` group has `builtin` as type, if you already applied 0022 before this fix.