### PR TITLE
Enable site usage to be tracked by Google Analytics

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -59,3 +59,4 @@ The follow is a list of settings and what they control:
 - **REDASH_VERSION_CEHCK**: *default "true"*
 - **REDASH_BIGQUERY_HTTP_TIMEOUT**: *default "600"*
 - **REDASH_SCHEMA_RUN_TABLE_SIZE_CALCULATIONS**: *default "false"*
+- **REDASH_GOOGLE_ANALYTICS_TRACKING_CODE**: code to track site usage in Google Analytics, *default ""*

--- a/rd_ui/app/app_layout.html
+++ b/rd_ui/app/app_layout.html
@@ -28,7 +28,18 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/images/favicon-96x96.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
+{% if ga_tracking_code %}
+  <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+  ga('create', '{{ga_tracking_code}}', 'auto');
+  ga('send', 'pageview');
+
+  </script>
+{% endif %}
 </head>
 <body{% if headless %} class="headless"{% endif %}>
 <div growl></div>

--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -57,7 +57,8 @@ def index(**kwargs):
     response = render_template("index.html",
                                user=json.dumps(user),
                                org_slug=current_org.slug,
-                               client_config=json.dumps(client_config))
+                               client_config=json.dumps(client_config),
+                               ga_tracking_code=settings.GA_TRACKING_CODE)
 
     return response, 200, headers
 

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -229,3 +229,6 @@ COMMON_CLIENT_CONFIG = {
     'mailSettingsMissing': MAIL_DEFAULT_SENDER is None,
     'logoUrl': LOGO_URL
 }
+
+# Google Analytics
+GA_TRACKING_CODE = os.environ.get("REDASH_GOOGLE_ANALYTICS_TRACKING_CODE", "")


### PR DESCRIPTION
Supply your GA tracking code to the Redash .env file using this env variable: REDASH_GOOGLE_ANALYTICS_TRACKING_CODE