### PR TITLE
Change: display user's password reset link to the admin when mail server disabled

### DIFF
--- a/rd_ui/app/scripts/controllers/users.js
+++ b/rd_ui/app/scripts/controllers/users.js
@@ -302,9 +302,9 @@
 
     $scope.sendPasswordReset = function() {
       $scope.disablePasswordResetButton = true;
-      $http.post('api/users/' + $scope.user.id + '/reset_password').success(function(user) {
+      $http.post('api/users/' + $scope.user.id + '/reset_password').success(function(data) {
         $scope.disablePasswordResetButton = false;
-        growl.addSuccessMessage("The user should receive a link to reset his password by email soon.")
+        $scope.passwordResetLink = data.reset_link;
       });
     };
   };

--- a/rd_ui/app/views/users/show.html
+++ b/rd_ui/app/views/users/show.html
@@ -34,9 +34,10 @@
         <p>
           <strong>The user should receive a link to reset his password by email soon.</strong>
         </p>
-        <p ng-if="clientConfig.mailSettingsMissing">
-          You can use the following link to reset the password yourself:<br/>
-          {{passwordResetLink}}
+        <p ng-if="!clientConfig.mailSettingsMissing">
+          You don't have mail server configured, please send the following link
+          to {{user.name}} to reset their password:<br/>
+          <a ng-href="passwordResetLink">{{passwordResetLink}}</a>
         </p>
       </div>
     </div>

--- a/rd_ui/app/views/users/show.html
+++ b/rd_ui/app/views/users/show.html
@@ -30,11 +30,11 @@
         </button>
       </div>
 
-      <div ng-if="passwordResetLink && !disablePasswordResetButton" class="alert alert-success">
-        <p>
+      <div ng-if="passwordResetLink" class="alert alert-success">
+        <p ng-if="!clientConfig.mailSettingMissing">
           <strong>The user should receive a link to reset his password by email soon.</strong>
         </p>
-        <p ng-if="!clientConfig.mailSettingsMissing">
+        <p ng-if="clientConfig.mailSettingsMissing">
           You don't have mail server configured, please send the following link
           to {{user.name}} to reset their password:<br/>
           <a ng-href="passwordResetLink">{{passwordResetLink}}</a>

--- a/rd_ui/app/views/users/show.html
+++ b/rd_ui/app/views/users/show.html
@@ -24,9 +24,11 @@
     </p>
     <div ng-if="currentUser.isAdmin">
       <hr/>
-      <button class="btn btn-default" ng-click="sendPasswordReset()" ng-disabled="disablePasswordResetButton">Send
-        Password Reset Email
-      </button>
+      <div class="form-group">
+        <button class="btn btn-default" ng-click="sendPasswordReset()" ng-disabled="disablePasswordResetButton">Send
+          Password Reset Email
+        </button>
+      </div>
 
       <div ng-if="passwordResetLink && !disablePasswordResetButton" class="alert alert-success">
         <p>

--- a/rd_ui/app/views/users/show.html
+++ b/rd_ui/app/views/users/show.html
@@ -27,6 +27,16 @@
       <button class="btn btn-default" ng-click="sendPasswordReset()" ng-disabled="disablePasswordResetButton">Send
         Password Reset Email
       </button>
+
+      <div ng-if="passwordResetLink && !disablePasswordResetButton" class="alert alert-success">
+        <p>
+          <strong>The user should receive a link to reset his password by email soon.</strong>
+        </p>
+        <p ng-if="clientConfig.mailSettingsMissing">
+          You can use the following link to reset the password yourself:<br/>
+          {{passwordResetLink}}
+        </p>
+      </div>
     </div>
   </div>
   <div ng-show="selectedTab == 'apiKey'" class="p-10">

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -74,6 +74,10 @@ class UserResetPasswordResource(BaseResource):
         user = models.User.get_by_id_and_org(user_id, self.current_org)
         reset_link = send_password_reset_email(user)
 
+        return {
+            'reset_link': reset_link,
+        }
+
 
 class UserResource(BaseResource):
     def get(self, user_id):


### PR DESCRIPTION
This is work in progress, I'm sending just to ask for some help. Adding the reset link is quite easy, I'm just wondering what would be the best way to display it to the user. We have a similar functionality when creating a new user, where we display the invite URL to the admin inside the template. Would that be the best approach for this?