### PR TITLE
Change: send Content-Type header (application/json) in query results responses

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -162,7 +162,8 @@ class QueryResultResource(BaseResource):
 
     def make_json_response(self, query_result):
         data = json.dumps({'query_result': query_result.to_dict()}, cls=utils.JSONEncoder)
-        return make_response(data, 200, {})
+        headers = {'Content-Type': "application/json"}
+        return make_response(data, 200, headers)
 
     @staticmethod
     def make_csv_response(query_result):


### PR DESCRIPTION
I found lack of Content-Type header in the response of QueryResultResource.