### PR TITLE
Adding oracle on default settings

### DIFF
--- a/redash/settings.py
+++ b/redash/settings.py
@@ -145,6 +145,7 @@ default_query_runners = [
     'redash.query_runner.oracle',
     'redash.query_runner.sqlite',
     'redash.query_runner.mssql',
+    'redash.query_runner.oracle',
 ]
 
 enabled_query_runners = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS", ",".join(default_query_runners)))


### PR DESCRIPTION
If you are not using Oracle, you will have no problem in application start.

I needed to make this change to work with docker. I hope that already in a nearby docker image.

tks