### PR TITLE
Add: Google Drive federated tables support in BigQuery query runner

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -119,6 +119,7 @@ class BigQuery(BaseQueryRunner):
     def _get_bigquery_service(self):
         scope = [
             "https://www.googleapis.com/auth/bigquery",
+	    "https://www.googleapis.com/auth/drive"
             ]
 
         key = json.loads(b64decode(self.configuration['jsonKeyFile']))
@@ -230,7 +231,7 @@ class BigQueryGCE(BigQuery):
         return requests.get('http://metadata/computeMetadata/v1/project/project-id', headers={'Metadata-Flavor': 'Google'}).content
 
     def _get_bigquery_service(self):
-        credentials = gce.AppAssertionCredentials(scope='https://www.googleapis.com/auth/bigquery')
+        credentials = gce.AppAssertionCredentials(scope='https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/drive')
         http = httplib2.Http()
         http = credentials.authorize(http)
 

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -231,7 +231,7 @@ class BigQueryGCE(BigQuery):
         return requests.get('http://metadata/computeMetadata/v1/project/project-id', headers={'Metadata-Flavor': 'Google'}).content
 
     def _get_bigquery_service(self):
-        credentials = gce.AppAssertionCredentials(scope='https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/drive')
+        credentials = gce.AppAssertionCredentials(scope='https://www.googleapis.com/auth/bigquery')
         http = httplib2.Http()
         http = credentials.authorize(http)
 


### PR DESCRIPTION
Google Big Query supports adding Google Drive files such as Google Spreadsheets as federated tables. To query these from Redash an additional scope is required during the OAuth.