### PR TITLE
When opening a query page, don't automatically execute it

### DIFF
--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -9,11 +9,11 @@
     var getQueryResult = function(maxAge) {
       // Collect params, and getQueryResult with params; getQueryResult merges it into the query
       var parameters = Query.collectParamsFromQueryString($location, $scope.query);
-      if (maxAge == undefined) {
+      if (maxAge === undefined) {
         maxAge = $location.search()['maxAge'];
       }
 
-      if (maxAge == undefined) {
+      if (maxAge === undefined) {
         maxAge = -1;
       }
 
@@ -91,7 +91,9 @@
     }
 
     Events.record(currentUser, 'view', 'query', $scope.query.id);
-    getQueryResult();
+    if ($scope.query.hasResult() || $scope.query.paramsRequired()) {
+      getQueryResult();
+    }
     $scope.queryExecuting = false;
 
     $scope.isQueryOwner = (currentUser.id === $scope.query.user.id) || currentUser.hasPermission('admin');
@@ -246,14 +248,6 @@
       }
 
       if (status == 'done') {
-        if ($scope.query.id &&
-          $scope.query.latest_query_data_id != $scope.queryResult.getId() &&
-          $scope.query.query_hash == $scope.queryResult.query_result.query_hash) {
-          Query.save({
-            'id': $scope.query.id,
-            'latest_query_data_id': $scope.queryResult.getId()
-          })
-        }
         $scope.query.latest_query_data_id = $scope.queryResult.getId();
         $scope.query.queryResult = $scope.queryResult;
 

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -470,6 +470,15 @@
       return moment.utc().hour(parts[0]).minute(parts[1]).local().format('HH:mm');
     };
 
+    Query.prototype.hasResult = function() {
+      return !!(this.latest_query_data || this.latest_query_data_id);
+    };
+
+    Query.prototype.paramsRequired = function() {
+      var queryParameters = this.getParameters();
+      return !_.isEmpty(queryParameters);
+    };
+
     Query.prototype.getQueryResult = function (maxAge, parameters) {
       if (!this.query) {
         return;

--- a/rd_ui/app/scripts/visualizations/chart.js
+++ b/rd_ui/app/scripts/visualizations/chart.js
@@ -102,6 +102,7 @@
               delete scope.options.columnMapping[column];
             });
         };
+
         refreshColumns();
 
         var refreshColumnsAndForm = function() {

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -202,7 +202,7 @@
                 </table>
             </div>
             <!-- tabs and data -->
-            <div ng-show="showDataset">
+            <div ng-if="showDataset">
                 <div class="row">
                     <div class="col-lg-12">
                         <ul class="nav nav-tabs">


### PR DESCRIPTION
Until now, whenever opening a query page we were either loading the latest result or executing it.

New behavior:
1. Only load existing results, and never execute a query automatically.
2. If this is a query with parameters, execute it.