### PR TITLE
Fix RST syntax for links

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -83,9 +83,9 @@ Heroku
 ------
 
 Due to the nature of Heroku deployments, upgrading to a newer version of Redash
-requires performing the steps outlined on the `"How to Upgrade"<http://docs.redash.io/en/latest/upgrade.html>`__ page.
+requires performing the steps outlined on the `"How to Upgrade" <http://docs.redash.io/en/latest/upgrade.html>`__ page.
 
-1. Install `Heroku CLI<https://toolbelt.heroku.com/>`__.
+1. Install `Heroku CLI <https://toolbelt.heroku.com/>`__.
 
 2. Create Heroku App::
 


### PR DESCRIPTION
I derped with the link syntax in #1092.
It seems RST wants a space between the link text and the `<url>`.
My RST previewer didn't show any issue, but readthedocs doesn't like it and the link text displays the RST syntax and shows an invalid link.
I've tested this locally with sphinx and it resolves the issue.