### PR TITLE
Strip HTML tags from Excel file download

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -180,12 +180,13 @@ class QueryResultResource(BaseResource):
 
         for (r, row) in enumerate(query_data['rows']):
             for (c, name) in enumerate(column_names):
-                sheet.write(r + 1, c, row[name])
+                sheet.write(r + 1, c, utils.clean_from_html_tags(row[name]))
 
         book.close()
 
         headers = {'Content-Type': "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}
         return make_response(s.getvalue(), 200, headers)
+
 
 
 class JobResource(BaseResource):

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -9,6 +9,7 @@ import re
 import hashlib
 import pytz
 import pystache
+import xml.etree.ElementTree
 
 from funcy import distinct
 
@@ -152,5 +153,12 @@ def base_url(org):
         return "https://{}/{}".format(settings.HOST, org.slug)
 
     return settings.HOST
+
+
+def clean_from_html_tags(result_cell):
+    if type(result_cell) in (str, unicode) and result_cell.strip().startswith('<'):
+        return ''.join(xml.etree.ElementTree.fromstring(result_cell).itertext())
+    else:
+        return result_cell
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from redash.utils import build_url, collect_query_parameters, collect_parameters_from_request
+from redash.utils import build_url, collect_query_parameters, collect_parameters_from_request, clean_from_html_tags
 from collections import namedtuple
 from unittest import TestCase
 
@@ -49,3 +49,15 @@ class TestCollectParametersFromRequest(TestCase):
 
     def test_takes_prefixed_values(self):
         self.assertDictEqual({'test': 1, 'something_else': 'test'}, collect_parameters_from_request({'p_test': 1, 'p_something_else': 'test'}))
+
+
+class TestCleanFromHtmlTags(TestCase):
+    def test_removes_html_tags(self):
+        dirty_string = '<a href="some/site" target="_brank">value</a>'
+        self.assertEqual('value', clean_from_html_tags(dirty_string))
+
+    def test_ignores_number(self):
+        self.assertEqual(3, clean_from_html_tags(3))
+
+    def test_ignores_string_with_no_html_tag(self):
+        self.assertEqual('value', clean_from_html_tags('value'))


### PR DESCRIPTION
Html tags in result values make Excel files produced by drill-down queries (such as [this one](http://demo.redash.io/api/queries/514/results/1096872.xlsx) from [this query](http://demo.redash.io/queries/514#table)) a bit unreadable and not too useful.

This change removes the html tags and preserves the value (the text attribute inside the tag).