### PR TITLE
Change: install libffi-dev for Cryptography (Ubuntu setup script)

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -28,7 +28,7 @@ fi
 # Base packages
 apt-get -y update
 apt-get -y dist-upgrade
-apt-get install -y python-pip python-dev nginx curl build-essential pwgen
+apt-get install -y python-pip python-dev nginx curl build-essential pwgen libffi-dev
 pip install -U setuptools==23.1.0
 
 # redash user


### PR DESCRIPTION
This fixes error `libffi-dev` is missing to install `Cryptography`.