### PR TITLE
Change: send events to webhook as JSON with a schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.0.0-rc.2 - Unreleased
+
+### Changed
+
+- [#1563](https://github.com/getredash/redash/pull/1563) Send events to webhook as JSON with a schema.
+
 ## v1.0.0-rc.1 - 2017-01-31
 
 This version has two big changes behind the scenes:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -409,7 +409,7 @@ class TestEvents(BaseTestCase):
 
         event = models.Event.record(raw_event)
 
-        self.assertDictEqual(json.loads(event.additional_properties), additional_properties)
+        self.assertDictEqual(event.additional_properties, additional_properties)
 
 
 class TestWidgetDeleteInstance(BaseTestCase):


### PR DESCRIPTION
Example of resulting event:

```json
{
   "data":{
      "user_id":null,
      "created_at":"2017-02-02T08:08:15+02:00",
      "object_type":"test",
      "org_id":1,
      "object_id":null,
      "additional_properties":{
         "test":1
      },
      "action":"test"
   },
   "schema":"iglu:io.redash.webhooks/event/jsonschema/1-0-0"
}
```

Closes #1552.