### PR TITLE
Fix duplicate alerts when listing them

### DIFF
--- a/redash/handlers/alerts.py
+++ b/redash/handlers/alerts.py
@@ -71,7 +71,8 @@ class AlertListResource(BaseResource):
 
     @require_permission('list_alerts')
     def get(self):
-        return [alert.to_dict() for alert in models.Alert.all(groups=self.current_user.groups)]
+        tmp = [alert.to_dict() for alert in models.Alert.all(groups=self.current_user.groups)]
+        return {v['id']: v for v in tmp}.values()
 
 
 class AlertSubscriptionListResource(BaseResource):


### PR DESCRIPTION
This fixes https://github.com/getredash/redash/issues/1049 with a dirty Python hack.

```
>>> L=[
... {'id':1,'name':'john', 'age':34},
... {'id':1,'name':'john', 'age':34},
... {'id':2,'name':'hanna', 'age':30},
... ]
>>> {v['id']: v for v in L}.values()
[{'age': 34, 'id': 1, 'name': 'john'}, {'age': 30, 'id': 2, 'name': 'hanna'}]
```