### PR TITLE
[Datasources] Add: support of google analytics v4 API

### DIFF
--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -174,8 +174,7 @@ class GoogleAnalytics(BaseSQLQueryRunner):
             error = None
             json_data = json.dumps(data, cls=JSONEncoder)
         else:
-            error = params
-            # error = 'Wrong query format'
+            error = 'Wrong query format'
             json_data = None
         return json_data, error
 

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,9 +1,9 @@
-google-api-python-client==1.2
+google-api-python-client==1.5.5
 gspread==0.2.5
 impyla==0.10.0
 influxdb==2.7.1
 MySQL-python==1.2.5
-oauth2client==1.2
+oauth2client==1.5.2
 pyhive==0.1.6
 pymongo==3.2.1
 pyOpenSSL==0.14


### PR DESCRIPTION
More info about v4 here: https://developers.google.com/analytics/devguides/reporting/core/v4/

**Example query:**
```
{"reportRequests": [{"dateRanges": [{"endDate": "today",
                                     "startDate": "7daysAgo"}],
                     "dimensions": [{"name": "ga:hostname"}],
                     "metrics": [{"expression": "ga:sessions"},
                                 {"expression": "ga:users"}],
                     "viewId": view_id}]}
```

v3 API is still supported.
