### PR TITLE
Allow passing branch name to bootstrap.sh

### DIFF
--- a/setup/amazon_linux/bootstrap.sh
+++ b/setup/amazon_linux/bootstrap.sh
@@ -8,7 +8,7 @@ REDASH_BRANCH="${REDASH_BRANCH:-master}"
 
 # Install latest version if not specified in REDASH_VERSION env var
 REDASH_VERSION=${REDASH_VERSION-0.9.2.b1536}
-LATEST_URL="https://github.com/getredash/redash/releases/download/${REDASH_BRANCH}/redash.${REDASH_VERSION}.tar.gz"
+LATEST_URL="https://github.com/getredash/redash/releases/download/v${REDASH_VERSION}/redash.${REDASH_VERSION}.tar.gz"
 VERSION_DIR="/opt/redash/redash.${REDASH_VERSION}"
 REDASH_TARBALL=/tmp/redash.tar.gz
 

--- a/setup/amazon_linux/bootstrap.sh
+++ b/setup/amazon_linux/bootstrap.sh
@@ -2,7 +2,17 @@
 set -eu
 
 REDASH_BASE_PATH=/opt/redash
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/master/setup/amazon_linux/files/
+
+# Default version to master
+version=master
+
+# If a version is specified on the command line, use it instead
+if [[ -n "$1" ]]; then
+  version=$1
+fi
+
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/$version/setup/amazon_linux/files/
+
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then
     if [ $# -ne 0 ]; then

--- a/setup/amazon_linux/bootstrap.sh
+++ b/setup/amazon_linux/bootstrap.sh
@@ -3,15 +3,16 @@ set -eu
 
 REDASH_BASE_PATH=/opt/redash
 
-# Default version to master
-version=master
+# Default branch/version to master if not specified in REDASH_BRANCH env var
+REDASH_BRANCH="${REDASH_BRANCH:-master}"
 
-# If a version is specified on the command line, use it instead
-if [[ -n "$1" ]]; then
-  version=$1
-fi
+# Install latest version if not specified in REDASH_VERSION env var
+REDASH_VERSION=${REDASH_VERSION-0.9.2.b1536}
+LATEST_URL="https://github.com/getredash/redash/releases/download/${REDASH_BRANCH}/redash.${REDASH_VERSION}.tar.gz"
+VERSION_DIR="/opt/redash/redash.${REDASH_VERSION}"
+REDASH_TARBALL=/tmp/redash.tar.gz
 
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/$version/setup/amazon_linux/files/
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/${REDASH_BRANCH}/setup/amazon_linux/files/
 
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then
@@ -112,13 +113,6 @@ fi
 if [ ! -f "/opt/redash/.env" ]; then
     sudo -u redash wget $FILES_BASE_URL"env" -O /opt/redash/.env
 fi
-
-# Install latest version
-REDASH_VERSION=${REDASH_VERSION-0.9.1.b1377}
-LATEST_URL="https://github.com/getredash/redash/releases/download/v${REDASH_VERSION}/redash.$REDASH_VERSION.tar.gz"
-VERSION_DIR="/opt/redash/redash.$REDASH_VERSION"
-REDASH_TARBALL=/tmp/redash.tar.gz
-REDASH_TARBALL=/tmp/redash.tar.gz
 
 if [ ! -d "$VERSION_DIR" ]; then
     sudo -u redash wget $LATEST_URL -O $REDASH_TARBALL

--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -8,7 +8,7 @@ REDASH_BRANCH="${REDASH_BRANCH:-master}"
 
 # Install latest version if not specified in REDASH_VERSION env var
 REDASH_VERSION=${REDASH_VERSION-0.9.2.b1536}
-LATEST_URL="https://github.com/getredash/redash/releases/download/${REDASH_BRANCH}/redash.${REDASH_VERSION}.tar.gz"
+LATEST_URL="https://github.com/getredash/redash/releases/download/v${REDASH_VERSION}/redash.${REDASH_VERSION}.tar.gz"
 VERSION_DIR="/opt/redash/redash.${REDASH_VERSION}"
 REDASH_TARBALL=/tmp/redash.tar.gz
 

--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -3,15 +3,16 @@ set -eu
 
 REDASH_BASE_PATH=/opt/redash
 
-# Default version to master
-version=master
+# Default branch/version to master if not specified in REDASH_BRANCH env var
+REDASH_BRANCH="${REDASH_BRANCH:-master}"
 
-# If a version is specified on the command line, use it instead
-if [[ -n "$1" ]]; then
-  version=$1
-fi
+# Install latest version if not specified in REDASH_VERSION env var
+REDASH_VERSION=${REDASH_VERSION-0.9.2.b1536}
+LATEST_URL="https://github.com/getredash/redash/releases/download/${REDASH_BRANCH}/redash.${REDASH_VERSION}.tar.gz"
+VERSION_DIR="/opt/redash/redash.${REDASH_VERSION}"
+REDASH_TARBALL=/tmp/redash.tar.gz
 
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/$version/setup/ubuntu/files/
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/${REDASH_BRANCH}/setup/ubuntu/files/
 
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then
@@ -106,12 +107,6 @@ fi
 if [ ! -f "/opt/redash/.env" ]; then
     sudo -u redash wget $FILES_BASE_URL"env" -O /opt/redash/.env
 fi
-
-# Install latest version
-REDASH_VERSION=${REDASH_VERSION-0.9.1.b1377}
-LATEST_URL="https://github.com/getredash/redash/releases/download/v${REDASH_VERSION}/redash.$REDASH_VERSION.tar.gz"
-VERSION_DIR="/opt/redash/redash.$REDASH_VERSION"
-REDASH_TARBALL=/tmp/redash.tar.gz
 
 if [ ! -d "$VERSION_DIR" ]; then
     sudo -u redash wget "$LATEST_URL" -O "$REDASH_TARBALL"

--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -2,7 +2,16 @@
 set -eu
 
 REDASH_BASE_PATH=/opt/redash
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/master/setup/ubuntu/files/
+
+# Default version to master
+version=master
+
+# If a version is specified on the command line, use it instead
+if [[ -n "$1" ]]; then
+  version=$1
+fi
+
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/$version/setup/ubuntu/files/
 
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then

--- a/setup/ubuntu_docker/bootstrap.sh
+++ b/setup/ubuntu_docker/bootstrap.sh
@@ -3,15 +3,10 @@ set -eu
 
 REDASH_BASE_PATH=/opt/redash_docker
 
-# Default version to master
-version=master
+# Default branch/version to master if not specified in REDASH_BRANCH env var
+REDASH_BRANCH="${REDASH_BRANCH:-master}"
 
-# If a version is specified on the command line, use it instead
-if [[ -n "$1" ]]; then
-  version=$1
-fi
-
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/$version/setup/ubuntu_docker/files/
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/${REDASH_BRANCH}/setup/ubuntu_docker/files/
 
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then

--- a/setup/ubuntu_docker/bootstrap.sh
+++ b/setup/ubuntu_docker/bootstrap.sh
@@ -2,8 +2,16 @@
 set -eu
 
 REDASH_BASE_PATH=/opt/redash_docker
-# TODO: change this to master after merging:
-FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/docker/setup/ubuntu_docker/files/
+
+# Default version to master
+version=master
+
+# If a version is specified on the command line, use it instead
+if [[ -n "$1" ]]; then
+  version=$1
+fi
+
+FILES_BASE_URL=https://raw.githubusercontent.com/getredash/redash/$version/setup/ubuntu_docker/files/
 
 # Verify running as root:
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
This ensures that it is possible to checkout a tag or branch and install from that tag using the same versioned files, for reliable repeatable builds.

e.g.

`bootstrap.sh`
will still install from the base url 
https://raw.githubusercontent.com/getredash/redash/master/setup/ubuntu/files/
but
```
git checkout v0.9.2.b1536
bootstrap.sh v0.9.2.b1536
```
will install from the base url:
https://raw.githubusercontent.com/getredash/redash/v0.9.2.b1536/setup/ubuntu/files/postgres_apt.sh
