### PR TITLE
Only execute the query that is highlighted

### DIFF
--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -138,6 +138,7 @@
               $scope.$parent.$on("angular-resizable.resizing", function (event, args) {
                 editor.resize();
               });
+              $scope.query.editor = editor;
 
               editor.focus();
             }

--- a/rd_ui/app/scripts/services/resources.js
+++ b/rd_ui/app/scripts/services/resources.js
@@ -488,7 +488,10 @@
       if (!this.query) {
         return;
       }
-      var queryText = this.query;
+      var queryText = this.editor.getSelectedText();
+      if (queryText === "") {
+        queryText = this.query;
+      }
 
       var parameters = this.getParameters();
       var missingParams = parameters.getMissing();
@@ -769,7 +772,7 @@
         "tabTrigger": this.trigger
       };
     }
-    
+
     return resource;
   };
 


### PR DESCRIPTION
Hello! I've just started using `redash` and this is my first PR. 

Basically, while using the query-editor I frequently type out & save many queries but I can only "execute" the query at the very bottom of the editor (at least those are the only results I get back). 

This change will, if present, run the selected query, else keep the existing behavior. 
- If multiple queries are selected the server will be sent all queries (as it currently does) and only the last query will be executed
- If a partial query is selected the server will return the database error and display it to the user (as it currently does)

Please let me know if there is any other information you need from me, thanks!
