### PR TITLE
Switch to HipChat V2 API

### DIFF
--- a/migrations/0023_add_notification_destination.py
+++ b/migrations/0023_add_notification_destination.py
@@ -43,10 +43,16 @@ if __name__ == '__main__':
             if settings.HIPCHAT_API_TOKEN:
                 # Have all existing alerts send to HipChat if already configured
                 schema = get_configuration_schema_for_destination_type('hipchat')
-                conf = {'token': settings.HIPCHAT_API_TOKEN,
-                        'room_id': settings.HIPCHAT_ROOM_ID}
+
+                conf = {}
+
                 if settings.HIPCHAT_API_URL:
-                    conf['url'] = settings.HIPCHAT_API_URL
+                    conf['url'] = '{url}/room/{room_id}/notification?auth_token={token}'.format(
+                        url=settings.HIPCHAT_API_URL, room_id=settings.HIPCHAT_ROOM_ID, token=settings.HIPCHAT_API_TOKEN)
+                else:
+                    conf['url'] = 'https://redash.hipchat.com/v2/room/{room_id}/notification?auth_token={token}'.format(
+                        room_id=settings.HIPCHAT_ROOM_ID, token=settings.HIPCHAT_API_TOKEN)
+
                 options = ConfigurationContainer(conf, schema)
 
                 hipchat = NotificationDestination.create(

--- a/migrations/0023_add_notification_destination.py
+++ b/migrations/0023_add_notification_destination.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
                     conf['url'] = '{url}/room/{room_id}/notification?auth_token={token}'.format(
                         url=settings.HIPCHAT_API_URL, room_id=settings.HIPCHAT_ROOM_ID, token=settings.HIPCHAT_API_TOKEN)
                 else:
-                    conf['url'] = 'https://redash.hipchat.com/v2/room/{room_id}/notification?auth_token={token}'.format(
+                    conf['url'] = 'https://hipchat.com/v2/room/{room_id}/notification?auth_token={token}'.format(
                         room_id=settings.HIPCHAT_ROOM_ID, token=settings.HIPCHAT_API_TOKEN)
 
                 options = ConfigurationContainer(conf, schema)

--- a/redash/destinations/hipchat.py
+++ b/redash/destinations/hipchat.py
@@ -1,8 +1,16 @@
+import json
 import logging
-import hipchat
+import requests
 
-from redash import settings
 from redash.destinations import *
+from redash.models import Alert
+
+
+colors = {
+    Alert.OK_STATE: 'green',
+    Alert.TRIGGERED_STATE: 'red',
+    Alert.UNKNOWN_STATE: 'yellow'
+}
 
 
 class HipChat(BaseDestination):
@@ -12,17 +20,11 @@ class HipChat(BaseDestination):
             "type": "object",
             "properties": {
                 "url": {
-                    "type": "string"
+                    "type": "string",
+                    "title": "HipChat Notification URL (get it from the Integrations page)"
                 },
-                "token": {
-                    "type": "string"
-                },
-                "room_id": {
-                    "type": "string"
-                }
             },
-            "required": ["token", "room_id"],
-            "secret": ["token"]
+            "required": ["url"]
         }
 
     @classmethod
@@ -31,17 +33,25 @@ class HipChat(BaseDestination):
 
     def notify(self, alert, query, user, new_state, app, host, options):
         try:
-            if options.url:
-                hipchat_client = hipchat.HipChat(token=options.token, url=options.url)
-            else:
-                hipchat_client = hipchat.HipChat(token=options.token)
-            html = """
-            Check <a href="{host}/alerts/{alert_id}">alert</a> / check <a href="{host}/queries/{query_id}">query</a>.
-            """.format(host=host, alert_id=alert.id, query_id=query.id)
-            message = '[' + new_state.upper() + '] ' + alert.name + '<br />' + html
-            hipchat_client.message_room(options.room_id, settings.NAME, message.encode('utf-8', 'ignore'), message_format='html')
+            alert_url = '{host}/alerts/{alert_id}'.format(host=host, alert_id=alert.id);
+            query_url = '{host}/queries/{query_id}'.format(host=host, query_id=query.id);
+
+            message = '<a href="{alert_url}">{alert_name}</a> changed state to {new_state} (based on <a href="{query_url}">this query</a>).'.format(
+                alert_name=alert.name, new_state=new_state.upper(),
+                alert_url=alert_url,
+                query_url=query_url)
+
+            data = {
+                'message': message,
+                'color': colors.get(new_state, 'green')
+            }
+            headers = {'Content-Type': 'application/json'}
+            response = requests.post(options['url'], data=json.dumps(data), headers=headers)
+
+            if response.status_code != 204:
+                logging.error('Bad status code received from HipChat: %d', response.status_code)
         except Exception:
-            logging.exception("hipchat send ERROR.")
+            logging.exception("HipChat Send ERROR.")
 
 
 register(HipChat)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ pycrypto==2.6.1
 funcy==1.5
 raven==5.9.2
 semver==2.2.1
-python-simple-hipchat==0.4.0
 xlsxwriter==0.8.4
 pystache==0.5.4
 parsedatetime==2.1


### PR DESCRIPTION
If you were using Re:dash with HipChat and already upgraded to 0.11 you will need to update manually HipChat's settings.