### PR TITLE
Fix: area chart stacking doesn't work

### DIFF
--- a/rd_ui/app/scripts/directives/plotly.js
+++ b/rd_ui/app/scripts/directives/plotly.js
@@ -314,8 +314,7 @@
           element.on('plotly_afterplot', function(d) {
             if(scope.options.globalSeriesType === 'area' && (scope.options.series.stacking === 'normal' || scope.options.series.stacking === 'percent')){
               d3.selectAll('.legendtoggle').each(function(d, i) {
-                // override plotly's default legend item on-click behaviour
-                d3.select(this).on('click', function() {
+                d3.select(this).on('click.legend_hack', function(){
                   var maxIndex = scope.data.length - 1;
                   var itemClicked = scope.data[maxIndex  - i];
 
@@ -327,6 +326,10 @@
                    }
                   Plotly.redraw(element);
                 });
+              });
+            } else {
+              d3.selectAll('.legendtoggle').each(function(d, i) {
+                d3.select(this).on('click.legend_hack', null);
               });
             }
           });

--- a/rd_ui/app/scripts/directives/plotly.js
+++ b/rd_ui/app/scripts/directives/plotly.js
@@ -144,7 +144,6 @@
   angular.module('plotly', [])
     .constant('ColorPalette', ColorPalette)
     .directive('plotlyChart', function () {
-      var bottomMargin = 50;
       return {
         restrict: 'E',
         template: '<div></div>',
@@ -185,10 +184,6 @@
           var recalculateOptions = function() {
             scope.data.length = 0;
             scope.layout.showlegend = _.has(scope.options, 'legend') ? scope.options.legend.enabled : true;
-            if(_.has(scope.options, 'bottomMargin')) {
-              bottomMargin = parseInt(scope.options.bottomMargin);
-              scope.layout.margin.b = bottomMargin;
-            }
             delete scope.layout.barmode;
             delete scope.layout.xaxis;
             delete scope.layout.yaxis;
@@ -309,8 +304,7 @@
           scope.$watch('series', recalculateOptions);
           scope.$watch('options', recalculateOptions, true);
 
-
-          scope.layout = {margin: {l: 50, r: 50, b: bottomMargin, t: 20, pad: 4}, autosize: true, hovermode: 'closest'};
+          scope.layout = {margin: {l: 50, r: 50, b: 50, t: 20, pad: 4}, height: scope.height, autosize: true, hovermode: 'closest'};
           scope.plotlyOptions = {showLink: false, displaylogo: false};
           scope.data = [];
 
@@ -319,23 +313,19 @@
 
           element.on('plotly_afterplot', function(d) {
             if(scope.options.globalSeriesType === 'area' && (scope.options.series.stacking === 'normal' || scope.options.series.stacking === 'percent')){
-              d3.selectAll('.legendtoggle').each(function(d, i) {
-                d3.select(this).on('click.legend_hack', function(){
-                  var maxIndex = scope.data.length - 1;
-                  var itemClicked = scope.data[maxIndex  - i];
+              $(element).find(".legendtoggle").each(function(i, rectDiv) {
+                  d3.select(rectDiv).on('click', function () {
+                    var maxIndex = scope.data.length - 1;
+                    var itemClicked = scope.data[maxIndex - i];
 
-                  itemClicked.visible = (itemClicked.visible === true) ? 'legendonly' : true;
-                   if (scope.options.series.stacking === 'normal') {
+                    itemClicked.visible = (itemClicked.visible === true) ? 'legendonly' : true;
+                    if (scope.options.series.stacking === 'normal') {
                       normalAreaStacking(scope.data);
-                   }else if(scope.options.series.stacking === 'percent'){
+                    } else if (scope.options.series.stacking === 'percent') {
                       percentAreaStacking(scope.data);
-                   }
-                  Plotly.redraw(element);
-                });
-              });
-            } else {
-              d3.selectAll('.legendtoggle').each(function(d, i) {
-                d3.select(this).on('click.legend_hack', null);
+                    }
+                    Plotly.redraw(element);
+                  });
               });
             }
           });

--- a/rd_ui/app/scripts/directives/plotly.js
+++ b/rd_ui/app/scripts/directives/plotly.js
@@ -45,59 +45,82 @@
     });
   };
 
-  var normalAreaStacking = function(seriesList) {
-    fillXValues(seriesList);
+  var storeOriginalHeightForEachSeries = function(seriesList) {
+    _.each(seriesList, function(series) {
+      if(!_.has(series,'visible')){
+        series.visible = true;
+        series.original_y = series.y.slice();
+      }
+    });
+  };
+
+  var getEnabledSeries = function(seriesList){
+    return _.filter(seriesList, function(series) {
+		  return series.visible === true;
+	  });
+  };
+
+  var initializeTextAndHover = function(seriesList){
     _.each(seriesList, function(series) {
       series.text = [];
       series.hoverinfo = 'text+name';
     });
-    for (var i = 0; i < seriesList.length; i++) {
-      for (var j = 0; j < seriesList[i].y.length; j++) {
-        var sum = i > 0 ? seriesList[i-1].y[j] : 0;
-        seriesList[i].text.push('Value: ' + seriesList[i].y[j] + '<br>Sum: ' + (sum + seriesList[i].y[j]));
-        seriesList[i].y[j] += sum;
+  };
+
+  var normalAreaStacking = function(seriesList) {
+    fillXValues(seriesList);
+    storeOriginalHeightForEachSeries(seriesList);
+    initializeTextAndHover(seriesList);
+    seriesList = getEnabledSeries(seriesList);
+
+    _.each(seriesList, function(series, seriesIndex, list){
+      _.each(series.y, function(undefined, yIndex, undefined2){
+        var cumulativeHeightOfPreviousSeries = seriesIndex > 0 ? list[seriesIndex-1].y[yIndex] : 0;
+        var cumulativeHeightWithThisSeries = cumulativeHeightOfPreviousSeries + series.original_y[yIndex];
+        series.y[yIndex] = cumulativeHeightWithThisSeries;
+        series.text.push('Value: ' + series.original_y[yIndex] + '<br>Sum: ' + cumulativeHeightWithThisSeries);
+      });
+    });
+  };
+
+  var lastVisibleY = function(seriesList, lastSeriesIndex, yIndex){
+    for(; lastSeriesIndex >= 0; lastSeriesIndex--){
+      if(seriesList[lastSeriesIndex].visible === true){
+        return seriesList[lastSeriesIndex].y[yIndex];
       }
     }
-  };
+    return 0;
+  }
 
   var percentAreaStacking = function(seriesList) {
     if (seriesList.length === 0) {
       return;
     }
-
     fillXValues(seriesList);
-    _.each(seriesList, function(series) {
-      series.text = [];
-      series.hoverinfo = 'text+name';
+    storeOriginalHeightForEachSeries(seriesList);
+    initializeTextAndHover(seriesList);
+
+    _.each(seriesList[0].y, function(seriesY, yIndex, undefined){
+
+      var sumOfCorrespondingDataPoints = _.reduce(seriesList, function(total, series){
+        return total + series.original_y[yIndex];
+      }, 0);
+
+      _.each(seriesList, function(series, seriesIndex, list){
+        var percentage = (series.original_y[yIndex] / sumOfCorrespondingDataPoints ) * 100;
+        var previousVisiblePercentage = lastVisibleY(seriesList, seriesIndex-1, yIndex);
+        series.y[yIndex] = percentage + previousVisiblePercentage;
+        series.text.push('Value: ' + series.original_y[yIndex] + '<br>Relative: ' + percentage.toFixed(2) + '%');
+      });
     });
-    for (var i = 0; i < seriesList[0].y.length; i++) {
-      var sum = 0;
-      for(var j = 0; j < seriesList.length; j++) {
-        sum += seriesList[j].y[i];
-      }
-
-      for(var j = 0; j < seriesList.length; j++) {
-        var value = seriesList[j].y[i] / sum * 100;
-        seriesList[j].text.push('Value: ' + seriesList[j].y[i] + '<br>Relative: ' + value.toFixed(2) + '%');
-
-        seriesList[j].y[i] = value;
-        if (j > 0) {
-          seriesList[j].y[i] += seriesList[j-1].y[i];
-        }
-      }
-    }
   };
 
   var percentBarStacking = function(seriesList) {
     if (seriesList.length === 0) {
       return;
     }
-
     fillXValues(seriesList);
-    _.each(seriesList, function(series) {
-      series.text = [];
-      series.hoverinfo = 'text+name';
-    });
+    initializeTextAndHover(seriesList);
     for (var i = 0; i < seriesList[0].y.length; i++) {
       var sum = 0;
       for(var j = 0; j < seriesList.length; j++) {
@@ -288,6 +311,25 @@
           var element = element[0].children[0];
           Plotly.newPlot(element, scope.data, scope.layout, scope.plotlyOptions);
 
+          element.on('plotly_afterplot', function(d) {
+            if(scope.options.globalSeriesType === 'area' && (scope.options.series.stacking === 'normal' || scope.options.series.stacking === 'percent')){
+              d3.selectAll('.legendtoggle').each(function(d, i) {
+                // override plotly's default legend item on-click behaviour
+                d3.select(this).on('click', function() {
+                  var maxIndex = scope.data.length - 1;
+                  var itemClicked = scope.data[maxIndex  - i];
+
+                  itemClicked.visible = (itemClicked.visible === true) ? 'legendonly' : true;
+                   if (scope.options.series.stacking === 'normal') {
+                      normalAreaStacking(scope.data);
+                   }else if(scope.options.series.stacking === 'percent'){
+                      percentAreaStacking(scope.data);
+                   }
+                  Plotly.redraw(element);
+                });
+              });
+            }
+          });
           scope.$watch('layout', function (layout, old) {
             if (angular.equals(layout, old)) {
               return;


### PR DESCRIPTION
This PR addresses issue #948 as recommended by Plotly maintainers [here](https://github.com/plotly/plotly.js/issues/344). 

Specifically, we recalculate the data appearance when the legend is clicked. This ensures that we show existing series at the updated heights. 

We also fix the behaviour of percentage area plots. Here, if the legend is clicked to disable a given series, the visualization is refreshed so that only enabled series are plotted. The percentage total is still calculated over the all series. This is designed to be consistent with the percentage bar charts, where after disabling a given series, the plotted visualizations add up to less than 100%. 