### PR TITLE
Fix: missing format call in Elasticsearch test method

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -228,7 +228,7 @@ class BaseElasticSearch(BaseQueryRunner):
             raise Exception("Redash failed to parse the results it got from ElasticSearch.")
 
     def test_connection(self):
-        r = requests.get("{0}/_cluster/health", auth=self.auth)
+        r = requests.get("{0}/_cluster/health".format(self.server_url), auth=self.auth)
         if r.status_code != 200:
             raise Exception("Connection test failed.. Return Code: {0}"
                             "   Reason: {1}".format(r.status_code, r.text))


### PR DESCRIPTION
Calling 'test' on an elasticsearch datasource displays an error along the lines of "could not connect to {0}/_cluster/health, did you mean http://{0}/_cluster/health".
This string is obviously intended to be a format string, but format is not called on it before it is used.
This commit adds the missing 'format' call with the 0'th parameter being `self.server_url` as per all the other urls.