### PR TITLE
Vagrant docs: add purging the cache step

### DIFF
--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -29,12 +29,13 @@ To get started with this box:
 8.  Update database schema to the latest version:
 
     ::
-    
+
         bin/run ./manage.py database drop_tables
         bin/run ./manage.py database create_tables
         bin/run ./manage.py users create --admin --password admin "Admin" "admin"
-
-9.  Start the server and background workers with
+9.  Purging the Redis cache
+    ``redis-cli -n 1 FLUSHALL``
+10. Start the server and background workers with
     ``bin/run honcho start -f Procfile.dev``.
-10. Now the server should be available on your host on port 9001 and you
+11. Now the server should be available on your host on port 9001 and you
     can login with username admin and password admin.


### PR DESCRIPTION
I got an error with Vagrant setup procedure in [Setting up development environment (using Vagrant)](http://docs.redash.io/en/latest/dev/vagrant.html).

This error to solve with purging the cache.

```
12:32:33 worker.1 | [2016-05-01 12:32:33,191: ERROR/MainProcess] Task redash.tasks.record_event[0c4fbabf-77b0-42ed-9bf6-52f071f15d82] raised unexpected: KeyError('org_id',)
12:32:33 worker.1 | Traceback (most recent call last):
12:32:33 worker.1 |   File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 240, in trace_task
12:32:33 worker.1 |     R = retval = fun(*args, **kwargs)
12:32:33 worker.1 |   File "/opt/redash/current/redash/tasks/base.py", line 13, in __call__
12:32:33 worker.1 |     return super(BaseTask, self).__call__(*args, **kwargs)
12:32:33 worker.1 |   File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 437, in __protected_call__
12:32:33 worker.1 |     return self.run(*args, **kwargs)
12:32:33 worker.1 |   File "/opt/redash/current/redash/tasks/general.py", line 13, in record_event
12:32:33 worker.1 |     models.Event.record(event)
12:32:33 worker.1 |   File "/opt/redash/current/redash/models.py", line 1046, in record
12:32:33 worker.1 |     org = event.pop('org_id')
12:32:33 worker.1 | KeyError: 'org_id'
```

Please review my changes.

Thanks,
