### PR TITLE
[ElasticSearch] Fix for #1521

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -119,12 +119,13 @@ class BaseElasticSearch(BaseQueryRunner):
         return mappings, error
 
     def _get_query_mappings(self, url):
-        mappings, error = self._get_mappings(url)
+        mappings_data, error = self._get_mappings(url)
         if error:
-            return mappings, error
+            return mappings_data, error
 
-        for index_name in mappings:
-            index_mappings = mappings[index_name]
+        mappings = {}
+        for index_name in mappings_data:
+            index_mappings = mappings_data[index_name]
             for m in index_mappings.get("mappings", {}):
                 for property_name in index_mappings["mappings"][m]["properties"]:
                     property_data = index_mappings["mappings"][m]["properties"][property_name]


### PR DESCRIPTION
The merge from #1521 fixed the invalid variable error
but it fixed in in a way that introduced another error:
"dictionary changed size during iteration".
The correct way to apply the fix is to add a new `mappings`
dict which takes the result schema.

These errors crept through because of caching. I believed I was testing the code but I was actually inspecting cached query results and cached schemas. My apologies for this.