### PR TITLE
Bring back filters if dashboard filters are enabled

### DIFF
--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -28,8 +28,9 @@
   <div class="col-lg-12 p-5 m-b-10 bg-orange c-white" ng-if="dashboard.is_archived">
     This dashboard is archived and won't appear in the dashboards list or search results.
   </div>
-
-
+  
+    <filters ng-if="dashboard.dashboard_filters_enabled"></filters>
+    
     <div ng-repeat="row in dashboard.widgets" class="row">
         <div ng-repeat="widget in row" class="col-lg-{{widget.width | colWidth}}" ng-controller='WidgetCtrl'>
             <div class="tile" ng-if="type=='visualization'">


### PR DESCRIPTION
After the redesign, dashboard filters were accidentally removed in this commit. https://github.com/getredash/redash/pull/984/commits/44f8ccfd756fe13550fd3847cc2f5d71317c2784

This one line PR fixes it :)