### PR TITLE
Change: modify the argument order of moment.add function call

### DIFF
--- a/rd_ui/app/scripts/controllers/admin_controllers.js
+++ b/rd_ui/app/scripts/controllers/admin_controllers.js
@@ -121,7 +121,7 @@
     $scope.setTab($location.hash() || 'in_progress');
 
     var refresh = function () {
-      $scope.refresh_time = moment().add('minutes', 1);
+      $scope.refresh_time = moment().add(1, 'minutes');
       $http.get('/api/admin/queries/tasks').success(function (data) {
         $scope.tasks = data;
         $scope.showingTasks = $scope.tasks[$scope.selectedTab];
@@ -190,7 +190,7 @@
     ];
 
     var refresh = function () {
-      $scope.refresh_time = moment().add('minutes', 1);
+      $scope.refresh_time = moment().add(1, 'minutes');
       $http.get('/api/admin/queries/outdated').success(function (data) {
         $scope.queries = data.queries;
         $scope.updatedAt = data.updated_at * 1000.0;


### PR DESCRIPTION
@arikfr 

Hi.

Argument of moment.add function is using the order in which become Deprecated in 2.8.0.
http://momentjs.com/docs/#/manipulating/add/

fix because uses the version 2.8.4 of moment.js.

![pasted image at 2016_07_20 12_15 am](https://cloud.githubusercontent.com/assets/2589319/16957620/1934380e-4e18-11e6-9c83-c8a276696fea.png)

![image](https://cloud.githubusercontent.com/assets/2589319/16957682/650a67da-4e18-11e6-8c14-3522b4993f23.png)
