### PR TITLE
Change: add support for Standard SQL in BigQuery query runner

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -103,6 +103,10 @@ class BigQuery(BaseQueryRunner):
                 'userDefinedFunctionResourceUri': {
                     "type": "string",
                     'title': 'UDF Source URIs (i.e. gs://bucket/date_utils.js, gs://bucket/string_utils.js )'
+                },
+                'useLegacySql': {
+                    "type": "boolean",
+                    'title': "use BigQuery's legacy SQL: https://cloud.google.com/bigquery/query-reference",
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
@@ -132,6 +136,7 @@ class BigQuery(BaseQueryRunner):
         job_data = {
             "query": query,
             "dryRun": True,
+            "useLegacySql": self.configuration.get('useLegacySql', False),
         }
         response = jobs.query(projectId=self._get_project_id(), body=job_data).execute()
         return int(response["totalBytesProcessed"])
@@ -142,6 +147,7 @@ class BigQuery(BaseQueryRunner):
             "configuration": {
                 "query": {
                     "query": query,
+                    "useLegacySql": self.configuration.get('useLegacySql', False),
                 }
             }
         }

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -104,9 +104,9 @@ class BigQuery(BaseQueryRunner):
                     "type": "string",
                     'title': 'UDF Source URIs (i.e. gs://bucket/date_utils.js, gs://bucket/string_utils.js )'
                 },
-                'useLegacySql': {
+                'useStandardSql(Beta)': {
                     "type": "boolean",
-                    'title': "use BigQuery's legacy SQL: https://cloud.google.com/bigquery/query-reference",
+                    'title': "use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/",
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
@@ -136,7 +136,7 @@ class BigQuery(BaseQueryRunner):
         job_data = {
             "query": query,
             "dryRun": True,
-            "useLegacySql": self.configuration.get('useLegacySql', False),
+            "useLegacySql": not self.configuration.get('useStandardSql(Beta)', False),
         }
         response = jobs.query(projectId=self._get_project_id(), body=job_data).execute()
         return int(response["totalBytesProcessed"])
@@ -147,7 +147,7 @@ class BigQuery(BaseQueryRunner):
             "configuration": {
                 "query": {
                     "query": query,
-                    "useLegacySql": self.configuration.get('useLegacySql', False),
+                    "useLegacySql": not self.configuration.get('useStandardSql(Beta)', False),
                 }
             }
         }

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -104,9 +104,9 @@ class BigQuery(BaseQueryRunner):
                     "type": "string",
                     'title': 'UDF Source URIs (i.e. gs://bucket/date_utils.js, gs://bucket/string_utils.js )'
                 },
-                'useStandardSql(Beta)': {
+                'useStandardSql': {
                     "type": "boolean",
-                    'title': "use BigQuery's standard SQL: https://cloud.google.com/bigquery/sql-reference/",
+                    'title': "Use Standard SQL (Beta)",
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
@@ -136,7 +136,7 @@ class BigQuery(BaseQueryRunner):
         job_data = {
             "query": query,
             "dryRun": True,
-            "useLegacySql": not self.configuration.get('useStandardSql(Beta)', False),
+            "useLegacySql": not self.configuration.get('useStandardSql', False),
         }
         response = jobs.query(projectId=self._get_project_id(), body=job_data).execute()
         return int(response["totalBytesProcessed"])
@@ -147,7 +147,7 @@ class BigQuery(BaseQueryRunner):
             "configuration": {
                 "query": {
                     "query": query,
-                    "useLegacySql": not self.configuration.get('useStandardSql(Beta)', False),
+                    "useLegacySql": not self.configuration.get('useStandardSql', False),
                 }
             }
         }


### PR DESCRIPTION
add checkbox to specify whether to use legacy or standard sql.

legacy: https://cloud.google.com/bigquery/query-reference
standard: https://cloud.google.com/bigquery/sql-reference/

updated:
![image](https://cloud.githubusercontent.com/assets/719262/17024570/61f3bb10-4f93-11e6-8004-e4e164a0bffa.png)


