### PR TITLE
Set SESSION_COOKIE_HTTPONLY

### DIFF
--- a/redash/settings.py
+++ b/redash/settings.py
@@ -124,6 +124,7 @@ STATIC_ASSETS_PATHS = [fix_assets_path(path) for path in os.environ.get("REDASH_
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 6))
 COOKIE_SECRET = os.environ.get("REDASH_COOKIE_SECRET", "c292a0a3aa32397cdb050e233733900f")
 SESSION_COOKIE_SECURE = parse_boolean(os.environ.get("REDASH_SESSION_COOKIE_SECURE") or str(ENFORCE_HTTPS))
+SESSION_COOKIE_HTTPONLY = not SESSION_COOKIE_SECURE
 
 LOG_LEVEL = os.environ.get("REDASH_LOG_LEVEL", "INFO")
 


### PR DESCRIPTION
Related to https://github.com/getredash/redash/pull/980

## Problem

I deployed Re:dash to HTTPS environment and set `REDASH_ENFORCE_COOKIE=true`.
Then I noticed that it returns weird session cookie.

```
set-cookie:session=***; Secure; HttpOnly; Path=/
```

It contains both of `Secure` and `HttpOnly`.

## Solution

Flask has a configuration named `SESSION_COOKIE_HTTPONLY`.
http://flask.pocoo.org/docs/0.10/config/

I think it should always be inverse of `SESSION_COOKIE_SECURE`.

With this change, now Re:dash returns session cookie correctly.

```
set-cookie:session=***; Secure; Path=/
```

---

Please review, thanks!