### PR TITLE
Swapping SystemRandom for a cryptographically strong random number generator in token generation

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -4,14 +4,13 @@ import codecs
 import decimal
 import datetime
 import json
-import random
 import re
 import hashlib
 import pytz
 import pystache
 
 from funcy import distinct
-
+from Crypto.Random import random
 from .human_time import parse_human_time
 from redash import settings
 
@@ -48,9 +47,7 @@ def generate_token(length):
     chars = ('abcdefghijklmnopqrstuvwxyz'
              'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
              '0123456789')
-
-    rand = random.SystemRandom()
-    return ''.join(rand.choice(chars) for x in range(length))
+    return ''.join(random.choice(chars) for x in range(length))
 
 
 class JSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
Hey Arik,
We ran [RATS](https://security.web.cern.ch/security/recommendations/en/codetools/rats.shtml) and this was one of the results:

Problem:  redash//redash/utils/__init__.py:49: Medium: choice
Standard random number generators should not be used to generate randomness used for security reasons.  For security sensitive randomness a crytographic randomness generator that provides sufficient entropy should be used.

Solution: Replaced SystemRandom's 'choice' with pycrypto 'choice'.  [SystemRandom's documentation](https://docs.python.org/3/library/random.html) warn "The pseudo-random generators of this module should not be used for security purposes."
