### PR TITLE
Feature: support configuring user's groups with SAML

### DIFF
--- a/docs/dev/saml.rst
+++ b/docs/dev/saml.rst
@@ -1,0 +1,34 @@
+SAML Authentication and Authorization
+#####################################
+
+Authentication
+==============
+
+Add to your .env file REDASH_SAML_METADATA_URL config value which
+needs to point to the SAML provider metadata url, eg https://app.onelogin.com/saml/metadata/
+
+And an optional REDASH_SAML_CALLBACK_SERVER_NAME which contains the
+ server name of the redash server for the callbacks from the SAML provider (eg demo.redash.io)
+
+On the SAML provider side, example configuration for OneLogin is:
+SAML Consumer URL: http://demo.redash.io/saml/login
+SAML Audience: http://demo.redash.io/saml/callback
+SAML Recipient: http://demo.redash.io/saml/callback
+
+Example configuration for Okta is:
+Single Sign On URL: http://demo.redash.io/saml/callback
+Recipient URL: http://demo.redash.io/saml/callback
+Destination URL: http://demo.redash.io/saml/callback
+
+with parameters 'FirstName' and 'LastName', both configured to be included in the SAML assertion.
+
+
+Authorization
+=============
+To manage group assignments in Redash using your SAML provider, configure SAML response to include
+attribute with key 'RedashGroups', and value as names of groups in Redash.
+
+Example configuration for Okta is:
+In the Group Attribute Statements -
+Name: RedashGroups
+Filter: Starts with: this-is-a-group-in-redash

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -69,6 +69,8 @@ def create_and_login_user(org, name, email):
 
     login_user(user_object, remember=True)
 
+    return user_object
+
 
 @blueprint.route('/<org_slug>/oauth/google', endpoint="authorize_org")
 def org_login(org_slug):

--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -85,7 +85,12 @@ def idp_initiated():
     # This is what as known as "Just In Time (JIT) provisioning".
     # What that means is that, if a user in a SAML assertion
     # isn't in the user store, we create that user first, then log them in
-    create_and_login_user(current_org, name, email)
+    user = create_and_login_user(current_org, name, email)
+
+    if 'RedashGroups' in authn_response.ava:
+        group_names = authn_response.ava.get('RedashGroups')
+        user.update_group_assignments(group_names, current_org)
+
     url = url_for('redash.index')
 
     return redirect(url)

--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -89,7 +89,7 @@ def idp_initiated():
 
     if 'RedashGroups' in authn_response.ava:
         group_names = authn_response.ava.get('RedashGroups')
-        user.update_group_assignments(group_names, current_org)
+        user.update_group_assignments(group_names)
 
     url = url_for('redash.index')
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -249,7 +249,7 @@ class Group(BaseModel, BelongsToOrgMixin):
         if len(group_names) == 0:
             return []
         result = cls.select().where(cls.org == org, cls.name << group_names)
-        return list(result) if result.count() > 0 else []
+        return list(result)
 
     def __unicode__(self):
         return unicode(self.id)

--- a/redash/models.py
+++ b/redash/models.py
@@ -337,9 +337,9 @@ class User(ModelTimestampsMixin, BaseModel, BelongsToOrgMixin, UserMixin, Permis
     def verify_password(self, password):
         return self.password_hash and pwd_context.verify(password, self.password_hash)
 
-    def update_group_assignments(self, group_names, org):
-        groups = Group.find_by_name(org, group_names)
-        groups.append(org.default_group)
+    def update_group_assignments(self, group_names):
+        groups = Group.find_by_name(self.org, group_names)
+        groups.append(self.org.default_group)
         self.groups = map(lambda g: g.id, groups)
         self.save()
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -246,8 +246,6 @@ class Group(BaseModel, BelongsToOrgMixin):
 
     @classmethod
     def find_by_name(cls, org, group_names):
-        if len(group_names) == 0:
-            return []
         result = cls.select().where(cls.org == org, cls.name << group_names)
         return list(result)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -416,19 +416,17 @@ class TestQueryAll(BaseTestCase):
 
 class TestUser(BaseTestCase):
     def test_default_group_always_added(self):
-        user = self.factory.user
-        org1 = self.factory.create_org()
+        user = self.factory.create_user()
 
-        user.update_group_assignments(["g_unknown"], org1)
-        self.assertItemsEqual([org1.default_group.id], user.groups)
+        user.update_group_assignments(["g_unknown"])
+        self.assertItemsEqual([user.org.default_group.id], user.groups)
 
     def test_update_group_assignments(self):
         user = self.factory.user
-        org1 = self.factory.create_org()
-        new_group = models.Group.create(id='999', name="g1", org=org1)
+        new_group = models.Group.create(id='999', name="g1", org=user.org)
 
-        user.update_group_assignments(["g1"], org1)
-        self.assertItemsEqual([org1.default_group.id, new_group.id], user.groups)
+        user.update_group_assignments(["g1"], user.org)
+        self.assertItemsEqual([user.org.default_group.id, new_group.id], user.groups)
 
 
 class TestGroup(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -425,7 +425,7 @@ class TestUser(BaseTestCase):
         user = self.factory.user
         new_group = models.Group.create(id='999', name="g1", org=user.org)
 
-        user.update_group_assignments(["g1"], user.org)
+        user.update_group_assignments(["g1"])
         self.assertItemsEqual([user.org.default_group.id, new_group.id], user.groups)
 
 


### PR DESCRIPTION
This PR allows Redash users to manage group assignments in using their SAML provider.

To do this, configure the SAML response to include an attribute with key 'RedashGroups', and value as a list of the names of the groups the user should be in, from Redash.