### PR TITLE
Add: use results row count as the value for the counter visualization.

### DIFF
--- a/client/app/visualizations/counter/counter-editor.html
+++ b/client/app/visualizations/counter/counter-editor.html
@@ -2,13 +2,13 @@
   <div class="form-group">
     <label class="col-lg-6">Counter Value Column Name</label>
     <div class="col-lg-6">
-      <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.counterColName" class="form-control"></select>
+      <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.counterColName" class="form-control" ng-disabled="visualization.options.countRow"></select>
     </div>
   </div>
   <div class="form-group">
     <label class="col-lg-6">Counter Value Row Number</label>
     <div class="col-lg-6">
-      <input type="number" ng-model="visualization.options.rowNumber" min="1" class="form-control">
+      <input type="number" ng-model="visualization.options.rowNumber" min="1" class="form-control" ng-disabled="visualization.options.countRow">
     </div>
   </div>
   <div class="form-group">
@@ -23,6 +23,12 @@
     <label class="col-lg-6">Target Value Row Number</label>
     <div class="col-lg-6">
       <input type="number" ng-model="visualization.options.targetRowNumber" min="1" class="form-control">
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-lg-6">
+      <input type="checkbox" ng-model="visualization.options.countRow">
+      <i class="input-helper"></i> Count Rows
     </div>
   </div>
 </div>

--- a/client/app/visualizations/counter/index.js
+++ b/client/app/visualizations/counter/index.js
@@ -14,10 +14,11 @@ function CounterRenderer() {
           const counterColName = $scope.visualization.options.counterColName;
           const targetColName = $scope.visualization.options.targetColName;
 
-          if (counterColName) {
+          if ($scope.visualization.options.countRow) {
+            $scope.counterValue = queryData.length;
+          } else if (counterColName) {
             $scope.counterValue = queryData[rowNumber][counterColName];
           }
-
           if (targetColName) {
             $scope.targetValue = queryData[targetRowNumber][targetColName];
 


### PR DESCRIPTION
This PR is a response to #889

Now Counter visualization can show the row count of resultset.

When one sees a counter value in a dashboard, he often wants to obtain detailed information through table data. With this PR, we can now provide table data and its row counter with one query.