### PR TITLE
Fix: schema loading query for Hive was wrong for non default schema

### DIFF
--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -78,11 +78,11 @@ class Hive(BaseSQLQueryRunner):
 
             tables_query = "show tables in %s"
 
-            columns_query = "show columns in %s"
+            columns_query = "show columns in %s.%s"
 
             for schema_name in filter(lambda a: len(a) > 0, map(lambda a: str(a['database_name']), self._run_query_internal(schemas_query))):
                 for table_name in filter(lambda a: len(a) > 0, map(lambda a: str(a['tab_name']), self._run_query_internal(tables_query % schema_name))):
-                    columns = filter(lambda a: len(a) > 0, map(lambda a: str(a['field']), self._run_query_internal(columns_query % table_name)))
+                    columns = filter(lambda a: len(a) > 0, map(lambda a: str(a['field']), self._run_query_internal(columns_query % (schema_name, table_name))))
 
                     if schema_name != 'default':
                         table_name = '{}.{}'.format(schema_name, table_name)


### PR DESCRIPTION
Table not found errors occurred in other than the default schema.
Add schema name to columns query.