### PR TITLE
fix alembic fail when run alembic upgrade head

### DIFF
--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,8 +1,10 @@
 # A generic, single database configuration.
 
 [alembic]
+script_location = alembic
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
+
 
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate


### PR DESCRIPTION
fix this behavior
    cd /opt/redash/migrations && alembic upgrade head

output:   FAILED: No 'script_location' key found in configuration.