### PR TITLE
Add caching for queries used in embeds

### DIFF
--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -84,7 +84,7 @@ def embed(query_id, visualization_id, org_slug=None):
             # WARNING: Note that the external query parameters
             #          are a potential risk of SQL injections.
             #
-            max_age = int(request.args['maxAge']) if 'maxAge' in request.args else 0
+            max_age = int(request.args.get('maxAge', 0))
             results = run_query_sync(query.data_source, parameter_values, query.query, max_age=max_age)
             if results is None:
                 abort(400, message="Unable to get results for this query")

--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -1,14 +1,16 @@
 import json
 import pystache
+import time
+import logging
 
 from funcy import project
 from flask import render_template, request
 from flask_login import login_required, current_user
 from flask_restful import abort
 
-from redash import models, settings
+from redash import models, settings, utils
 from redash import serializers
-from redash.utils import json_dumps, collect_parameters_from_request
+from redash.utils import json_dumps, collect_parameters_from_request, gen_query_hash
 from redash.handlers import routes
 from redash.handlers.base import org_scoped_rule, record_event
 from redash.handlers.query_results import collect_query_parameters
@@ -21,7 +23,7 @@ from authentication import current_org
 #             removed once we refactor the query results API endpoints and handling
 #             on the client side. Please don't reuse in other API handlers.
 #
-def run_query_sync(data_source, parameter_values, query_text):
+def run_query_sync(data_source, parameter_values, query_text, max_age=0):
     query_parameters = set(collect_query_parameters(query_text))
     missing_params = set(query_parameters) - set(parameter_values.keys())
     if missing_params:
@@ -30,13 +32,36 @@ def run_query_sync(data_source, parameter_values, query_text):
     if query_parameters:
         query_text = pystache.render(query_text, parameter_values)
 
+    if max_age <= 0:
+        query_result = None
+    else:
+        query_result = models.QueryResult.get_latest(data_source, query_text, max_age)
+
+    query_hash = gen_query_hash(query_text)
+
+    if query_result:
+        logging.info("Returning cached result for query %s" % query_hash)
+        return query_result.data
+
     try:
+        started_at = time.time()
         data, error = data_source.query_runner.run_query(query_text)
+
         if error:
             return None
+        # update cache
+        if max_age > 0:
+            run_time = time.time() - started_at
+            query_result, updated_query_ids = models.QueryResult.store_result(data_source.org_id, data_source.id,
+                                                                                  query_hash, query_text, data,
+                                                                                  run_time, utils.utcnow())
+
         return data
     except Exception, e:
-        abort(503, message="Unable to get result from the database.")
+        if max_age > 0:
+            abort(404, message="Unable to get result from the database, and no cached query result found.")
+        else:
+            abort(503, message="Unable to get result from the database.")
         return None
 
 
@@ -59,7 +84,8 @@ def embed(query_id, visualization_id, org_slug=None):
             # WARNING: Note that the external query parameters
             #          are a potential risk of SQL injections.
             #
-            results = run_query_sync(query.data_source, parameter_values, query.query)
+            max_age = int(request.args['maxAge']) if 'maxAge' in request.args else 0
+            results = run_query_sync(query.data_source, parameter_values, query.query, max_age=max_age)
             if results is None:
                 abort(400, message="Unable to get results for this query")
             else:


### PR DESCRIPTION
This PR adds caching of query results for queries used in embeds.

Following the notation already used in `query_view.js`, users can specify a *maxAge* parameter in the URL to limit the result's maximum cache age.

Tests have been updated to cover this new functionality.