### PR TITLE
Change: annotate Presto queries with metadata

### DIFF
--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -60,10 +60,6 @@ class Presto(BaseQueryRunner):
         return enabled
 
     @classmethod
-    def annotate_query(cls):
-        return False
-
-    @classmethod
     def type(cls):
         return "presto"
 


### PR DESCRIPTION
I want to use the annotate_query in Presto.
There is no reason for the "False".
