### PR TITLE
[Athena] Change: enable query annotations

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -41,9 +41,6 @@ class Athena(BaseQueryRunner):
             'secret': ['aws_secret_key']
         }
 
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def get_schema(self, get_stats=False):
         schema = {}


### PR DESCRIPTION
The Athena query runner currently has the annotation (comment on top of query) disabled. This PR will enable it so we can see who is running what from Athena history.