### PR TITLE
Return meaningful error when there is no cached result.

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -115,6 +115,8 @@ class QueryResultResource(BaseResource):
 
         if query_result_id:
             query_result = get_object_or_404(models.QueryResult.get_by_id_and_org, query_result_id, self.current_org)
+        else:
+            query_result = None
 
         if query_result:
             require_access(query_result.data_source.groups, self.current_user, view_only)
@@ -156,7 +158,7 @@ class QueryResultResource(BaseResource):
             return response
 
         else:
-            abort(404)
+            abort(404, message='No cached result found for this query.')
 
     def make_json_response(self, query_result):
         data = json.dumps({'query_result': query_result.to_dict()}, cls=utils.JSONEncoder)

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -16,6 +16,12 @@ class TestQueryResultsCacheHeaders(BaseTestCase):
         rv = self.make_request('get', '/api/queries/{}/results.json'.format(query.id))
         self.assertNotIn('Cache-Control', rv.headers)
 
+    def test_returns_404_if_no_cached_result_found(self):
+        query = self.factory.create_query(latest_query_data=None)
+
+        rv = self.make_request('get', '/api/queries/{}/results.json'.format(query.id))
+        self.assertEqual(404, rv.status_code)
+
 
 class TestQueryResultListAPI(BaseTestCase):
     def test_get_existing_result(self):
@@ -107,3 +113,4 @@ class TestQueryResultAPI(BaseTestCase):
 
         rv = self.make_request('get', '/api/query_results/{}'.format(query_result.id))
         self.assertEquals(rv.status_code, 200)
+


### PR DESCRIPTION
Previously it was crashing as it was trying to access an unreferenced variables (query_result).