### PR TITLE
Add: scheduled query backoff in case of errors

### DIFF
--- a/migrations/versions/d1eae8b9893e_.py
+++ b/migrations/versions/d1eae8b9893e_.py
@@ -1,0 +1,25 @@
+"""add Query.schedule_failures
+
+Revision ID: d1eae8b9893e
+Revises: 65fc9ede4746
+Create Date: 2017-02-03 01:45:02.954923
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd1eae8b9893e'
+down_revision = '65fc9ede4746'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('queries', sa.Column('schedule_failures', sa.Integer(),
+                                       nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('queries', 'schedule_failures')

--- a/redash/models.py
+++ b/redash/models.py
@@ -789,7 +789,8 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         queries = (db.session.query(Query)
                    .join(QueryResult)
                    .join(DataSource)
-                   .filter(Query.schedule != None))
+                   .filter(Query.schedule != None)
+                   .order_by(Query.id))
 
         now = utils.utcnow()
         outdated_queries = {}

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -197,7 +197,8 @@ class QueryTask(object):
         return self._async_result.revoke(terminate=True, signal='SIGINT')
 
 
-def enqueue_query(query, data_source, user_id, scheduled=False, metadata={}):
+def enqueue_query(query, data_source, user_id, scheduled_query=None,
+                  metadata={}):
     query_hash = gen_query_hash(query)
     logging.info("Inserting job for %s with metadata=%s", query_hash, metadata)
     try_count = 0
@@ -223,14 +224,21 @@ def enqueue_query(query, data_source, user_id, scheduled=False, metadata={}):
             if not job:
                 pipe.multi()
 
-                if scheduled:
+                if scheduled_query:
                     queue_name = data_source.scheduled_queue_name
+                    scheduled_query_id = scheduled_query.id
                 else:
                     queue_name = data_source.queue_name
+                    scheduled_query_id = None
 
-                result = execute_query.apply_async(args=(query, data_source.id, metadata, user_id), queue=queue_name)
+                result = execute_query.apply_async(args=(
+                    query, data_source.id, metadata, user_id,
+                    scheduled_query_id),
+                                                   queue=queue_name)
                 job = QueryTask(async_result=result)
-                tracker = QueryTaskTracker.create(result.id, 'created', query_hash, data_source.id, scheduled, metadata)
+                tracker = QueryTaskTracker.create(
+                    result.id, 'created', query_hash, data_source.id,
+                    scheduled_query is not None, metadata)
                 tracker.save(connection=pipe)
 
                 logging.info("[%s] Created new job: %s", query_hash, job.id)
@@ -262,7 +270,7 @@ def refresh_queries():
                 logging.info("Skipping refresh of %s because datasource - %s is paused (%s).", query.id, query.data_source.name, query.data_source.pause_reason)
             else:
                 enqueue_query(query.query_text, query.data_source, query.user_id,
-                              scheduled=True,
+                              scheduled_query=query,
                               metadata={'Query ID': query.id, 'Username': 'Scheduled'})
 
             query_ids.append(query.id)
@@ -378,7 +386,8 @@ class QueryExecutionError(Exception):
 # We could have created this as a celery.Task derived class, and act as the task itself. But this might result in weird
 # issues as the task class created once per process, so decided to have a plain object instead.
 class QueryExecutor(object):
-    def __init__(self, task, query, data_source_id, user_id, metadata):
+    def __init__(self, task, query, data_source_id, user_id, metadata,
+                 scheduled_query):
         self.task = task
         self.query = query
         self.data_source_id = data_source_id
@@ -389,6 +398,7 @@ class QueryExecutor(object):
         else:
             self.user = None
         self.query_hash = gen_query_hash(self.query)
+        self.scheduled_query = scheduled_query
         # Load existing tracker or create a new one if the job was created before code update:
         self.tracker = QueryTaskTracker.get_by_task_id(task.request.id) or QueryTaskTracker.create(task.request.id,
                                                                                                    'created',
@@ -423,7 +433,14 @@ class QueryExecutor(object):
         if error:
             self.tracker.update(state='failed')
             result = QueryExecutionError(error)
+            if self.scheduled_query:
+                self.scheduled_query.schedule_failures += 1
+                models.db.session.add(self.scheduled_query)
         else:
+            if (self.scheduled_query and
+                    self.scheduled_query.schedule_failures > 0):
+                self.scheduled_query.schedule_failures = 0
+                models.db.session.add(self.scheduled_query)
             query_result, updated_query_ids = models.QueryResult.store_result(
                 self.data_source.org, self.data_source,
                 self.query_hash, self.query, data,
@@ -450,10 +467,14 @@ class QueryExecutor(object):
         return annotated_query
 
     def _log_progress(self, state):
-        logger.info(u"task=execute_query state=%s query_hash=%s type=%s ds_id=%d task_id=%s queue=%s query_id=%s username=%s",
-                    state,
-                    self.query_hash, self.data_source.type, self.data_source.id, self.task.request.id, self.task.request.delivery_info['routing_key'],
-                    self.metadata.get('Query ID', 'unknown'), self.metadata.get('Username', 'unknown'))
+        logger.info(
+            u"task=execute_query state=%s query_hash=%s type=%s ds_id=%d  "
+            "task_id=%s queue=%s query_id=%s username=%s",
+            state, self.query_hash, self.data_source.type, self.data_source.id,
+            self.task.request.id,
+            self.task.request.delivery_info['routing_key'],
+            self.metadata.get('Query ID', 'unknown'),
+            self.metadata.get('Username', 'unknown'))
         self.tracker.update(state=state)
 
     def _load_data_source(self):
@@ -464,5 +485,11 @@ class QueryExecutor(object):
 # user_id is added last as a keyword argument for backward compatability -- to support executing previously submitted
 # jobs before the upgrade to this version.
 @celery.task(name="redash.tasks.execute_query", bind=True, track_started=True)
-def execute_query(self, query, data_source_id, metadata, user_id=None):
-    return QueryExecutor(self, query, data_source_id, user_id, metadata).run()
+def execute_query(self, query, data_source_id, metadata, user_id=None,
+                  scheduled_query_id=None):
+    if scheduled_query_id is not None:
+        scheduled_query = models.Query.query.get(scheduled_query_id)
+    else:
+        scheduled_query = None
+    return QueryExecutor(self, query, data_source_id, user_id, metadata,
+                         scheduled_query).run()

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -1,10 +1,13 @@
-from tests import BaseTestCase
-from redash import redis_connection
-from redash.tasks.queries import QueryTaskTracker, enqueue_query, execute_query
 from unittest import TestCase
-from mock import MagicMock
 from collections import namedtuple
 import uuid
+
+import mock
+
+from tests import BaseTestCase
+from redash import redis_connection, models
+from redash.query_runner.pg import PostgreSQL
+from redash.tasks.queries import QueryTaskTracker, enqueue_query, execute_query
 
 
 class TestPrune(TestCase):
@@ -45,7 +48,7 @@ def gen_hash(*args, **kwargs):
 class TestEnqueueTask(BaseTestCase):
     def test_multiple_enqueue_of_same_query(self):
         query = self.factory.create_query()
-        execute_query.apply_async = MagicMock(side_effect=gen_hash)
+        execute_query.apply_async = mock.MagicMock(side_effect=gen_hash)
 
         enqueue_query(query.query_text, query.data_source, True, {'Username': 'Arik', 'Query ID': query.id})
         enqueue_query(query.query_text, query.data_source, True, {'Username': 'Arik', 'Query ID': query.id})
@@ -58,7 +61,7 @@ class TestEnqueueTask(BaseTestCase):
 
     def test_multiple_enqueue_of_different_query(self):
         query = self.factory.create_query()
-        execute_query.apply_async = MagicMock(side_effect=gen_hash)
+        execute_query.apply_async = mock.MagicMock(side_effect=gen_hash)
 
         enqueue_query(query.query_text, query.data_source, True, {'Username': 'Arik', 'Query ID': query.id})
         enqueue_query(query.query_text + '2', query.data_source, True, {'Username': 'Arik', 'Query ID': query.id})
@@ -68,3 +71,79 @@ class TestEnqueueTask(BaseTestCase):
         self.assertEqual(3, redis_connection.zcard(QueryTaskTracker.WAITING_LIST))
         self.assertEqual(0, redis_connection.zcard(QueryTaskTracker.IN_PROGRESS_LIST))
         self.assertEqual(0, redis_connection.zcard(QueryTaskTracker.DONE_LIST))
+
+
+class QueryExecutorTests(BaseTestCase):
+
+    def test_success(self):
+        """
+        ``execute_query`` invokes the query runner and stores a query result.
+        """
+        cm = mock.patch("celery.app.task.Context.delivery_info",
+                        {'routing_key': 'test'})
+        with cm, mock.patch.object(PostgreSQL, "run_query") as qr:
+            qr.return_value = ([1, 2], None)
+            result_id = execute_query("SELECT 1, 2",
+                                      self.factory.data_source.id, {})
+            self.assertEqual(1, qr.call_count)
+            result = models.QueryResult.query.get(result_id)
+            self.assertEqual(result.data, '{1,2}')
+
+    def test_success_scheduled(self):
+        """
+        Scheduled queries remember their latest results.
+        """
+        cm = mock.patch("celery.app.task.Context.delivery_info",
+                        {'routing_key': 'test'})
+        q = self.factory.create_query(query_text="SELECT 1, 2", schedule=300)
+        with cm, mock.patch.object(PostgreSQL, "run_query") as qr:
+            qr.return_value = ([1, 2], None)
+            result_id = execute_query(
+                "SELECT 1, 2",
+                self.factory.data_source.id, {},
+                scheduled_query_id=q.id)
+            models.db.session.refresh(q)
+            self.assertEqual(q.schedule_failures, 0)
+            result = models.QueryResult.query.get(result_id)
+            self.assertEqual(q.latest_query_data, result)
+
+    def test_failure_scheduled(self):
+        """
+        Scheduled queries that fail have their failure recorded.
+        """
+        cm = mock.patch("celery.app.task.Context.delivery_info",
+                        {'routing_key': 'test'})
+        q = self.factory.create_query(query_text="SELECT 1, 2", schedule=300)
+        with cm, mock.patch.object(PostgreSQL, "run_query") as qr:
+            qr.exception = ValueError("broken")
+            execute_query("SELECT 1, 2",
+                          self.factory.data_source.id, {},
+                          scheduled_query_id=q.id)
+            self.assertEqual(q.schedule_failures, 1)
+            execute_query("SELECT 1, 2",
+                          self.factory.data_source.id, {},
+                          scheduled_query_id=q.id)
+            models.db.session.refresh(q)
+            self.assertEqual(q.schedule_failures, 2)
+
+    def test_success_after_failure(self):
+        """
+        Query execution success resets the failure counter.
+        """
+        cm = mock.patch("celery.app.task.Context.delivery_info",
+                        {'routing_key': 'test'})
+        q = self.factory.create_query(query_text="SELECT 1, 2", schedule=300)
+        with cm, mock.patch.object(PostgreSQL, "run_query") as qr:
+            qr.exception = ValueError("broken")
+            execute_query("SELECT 1, 2",
+                          self.factory.data_source.id, {},
+                          scheduled_query_id=q.id)
+            models.db.session.refresh(q)
+            self.assertEqual(q.schedule_failures, 1)
+        with cm, mock.patch.object(PostgreSQL, "run_query") as qr:
+            qr.return_value = ([1, 2], None)
+            execute_query("SELECT 1, 2",
+                          self.factory.data_source.id, {},
+                          scheduled_query_id=q.id)
+            models.db.session.refresh(q)
+            self.assertEqual(q.schedule_failures, 0)

--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -21,9 +21,9 @@ class TestRefreshQuery(BaseTestCase):
             self.assertEqual(add_job_mock.call_count, 2)
             add_job_mock.assert_has_calls([
                 call(query1.query_text, query1.data_source, query1.user_id,
-                     scheduled=True, metadata=ANY),
+                     scheduled_query=query1, metadata=ANY),
                 call(query2.query_text, query2.data_source, query2.user_id,
-                     scheduled=True, metadata=ANY)], any_order=True)
+                     scheduled_query=query2, metadata=ANY)], any_order=True)
 
     def test_doesnt_enqueue_outdated_queries_for_paused_data_source(self):
         """
