### PR TITLE
[ElasticSearch] Change: use simplejson for better error descriptions

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 import logging
 import sys
 import urllib

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ pystache==0.5.4
 parsedatetime==2.1
 cryptography==1.4
 Flask-Limiter==0.9.3
+simplejson==3.10.0


### PR DESCRIPTION
The standard json library only provides an error
that the json failed to parse (“No JSON object could be decoded”).
simplejson provides actual character and line numbers
along with an expected character in it's errors.
This makes writing elasticsearch queries much easier.

I have only applied this to the ElasticSearch query runner.
There are other modules that could use it for error-checking queries (MongoDB, etc).

![screen shot 2016-12-01 at 11 41 46 am](https://cloud.githubusercontent.com/assets/1239156/20777447/2eeaa298-b7bb-11e6-8856-4f8bb0bd04f1.png)
