### PR TITLE
[Impala] enable schema browser

### DIFF
--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -82,11 +82,11 @@ class Impala(BaseSQLQueryRunner):
     def _get_tables(self, schema_dict):
         schemas_query = "show schemas;"
         tables_query = "show tables in %s;"
-        columns_query = "show column stats %s;"
+        columns_query = "show column stats %s.%s;"
 
-        for schema_name in map(lambda a: a['name'], self._run_query_internal(schemas_query)):
-            for table_name in map(lambda a: a['name'], self._run_query_internal(tables_query % schema_name)):
-                columns = map(lambda a: a['Column'], self._run_query_internal(columns_query % table_name))
+        for schema_name in filter(lambda a: len(a) > 0, map(lambda a: str(a['name']), self._run_query_internal(schemas_query))):
+            for table_name in filter(lambda a: len(a) > 0, map(lambda a: str(a['name']), self._run_query_internal(tables_query % schema_name))):
+                columns = filter(lambda a: len(a) > 0, map(lambda a: str(a['Column']), self._run_query_internal(columns_query % (schema_name, table_name))))
 
                 if schema_name != 'default':
                     table_name = '{}.{}'.format(schema_name, table_name)

--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -84,9 +84,9 @@ class Impala(BaseSQLQueryRunner):
         tables_query = "show tables in %s;"
         columns_query = "show column stats %s.%s;"
 
-        for schema_name in filter(lambda a: len(a) > 0, map(lambda a: str(a['name']), self._run_query_internal(schemas_query))):
-            for table_name in filter(lambda a: len(a) > 0, map(lambda a: str(a['name']), self._run_query_internal(tables_query % schema_name))):
-                columns = filter(lambda a: len(a) > 0, map(lambda a: str(a['Column']), self._run_query_internal(columns_query % (schema_name, table_name))))
+        for schema_name in map(lambda a: unicode(a['name']), self._run_query_internal(schemas_query)):
+            for table_name in map(lambda a: unicode(a['name']), self._run_query_internal(tables_query % schema_name)):
+                columns = map(lambda a: unicode(a['Column']), self._run_query_internal(columns_query % (schema_name, table_name)))
 
                 if schema_name != 'default':
                     table_name = '{}.{}'.format(schema_name, table_name)


### PR DESCRIPTION
Thank you for this great tool

line 89, in the "redash/query_runner/impala_ds.py" causes 500 error
The impala schema list was not displayed.

This error is `show column stats %s`  impala query 
`columns_query = "show column stats %s" ` to `columns_query = "show column stats %s.%s" ` 

For this reason, I have sent a pull request.
Thank you.