@@ -44,4 +44,4 @@ class TestRefreshQuery(BaseTestCase):
                 refresh_queries()
                 add_job_mock.assert_called_with(
                     query.query_text, query.data_source, query.user_id,
-                    scheduled=True, metadata=ANY)
+                    scheduled_query=query, metadata=ANY)

--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -1,109 +1,47 @@
-import datetime
 from mock import patch, call, ANY
 from tests import BaseTestCase
-from redash.utils import utcnow
 from redash.tasks import refresh_queries
-from redash.models import db
+from redash.models import Query
 
 
-# TODO: this test should be split into two:
-# 1. tests for Query.outdated_queries method
-# 2. test for the refresh_query task
-class TestRefreshQueries(BaseTestCase):
+class TestRefreshQuery(BaseTestCase):
     def test_enqueues_outdated_queries(self):
-        query = self.factory.create_query(schedule="60")
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                   query_hash=query.query_hash)
-        query.latest_query_data = query_result
-        db.session.add(query)
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
+        """
+        refresh_queries() launches an execution task for each query returned
+        from Query.outdated_queries().
+        """
+        query1 = self.factory.create_query()
+        query2 = self.factory.create_query(
+            query_text="select 42;",
+            data_source=self.factory.create_data_source())
+        oq = staticmethod(lambda: [query1, query2])
+        with patch('redash.tasks.queries.enqueue_query') as add_job_mock, \
+                patch.object(Query, 'outdated_queries', oq):
             refresh_queries()
