### PR TITLE
Change: improve error message for exception in the Python query runner

### DIFF
--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -233,7 +233,7 @@ class Python(BaseQueryRunner):
             error = "Query cancelled by user."
             json_data = None
         except Exception as e:
-            error = str(e)
+            error = str(type(e)) + " " + str(e)
             json_data = None
 
         return json_data, error


### PR DESCRIPTION
This improves error message shown to users for python data sources.

from:

> Error running query: u'ss'

to:


> Error running query: &lt;type 'exceptions.KeyError'&gt; u'ss'


which I believe would help debugging python scripts from web UI.