### PR TITLE
Add test case for embeds with parameters

### DIFF
--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -1,4 +1,5 @@
 import json
+import pystache
 
 from funcy import project
 from flask import render_template, request
@@ -10,6 +11,7 @@ from redash import serializers
 from redash.utils import json_dumps, collect_parameters_from_request
 from redash.handlers import routes
 from redash.handlers.base import org_scoped_rule, record_event
+from redash.handlers.query_results import collect_query_parameters
 from redash.permissions import require_access, view_only
 from authentication import current_org
 
@@ -34,6 +36,7 @@ def run_query_sync(data_source, parameter_values, query_text):
             return None
         return data
     except Exception, e:
+        abort(503, message="Unable to get result from the database.")
         return None
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -71,6 +71,16 @@ query_factory = ModelFactory(redash.models.Query,
                              data_source=data_source_factory.create,
                              org=1)
 
+query_with_params_factory = ModelFactory(redash.models.Query,
+                             name='New Query with Params',
+                             description='',
+                             query='SELECT {{param1}}',
+                             user=user_factory.create,
+                             is_archived=False,
+                             schedule=None,
+                             data_source=data_source_factory.create,
+                             org=1)
+
 alert_factory = ModelFactory(redash.models.Alert,
                              name=Sequence('Alert {}'),
                              query=query_factory.create,
@@ -199,6 +209,15 @@ class Factory(object):
         args.update(kwargs)
         return query_factory.create(**args)
 
+    def create_query_with_params(self, **kwargs):
+        args = {
+            'user': self.user,
+            'data_source': self.data_source,
+            'org': self.org
+        }
+        args.update(kwargs)
+        return query_with_params_factory.create(**args)
+
     def create_query_result(self, **kwargs):
         args = {
             'data_source': self.data_source,
@@ -214,6 +233,13 @@ class Factory(object):
     def create_visualization(self, **kwargs):
         args = {
             'query': self.create_query()
+        }
+        args.update(kwargs)
+        return visualization_factory.create(**args)
+
+    def create_visualization_with_params(self, **kwargs):
+        args = {
+            'query': self.create_query_with_params()
         }
         args.update(kwargs)
         return visualization_factory.create(**args)


### PR DESCRIPTION
@arikfr, this PR contains a test case for embeds with parameters, and adds a minor fix to `embeds.py`  which had a bug (missing import) in our previous PR (https://github.com/getredash/redash/pull/1014). Apologies for pushing the previous PR prematurely without proper testing.
Cheers