### PR TITLE
Add: support for snapshot generation service

### DIFF
--- a/rd_ui/app/scripts/controllers/query_view.js
+++ b/rd_ui/app/scripts/controllers/query_view.js
@@ -324,6 +324,9 @@
             $modalInstance.close();
           }
           $scope.embedUrl = basePath + 'embed/query/' + query.id + '/visualization/' + visualization.id + '?api_key=' + query.api_key;
+          if (window.snapshotUrlBuilder) {
+            $scope.snapshotUrl = snapshotUrlBuilder(query, visualization);
+          }
         }]
       })
     }

--- a/rd_ui/app/views/dialogs/embed_code.html
+++ b/rd_ui/app/views/dialogs/embed_code.html
@@ -3,8 +3,15 @@
     <h4 class="modal-title">Embed Code</h4>
 </div>
 <div class="modal-body">
+    <h5>IFrame Embed</h5>
     <div>
       <code>&lt;iframe src="{{ embedUrl }}" width="720" height="391"&gt;&lt;/iframe&gt;</code>
     </div>
     <span class="text-muted">(height should be adjusted)</span>
+    <div ng-if="snapshotUrl">
+      <h5>Image Embed</h5>
+      <div>
+        <code style="overflow-wrap:break-word;">{{snapshotUrl}}</code>
+      </div>
+    </div>
 </div>


### PR DESCRIPTION
This is provisioning for a feature currently available on the hosted version only. The ability to get image (png) embeds of visualizations.

I guess it will be open sourced at some point, but until then...