### PR TITLE
Fix: schema not loading when table name has unicode characters

### DIFF
--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -92,7 +92,7 @@ class SqlServer(BaseSQLQueryRunner):
 
         for row in results['rows']:
             if row['table_schema'] != self.configuration['db']:
-                table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
+                table_name = u'{}.{}'.format(row['table_schema'], row['table_name'])
             else:
                 table_name = row['table_name']
 


### PR DESCRIPTION
Fix: Left Pane is not shown when database contains table that name has unicode characters (MSSQL)

- Update table_name to be unicode (not str).