### PR TITLE
Fix "http directive is not allowed here" on Ubuntu and Amazon Linux

### DIFF
--- a/setup/amazon_linux/files/nginx_redash_site
+++ b/setup/amazon_linux/files/nginx_redash_site
@@ -2,23 +2,22 @@ upstream rd_servers {
   server 127.0.0.1:5000;
 }
 
-http {
+server {
+
   server_tokens off;
 
-  server {
-    listen 80 default;
+  listen 80 default;
 
-    access_log /var/log/nginx/rd.access.log;
+  access_log /var/log/nginx/rd.access.log;
 
-    gzip on;
-    gzip_types *;
-    gzip_proxied any;
+  gzip on;
+  gzip_types *;
+  gzip_proxied any;
 
-    location / {
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_pass       http://rd_servers;
-    }
+  location / {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass       http://rd_servers;
   }
 }

--- a/setup/ubuntu/files/nginx_redash_site
+++ b/setup/ubuntu/files/nginx_redash_site
@@ -2,24 +2,23 @@ upstream rd_servers {
   server 127.0.0.1:5000;
 }
 
-http {
+server {
+
   server_tokens off;
 
-  server {
-    listen 80 default;
+  listen 80 default;
 
-    access_log /var/log/nginx/rd.access.log;
+  access_log /var/log/nginx/rd.access.log;
 
-    gzip on;
-    gzip_types *;
-    gzip_proxied any;
+  gzip on;
+  gzip_types *;
+  gzip_proxied any;
 
-    location / {
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_pass       http://rd_servers;
-    }
+  location / {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass       http://rd_servers;
   }
 }


### PR DESCRIPTION
The error:
"http" directive is not allowed here in /etc/nginx/sites-enabled/redash:5
was introduced by commit:
https://github.com/getredash/redash/commit/d2a57cbf626a50e66f98f3c5ba2423ce216cff6b
The commit above adds the server_tokens off; line, which is fine, but it also adds http directives to the Ubuntu and Amazon Linux nginx files. This does not work for those files because they are vhost configurations (differing from the Docker configuration).

This fix removes the http directive for those files only, but keeps the server_tokens off; line, moving it into the server directive where it is valid:
http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens