### PR TITLE
Add: show views in schema browser for Vertica data sources

### DIFF
--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -70,7 +70,9 @@ class Vertica(BaseSQLQueryRunner):
 
     def _get_tables(self, schema):
         query = """
-        Select table_schema, table_name, column_name from columns where is_system_table=false;
+        Select table_schema, table_name, column_name from columns where is_system_table=false
+        union all
+        select table_schema, table_name, column_name from view_columns;
         """
 
         results, error = self.run_query(query)


### PR DESCRIPTION
Currently only metadata from tables show up for Vertica. View metadata has to be queried from another system view.