### PR TITLE
Fix #994: query description was rendered with bigger font than name

### DIFF
--- a/rd_ui/app/scripts/embed.js
+++ b/rd_ui/app/scripts/embed.js
@@ -43,12 +43,13 @@ angular.module('redash', [
     }
   ])
    .controller('EmbedCtrl', ['$scope', function ($scope) {} ])
-   .controller('EmbeddedVisualizationCtrl', ['$scope', 'Query', 'QueryResult',
-    function ($scope, Query, QueryResult) {
+   .controller('EmbeddedVisualizationCtrl', ['$scope', '$location', 'Query', 'QueryResult',
+     function ($scope, $location, Query, QueryResult) {
+       $scope.showQueryDescription = $location.search()['showDescription'];
        $scope.embed = true;
        $scope.visualization = visualization;
        $scope.query = visualization.query;
        query = new Query(visualization.query);
-       $scope.queryResult = new QueryResult({query_result:query_result});
-    } ])
+       $scope.queryResult = new QueryResult({query_result: query_result});
+     }])
    ;

--- a/rd_ui/app/scripts/visualizations/base.js
+++ b/rd_ui/app/scripts/visualizations/base.js
@@ -60,7 +60,7 @@
       scope: {
         visualization: '='
       },
-      template: '<small>{{name}}</small>',
+      template: '{{name}}',
       replace: false,
       link: function (scope) {
         if (Visualization.visualizations[scope.visualization.type].name !== scope.visualization.name) {

--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -38,7 +38,7 @@
                         <p class="hidden-print">
                             <span ng-hide="currentUser.hasPermission('view_query')">{{query.name}}</span>
                             <query-link query="query" visualization="widget.visualization" ng-show="currentUser.hasPermission('view_query')"></query-link>
-                            <visualization-name visualization="widget.visualization"/>
+                            <small><visualization-name visualization="widget.visualization"/></small>
                         </p>
                         <p class="visible-print">
                           {{query.name}}

--- a/rd_ui/app/views/visualization-embed.html
+++ b/rd_ui/app/views/visualization-embed.html
@@ -6,7 +6,7 @@
         {{query.name}}
         <small><visualization-name visualization="visualization"/></small>
       </p>
-      <small>
+      <small ng-if="showQueryDescription">
         <div class="text-muted" ng-bind-html="query.description | markdown"></div>
       </small>
     </h3>

--- a/rd_ui/app/views/visualization-embed.html
+++ b/rd_ui/app/views/visualization-embed.html
@@ -1,18 +1,21 @@
-<div class="tile" ng-controller='EmbeddedVisualizationCtrl'>
-  <div class="t-heading">
+<div class="tile m-10" ng-controller='EmbeddedVisualizationCtrl'>
+  <div class="t-heading p-10">
     <h3 class="th-title">
       <p>
         <img src="/images/redash_icon_small.png" style="height: 24px;"/>
-        <visualization-name visualization="visualization"/>
+        {{query.name}}
+        <small><visualization-name visualization="visualization"/></small>
       </p>
-      <div class="text-muted" ng-bind-html="query.description | markdown"></div>
+      <small>
+        <div class="text-muted" ng-bind-html="query.description | markdown"></div>
+      </small>
     </h3>
   </div>
 
-  <visualization-renderer visualization="visualization" query-result="queryResult" class="t-body">
+  <visualization-renderer visualization="visualization" query-result="queryResult" class="t-body p-10">
   </visualization-renderer>
 
-  <div class="row bg-ace p-10">
+  <div class="bg-ace clearfix p-10">
     <div class="col-sm-6">
       <span class="label label-default">Updated: <span am-time-ago="queryResult.getUpdatedAt()"></span></span>
     </div>

--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -41,7 +41,6 @@ def embed(query_id, visualization_id, org_slug=None):
     vis['query'] = project(vis['query'], ('created_at', 'description', 'name', 'id', 'latest_query_data_id', 'name', 'updated_at'))
 
     return render_template("embed.html",
-
                            client_config=json_dumps(client_config),
                            visualization=json_dumps(vis),
                            query_result=json_dumps(qr))


### PR DESCRIPTION
Result:

![re_dash__](https://cloud.githubusercontent.com/assets/71468/14609980/b0d306bc-0594-11e6-9a51-30693224e6ec.png)

I've also added the query name to the embed. Anyone sees an issue with showing it?