### PR TITLE
Fix: Bower install fails in vagrant

### DIFF
--- a/setup/vagrant/provision.sh
+++ b/setup/vagrant/provision.sh
@@ -3,9 +3,7 @@
 
 cd /opt/redash/current
 cp /opt/redash/.env /opt/redash/current
-cd /opt/redash/current/rd_ui
 bower install
-cd /opt/redash/current
 
 #install requirements
 sudo pip install -r /opt/redash/current/requirements_dev.txt


### PR DESCRIPTION
When I run the "vagrant provision", "bower install" failed.

```
$ vagrant provision
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: bower                           ENOENT No bower.json present
...
```

Now, the path of `bower.json` is not `/opt/redash/current/rd_ui` but `/opt/redash/current`.