### PR TITLE
Improvements to Plotly.js integration

### DIFF
--- a/rd_ui/app/scripts/app.js
+++ b/rd_ui/app/scripts/app.js
@@ -6,7 +6,6 @@ angular.module('redash', [
   'redash.services',
   'redash.visualization',
   'plotly',
-  'plotly-chart',
   'angular-growl',
   'angularMoment',
   'ui.bootstrap',

--- a/rd_ui/app/scripts/directives/plotly.js
+++ b/rd_ui/app/scripts/directives/plotly.js
@@ -201,7 +201,7 @@
             }
 
             _.each(scope.series, function(series, index) {
-              var seriesOptions = scope.options.seriesOptions[series.name] || {};
+              var seriesOptions = scope.options.seriesOptions[series.name] || {type: scope.options.globalSeriesType};
               var plotlySeries = {x: [],
                                   y: [],
                                   name: seriesOptions.name || series.name,

--- a/rd_ui/app/scripts/directives/plotly.js
+++ b/rd_ui/app/scripts/directives/plotly.js
@@ -127,7 +127,7 @@
         scope: {
           options: "=",
           series: "=",
-          minHeight: "="
+          height: "="
         },
         link: function (scope) {
           var getScaleType = function(scale) {
@@ -158,8 +158,6 @@
             return ColorPaletteArray[index % ColorPaletteArray.length];
           };
 
-          var bottomMargin = 50,
-              pixelsPerLegendRow = 21;
           var redraw = function() {
             scope.data.length = 0;
             scope.layout.showlegend = _.has(scope.options, 'legend') ? scope.options.legend.enabled : true;
@@ -176,7 +174,6 @@
               var cellHeight = 1 / rows;
               var xPadding = 0.02;
               var yPadding = 0.05;
-              var largestXCount = 0;
               _.each(scope.series, function(series, index) {
                 var xPosition = (index % cellsInRow) * cellWidth;
                 var yPosition = Math.floor(index / cellsInRow) * cellHeight;
@@ -190,15 +187,10 @@
                   plotlySeries.labels.push(hasX ? row.x : 'Slice ' + index);
                 });
                 scope.data.push(plotlySeries);
-                largestXCount = Math.max(largestXCount, plotlySeries.labels.length);
               });
-              scope.layout.height = Math.max(scope.minHeight, pixelsPerLegendRow * largestXCount);
-              scope.layout.margin.b = scope.layout.height - (scope.minHeight - bottomMargin);
               return;
             }
 
-            scope.layout.height = Math.max(scope.minHeight, pixelsPerLegendRow * scope.series.length);
-            scope.layout.margin.b = scope.layout.height - (scope.minHeight - bottomMargin);
             var hasY2 = false;
             var sortX = scope.options.sortX === true || scope.options.sortX === undefined;
             var useUnifiedXaxis = sortX && scope.options.xAxis.type === 'category';
@@ -288,7 +280,7 @@
 
           scope.$watch('series', redraw);
           scope.$watch('options', redraw, true);
-          scope.layout = {margin: {l: 50, r: 50, b: 50, t: 20, pad: 4}, hovermode: 'closest'};
+          scope.layout = {margin: {l: 50, r: 50, b: 50, t: 20, pad: 4}, height: scope.height, autosize: true, hovermode: 'closest'};
           scope.plotlyOptions = {showLink: false, displaylogo: false};
           scope.data = [];
         }

--- a/rd_ui/app/vendor_scripts.html
+++ b/rd_ui/app/vendor_scripts.html
@@ -29,7 +29,7 @@
 <script src="/bower_components/underscore.string/lib/underscore.string.js"></script>
 <script src="/bower_components/marked/lib/marked.js"></script>
 <script src="/bower_components/angular-base64-upload/dist/angular-base64-upload.js"></script>
-<script src="/bower_components/plotly/plotly.js"></script>
+<script src="/bower_components/plotly.js/dist/plotly.js"></script>
 <script src="/bower_components/angular-plotly/src/angular-plotly.js"></script>
 <script src="/scripts/directives/plotly.js"></script>
 <script src="/scripts/ng_smart_table.js"></script>

--- a/rd_ui/app/vendor_scripts.html
+++ b/rd_ui/app/vendor_scripts.html
@@ -30,7 +30,6 @@
 <script src="/bower_components/marked/lib/marked.js"></script>
 <script src="/bower_components/angular-base64-upload/dist/angular-base64-upload.js"></script>
 <script src="/bower_components/plotly.js/dist/plotly.js"></script>
-<script src="/bower_components/angular-plotly/src/angular-plotly.js"></script>
 <script src="/scripts/directives/plotly.js"></script>
 <script src="/scripts/ng_smart_table.js"></script>
 <script src="/bower_components/angular-ui-bootstrap-bower/ui-bootstrap-tpls.js"></script>

--- a/rd_ui/app/views/visualizations/chart.html
+++ b/rd_ui/app/views/visualizations/chart.html
@@ -1,3 +1,3 @@
-<div style="max-height: 300px;">
-  <plotly-chart options='plotlyOptions' series='chartSeries' min-height="300"></plotly-chart>
+<div>
+  <plotly-chart options='plotlyOptions' series='chartSeries' height="300"></plotly-chart>
 </div>

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -34,16 +34,15 @@
     "d3": "3.5.6",
     "angular-ui-sortable": "~0.13.4",
     "angular-plotly": "~0.1.2",
-    "plotly": "~1.4.1",
     "angular-resizable": "^1.2.0",
-    "material-design-iconic-font": "^2.2.0"
+    "material-design-iconic-font": "^2.2.0",
+    "plotly.js": "^1.9.0"
   },
   "devDependencies": {
     "angular-mocks": "1.2.18",
     "angular-scenario": "1.2.18"
   },
   "resolutions": {
-    "angular": "1.2.18",
-    "bootstrap": "3.3.6"
+    "angular": "1.2.18"
   }
 }

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -8,7 +8,7 @@
     "angular-growl": "0.4.0",
     "json3": "3.2.4",
     "jquery": "1.9.1",
-    "bootstrap": "3.0.0",
+    "bootstrap": "3.3.6",
     "es5-shim": "2.0.8",
     "angular-moment": "0.10.3",
     "moment": "~2.8.0",

--- a/rd_ui/bower.json
+++ b/rd_ui/bower.json
@@ -33,7 +33,6 @@
     "angular-sanitize": "1.2.18",
     "d3": "3.5.6",
     "angular-ui-sortable": "~0.13.4",
-    "angular-plotly": "~0.1.2",
     "angular-resizable": "^1.2.0",
     "material-design-iconic-font": "^2.2.0",
     "plotly.js": "^1.9.0"


### PR DESCRIPTION
- Upgrade to latest version (1.9.0).
- Use Plotly's legend scrolling instead of our own and switch to their implementation of auto-resize (should be more stable; closes #885).
- Fix #779 (default chart type was ignored for series that were not present when the chart was defined).