### PR TITLE
Fix: RST formatting of the Vagrant documentation

### DIFF
--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -10,14 +10,14 @@ AWS/GCE images).
 
 To get started with this box:
 
-1.  Make sure you have recent version of
-    `Vagrant <https://www.vagrantup.com/>`__ installed.
-2.  Clone the Re:dash repository:
-    ``git clone https://github.com/getredash/redash.git``.
-3.  Change dir into the repository (``cd redash``)
-4a. To execute tests, run ``./bin/vagrant_ctl.sh test``
-4b. To run the app, run ``./bin/vagrant_ctl.sh start``.
-    This might take some time the first time you run it,
-    as it downloads the Vagrant virtual box.
-    Now the server should be available on your host on port 9001 and you
-    can login with username admin and password admin.
+1. Make sure you have recent version of
+   `Vagrant <https://www.vagrantup.com/>`__ installed.
+2. Clone the Re:dash repository:
+   ``git clone https://github.com/getredash/redash.git``.
+3. Change dir into the repository (``cd redash``)
+4. To execute tests, run ``./bin/vagrant_ctl.sh test``
+5. To run the app, run ``./bin/vagrant_ctl.sh start``.
+   This might take some time the first time you run it,
+   as it downloads the Vagrant virtual box.
+   Now the server should be available on your host on port 9001 and you
+   can login with username admin and password admin.


### PR DESCRIPTION
http://docs.redash.io/en/latest/dev/vagrant.html

## before:

<img width="740" alt="screen shot 2016-08-06 at 1 30 32 am" src="https://cloud.githubusercontent.com/assets/39471/17443577/4f4167b2-5b76-11e6-9373-dc8b1ec29c4a.png">

## after:

<img width="764" alt="screen shot 2016-08-06 at 1 30 37 am" src="https://cloud.githubusercontent.com/assets/39471/17443581/54dc70ea-5b76-11e6-8c68-4bf1a9aac9dd.png">