-            add_job_mock.assert_called_with(query.query_text, query.data_source, query.user_id, scheduled=True, metadata=ANY)
+            self.assertEqual(add_job_mock.call_count, 2)
+            add_job_mock.assert_has_calls([
+                call(query1.query_text, query1.data_source, query1.user_id,
+                     scheduled=True, metadata=ANY),
+                call(query2.query_text, query2.data_source, query2.user_id,
+                     scheduled=True, metadata=ANY)], any_order=True)
 
     def test_doesnt_enqueue_outdated_queries_for_paused_data_source(self):
-        query = self.factory.create_query(schedule="60")
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                        query_hash=query.query_hash)
-        query.latest_query_data = query_result
-        db.session.add(query)
-        db.session.commit()
-
+        """
+        refresh_queries() does not launch execution tasks for queries whose
+        data source is paused.
+        """
+        query = self.factory.create_query()
+        oq = staticmethod(lambda: [query])
         query.data_source.pause()
+        with patch.object(Query, 'outdated_queries', oq):
+            with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
+                refresh_queries()
+                add_job_mock.assert_not_called()
 
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            add_job_mock.assert_not_called()
+            query.data_source.resume()
 
-        query.data_source.resume()
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            add_job_mock.assert_called_with(query.query_text, query.data_source, query.user_id, scheduled=True, metadata=ANY)
-
-    def test_skips_fresh_queries(self):
-        query = self.factory.create_query(schedule="1200")
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                        query_hash=query.query_hash)
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            self.assertFalse(add_job_mock.called)
-
-    def test_skips_queries_with_no_ttl(self):
-        query = self.factory.create_query(schedule=None)
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                        query_hash=query.query_hash)
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            self.assertFalse(add_job_mock.called)
-
-    def test_enqueues_query_only_once(self):
-        query = self.factory.create_query(schedule="60")
-        query2 = self.factory.create_query(schedule="60", query_text=query.query_text, query_hash=query.query_hash)
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                        query_hash=query.query_hash)
-        query.latest_query_data = query_result
-        query2.latest_query_data = query_result
-        db.session.add_all([query, query2])
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            add_job_mock.assert_called_once_with(query.query_text, query.data_source, query.user_id, scheduled=True, metadata=ANY)#{'Query ID': query.id, 'Username': 'Scheduled'})
-
-    def test_enqueues_query_with_correct_data_source(self):
-        query = self.factory.create_query(schedule="60", data_source=self.factory.create_data_source())
-        query2 = self.factory.create_query(schedule="60", query_text=query.query_text, query_hash=query.query_hash)
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                        query_hash=query.query_hash)
-        query.latest_query_data = query_result
-        query2.latest_query_data = query_result
-        db.session.add_all([query, query2])
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            add_job_mock.assert_has_calls([call(query2.query_text, query2.data_source, query2.user_id, scheduled=True, metadata=ANY),
-                                           call(query.query_text, query.data_source, query.user_id, scheduled=True, metadata=ANY)],
-                                          any_order=True)
-            self.assertEquals(2, add_job_mock.call_count)
-
-    def test_enqueues_only_for_relevant_data_source(self):
-        query = self.factory.create_query(schedule="60")
-        query2 = self.factory.create_query(schedule="3600", query_text=query.query_text, query_hash=query.query_hash)
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(retrieved_at=retrieved_at, query_text=query.query_text,
-                                                        query_hash=query.query_hash)
-        query.latest_query_data = query_result
-        query2.latest_query_data = query_result
-        db.session.add_all([query, query2])
-
-        with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
-            refresh_queries()
-            add_job_mock.assert_called_once_with(query.query_text, query.data_source, query.user_id, scheduled=True, metadata=ANY)
+            with patch('redash.tasks.queries.enqueue_query') as add_job_mock:
+                refresh_queries()
+                add_job_mock.assert_called_with(
+                    query.query_text, query.data_source, query.user_id,
+                    scheduled=True, metadata=ANY)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,6 +62,14 @@ class ShouldScheduleNextTest(TestCase):
         self.assertTrue(models.should_schedule_next(previous, now, schedule,
                                                     0))
 
