### PR TITLE
Fix: connection test was broken for MySQL

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -27,7 +27,7 @@ types_map = {
 }
 
 class Mysql(BaseSQLQueryRunner):
-    noop_method = "SELECT 1"
+    noop_query = "SELECT 1"
 
     @classmethod
     def configuration_schema(cls):


### PR DESCRIPTION
Hello, I use Re:dash. Re:dash is very cool !

I have a problem...
Mysql test connection is always failed of data source page.
Maybe "noop_method" is invalid, because query_runner/\__init__.py defined "noop_query" for test_connection.
Please check my pull request. Thank you.