### PR TITLE
Avoid cross site scripting risk point in query formatter

### DIFF
--- a/rd_ui/app/scripts/directives/query_directives.js
+++ b/rd_ui/app/scripts/directives/query_directives.js
@@ -184,6 +184,9 @@
   }
 
   function queryFormatter($http, growl) {
+    var unescape = function(convert){
+      return $("<span />", { html: convert }).text();
+    };
     return {
       restrict: 'E',
       // don't create new scope to avoid ui-codemirror bug
@@ -208,7 +211,7 @@
             $http.post('api/queries/format', {
               'query': $scope.query.query
             }).success(function (response) {
-              $scope.query.query = response;
+              $scope.query.query = unescape(response);
             }).finally(function () {
               $scope.queryFormatting = false;
             });

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -1,6 +1,7 @@
 from flask import request
 from flask_restful import abort
 from flask_login import login_required
+import cgi
 import sqlparse
 
 from funcy import distinct, take
@@ -21,7 +22,7 @@ def format_sql_query(org_slug=None):
     arguments = request.get_json(force=True)
     query = arguments.get("query", "")
 
-    return sqlparse.format(query, reindent=True, keyword_case='upper')
+    return cgi.escape(sqlparse.format(query, reindent=True, keyword_case='upper'))
 
 
 class QuerySearchResource(BaseResource):


### PR DESCRIPTION
Our internal security analysis found the potential for an XSS vulnerability in the query formatter. If not supplied with SQL, the query formatter returned exactly what was sent to it.