### PR TITLE
[Jira JQL] Add: support custom JIRA fields and enhance value mapping

### DIFF
--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -72,8 +72,8 @@ def put_value(result, k, v, mapping):
                     listValues.append(listItem[mapping['member']])
             else:
                 listValues.append(listItem)
-
-        result[k] = ','.join(listValues)
+        if len(listValues) > 0:
+            result[k] = ','.join(listValues)
 
     else:
         result[k] = v

--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -26,15 +26,15 @@ class ResultSet(object):
         return json.dumps({'rows': self.rows, 'columns': self.columns.values()})
 
 
-def parse_issue(issue, fieldMapping):
+def parse_issue(issue, field_mapping):
     result = OrderedDict()
     result['key'] = issue['key']
 
     for k, v in issue['fields'].iteritems():
 
         # if field mapping is defined optionally change output key and parsing rules for value
-        if k in fieldMapping:
-            mapping = fieldMapping[k]
+        if k in field_mapping:
+            mapping = field_mapping[k]
             output_key = k
             if 'name' in mapping:
                 output_key = mapping['name']
@@ -79,11 +79,11 @@ def put_value(result, k, v, mapping):
         result[k] = v
 
 
-def parse_issues(data, fieldMapping):
+def parse_issues(data, field_mapping):
     results = ResultSet()
 
     for issue in data['issues']:
-        results.add_row(parse_issue(issue, fieldMapping))
+        results.add_row(parse_issue(issue, field_mapping))
 
     return results
 
@@ -135,7 +135,7 @@ class JiraJQL(BaseQueryRunner):
         try:
             query = json.loads(query)
             query_type = query.pop('queryType', 'select')
-            fieldMapping = query.pop('fieldMapping', {})
+            field_mapping = query.pop('fieldMapping', {})
 
             if query_type == 'count':
                 query['maxResults'] = 1
@@ -154,7 +154,7 @@ class JiraJQL(BaseQueryRunner):
             if query_type == 'count':
                 results = parse_count(data)
             else:
-                results = parse_issues(data, fieldMapping)
+                results = parse_issues(data, field_mapping)
 
             return results.to_json(), None
         except KeyboardInterrupt:

