### PR TITLE
Docs: add a link to settings documentation.

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -232,6 +232,11 @@ It's recommended to upgrade once in a while your Re:dash instance to
 benefit from bug fixes and new features. See :doc:`here </upgrade>` for full upgrade
 instructions (including Fabric script).
 
+Configuration
+-------------
+
+For a full list of environment variables, see :doc:`the settings page </settings>`.
+
 Notes
 =====
 


### PR DESCRIPTION
The settings page doesn't seem to have any links to it.
The only way to find it is through searching for it.
So we'll add one to the setup.rst page.