### PR TITLE
Fix: multi filter wasn't working with __ syntax

### DIFF
--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -279,7 +279,7 @@
       var typeSplit;
       if (column.indexOf("::") != -1) {
         typeSplit = "::";
-      } else if (column.indexOf("__" != -1)) {
+      } else if (column.indexOf("__") != -1) {
         typeSplit = "__";
       } else {
         return column;


### PR DESCRIPTION
Multi filter doesn't work where namespace is __. This pull request fixes it. @arikfr Please look into it. 