### PR TITLE
Added global params to dashboards

### DIFF
--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -4,6 +4,9 @@
 <div class="container">
     <page-header title="{{dashboard.name}}">
       <span ng-if="!dashboard.is_archived && !public" class="hidden-print">
+          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !refreshEnabled, 'btn-primary': refreshEnabled}" tooltip="Manual Refresh" ng-click="reload()">
+            <span class="zmdi zmdi-refresh-sync-alert"></span>
+          </button>
           <button type="button" class="btn btn-sm" ng-class="{'btn-default': !refreshEnabled, 'btn-primary': refreshEnabled}" tooltip="Enable/Disable Auto Refresh" ng-click="triggerRefresh()">
             <span class="zmdi zmdi-refresh"></span>
           </button>
@@ -32,6 +35,10 @@
 
   <div class="m-b-5">
     <filters ng-if="dashboard.dashboard_filters_enabled"></filters>
+  </div>
+
+  <div class="m-b-5">
+    <parameters parameters="globalParams"></parameters>
   </div>
 
     <div ng-repeat="row in dashboard.widgets" class="row">


### PR DESCRIPTION
I think master is currently in a broken state, so I couldn't actually make this change there, but I did start from the last release `v0.12.0.b2449` and made this change. I can't propose a PR from a tag or propose a new branch though.

If you prefix a parameter with `$` then when viewing it at the dashboard level it gets promoted to be a dashboard level param and queries can share these params.

Feature request here: https://discuss.redash.io/t/add-ui-for-query-params-at-dashboard-level/236/8

Video of the feature here: https://goo.gl/photos/UEjDv3fDhCrb2AnU6

I guess in order to merge this, we'd need a new branch for a `v0.13.0` release or something similar. When master is stable and I would be more than happy to add this there too (and make it slightly less hacky). Our team needs this to adopt redash, and we don't want to be stuck on an old version 😄 