### PR TITLE
InfluxDB: Added support for multiple queries and tags

### DIFF
--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -19,7 +19,7 @@ def _transform_result(results):
     result_rows = []
 
     for result in results:
-        for series in result.raw['series']:
+        for series in result.raw.get('series', []):
             for column in series['columns']:
                 if column not in result_columns:
                     result_columns.append(column)
@@ -29,7 +29,7 @@ def _transform_result(results):
                     result_columns.append(key)
 
     for result in results:
-        for series in result.raw['series']:
+        for series in result.raw.get('series', []):
             for point in series['values']:
                 result_row = {}
                 for column in result_columns:

--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -23,7 +23,8 @@ def _transform_result(results):
             for column in series['columns']:
                 if column not in result_columns:
                     result_columns.append(column)
-            for key in series['tags'].keys():
+            tags = series.get('tags', {})
+            for key in tags.keys():
                 if key not in result_columns:
                     result_columns.append(key)
 
@@ -32,8 +33,9 @@ def _transform_result(results):
             for point in series['values']:
                 result_row = {}
                 for column in result_columns:
-                    if column in series['tags']:
-                        result_row[column] = series['tags'][column]
+                    tags = series.get('tags', {})
+                    if column in tags:
+                        result_row[column] = tags[column]
                     elif column in series['columns']:
                         index = series['columns'].index(column)
                         value = point[index]


### PR DESCRIPTION
Multiple queries are separated by semicolons and could possibly have
different columns and tags.
https://docs.influxdata.com/influxdb/v0.11/guides/querying_data/#multiple-queries

Tags come in to the result set when you use a GROUP BY statement.