### PR TITLE
Control celery worker count with environment variables, defaults to 2

### DIFF
--- a/Procfile.heroku
+++ b/Procfile.heroku
@@ -1,2 +1,2 @@
 web: ./manage.py runserver -d -r -p $PORT --host 0.0.0.0
-worker: celery worker --app=redash.worker -c2 --beat -Q queries,celery,scheduled_queries
+worker: celery worker --app=redash.worker -c${REDASH_HEROKU_CELERY_WORKER_COUNT:-2} --beat -Q queries,celery,scheduled_queries

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -14,6 +14,7 @@ The follow is a list of settings and what they control:
 - **REDASH_DATABASE_URL**: *default "postgresql://postgres"*
 - **REDASH_CELERY_BROKER**: *default REDIS_URL*
 - **REDASH_CELERY_BACKEND**: *default CELERY_BROKER*
+- **REDASH_HEROKU_CELERY_WORKER_COUNT**: *default 2*
 - **REDASH_QUERY_RESULTS_CLEANUP_ENABLED**: *default "true"*
 - **REDASH_QUERY_RESULTS_CLEANUP_COUNT**: *default "100"*
 - **REDASH_QUERY_RESULTS_CLEANUP_MAX_AGE**: *default "7"*


### PR DESCRIPTION
Add to, or replace all instances of -c2, in celery commands
with -c${REDASH_CELERY_WORKER_COUNT:-2}.
Some commands had no -c value, most had -c2, 1 had -c1.
Add REDASH_CELERY_WORKER_COUNT to the settings page.