--- a/tests/query_runner/test_jql.py
+++ b/tests/query_runner/test_jql.py
@@ -1,0 +1,104 @@
+from unittest import TestCase
+from redash.query_runner.jql import FieldMapping, parse_issue
+
+
+class TestFieldMapping(TestCase):
+
+    def test_empty(self):
+        field_mapping = FieldMapping({})
+
+        self.assertEqual(field_mapping.get_output_field_name('field1'), 'field1')
+        self.assertEqual(field_mapping.get_dict_output_field_name('field1','member1'), None)
+        self.assertEqual(field_mapping.get_dict_members('field1'), [])
+
+    def test_with_mappings(self):
+        field_mapping = FieldMapping({
+            'field1': 'output_name_1',
+            'field2.member1': 'output_name_2',
+            'field2.member2': 'output_name_3'
+            })
+
+        self.assertEqual(field_mapping.get_output_field_name('field1'), 'output_name_1')
+        self.assertEqual(field_mapping.get_dict_output_field_name('field1','member1'), None)
+        self.assertEqual(field_mapping.get_dict_members('field1'), [])
+
+        self.assertEqual(field_mapping.get_output_field_name('field2'), 'field2')
+        self.assertEqual(field_mapping.get_dict_output_field_name('field2','member1'), 'output_name_2')
+        self.assertEqual(field_mapping.get_dict_output_field_name('field2','member2'), 'output_name_3')
+        self.assertEqual(field_mapping.get_dict_output_field_name('field2','member3'), None)
+        self.assertEqual(field_mapping.get_dict_members('field2'), ['member1','member2'])
+
+
+class TestParseIssue(TestCase):
+    issue = {
+        'key': 'KEY-1',
+        'fields': {
+            'string_field': 'value1',
+            'int_field': 123,
+            'string_list_field': ['value1','value2'],
+            'dict_field': {'member1':'value1','member2': 'value2'},
+            'dict_list_field': [
+                {'member1':'value1a','member2': 'value2a'},
+                {'member1':'value1b','member2': 'value2b'}
+            ],
+            'dict_legacy': {'key':'legacyKey','name':'legacyName','dict_legacy':'legacyValue'},
+            'watchers': {'watchCount':10}
+        }
+    }
+
+    def test_no_mapping(self):
+        result = parse_issue(self.issue, FieldMapping({}))
+
+        self.assertEqual(result['key'], 'KEY-1')
+        self.assertEqual(result['string_field'], 'value1')
+        self.assertEqual(result['int_field'], 123)
+        self.assertEqual(result['string_list_field'], 'value1,value2')
+        self.assertEqual('dict_field' in result, False)
+        self.assertEqual('dict_list_field' in result, False)
+        self.assertEqual(result['dict_legacy'], 'legacyValue')
+        self.assertEqual(result['dict_legacy_key'], 'legacyKey')
+        self.assertEqual(result['dict_legacy_name'], 'legacyName')
+        self.assertEqual(result['watchers'], 10)
+
+    def test_mapping(self):
+        result = parse_issue(self.issue, FieldMapping({
+            'string_field': 'string_output_field',
+            'string_list_field': 'string_output_list_field',
+            'dict_field.member1': 'dict_field_1',
+            'dict_field.member2': 'dict_field_2',
+            'dict_list_field.member1': 'dict_list_field_1',
+            'dict_legacy.key': 'dict_legacy',
+            'watchers.watchCount': 'watchCount',
+        }))
+
+        self.assertEqual(result['key'], 'KEY-1')
+        self.assertEqual(result['string_output_field'], 'value1')
+        self.assertEqual(result['int_field'], 123)
+        self.assertEqual(result['string_output_list_field'], 'value1,value2')
+        self.assertEqual(result['dict_field_1'], 'value1')
+        self.assertEqual(result['dict_field_2'], 'value2')
+        self.assertEqual(result['dict_list_field_1'], 'value1a,value1b')
+        self.assertEqual(result['dict_legacy'], 'legacyKey')
+        self.assertEqual('dict_legacy_key' in result, False)
+        self.assertEqual('dict_legacy_name' in result, False)
+        self.assertEqual('watchers' in result, False)
+        self.assertEqual(result['watchCount'], 10)
+
+
+    def test_mapping_nonexisting_field(self):
+        result = parse_issue(self.issue, FieldMapping({
+            'non_existing_field': 'output_name1',
+            'dict_field.non_existing_member': 'output_name2',
+            'dict_list_field.non_existing_member': 'output_name3'
+        }))
+
+        self.assertEqual(result['key'], 'KEY-1')
+        self.assertEqual(result['string_field'], 'value1')
+        self.assertEqual(result['int_field'], 123)
+        self.assertEqual(result['string_list_field'], 'value1,value2')
+        self.assertEqual('dict_field' in result, False)
+        self.assertEqual('dict_list_field' in result, False)
+        self.assertEqual(result['dict_legacy'], 'legacyValue')
+        self.assertEqual(result['dict_legacy_key'], 'legacyKey')
+        self.assertEqual(result['dict_legacy_name'], 'legacyName')
+        self.assertEqual(result['watchers'], 10)


### PR DESCRIPTION
Enhancements to JQL Query Runner support:
* Do not skip fields starting with customfield_
* Convert list values to concatenated strings, and skip list items if they are dicts without specific mapping rules. This produces nicer outputs, and fixes errors with excel download when the result contained lists or lists with dicts in it.
* Add support for `fieldMapping` query property which allows to rename output columns or pick specific members from dict values
* the previous implementation contains some magic special mappings for key, name, watchCount. They are still applied if no field mapping is defined for a column for backwards compatibility.

example JQL:

```json
{
    "fields": "summary,priority,customfield_10672,resolutiondate,fixVersions,watches,labels",
    "jql": "project = PVTC ORDER BY priority DESC, key ASC",
    "queryType": "select",
    "maxResults": 500,
    "fieldMapping": {
        "customfield_10672": {
            "name": "myCustomField"
        },
        "priority": {
            "member": "id"
        },
        "fixVersions": {
            "member": "name",
            "name": "myFixVersion"
        }
    }
}
```

the three field mappings define:
* rename field customfield_10672 to myCustomField in the result
* pick only a specific member 'id' from the priority field
* pick a specific member 'name' from the fixVersions field and rename it to 'myFixVersion'