+    def test_backoff(self):
+        now = utcnow()
+        two_hours_ago = now - datetime.timedelta(hours=2)
+        self.assertTrue(models.should_schedule_next(two_hours_ago, now, "3600",
+                                                    5))
+        self.assertFalse(models.should_schedule_next(two_hours_ago, now,
+                                                     "3600", 10))
+
 
 class QueryOutdatedQueriesTest(BaseTestCase):
     # TODO: this test can be refactored to use mock version of should_schedule_next to simplify it.
@@ -160,7 +168,7 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         for scheduling future execution.
         """
         query = self.factory.create_query(schedule="60", schedule_failures=4)
-        retrieved_at = utcnow() - datetime.timedelta(minutes=14)
+        retrieved_at = utcnow() - datetime.timedelta(minutes=16)
         query_result = self.factory.create_query_result(
             retrieved_at=retrieved_at, query_text=query.query_text,
             query_hash=query.query_hash)
@@ -168,7 +176,7 @@ class QueryOutdatedQueriesTest(BaseTestCase):
 
         self.assertEqual(list(models.Query.outdated_queries()), [])
 
-        query_result.retrieved_at = utcnow() - datetime.timedelta(minutes=15)
+        query_result.retrieved_at = utcnow() - datetime.timedelta(minutes=17)
         self.assertEqual(list(models.Query.outdated_queries()), [query])
 
 


### PR DESCRIPTION
This tracks scheduled query model objects all through the celery task for execution so that failure can be recorded. Number of failures are then used to decide how much longer to delay query execution.