### PR TITLE
Change: don't annotate BigQuery queries

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -113,6 +113,10 @@ class BigQuery(BaseQueryRunner):
             'secret': ['jsonKeyFile']
         }
 
+    @classmethod
+    def annotate_query(cls):
+        return False
+
     def __init__(self, configuration):
         super(BigQuery, self).__init__(configuration)
 


### PR DESCRIPTION
It's not really useful anyway and breaks support for `#StandardSQL` directive.