### PR TITLE
Change: generate sourcemaps for modules (original source files)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,8 +79,7 @@ var config = {
 
     ]
   },
-  // devtool: 'eval-source-map',
-  devtool: 'cheap-eval-source-map',
+  devtool: 'cheap-eval-module-source-map',
   devServer: {
     inline: true,
     historyApiFallback: true,


### PR DESCRIPTION
This enables sourcemaps for original files instead of transpiled code.

Before (this is `app/components/filters.js`):
![image](https://cloud.githubusercontent.com/assets/3965316/22454695/c9e49e90-e798-11e6-80f3-1cb096116ae2.png)

After:
![image](https://cloud.githubusercontent.com/assets/3965316/22454733/2b0ada40-e799-11e6-8be2-83661c002b19.png)

