### PR TITLE
Add an ISSUE_TEMPLATE.md to direct people at the forum

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+Welcome to Redash's GitHub repo! 👋🎉
+
+Do you need help or have a question? Checkout the Support category in our discussion forum: https://discuss.redash.io/c/support.
+Got an idea for a new feature? Check if it isn't on the roadmap already: http://bit.ly/redash-roadmap and start a new discussion
+in the features category: https://discuss.redash.io/c/feature-requests 🌟.
+
+Found a bug? Please fill out the sections below... thank you 👍
+
+### Issue Summary
+
+A summary of the issue and the browser/OS environment in which it occurs.
+
+### Steps to Reproduce
+
+1. This is the first step
+2. This is the second step, etc.
+
+Any other info e.g. Why do you consider this to be a bug? What did you expect to happen instead?
+
+### Technical details:
+
+* Redash Version:
+* Browser/OS:
+* How did you install Redash:


### PR DESCRIPTION
I setup a [Discourse instance](https://discuss.redash.io) for Redash, so now all support questions and new feature discussions will be directed there. This issue template should help people find it.

(I copied the template from Ghost's repo...).