### PR TITLE
Fix: change parameters for 'manage.py ds new' CLI

### DIFF
--- a/setup/docker/create_database.sh
+++ b/setup/docker/create_database.sh
@@ -24,4 +24,4 @@ $run_psql -c "grant select(id,name,type) ON data_sources to redash_reader;"
 $run_psql -c "grant select(id,name) ON users to redash_reader;"
 $run_psql -c "grant select on events, queries, dashboards, widgets, visualizations, query_results to redash_reader;"
 
-$run_redash /opt/redash/current/manage.py ds new -n "re:dash metadata" -t "pg" -o "{\"user\": \"redash_reader\", \"password\": \"redash_reader\", \"host\": \"postgres\", \"dbname\": \"postgres\"}"
+$run_redash /opt/redash/current/manage.py ds new "re:dash metadata" --type "pg" --options "{\"user\": \"redash_reader\", \"password\": \"redash_reader\", \"host\": \"postgres\", \"dbname\": \"postgres\"}"


### PR DESCRIPTION
When running the setup script `redash/setup/docker/create_database.sh` we get the following error:
```
usage: manage.py [-h]
                 {status,shell,users,database,send_test_mail,runserver,version,groups,org,ds,runworkers,check_settings}
                 ...
manage.py: error: unrecognized arguments: -n
```

This PR fixes the error removing the **-n** parameter and using **--options** and **--type** as well, instead of _-o_ and _-t_.