### PR TITLE
[SQL Server] Fix: schema won't load if the server is case sensitive

### DIFF
--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -94,7 +94,7 @@ class SqlServer(BaseSQLQueryRunner):
     def _get_tables(self, schema):
         query = """
         SELECT table_schema, table_name, column_name
-        FROM information_schema.columns
+        FROM INFORMATION_SCHEMA.COLUMNS
         WHERE table_schema NOT IN ('guest','INFORMATION_SCHEMA','sys','db_owner','db_accessadmin'
                                   ,'db_securityadmin','db_ddladmin','db_backupoperator','db_datareader'
                                   ,'db_datawriter','db_denydatareader','db_denydatawriter'


### PR DESCRIPTION
Fixes _get_tables() for MSSQL with case sensitive object setup.

Changing the object name INFORMATION_SCHEMA.COLUMNS to uppercase makes the query compatible with both case insensitive and case sensitive setups.

Closes #1571.