### PR TITLE
Change: bootstrap.sh - use non interactive dist-upgrade

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -27,7 +27,7 @@ fi
 
 # Base packages
 apt-get -y update
-apt-get -y dist-upgrade
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
 apt-get install -y python-pip python-dev nginx curl build-essential pwgen
 pip install -U setuptools==23.1.0
 


### PR DESCRIPTION
`apt-get -y dist-upgrade` may prompt grub config and stop process.
This patch makes `apt-get -y dist-upgrade` non-interactive.