### PR TITLE
Add: CTRL+K hotkey for dashboards search

### DIFF
--- a/rd_ui/app/scripts/controllers/controllers.js
+++ b/rd_ui/app/scripts/controllers/controllers.js
@@ -150,7 +150,37 @@
     });
   }
 
-  var MainCtrl = function ($scope, $location, Dashboard) {
+  var DashboardSearchCtrl = function($scope, $modalInstance, $http, $location, Dashboard) {
+    $scope.dashboardSelected = {};
+
+    Dashboard.query(function (dashboards) {
+        $scope.dashboards = _.sortBy(dashboards, "name");
+    });
+
+    $scope.close = function() {
+      $modalInstance.close();
+    };
+
+    $scope.openSelectedDashboard = function(dashboard){
+      $scope.close();
+      $location.path('/dashboard/' + dashboard.slug).replace();
+    }
+
+    $scope.findDashboard = function(search){
+      if (search == "") {
+        return;
+      }
+
+      if ($scope.dashboards === undefined) {
+        Dashboard.query(function(dashboards) {
+          $scope.dashboards = _.sortBy(dashboards, ["name"]);
+        });
+      }
+    }
+
+  }
+
+  var MainCtrl = function ($scope, $modal, KeyboardShortcuts, $location) {
     $scope.$on("$routeChangeSuccess", function (event, current, previous, rejection) {
       if ($scope.showPermissionError) {
         $scope.showPermissionError = false;
@@ -171,6 +201,28 @@
       'name': null,
       'layout': null
     }
+
+    $scope.openSearchBox = function(event, key) {
+      if(angular.isDefined($scope.searchBoxModal)){
+        $scope.searchBoxModal.close(key);
+        delete $scope.searchBoxModal;
+        return;
+      }
+
+      $scope.searchBoxModal = $modal.open({
+        templateUrl: '/views/dashboard_search.html',
+        scope: $scope,
+        controller: ['$scope', '$modalInstance', '$http', '$location', 'Dashboard', DashboardSearchCtrl]
+      });
+    }
+
+    var shortcuts = {
+      'meta+k': $scope.openSearchBox,
+      'ctrl+k': $scope.openSearchBox
+    };
+
+    KeyboardShortcuts.bind(shortcuts);
+
   };
 
   var IndexCtrl = function ($scope, Events, Dashboard, Query) {
@@ -184,6 +236,6 @@
   angular.module('redash.controllers', [])
     .controller('QueriesCtrl', ['$scope', '$http', '$location', '$filter', 'Query', QueriesCtrl])
     .controller('IndexCtrl', ['$scope', 'Events', 'Dashboard', 'Query', IndexCtrl])
-    .controller('MainCtrl', ['$scope', '$location', 'Dashboard', MainCtrl])
+    .controller('MainCtrl', ['$scope', '$modal', 'KeyboardShortcuts', '$location', MainCtrl])
     .controller('QuerySearchCtrl', ['$scope', '$location', '$filter', 'Events', 'Query',  QuerySearchCtrl]);
 })();

--- a/rd_ui/app/views/dashboard_search.html
+++ b/rd_ui/app/views/dashboard_search.html
@@ -1,0 +1,19 @@
+<div class="modal-header">
+  <button type="button" class="close" aria-label="Close" ng-click="close()"><span aria-hidden="true">&times;</span>
+  </button>
+  <h4 class="modal-title"><i class="fa fa-search"></i> Search</h4>
+</div>
+
+<div class="modal-body">
+      <ui-select autofocus ng-model="dashboardSelected.selected" on-select="openSelectedDashboard($item)">
+        <ui-select-match placeholder="enter dashboard name..."></ui-select-match>
+        <ui-select-choices
+            repeat="dashboard in dashboards | filter:$select.search"
+            refresh="findDashboard($select.search)"
+            refresh-delay="0">
+          <div>
+            {{dashboard.name}}
+          </div>
+        </ui-select-choices>
+      </ui-select>
+</div>


### PR DESCRIPTION
Nowadays, if we have a lot of dashboards, the menu list grows and at some time you cannot see all dashboards.

This PR aims to address this issue and add the hotkey `CMD + K`/`CTRL + K`, used for search on Slack/Mattermost

![captura de tela 2016-09-02 as 17 58 29](https://cloud.githubusercontent.com/assets/755254/18218136/07fe9e48-7137-11e6-9b30-ba7a22111659.png)
