### PR TITLE
[MySQL] Change: faster retrieval of schema

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -93,12 +93,7 @@ class Mysql(BaseSQLQueryRunner):
                col.table_name,
                col.column_name
         FROM `information_schema`.`columns` col
-        INNER JOIN
-          (SELECT table_schema,
-                  TABLE_NAME
-           FROM information_schema.tables
-           WHERE table_type <> 'SYSTEM VIEW' AND table_schema NOT IN ('performance_schema', 'mysql')) tables ON tables.table_schema = col.table_schema
-        AND tables.TABLE_NAME = col.TABLE_NAME;
+        WHERE col.table_schema NOT IN ('information_schema', 'performance_schema', 'mysql');
         """
 
         results, error = self.run_query(query, None)


### PR DESCRIPTION
Because `information_schema.tables` and `information_schema.columns` do not have indexes on them, when they get large, joining them becomes painful. We have a database with over 10k tables and more than 200k columns. The old query takes forever.

The new query do not look at `information_schema.tables` at all. This works if your `information_schema.columns` table is in good shape in terms of data integrity (and it should be).

Tested on MySQL 5.5, 5.6(Percona), 5.7(Percona). The schema has not changed since then.