### PR TITLE
Add: ability to register user defined function (UDF) resources for BigQuery DataSource/Query

### DIFF
--- a/docs/datasources.rst
+++ b/docs/datasources.rst
@@ -49,6 +49,8 @@ Google BigQuery
 
    -  Project ID (mandatory)
    -  JSON key file, generated when creating a service account (see `instructions <https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`__).
+   -  UDF Source URIs (see `more details <https://cloud.google.com/bigquery/user-defined-functions#api>`__ )
+        - References to JavaScript source files stored in Google Cloud Storage (comma separated)
 
 
 -  **Additional requirements**:

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -99,6 +99,10 @@ class BigQuery(BaseQueryRunner):
                 'totalMBytesProcessedLimit': {
                     "type": "number",
                     'title': 'Total MByte Processed Limit'
+                },
+                'userDefinedFunctionResourceUri': {
+                    "type": "string",
+                    'title': 'UDF Source URIs (i.e. gs://bucket/date_utils.js, gs://bucket/string_utils.js )'
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
@@ -141,6 +145,11 @@ class BigQuery(BaseQueryRunner):
                 }
             }
         }
+
+        if "userDefinedFunctionResourceUri" in self.configuration:
+            resource_uris = self.configuration["userDefinedFunctionResourceUri"].split(',')
+            job_data["configuration"]["query"]["userDefinedFunctionResources"] = map(
+                lambda resource_uri: {"resourceUri": resource_uri}, resource_uris)
 
         insert_response = jobs.insert(projectId=project_id, body=job_data).execute()
         current_row = 0


### PR DESCRIPTION
The [idea](https://discuss.redash.io/t/ability-to-register-user-defined-function-udf-resources-for-bigquery-datasource-query/80) is to add a new optional configuration property to the BigQuery data source: **[UDFs Source Uris](https://cloud.google.com/bigquery/user-defined-functions#api)**
The user can fill it with a path to one or more files stored on GCS containing the UDF functions ( i.e. [gs://redash-bigquery-udfs/url_decode.js](https://storage.googleapis.com/redash-bigquery-udfs/url_decode.js) ).

![redash_bigquery_ds_udf](https://cloud.githubusercontent.com/assets/308613/16150426/7c2983e8-346d-11e6-98b6-39c65cf552a5.png)

If this configuration is present redash adds the files to the BigQuery job definition and the user can use the UDFs in his/her queries.

![redash_query_with_udf](https://cloud.githubusercontent.com/assets/308613/16150436/8869ae4e-346d-11e6-82a0-a2534cb5c7f6.png)
