### PR TITLE
Fix: when shared dashboard token not found, return 404

### DIFF
--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -125,7 +125,12 @@ def embed(query_id, visualization_id, org_slug=None):
 def public_dashboard(token, org_slug=None):
     # TODO: verify object is a dashboard?
     if not isinstance(current_user, models.ApiUser):
-        api_key = models.ApiKey.get_by_api_key(token)
+        try:
+            api_key = models.ApiKey.get_by_api_key(token)
+        except models.ApiKey.DoesNotExist, e:
+            response = render_template("404.html")
+            return response, 404
+
         dashboard = api_key.object
     else:
         dashboard = current_user.object

--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -12,7 +12,7 @@ from redash import models, settings, utils
 from redash import serializers
 from redash.utils import json_dumps, collect_parameters_from_request, gen_query_hash
 from redash.handlers import routes
-from redash.handlers.base import org_scoped_rule, record_event
+from redash.handlers.base import org_scoped_rule, record_event, get_object_or_404
 from redash.handlers.query_results import collect_query_parameters
 from redash.permissions import require_access, view_only
 from authentication import current_org
@@ -125,12 +125,7 @@ def embed(query_id, visualization_id, org_slug=None):
 def public_dashboard(token, org_slug=None):
     # TODO: verify object is a dashboard?
     if not isinstance(current_user, models.ApiUser):
-        try:
-            api_key = models.ApiKey.get_by_api_key(token)
-        except models.ApiKey.DoesNotExist, e:
-            response = render_template("404.html")
-            return response, 404
-
+        api_key = get_object_or_404(models.ApiKey.get_by_api_key, token)
         dashboard = api_key.object
     else:
         dashboard = current_user.object


### PR DESCRIPTION
Today, if we click on a link that points to a dashboards shared publicly and the link is not available anymore, the user gets a 500 error page. 
Which actually is not the case, we just do not found the dashboard with the given token.

This PR aims to better report to the user what really happened. 
We respond with the 404 error page.