### PR TITLE
Add environment variable to override secure_flag on session cookie

### DIFF
--- a/redash/settings.py
+++ b/redash/settings.py
@@ -122,7 +122,7 @@ STATIC_ASSETS_PATHS = [fix_assets_path(path) for path in os.environ.get("REDASH_
 
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 6))
 COOKIE_SECRET = os.environ.get("REDASH_COOKIE_SECRET", "c292a0a3aa32397cdb050e233733900f")
-SESSION_COOKIE_SECURE = os.environ.get("REDASH_SESSION_COOKIE_SECURE", False)
+SESSION_COOKIE_SECURE = parse_boolean(os.environ.get("REDASH_SESSION_COOKIE_SECURE") or str(ENFORCE_HTTPS))
 
 LOG_LEVEL = os.environ.get("REDASH_LOG_LEVEL", "INFO")
 

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -122,6 +122,8 @@ STATIC_ASSETS_PATHS = [fix_assets_path(path) for path in os.environ.get("REDASH_
 
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 6))
 COOKIE_SECRET = os.environ.get("REDASH_COOKIE_SECRET", "c292a0a3aa32397cdb050e233733900f")
+SESSION_COOKIE_SECURE = os.environ.get("REDASH_SESSION_COOKIE_SECURE", False)
+
 LOG_LEVEL = os.environ.get("REDASH_LOG_LEVEL", "INFO")
 
 # Mail settings:


### PR DESCRIPTION
This commit creates an environment variable that allows Developers to set the secure flag[1] on browser cookies. By default, this is set to False by flask[2]. 
1. More on Secure Flag here: https://www.owasp.org/index.php/SecureFlag
2. See SESSION_COOKIE_SECURE here: http://flask.pocoo.org/docs/0.10/config/