### PR TITLE
Fix: options selection in the map visualization editor (lat, long, groupBy)

### DIFF
--- a/client/app/visualizations/map/index.js
+++ b/client/app/visualizations/map/index.js
@@ -218,7 +218,9 @@ function mapEditor() {
     template: editorTemplate,
     link($scope) {
       $scope.currentTab = 'general';
-      $scope.classify_columns = $scope.queryResult.columnNames.concat('none');
+      $scope.columns = $scope.queryResult.getColumns();
+      $scope.columnNames = _.pluck($scope.columns, 'name');
+      $scope.classify_columns = $scope.columnNames.concat('none');
       $scope.mapTiles = [
         {
           name: 'OpenStreetMap',

--- a/client/app/visualizations/map/map-editor.html
+++ b/client/app/visualizations/map/map-editor.html
@@ -8,20 +8,35 @@
   <div ng-show="currentTab == 'general'">
     <div class="form-group">
       <label class="control-label">Latitude Column Name</label>
-      <select ng-options="name for name in queryResult.columnNames" ng-model="visualization.options.latColName"
-              class="form-control"></select>
+      <ui-select name="form-control" required ng-model="visualization.options.latColName">
+        <ui-select-match placeholder="Choose column...">{{$select.selected}}</ui-select-match>
+        <ui-select-choices repeat="column in columnNames | remove:visualization.options.classify | remove:visualization.options.lonColName">
+          <span ng-bind-html="column | highlight: $select.search"></span><span> </span>
+          <small class="text-muted" ng-bind="columns[column].type"></small>
+        </ui-select-choices>
+      </ui-select>
     </div>
 
     <div class="form-group">
       <label class="control-label">Longitude Column Name</label>
-      <select ng-options="name for name in queryResult.columnNames" ng-model="visualization.options.lonColName"
-              class="form-control"></select>
+      <ui-select name="form-control" required ng-model="visualization.options.lonColName">
+        <ui-select-match placeholder="Choose column...">{{$select.selected}}</ui-select-match>
+        <ui-select-choices repeat="column in columnNames | remove:visualization.options.classify | remove:visualization.options.latColName">
+          <span ng-bind-html="column | highlight: $select.search"></span><span> </span>
+          <small class="text-muted" ng-bind="columns[column].type"></small>
+        </ui-select-choices>
+      </ui-select>
     </div>
 
     <div class="form-group">
       <label class="control-label">Group By</label>
-      <select ng-options="name for name in classify_columns" ng-model="visualization.options.classify"
-              class="form-control"></select>
+      <ui-select name="form-control" required ng-model="visualization.options.classify">
+        <ui-select-match placeholder="Choose column...">{{$select.selected}}</ui-select-match>
+        <ui-select-choices repeat="column in classify_columns | remove:visualization.options.lonColName | remove:visualization.options.latColName">
+          <span ng-bind-html="column | highlight: $select.search"></span><span> </span>
+          <small class="text-muted" ng-bind="columns[column].type"></small>
+        </ui-select-choices>
+      </ui-select>
     </div>
   </div>
 


### PR DESCRIPTION
Currently (1.0.0-rc1) column options of a result query won't show up in the map visualization editor (see attached images). Changing column name handling similar to the chart visualization editor.

![screen shot 2017-02-02 at 15 56 01](https://cloud.githubusercontent.com/assets/1479098/22555003/843e840c-e962-11e6-89ea-f800e4f3905c.png)

![screen shot 2017-02-02 at 15 54 42](https://cloud.githubusercontent.com/assets/1479098/22555007/87f5ba20-e962-11e6-86fc-e5c4ee206c05.png)

