### PR TITLE
Fix: TreasureData get_schema method was returning array instead of string as column name

### DIFF
--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -84,7 +84,10 @@ class TreasureData(BaseQueryRunner):
                     for table in client.tables(self.configuration.get('db')):
                         table_name = '{}.{}'.format(self.configuration.get('db'), table.name)
                         for table_schema in table.schema:
-                            schema[table_name] = {'name': table_name, 'columns': table.schema}
+                            schema[table_name] = {
+                                'name': table_name,
+                                'columns': [column[0] for column in table.schema],
+                            }
             except Exception, ex:
                 raise Exception("Failed getting schema")
         return schema.values()


### PR DESCRIPTION
Fix schema information widget on Query Source View.

For details, Please see below screenshots.

---

Before

<img width="442" alt="before" src="https://cloud.githubusercontent.com/assets/635649/18225013/e59b2bd0-7223-11e6-97d3-64c517bc6417.png">

After

<img width="441" alt="after" src="https://cloud.githubusercontent.com/assets/635649/18225014/eb62efbc-7223-11e6-8e79-1d0aa00fc7b8.png">