### PR TITLE
Fix dashboard permissions, if user doesn't have access to any of the …

### DIFF
--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -11,11 +11,11 @@ from redash.handlers.base import BaseResource, get_object_or_404
 class RecentDashboardsResource(BaseResource):
     @require_permission('list_dashboards')
     def get(self):
-        recent = [d.to_dict() for d in models.Dashboard.recent(self.current_org, self.current_user.id)]
+        recent = [d.to_dict() for d in models.Dashboard.recent(self.current_org, self.current_user.groups, self.current_user.id)]
 
         global_recent = []
         if len(recent) < 10:
-            global_recent = [d.to_dict() for d in models.Dashboard.recent(self.current_org)]
+            global_recent = [d.to_dict() for d in models.Dashboard.recent(self.current_org, self.current_user.groups)]
 
         return take(20, distinct(chain(recent, global_recent), key=lambda d: d['id']))
 
@@ -23,7 +23,7 @@ class RecentDashboardsResource(BaseResource):
 class DashboardListResource(BaseResource):
     @require_permission('list_dashboards')
     def get(self):
-        dashboards = [d.to_dict() for d in models.Dashboard.all(self.current_org)]
+        dashboards = [d.to_dict() for d in models.Dashboard.all(self.current_org, self.current_user.groups)]
 
         return dashboards
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 nose==1.3.0
 coverage==3.7.1
 mock==1.0.1
+pymongo==3.2.1

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -89,7 +89,8 @@ class DashboardAPITest(BaseTestCase, AuthenticationTestMixin):
     def test_get_dashboard_filters_unauthorized_widgets(self):
         dashboard = self.factory.create_dashboard()
 
-        restricted_ds = self.factory.create_data_source(group=self.factory.create_group())
+        group = self.factory.create_group()
+        restricted_ds = self.factory.create_data_source(group=group)
         query = self.factory.create_query(data_source=restricted_ds)
         vis = self.factory.create_visualization(query=query)
         restricted_widget = self.factory.create_widget(visualization=vis, dashboard=dashboard)
@@ -99,9 +100,8 @@ class DashboardAPITest(BaseTestCase, AuthenticationTestMixin):
 
         rv = self.make_request('get', '/api/dashboards/{0}'.format(dashboard.slug))
         self.assertEquals(rv.status_code, 200)
-
-        self.assertTrue(rv.json['widgets'][0][1]['restricted'])
-        self.assertNotIn('restricted', rv.json['widgets'][0][0])
+        self.assertEquals(1, len(rv.json['widgets']))
+        self.assertEquals(widget.id, rv.json['widgets'][0][0]['id'])
 
     def test_get_non_existing_dashboard(self):
         rv = self.make_request('get', '/api/dashboards/not_existing')


### PR DESCRIPTION
Fix dashboard permissions, if user doesn't have access to any of the datasources used in the widgets (except text widget) of a dashboard then do not show that dashboard to the user.

This PR shows users only the Dashboards with at least one of the widgets accessible to the user (based on the datasource used in the widget). If a Dashboard contains any text widget, and then that Dashboard is also visible to the user.
