### PR TITLE
Add: configuration flag to disable scheduled queries

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -57,5 +57,6 @@ The follow is a list of settings and what they control:
 - **REDASH_FEATURE_ALLOW_ALL_TO_EDIT**: *default "true"*
 - **REDASH_FEATURE_TABLES_PERMISSIONS**: *default "false"*
 - **REDASH_VERSION_CEHCK**: *default "true"*
+- **REDASH_FEATURE_DISABLE_REFRESH_QUERIES**: disable scheduled query execution, *default "false"*
 - **REDASH_BIGQUERY_HTTP_TIMEOUT**: *default "600"*
 - **REDASH_SCHEMA_RUN_TABLE_SIZE_CALCULATIONS**: *default "false"*

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -209,6 +209,7 @@ DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
 FEATURE_ALLOW_ALL_TO_EDIT_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_ALLOW_ALL_TO_EDIT", "true"))
 FEATURE_TABLES_PERMISSIONS = parse_boolean(os.environ.get("REDASH_FEATURE_TABLES_PERMISSIONS", "false"))
 VERSION_CHECK = parse_boolean(os.environ.get("REDASH_VERSION_CHECK", "true"))
+FEATURE_DISABLE_REFRESH_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_DISABLE_REFRESH_QUERIES", "false"))
 
 # BigQuery
 BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"))

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -259,7 +259,9 @@ def refresh_queries():
 
     with statsd_client.timer('manager.outdated_queries_lookup'):
         for query in models.Query.outdated_queries():
-            if query.data_source.paused:
+            if settings.FEATURE_DISABLE_REFRESH_QUERIES: 
+                logging.info("Disabled refresh queries.")
+            elif query.data_source.paused:
                 logging.info("Skipping refresh of %s because datasource - %s is paused (%s).", query.id, query.data_source.name, query.data_source.pause_reason)
             else:
                 enqueue_query(query.query, query.data_source,


### PR DESCRIPTION
Add a setting to disable refresh of queries during development. While doing development using re:dash, I want to be able to avoid unwanted processing cost in the query runner(e.g. B
igQuery) by preventing queries from being executed automatically.