### PR TITLE
Fix Vagrant provisioning script

### DIFF
--- a/setup/vagrant/provision.sh
+++ b/setup/vagrant/provision.sh
@@ -3,9 +3,7 @@
 
 cd /opt/redash/current
 cp /opt/redash/.env /opt/redash/current
-cd /opt/redash/current/rd_ui
 bower install
-cd /opt/redash/current
 
 #install requirements
 sudo pip install -r /opt/redash/current/requirements_dev.txt


### PR DESCRIPTION
Fix Vagrant provisioning error at `bower install`.

### Repro steps

```bash
$ git clone https://github.com/getredash/redash.git
Cloning into 'redash'...
remote: Counting objects: 16269, done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 16269 (delta 0), reused 0 (delta 0), pack-reused 16267
Receiving objects: 100% (16269/16269), 6.46 MiB | 2.08 MiB/s, done.
Resolving deltas: 100% (11055/11055), done.
Checking connectivity... done.
$ cd redash
$ ./bin/vagrant_ctl.sh start
# (snip)
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: bower                           ENOENT No bower.json present
# (snip)
```