### PR TITLE
Presto QueryRunner supports tinyint and smallint

### DIFF
--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -17,6 +17,8 @@ except ImportError:
 
 PRESTO_TYPES_MAPPING = {
     "integer": TYPE_INTEGER,
+    "tinyint": TYPE_INTEGER,
+    "smallint": TYPE_INTEGER,
     "long": TYPE_INTEGER,
     "bigint": TYPE_INTEGER,
     "float": TYPE_FLOAT,


### PR DESCRIPTION
Presto0.148 started to support tinyint and smallint.
https://prestodb.io/docs/current/release/release-0.148.html