### PR TITLE
Add server-side parameter handling for embeds

### DIFF
--- a/redash/settings.py
+++ b/redash/settings.py
@@ -203,6 +203,10 @@ BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"
 # Enhance schema fetching
 SCHEMA_RUN_TABLE_SIZE_CALCULATIONS = parse_boolean(os.environ.get("REDASH_SCHEMA_RUN_TABLE_SIZE_CALCULATIONS", "false"))
 
+# Allow Parameters in Embeds
+# WARNING: With this option enabled, Redash reads query parameters from the request URL (risk of SQL injection!)
+ALLOW_PARAMETERS_IN_EMBEDS = parse_boolean(os.environ.get("REDASH_ALLOW_PARAMETERS_IN_EMBEDS", "false"))
+
 ### Common Client config
 COMMON_CLIENT_CONFIG = {
     'allowScriptsInUserInput': ALLOW_SCRIPTS_IN_USER_INPUT,


### PR DESCRIPTION
Hey @arikfr,

This is an updated pull request fulfilling #929, taking a slightly different approach than our previous PR (https://github.com/getredash/redash/pull/995). Instead of retrieving the query template and filling in the parameter on the client side, this code receives the parameters and renders the query template on the server side (via `pystache.render`) and then returns the result.

It seems that this is a much simpler approach which integrates nicely with the existing `embed.html`. It is potentially also safer because the SQL query is not exposed to the client. SQL injection is still a potential threat, though, therefore we keep a warning message in the `settings.py` and disable this feature by default.

In general, it seems that other parts of the framework are also affected by potential SQL injection (e.g.,`QueryResultListResource::post` uses plain parameters). As part of a future work item, maybe we could use a proper SQL templating engine to prevent SQL injection altogether. However, for our current use cases this solution is sufficient (it is used mostly internally).

Please let us know what you think. Thanks