### PR TITLE
Fix: old task trackers were not really removed

### DIFF
--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -123,7 +123,7 @@ class QueryTaskTracker(object):
 
         remove_count = count - keep_count
         keys = redis_connection.zrange(list_name, 0, remove_count - 1)
-        redis_connection.delete(keys)
+        redis_connection.delete(*keys)
         redis_connection.zremrangebyrank(list_name, 0, remove_count - 1)
 
         return remove_count

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -7,8 +7,12 @@ class TestPrune(TestCase):
     def setUp(self):
         self.list = "test_list"
         redis_connection.delete(self.list)
+        self.keys = []
         for score in range(0, 100):
-            redis_connection.zadd(self.list, score, 'k:{}'.format(score))
+            key = 'k:{}'.format(score)
+            self.keys.append(key)
+            redis_connection.zadd(self.list, score, key)
+            redis_connection.set(key, 1)
 
     def test_does_nothing_when_below_threshold(self):
         remove_count = QueryTaskTracker.prune(self.list, 100)
@@ -22,3 +26,6 @@ class TestPrune(TestCase):
 
         self.assertEqual(redis_connection.zscore(self.list, 'k:99'), 99.0)
         self.assertIsNone(redis_connection.zscore(self.list, 'k:1'))
+
+        for k in self.keys[0:50]:
+            self.assertFalse(redis_connection.exists(k))


### PR DESCRIPTION
Due to stupid mistake, old task trackers are not removed from Redis which results in ever increasing memory usage.

This pull request fixes this, but if you want to cleanup your instance, you can use the following script:

```python
from redash import redis_connection

if __name__ == '__main__':
    for k in redis_connection.keys('query_task_tracker:*'):
        if redis_connection.zscore('query_task_trackers:done', k) is None and redis_connection.zscore('query_task_trackers:waiting', k) is None and redis_connection.zscore('query_task_trackers:in_progress', k) is None:
            redis_connection.delete(k)   
```
(this script is not efficient, but will do the job)