### PR TITLE
Mark basic_auth_password as secret

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -64,7 +64,8 @@ class BaseElasticSearch(BaseQueryRunner):
                     'title': 'Basic Auth Password'
                 }
             },
-            "required" : ["server"]
+            "secret": ["basic_auth_password"],
+            "required": ["server"]
         }
 
     @classmethod


### PR DESCRIPTION
Correctly marks the Elasticsearch datasource password as being secret.
Without this, passwords are included in serialized elasticsearch datasources.