### PR TITLE
Bring back IE11 support

### DIFF
--- a/client/app/pages/index.js
+++ b/client/app/pages/index.js
@@ -1,3 +1,7 @@
+import ObjectAssign from 'es6-object-assign';
+
+ObjectAssign.polyfill();
+
 export { default as home } from './home';
 export { default as queriesList } from './queries-list';
 export { default as alertsList } from './alerts-list';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -614,6 +614,11 @@
       "from": "es6-promise@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
     },
+    "es6-object-assign": {
+      "version": "1.0.3",
+      "from": "es6-object-assign@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.0.3.tgz"
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "d3": "^3.5.17",
     "d3-cloud": "^1.2.1",
     "debug": "^2.2.0",
+    "es6-object-assign": "^1.0.3",
     "font-awesome": "^4.7.0",
     "jquery": "^3.1.1",
     "jquery-ui": "^1.12.1",


### PR DESCRIPTION
This attempts to bring back IE11 support.

This PR adds polyfill es6-object-assign, which defines Mozilla foundation's polyfill definition of Object.assign() only if it is not defined.

Tested with IE11 and Chrome 56.0.2924.87 by pulling from my branch and then docker-compose.

I don't like the fact that I had to write polyfill() in pages/index.js, but this was the only place I could find. Please review.

[https://www.npmjs.com/package/es6-object-assign](https://www.npmjs.com/package/es6-object-assign)

