### PR TITLE
Add: ability to enable global search in table visualizations

### DIFF
--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -368,7 +368,15 @@
       });
 
       this.filters = filters;
-    }
+    };
+
+    QueryResult.prototype.isGlobalSearchActivated = function () {
+      return _.some(this.getColumns(), function(col){
+        var name = col.name;
+        var suffix = name.split('::')[1] || name.split('__')[1];
+        return suffix === 'globalSearch';
+      });
+    };
 
     var refreshStatus = function (queryResult, query) {
       Job.get({'id': queryResult.job.id}, function (response) {

--- a/rd_ui/app/scripts/visualizations/table.js
+++ b/rd_ui/app/scripts/visualizations/table.js
@@ -39,6 +39,7 @@
             $scope.filters = [];
           } else {
             $scope.filters = $scope.queryResult.getFilters();
+            $scope.gridConfig.isGlobalSearchActivated = $scope.queryResult.isGlobalSearchActivated();
 
             var prepareGridData = function (data) {
               var gridData = _.map(data, function (row) {


### PR DESCRIPTION
Allow users to enable smart-table's global search in table visualizations by appending the suffix `__globalSearch` to any of the columns in the query.

Since global search functionality is very similar to filter's, I thought that using the same mechanics would be a good idea.

Thoughts ?