### PR TITLE
Fix missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,6 @@ semver==2.2.1
 xlsxwriter==0.8.4
 pystache==0.5.4
 parsedatetime==2.1
+cffi==1.8.3
 cryptography==1.4
+oauthlib==2.0.0


### PR DESCRIPTION
Step to reproduce the problem.

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'redash/dev'...
==> default: Matching MAC address for NAT networking...

...snip...

==> default:   Running setup.py install for cryptography
==> default:
==> default:     Installed /tmp/pip_build_root/cryptography/cffi-1.8.3-py2.7-linux-x86_64.egg
==> default:     Traceback (most recent call last):
==> default:       File "<string>", line 1, in <module>
==> default:       File "/tmp/pip_build_root/cryptography/setup.py", line 333, in <module>
==> default:         **keywords_with_side_effects(sys.argv)
==> default:       File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
==> default:         _setup_distribution = dist = klass(attrs)
==> default:       File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 243, in __init__
==> default:         _Distribution.__init__(self,attrs)
==> default:       File "/usr/lib/python2.7/distutils/dist.py", line 287, in __init__
==> default:         self.finalize_options()
==> default:       File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 277, in finalize_options
==> default:         ep.load()(self, ep.name, value)
==> default:       File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2088, in load
==> default:         entry = __import__(self.module_name, globals(),globals(), ['__name__'])
==> default:     ImportError: No module named setuptools_ext
==> default:     Complete output from command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/cryptography/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-HIo4YP-record/install-record.txt --single-version-externally-managed --compile:
==> default:
==> default:
==> default: Installed /tmp/pip_build_root/cryptography/cffi-1.8.3-py2.7-linux-x86_64.egg
==> default:
==> default: Traceback (most recent call last):
==> default:
==> default:   File "<string>", line 1, in <module>
==> default:
==> default:   File "/tmp/pip_build_root/cryptography/setup.py", line 333, in <module>
==> default:
==> default:     **keywords_with_side_effects(sys.argv)
==> default:
==> default:   File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
==> default:
==> default:     _setup_distribution = dist = klass(attrs)
==> default:
==> default:   File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 243, in __init__
==> default:
==> default:     _Distribution.__init__(self,attrs)
==> default:
==> default:   File "/usr/lib/python2.7/distutils/dist.py", line 287, in __init__
==> default:
==> default:     self.finalize_options()
==> default:
==> default:   File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 277, in finalize_options
==> default:
==> default:     ep.load()(self, ep.name, value)
==> default:
==> default:   File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2088, in load
==> default:
==> default:     entry = __import__(self.module_name, globals(),globals(), ['__name__'])
==> default:
==> default: ImportError: No module named setuptools_ext
==> default:
==> default: ----------------------------------------
==> default:   Rolling back uninstall of cryptography
==> default: Cleaning up...
==> default: Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/cryptography/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-HIo4YP-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/cryptography
==> default: Storing debug log for failure in /home/vagrant/.pip/pip.log
==> default: Downloading/unpacking pymongo==3.2.1
==> default:   Running setup.py (path:/tmp/pip_build_root/pymongo/setup.py) egg_info for package pymongo
==> default:
==> default: Installing collected packages: pymongo
==> default:   Found existing installation: pymongo 2.7.2
==> default:     Uninstalling pymongo:
==> default:       Successfully uninstalled pymongo
==> default:   Running setup.py install for pymongo
==> default:     building 'bson._cbson' extension
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Ibson -I/usr/include/python2.7 -c bson/_cbsonmodule.c -o build/temp.linux-x86_64-2.7/bson/_cbsonmodule.o
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Ibson -I/usr/include/python2.7 -c bson/time64.c -o build/temp.linux-x86_64-2.7/bson/time64.o
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Ibson -I/usr/include/python2.7 -c bson/buffer.c -o build/temp.linux-x86_64-2.7/bson/buffer.o
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Ibson -I/usr/include/python2.7 -c bson/encoding_helpers.c -o build/temp.linux-x86_64-2.7/bson/encoding_helpers.o
==> default:     x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/bson/_cbsonmodule.o build/temp.linux-x86_64-2.7/bson/time64.o build/temp.linux-x86_64-2.7/bson/buffer.o build/temp.linux-x86_64-2.7/bson/encoding_helpers.o -o build/lib.linux-x86_64-2.7/bson/_cbson.so
==> default:     building 'pymongo._cmessage' extension
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Ibson -I/usr/include/python2.7 -c pymongo/_cmessagemodule.c -o build/temp.linux-x86_64-2.7/pymongo/_cmessagemodule.o
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Ibson -I/usr/include/python2.7 -c bson/buffer.c -o build/temp.linux-x86_64-2.7/bson/buffer.o
==> default:     x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/pymongo/_cmessagemodule.o build/temp.linux-x86_64-2.7/bson/buffer.o -o build/lib.linux-x86_64-2.7/pymongo/_cmessage.so
==> default:
==> default: Successfully installed pymongo
==> default: Cleaning up...
==> default: [2016-09-20 12:42:32,884][PID:1840][WARNING][redash.query_runner] GoogleSpreadsheet query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:32,938][PID:1840][WARNING][redash.query_runner] InfluxDB query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:32,948][PID:1840][WARNING][redash.query_runner] Presto query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:32,952][PID:1840][WARNING][redash.query_runner] Hive query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:32,959][PID:1840][WARNING][redash.query_runner] Vertica query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:32,962][PID:1840][WARNING][redash.query_runner] TreasureData query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:32,975][PID:1840][WARNING][redash.query_runner] Microsoft SQL Server query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: Traceback (most recent call last):
==> default:   File "/opt/redash/current/manage.py", line 10, in <module>
==> default:
==> default: from redash.wsgi import app
==> default:   File "/opt/redash/current/redash/wsgi.py", line 3, in <module>
==> default:
==> default: app = create_app()
==> default:   File "/opt/redash/current/redash/__init__.py", line 84, in create_app
==> default:
==> default: from redash import handlers
==> default:   File "/opt/redash/current/redash/handlers/__init__.py", line 5, in <module>
==> default:
==> default: from redash.authentication.org_resolving import current_org
==> default:   File "/opt/redash/current/redash/authentication/__init__.py", line 11, in <module>
==> default:
==> default: from redash.authentication import google_oauth, saml_auth, remote_user_auth
==> default:   File "/opt/redash/current/redash/authentication/google_oauth.py", line 5, in <module>
==> default:
==> default: from flask_oauthlib.client import OAuth
==> default:   File "/usr/local/lib/python2.7/dist-packages/flask_oauthlib/client.py", line 12, in <module>
==> default:
==> default: import oauthlib.oauth1
==> default: ImportError
==> default: :
==> default: No module named oauthlib.oauth1
==> default: [2016-09-20 12:42:33,713][PID:1847][WARNING][redash.query_runner] GoogleSpreadsheet query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:33,760][PID:1847][WARNING][redash.query_runner] InfluxDB query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:33,771][PID:1847][WARNING][redash.query_runner] Presto query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:33,773][PID:1847][WARNING][redash.query_runner] Hive query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:33,782][PID:1847][WARNING][redash.query_runner] Vertica query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:33,786][PID:1847][WARNING][redash.query_runner] TreasureData query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:33,799][PID:1847][WARNING][redash.query_runner] Microsoft SQL Server query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: Traceback (most recent call last):
==> default:   File "/opt/redash/current/manage.py", line 10, in <module>
==> default:
==> default: from redash.wsgi import app
==> default:   File "/opt/redash/current/redash/wsgi.py", line 3, in <module>
==> default:
==> default: app = create_app()
==> default:   File "/opt/redash/current/redash/__init__.py", line 84, in create_app
==> default:
==> default: from redash import handlers
==> default:   File "/opt/redash/current/redash/handlers/__init__.py", line 5, in <module>
==> default:
==> default: from redash.authentication.org_resolving import current_org
==> default:   File "/opt/redash/current/redash/authentication/__init__.py", line 11, in <module>
==> default:
==> default: from redash.authentication import google_oauth, saml_auth, remote_user_auth
==> default:   File "/opt/redash/current/redash/authentication/google_oauth.py", line 5, in <module>
==> default:
==> default: from flask_oauthlib.client import OAuth
==> default:   File "/usr/local/lib/python2.7/dist-packages/flask_oauthlib/client.py", line 12, in <module>
==> default:
==> default: import oauthlib.oauth1
==> default: ImportError
==> default: :
==> default: No module named oauthlib.oauth1
==> default: [2016-09-20 12:42:34,554][PID:1853][WARNING][redash.query_runner] GoogleSpreadsheet query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:34,599][PID:1853][WARNING][redash.query_runner] InfluxDB query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:34,609][PID:1853][WARNING][redash.query_runner] Presto query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:34,614][PID:1853][WARNING][redash.query_runner] Hive query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:34,620][PID:1853][WARNING][redash.query_runner] Vertica query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:34,623][PID:1853][WARNING][redash.query_runner] TreasureData query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: [2016-09-20 12:42:34,635][PID:1853][WARNING][redash.query_runner] Microsoft SQL Server query runner enabled but not supported, not registering. Either disable or install missing dependencies.
==> default: Traceback (most recent call last):
==> default:   File "/opt/redash/current/manage.py", line 10, in <module>
==> default:
==> default: from redash.wsgi import app
==> default:   File "/opt/redash/current/redash/wsgi.py", line 3, in <module>
==> default:
==> default: app = create_app()
==> default:   File "/opt/redash/current/redash/__init__.py", line 84, in create_app
==> default:
==> default: from redash import handlers
==> default:   File "/opt/redash/current/redash/handlers/__init__.py", line 5, in <module>
==> default:
==> default: from redash.authentication.org_resolving import current_org
==> default:   File "/opt/redash/current/redash/authentication/__init__.py", line 11, in <module>
==> default:
==> default: from redash.authentication import google_oauth, saml_auth, remote_user_auth
==> default:   File "/opt/redash/current/redash/authentication/google_oauth.py", line 5, in <module>
==> default:
==> default: from flask_oauthlib.client import OAuth
==> default:   File "/usr/local/lib/python2.7/dist-packages/flask_oauthlib/client.py", line 12, in <module>
==> default:
==> default: import oauthlib.oauth1
==> default: ImportError
==> default: :
==> default: No module named oauthlib.oauth1

...snip...
```
