### PR TITLE
Add link to embeds to open query page in new window

### DIFF
--- a/rd_ui/app/views/visualization-embed.html
+++ b/rd_ui/app/views/visualization-embed.html
@@ -20,7 +20,10 @@
                     <span class="label label-default">Updated: <span am-time-ago="queryResult.getUpdatedAt()"></span></span>
 
                     <span class="pull-right">
-                        <a class="btn btn-default btn-xs" ng-disabled="!queryResult.getData()" query-result-link target="_self">
+                        <a class="btn btn-default btn-xs" ng-href="/queries/{{visualization.query.id}}#{{visualization.id}}" target="_blank" tooltip="Open in re:dash">
+                            <span class="glyphicon glyphicon-link"></span>
+                        </a>
+                        <a class="btn btn-default btn-xs" ng-disabled="!queryResult.getData()" query-result-link target="_self" tooltip="Download as CSV">
                             <span class="glyphicon glyphicon-cloud-download"></span>
                         </a>
                     </span>
@@ -29,3 +32,5 @@
         </div>
     </div>
 </div>
+
+

--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -38,7 +38,7 @@ def embed(query_id, visualization_id, org_slug=None):
 
     qr = project(qr, ('data', 'id', 'retrieved_at'))
     vis = project(vis, ('description', 'name', 'id', 'options', 'query', 'type', 'updated_at'))
-    vis['query'] = project(vis, ('created_at', 'description', 'name', 'id', 'latest_query_data_id', 'name', 'updated_at'))
+    vis['query'] = project(vis['query'], ('created_at', 'description', 'name', 'id', 'latest_query_data_id', 'name', 'updated_at'))
 
     return render_template("embed.html",
                            name=settings.NAME,


### PR DESCRIPTION
At Atlassian most of our reports will be consumed through Embeds.  This little tweak to add a pop-out link back to re:dash will help tie the embed with redash itself.  I used a button that is used in a similar fashion on dashboards.

Also fixed a bug in embed.py that was pulling visualisation attributes into the visualisation.query object.

![screen shot 2016-04-12 at 12 10 25 pm](https://cloud.githubusercontent.com/assets/18389466/14447927/94e4b37a-00a7-11e6-9b59-a2df80ef3b9d.png)