### PR TITLE
Add: 'list' command for org and groups CLI

### DIFF
--- a/redash/cli/groups.py
+++ b/redash/cli/groups.py
@@ -49,3 +49,19 @@ def extract_permissions_string(permissions):
         permissions = permissions.split(',')
         permissions = [p.strip() for p in permissions]
     return permissions
+
+
+@manager.option('--org', dest='organization', default=None, help="The organization to limit to (leave blank for all).")
+def list(organization=None):
+    """List all groups"""
+    if organization:
+        org = models.Organization.get_by_slug(organization)
+        groups = models.Group.select().where(models.Group.org == org)
+    else:
+        groups = models.Group.select()
+
+    for i, group in enumerate(groups):
+        if i > 0:
+            print "-" * 20
+
+        print "Id: {}\nName: {}\nType: {}\nOrganization: {}".format(group.id, group.name, group.type, group.org.slug)

--- a/redash/cli/organization.py
+++ b/redash/cli/organization.py
@@ -18,3 +18,14 @@ def set_google_apps_domains(domains):
 def show_google_apps_domains():
     organization = models.Organization.select().first()
     print "Current list of Google Apps domains: {}".format(organization.google_apps_domains)
+
+
+@manager.command
+def list():
+    """List all organizations"""
+    orgs = models.Organization.select()
+    for i, org in enumerate(orgs):
+        if i > 0:
+            print "-" * 20
+
+        print "Id: {}\nName: {}\nSlug: {}".format(org.id, org.name, org.slug)


### PR DESCRIPTION
Adds a `list` subcommand for both `org` and `group` commands.
`group list` can be filtered based on organziation with the `--org` parameter.
Output is in the format of the existing `users list` command.