### PR TITLE
[Presto/Athena] Change: remove special rule around public schema

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -7,7 +7,6 @@ from redash.query_runner import BaseQueryRunner, register
 
 PROXY_URL = os.environ.get('ATHENA_PROXY_URL')
 
-
 class Athena(BaseQueryRunner):
     noop_query = 'SELECT 1'
 
@@ -61,10 +60,7 @@ class Athena(BaseQueryRunner):
         results = json.loads(results)
 
         for row in results['rows']:
-            if row['table_schema'] != 'public':
-                table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
-            else:
-                table_name = row['table_name']
+            table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
 
             if table_name not in schema:
                 schema[table_name] = {'name': table_name, 'columns': []}

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -84,11 +84,8 @@ class Presto(BaseQueryRunner):
         results = json.loads(results)
 
         for row in results['rows']:
-            if row['table_schema'] != 'public':
-                table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
-            else:
-                table_name = row['table_name']
-
+            table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
+            
             if table_name not in schema:
                 schema[table_name] = {'name': table_name, 'columns': []}
 


### PR DESCRIPTION
Both the Presto and Athena query runners currently have a special rule for the "public" schema. But you do need to define the schema in all situations (even if it's public). I think this rule was copied across when we copied the code from the Postgres query runner.

This PR removes this special rule and treats "public" as just a normal schema.