### PR TITLE
Docs: add warning re. quotes on column names and BigQuery

### DIFF
--- a/docs/usage/special_features.rst
+++ b/docs/usage/special_features.rst
@@ -27,7 +27,7 @@ If you are interested in multi filters (meaning that you can select multiple val
 
 You can see this query and the rendered UI `here <http://demo.redash.io/queries/144/source#table>`_.
 
-Note that you can use ``__filter`` or ``__multiFilter`` if your database doesn't support ``::`` in column names (such as BigQuery).
+Note that you can use ``__filter`` or ``__multiFilter``, (without double quotes) if your database doesn't support ``::`` in column names (such as BigQuery).
 
 Dashboards
 ==========


### PR DESCRIPTION
Bigquery (unlike PostgresQL) doesn't work with "Action__filter" as it doesn't support quoted field names. in order to use the filter function you need to use an unquoted column name.
![image](https://cloud.githubusercontent.com/assets/1475340/17810478/42d76ffe-6615-11e6-8c75-60530aeac0e5.png)
