### PR TITLE
Change: disable version counter for queries:

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -863,20 +863,6 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         db.session.add(forked_query)
         return forked_query
 
-    def update_instance_tracked(self, changing_user, old_object=None, *args, **kwargs):
-        self.version += 1
-        self.update_instance(*args, **kwargs)
-        # save Change record
-        new_change = Change.save_change(user=changing_user, old_object=old_object, new_object=self)
-        return new_change
-
-    def tracked_save(self, changing_user, old_object=None, *args, **kwargs):
-        self.version += 1
-        self.save(*args, **kwargs)
-        # save Change record
-        new_change = Change.save_change(user=changing_user, old_object=old_object, new_object=self)
-        return new_change
-
     @property
     def runtime(self):
         return self.latest_query_data.runtime

--- a/redash/models.py
+++ b/redash/models.py
@@ -687,8 +687,9 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     __tablename__ = 'queries'
     __mapper_args__ = {
-        "version_id_col": version
-        }
+        "version_id_col": version,
+        'version_id_generator': False
+    }
 
     def to_dict(self, with_stats=False, with_visualizations=False, with_user=True, with_last_modified_by=True):
         d = {

--- a/redash/models.py
+++ b/redash/models.py
@@ -662,7 +662,7 @@ def should_schedule_next(previous_iteration, now, schedule):
 
 class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
-    version = Column(db.Integer)
+    version = Column(db.Integer, default=1)
     org_id = Column(db.Integer, db.ForeignKey('organizations.id'))
     org = db.relationship(Organization, backref="queries")
     data_source_id = Column(db.Integer, db.ForeignKey("data_sources.id"), nullable=True)

--- a/tests/models/test_changes.py
+++ b/tests/models/test_changes.py
@@ -62,7 +62,8 @@ class TestLogChange(BaseTestCase):
         change = Change.last_change(obj)
 
         self.assertIsNotNone(change)
-        self.assertEqual(change.object_version, 2)
+        # TODO: https://github.com/getredash/redash/issues/1550
+        # self.assertEqual(change.object_version, 2)
         self.assertEqual(change.object_version, obj.version)
         self.assertIn('name', change.change)
         self.assertIn('description', change.change)


### PR DESCRIPTION
Since the move to SQLAlchemy, version is managed automatically. When running a query, the worker updates the query row and increments the version. This results in the user's inability to save the query after that.

From reviewing SQLA's documentation, it looks like we will have to manage the version value ourselves. For now, I'm just disabling the version auto increment. In a follow up update we need to actually implement the manual increment where we think it's needed.