### PR TITLE
Feature: add --org option to all relevant CLI commands.

### DIFF
--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -98,7 +98,7 @@ def new(name=None, type=None, options=None, organization='default'):
 
 @manager.option('name', default=None, help="name of data source to delete")
 @manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
-def delete(name, organization):
+def delete(name, organization='default'):
     """Delete data source by name."""
     try:
         org = models.Organization.get_by_slug(organization)

--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -8,7 +8,7 @@ from redash.utils.configuration import ConfigurationContainer
 manager = Manager(help="Data sources management commands.")
 
 
-@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to (leave blank for all organizations).")
 def list(organization=None):
     """List currently configured data sources."""
     if organization:
@@ -32,7 +32,7 @@ def validate_data_source_type(type):
 @manager.option('name', default=None, help="name of data source to create")
 @manager.option('--type', dest='type', default=None, help="new type for the data source")
 @manager.option('--options', dest='options', default=None, help="updated options for the data source")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to (leave blank for 'default').")
 def new(name=None, type=None, options=None, organization='default'):
     """Create new data source."""
     if name is None:
@@ -97,7 +97,7 @@ def new(name=None, type=None, options=None, organization='default'):
 
 
 @manager.option('name', default=None, help="name of data source to delete")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to (leave blank for 'default').")
 def delete(name, organization='default'):
     """Delete data source by name."""
     try:
@@ -123,7 +123,7 @@ def update_attr(obj, attr, new_value):
 @manager.option('--name', dest='new_name', default=None, help="new name for the data source")
 @manager.option('--options', dest='options', default=None, help="updated options for the data source")
 @manager.option('--type', dest='type', default=None, help="new type for the data source")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to (leave blank for 'default').")
 def edit(name, new_name=None, options=None, type=None, organization='default'):
     """Edit data source settings (name, options, type)."""
     try:

