### PR TITLE
Change: update bootstrap.sh to support Ubuntu 16.04

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -40,6 +40,7 @@ apt-get install -y libsasl2-dev
 #Saml dependency
 apt-get install -y xmlsec1
 
+pip install --upgrade pip
 pip install -U setuptools==23.1.0
 
 # redash user

--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -40,7 +40,10 @@ apt-get install -y libsasl2-dev
 #Saml dependency
 apt-get install -y xmlsec1
 
-pip install --upgrade pip
+# Upgrade pip if host is Ubuntu 16.04
+if [[ $(lsb_release -d) = *Ubuntu* ]] && [[ $(lsb_release -rs) = *16.04* ]]; then
+	pip install --upgrade pip
+fi
 pip install -U setuptools==23.1.0
 
 # redash user


### PR DESCRIPTION
Testing script on clean install of Ubuntu Desktop 16.04.1.

pip fails if not upgraded beforehand, whether "sudo" or "sudo -s" or "sudo -sH" is run.

After this modification it works perfectly from a clean install.  Below are my steps if anyone should want to replicate or validate:
1. Clean install of Ubuntu 16.04.1 Desktop (on VM)
2. sudo apt-get -y install git
3. mkdir ~/git
4. cd ~/git
5. git clone https://github.com/getredash/redash
6. cd ~/git/redash/setup/ubuntu
7. chmod +x bootstrap.sh
8. nano bootstrap.sh
9. added "pip install --upgrade pip" to the script above the "pip install -U..." line.
10. Saved script.
11. sudo -H ./bootstrap.sh

Note that the "-H" is necessary in order to run the script successfully, otherwise you will run into pip ownership issues.