### PR TITLE
Fix: support large schemas in schema browser

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "angular-resizable": "^1.2.0",
     "material-design-iconic-font": "^2.2.0",
     "plotly.js": "^1.9.0",
-    "angular-ui-ace": "bower"
+    "angular-ui-ace": "bower",
+    "angular-vs-repeat": "^1.1.7"
   },
   "devDependencies": {
     "angular-mocks": "1.2.18",

--- a/rd_ui/app/scripts/app.js
+++ b/rd_ui/app/scripts/app.js
@@ -18,7 +18,8 @@ angular.module('redash', [
   'naif.base64',
   'ui.bootstrap.showErrors',
   'angularResizable',
-  'ngSanitize'
+  'ngSanitize',
+  'vs-repeat'
 ]).config(['$routeProvider', '$locationProvider', '$compileProvider', 'growlProvider', 'uiSelectConfig', '$httpProvider',
   function ($routeProvider, $locationProvider, $compileProvider, growlProvider, uiSelectConfig, $httpProvider) {
     function getQuery(Query, $route) {

--- a/rd_ui/app/vendor_scripts.html
+++ b/rd_ui/app/vendor_scripts.html
@@ -40,4 +40,5 @@
 <script src="/bower_components/d3/d3.js"></script>
 <script src="/bower_components/angular-ui-sortable/sortable.js"></script>
 <script src="/bower_components/angular-ui-ace/ui-ace.js"></script>
+<script src="/bower_components/angular-vs-repeat/src/angular-vs-repeat.js"></script>
 <!-- endbuild -->

--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -98,11 +98,11 @@
       <div class="row bg-white p-b-5" ng-if="sourceMode" resizable r-directions="['bottom']" r-height="300" style="min-height:100px;">
 
         <div class="col-md-3 schema-container hidden-sm hidden-xs" ng-show="hasSchema">
-          <div ng-show="schema.length < 500" class="p-t-5 p-b-5">
+          <div class="p-t-5 p-b-5">
             <input type="text" placeholder="Search schema..." class="form-control" ng-model="schemaFilter">
           </div>
 
-          <div class="schema-browser">
+          <div class="schema-browser" vs-repeat>
             <div ng-repeat="table in schema | filter:schemaFilter track by table.name">
               <div class="table-name" ng-click="table.collapsed = !table.collapsed">
                 <i class="fa fa-table"></i> <strong><span title="{{table.name}}">{{table.name}}</span><span


### PR DESCRIPTION
We can now enable search for schemas of all sizes and the browser doesn't hang when loading large schema (I tested it with 1669 tables and 38871 columns across all tables).

Closes #1065.