--- a/redash/cli/groups.py
+++ b/redash/cli/groups.py
@@ -6,7 +6,7 @@ manager = Manager(help="Groups management commands. This commands assume single 
 @manager.option('name', help="Group's name")
 @manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
 @manager.option('--permissions', dest='permissions', default=None, help="Comma seperated list of permissions ('create_dashboard', 'create_query', 'edit_dashboard', 'edit_query', 'view_query', 'view_source', 'execute_query', 'list_users', 'schedule_query', 'list_dashboards', 'list_alerts', 'list_data_sources') (leave blank for default).")
-def create(name, organization, permissions=None):
+def create(name, permissions=None, organization='default'):
     print "Creating group (%s)..." % (name)
 
     org = models.Organization.get_by_slug(organization)

--- a/redash/cli/groups.py
+++ b/redash/cli/groups.py
@@ -4,11 +4,12 @@ from redash import models
 manager = Manager(help="Groups management commands. This commands assume single organization operation.")
 
 @manager.option('name', help="Group's name")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
 @manager.option('--permissions', dest='permissions', default=None, help="Comma seperated list of permissions ('create_dashboard', 'create_query', 'edit_dashboard', 'edit_query', 'view_query', 'view_source', 'execute_query', 'list_users', 'schedule_query', 'list_dashboards', 'list_alerts', 'list_data_sources') (leave blank for default).")
-def create(name, permissions=None):
+def create(name, organization, permissions=None):
     print "Creating group (%s)..." % (name)
 
-    org = models.Organization.get_by_slug('default')
+    org = models.Organization.get_by_slug(organization)
 
     permissions = extract_permissions_string(permissions)
 
@@ -17,7 +18,7 @@ def create(name, permissions=None):
     try:
         models.Group.create(name=name, org=org, permissions=permissions)
     except Exception, e:
-        print "Failed create group: %s" % e.message  
+        print "Failed create group: %s" % e.message
 
 @manager.option('id', help="Group's id")
 @manager.option('--permissions', dest='permissions', default=None, help="Comma seperated list of permissions ('create_dashboard', 'create_query', 'edit_dashboard', 'edit_query', 'view_query', 'view_source', 'execute_query', 'list_users', 'schedule_query', 'list_dashboards', 'list_alerts', 'list_data_sources') (leave blank for default).")
@@ -30,7 +31,7 @@ def change_permissions(id, permissions=None):
         print "User [%s] not found." % id
         return
 
-    permissions = extract_permissions_string(permissions)    
+    permissions = extract_permissions_string(permissions)
     print "current permissions [%s] will be modify to [%s]" % (",".join(group.permissions), ",".join(permissions))
 
     group.permissions = permissions
@@ -38,7 +39,7 @@ def change_permissions(id, permissions=None):
     try:
         group.save()
     except Exception, e:
-        print "Failed change permission: %s" % e.message  
+        print "Failed change permission: %s" % e.message
 
 
 def extract_permissions_string(permissions):

--- a/redash/cli/groups.py
+++ b/redash/cli/groups.py
@@ -1,10 +1,10 @@
 from flask_script import Manager, prompt_pass
 from redash import models
 
-manager = Manager(help="Groups management commands. This commands assume single organization operation.")
+manager = Manager(help="Groups management commands.")
 
 @manager.option('name', help="Group's name")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to (leave blank for 'default').")
 @manager.option('--permissions', dest='permissions', default=None, help="Comma seperated list of permissions ('create_dashboard', 'create_query', 'edit_dashboard', 'edit_query', 'view_query', 'view_source', 'execute_query', 'list_users', 'schedule_query', 'list_dashboards', 'list_alerts', 'list_data_sources') (leave blank for default).")
 def create(name, permissions=None, organization='default'):
     print "Creating group (%s)..." % (name)

--- a/redash/cli/users.py
+++ b/redash/cli/users.py
@@ -23,7 +23,7 @@ def build_groups(org, groups, is_admin):
 
 @manager.option('email', help="email address of the user to grant admin to")
 @manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
-def grant_admin(email, organization):
+def grant_admin(email, organization='default'):
     try:
         org = models.Organization.get_by_slug(organization)
         admin_group = org.admin_group
@@ -47,7 +47,7 @@ def grant_admin(email, organization):
 @manager.option('--google', dest='google_auth', action="store_true", default=False, help="user uses Google Auth to login")
 @manager.option('--password', dest='password', default=None, help="Password for users who don't use Google Auth (leave blank for prompt).")
 @manager.option('--groups', dest='groups', default=None, help="Comma seperated list of groups (leave blank for default).")
-def create(email, name, organization, groups, is_admin=False, google_auth=False, password=None):
+def create(email, name, groups, is_admin=False, google_auth=False, password=None, organization='default'):
     print "Creating user (%s, %s) in organization %s..." % (email, name, organization)
     print "Admin: %r" % is_admin
     print "Login with Google Auth: %r\n" % google_auth
@@ -68,7 +68,7 @@ def create(email, name, organization, groups, is_admin=False, google_auth=False,
 
 @manager.option('email', help="email address of user to delete")
 @manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
-def delete(email, organization):
+def delete(email, organization=None):
     if organization:
         org = models.Organization.get_by_slug(organization)
         deleted_count = models.User.delete().where(
@@ -83,7 +83,7 @@ def delete(email, organization):
 @manager.option('password', help="new password for the user")
 @manager.option('email', help="email address of the user to change password for")
 @manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
-def password(email, password, organization):
+def password(email, password, organization=None):
     try:
         if organization:
             org = models.Organization.get_by_slug(organization)
@@ -108,7 +108,7 @@ def password(email, password, organization):
 @manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
 @manager.option('--admin', dest='is_admin', action="store_true", default=False, help="set user as admin")
 @manager.option('--groups', dest='groups', default=None, help="Comma seperated list of groups (leave blank for default).")
-def invite(email, name, inviter_email, organization, groups, is_admin=False):
+def invite(email, name, inviter_email, groups, is_admin=False, organization='default'):
     org = models.Organization.get_by_slug(organization)
     groups = build_groups(org, groups, is_admin)
     try:
@@ -129,7 +129,7 @@ def invite(email, name, inviter_email, organization, groups, is_admin=False):
 
 
 @manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
-def list():
+def list(organization=None):
     """List all users"""
     if organization:
         org = models.Organization.get_by_slug(organization)

--- a/redash/cli/users.py
+++ b/redash/cli/users.py
@@ -4,7 +4,7 @@ from peewee import IntegrityError
 from redash import models
 from redash.handlers.users import invite_user
 
-manager = Manager(help="Users management commands. This commands assume single organization operation.")
+manager = Manager(help="Users management commands.")
 
 
 def build_groups(org, groups, is_admin):
@@ -22,7 +22,7 @@ def build_groups(org, groups, is_admin):
     return groups
 
 @manager.option('email', help="email address of the user to grant admin to")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="the organization the user belongs to, (leave blank for 'default').")
 def grant_admin(email, organization='default'):
     try:
         org = models.Organization.get_by_slug(organization)
@@ -42,7 +42,7 @@ def grant_admin(email, organization='default'):
 
 @manager.option('email', help="User's email")
 @manager.option('name', help="User's full name")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to (leave blank for 'default').")
 @manager.option('--admin', dest='is_admin', action="store_true", default=False, help="set user as admin")
 @manager.option('--google', dest='google_auth', action="store_true", default=False, help="user uses Google Auth to login")
 @manager.option('--password', dest='password', default=None, help="Password for users who don't use Google Auth (leave blank for prompt).")
@@ -67,7 +67,7 @@ def create(email, name, groups, is_admin=False, google_auth=False, password=None
 
 
 @manager.option('email', help="email address of user to delete")
-@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to (leave blank for all organizations).")
 def delete(email, organization=None):
     if organization:
         org = models.Organization.get_by_slug(organization)
@@ -82,7 +82,7 @@ def delete(email, organization=None):
 
 @manager.option('password', help="new password for the user")
 @manager.option('email', help="email address of the user to change password for")
-@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to (leave blank for all organizations).")
 def password(email, password, organization=None):
     try:
         if organization:
@@ -105,7 +105,7 @@ def password(email, password, organization=None):
 @manager.option('email', help="The invitee's email")
 @manager.option('name', help="The invitee's full name")
 @manager.option('inviter_email', help="The email of the inviter")
-@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to (leave blank for 'default')")
 @manager.option('--admin', dest='is_admin', action="store_true", default=False, help="set user as admin")
 @manager.option('--groups', dest='groups', default=None, help="Comma seperated list of groups (leave blank for default).")
 def invite(email, name, inviter_email, groups, is_admin=False, organization='default'):
@@ -128,7 +128,7 @@ def invite(email, name, inviter_email, groups, is_admin=False, organization='def
         print "The inviter [%s] was not found." % inviterEmail
 
 
-@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to (leave blank for all organizations)")
 def list(organization=None):
     """List all users"""
     if organization:

--- a/redash/cli/users.py
+++ b/redash/cli/users.py
@@ -7,8 +7,7 @@ from redash.handlers.users import invite_user
 manager = Manager(help="Users management commands. This commands assume single organization operation.")
 
 
-def build_groups(groups, is_admin):
-    org = models.Organization.get_by_slug('default')
+def build_groups(org, groups, is_admin):
     if isinstance(groups, basestring):
         groups= groups.split(',')
         groups.remove('') # in case it was empty string
@@ -23,9 +22,10 @@ def build_groups(groups, is_admin):
     return groups
 
 @manager.option('email', help="email address of the user to grant admin to")
-def grant_admin(email):
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
+def grant_admin(email, organization):
     try:
-        org = models.Organization.get_by_slug('default')
+        org = models.Organization.get_by_slug(organization)
         admin_group = org.admin_group
         user = models.User.get_by_email_and_org(email, org)
 
@@ -42,17 +42,18 @@ def grant_admin(email):
 
 @manager.option('email', help="User's email")
 @manager.option('name', help="User's full name")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
 @manager.option('--admin', dest='is_admin', action="store_true", default=False, help="set user as admin")
 @manager.option('--google', dest='google_auth', action="store_true", default=False, help="user uses Google Auth to login")
 @manager.option('--password', dest='password', default=None, help="Password for users who don't use Google Auth (leave blank for prompt).")
 @manager.option('--groups', dest='groups', default=None, help="Comma seperated list of groups (leave blank for default).")
-def create(email, name, groups, is_admin=False, google_auth=False, password=None):
-    print "Creating user (%s, %s)..." % (email, name)
+def create(email, name, organization, groups, is_admin=False, google_auth=False, password=None):
+    print "Creating user (%s, %s) in organization %s..." % (email, name, organization)
     print "Admin: %r" % is_admin
     print "Login with Google Auth: %r\n" % google_auth
 
-    org = models.Organization.get_by_slug('default')
-    groups = build_groups(groups, is_admin)
+    org = models.Organization.get_by_slug(organization)
+    groups = build_groups(org, groups, is_admin)
 
     user = models.User(org=org, email=email, name=name, groups=groups)
     if not google_auth:
@@ -66,16 +67,32 @@ def create(email, name, groups, is_admin=False, google_auth=False, password=None
 
 
 @manager.option('email', help="email address of user to delete")
-def delete(email):
-    deleted_count = models.User.delete().where(models.User.email == email).execute()
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
+def delete(email, organization):
+    if organization:
+        org = models.Organization.get_by_slug(organization)
+        deleted_count = models.User.delete().where(
+            models.User.email == email,
+            models.User.org == org.id,
+        ).execute()
+    else:
+        deleted_count = models.User.delete().where(models.User.email == email).execute()
     print "Deleted %d users." % deleted_count
 
 
 @manager.option('password', help="new password for the user")
 @manager.option('email', help="email address of the user to change password for")
-def password(email, password):
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
+def password(email, password, organization):
     try:
-        user = models.User.get_by_email_and_org(email, models.Organization.get_by_slug('default'))
+        if organization:
+            org = models.Organization.get_by_slug(organization)
+            user = models.User.select().where(
+                models.User.email == email,
+                models.User.org == org.id,
+            ).first()
+        else:
+            user = models.User.select().where(models.User.email == email).first()
 
         user.hash_password(password)
         user.save()
@@ -88,11 +105,12 @@ def password(email, password):
 @manager.option('email', help="The invitee's email")
 @manager.option('name', help="The invitee's full name")
 @manager.option('inviter_email', help="The email of the inviter")
+@manager.option('--org', dest='organization', default='default', help="The organization the user belongs to")
 @manager.option('--admin', dest='is_admin', action="store_true", default=False, help="set user as admin")
 @manager.option('--groups', dest='groups', default=None, help="Comma seperated list of groups (leave blank for default).")
-def invite(email, name, inviter_email, groups, is_admin=False):
-    org = models.Organization.get_by_slug('default')
-    groups = build_groups(groups, is_admin)
+def invite(email, name, inviter_email, organization, groups, is_admin=False):
+    org = models.Organization.get_by_slug(organization)
+    groups = build_groups(org, groups, is_admin)
     try:
         user_from = models.User.get_by_email_and_org(inviter_email, org)
         user = models.User(org=org, name=name, email=email, groups=groups)
@@ -110,11 +128,16 @@ def invite(email, name, inviter_email, groups, is_admin=False):
         print "The inviter [%s] was not found." % inviterEmail
 
 
-@manager.command
+@manager.option('--org', dest='organization', default=None, help="The organization the user belongs to")
 def list():
     """List all users"""
-    for i, user in enumerate(models.User.select()):
+    if organization:
+        org = models.Organization.get_by_slug(organization)
+        users = models.Users.select().where(models.Users.org==org.id)
+    else:
+        users = models.DataSource.select()
+    for i, user in enumerate(users):
         if i > 0:
             print "-" * 20
 
-        print "Id: {}\nName: {}\nEmail: {}".format(user.id, user.name.encode('utf-8'), user.email)
+        print "Id: {}\nName: {}\nEmail: {}\nOrganization: {}".format(user.id, user.name.encode('utf-8'), user.email, user.org.name)


### PR DESCRIPTION
--org is the organization slug, not the name.
Allows the management of users, datasources and groups
with respect to organisations.
All commands default to 'default' slug, or None where
relevant, which means the commands will still work
as they did before without any changes.