### PR TITLE
Change: use redash.utils.json_dumps instead of json.dumps in Python query runner

### DIFF
--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -4,6 +4,7 @@ import logging
 import sys
 
 from redash.query_runner import *
+from redash.utils import json_dumps
 from redash import models
 
 import importlib
@@ -228,7 +229,7 @@ class Python(BaseQueryRunner):
 
             result = self._script_locals['result']
             result['log'] = self._custom_print.lines
-            json_data = json.dumps(result)
+            json_data = json_dumps(result)
         except KeyboardInterrupt:
             error = "Query cancelled by user."
             json_data = None


### PR DESCRIPTION
Currently, python runner is returning datetime objects as unicode strings. `redash.utils.json_dumps` returns them as native python datetime objects.