### PR TITLE
Fix: don't show warning when query string (parameters value) changes

### DIFF
--- a/rd_ui/app/scripts/directives/directives.js
+++ b/rd_ui/app/scripts/directives/directives.js
@@ -58,7 +58,7 @@
         }
 
         $scope.$on('$locationChangeStart', function (event, next, current) {
-          if (next.split("#")[0] == current.split("#")[0]) {
+          if (next.split("?")[0] == current.split("?")[0] || next.split("#")[0] == current.split("#")[0]) {
             return;
           }
 


### PR DESCRIPTION
This pull-request fixes #1174