### PR TITLE
Change: ability to set pymssql TDS version (to support Azure Database) #backward-incompatible

### DIFF
--- a/docs/datasources.rst
+++ b/docs/datasources.rst
@@ -258,4 +258,4 @@ Microsoft SQL Server
 -  **Additional requirements**:
 
    - ``freetds-dev`` C library
-   - ``pymsssql`` python package, requires FreeTDS to be installed first
+   - ``pymssql`` python package, requires FreeTDS to be installed first

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -49,6 +49,11 @@ class SqlServer(BaseSQLQueryRunner):
                     "type": "number",
                     "default": 1433
                 },
+                "tds_version": {
+                    "type": "string",
+                    "default": "7.0",
+                    "title": "TDS Version"
+                },
                 "db": {
                     "type": "string",
                     "title": "Database Name"
@@ -114,11 +119,12 @@ class SqlServer(BaseSQLQueryRunner):
             password = self.configuration.get('password', '')
             db = self.configuration['db']
             port = self.configuration.get('port', 1433)
+            tds_version = self.configuration.get('tds_version', '7.0')
 
             if port != 1433:
                 server = server + ':' + str(port)
 
-            connection = pymssql.connect(server, user, password, db)
+            connection = pymssql.connect(server=server, user=user, password=password, database=db, tds_version=tds_version)
             cursor = connection.cursor()
             logger.debug("SqlServer running query: %s", query)
 

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -9,7 +9,7 @@ pymongo==3.2.1
 pyOpenSSL==0.14
 vertica-python==0.5.1
 td-client==0.4.1
-pymssql==2.1.1
+pymssql==2.1.2
 dql==0.5.16
 dynamo3==0.4.7
 botocore==1.4.4

--- a/setup/amazon_linux/bootstrap.sh
+++ b/setup/amazon_linux/bootstrap.sh
@@ -139,7 +139,7 @@ pip install MySQL-python==1.2.5
 
 # Microsoft SQL Server dependencies (`sudo` required):
 sudo yum install -y freetds-devel
-sudo pip install pymssql==2.1.1
+sudo pip install pymssql==2.1.2
 
 # Mongo dependencies:
 pip install pymongo==2.7.2


### PR DESCRIPTION
Azure Database requires tds_version 7.0 but pymssql 2.1.1 doesn't have option of tds_version.

* Update pymssql to 2.1.2 (added tds_version option from this version)
* Add configuration of tds_version (At least azure requires 7.0 so for now default version is it. However I don't know how is the best choice.)