### PR TITLE
[DynamoDB] Fix: handle count(*) queries

### DIFF
--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -2,7 +2,6 @@ import json
 import logging
 import sys
 
-
 from redash.query_runner import *
 from redash.utils import JSONEncoder
 
@@ -98,14 +97,17 @@ class DynamoDBSQL(BaseSQLQueryRunner):
         try:
             engine = self._connect()
 
-            res_dict = engine.execute(query if str(query).endswith(';') else str(query)+';')
+            result = engine.execute(query if str(query).endswith(';') else str(query)+';')
 
             columns = []
             rows = []
+
+            # When running a count query it returns the value as a string, in which case
+            # we transform it into a dictionary to be the same as regular queries.
             if isinstance(result, basestring):
                 result = [{"value": result}]
-            for item in res_dict:
 
+            for item in result:
                 if not columns:
                     for k, v in item.iteritems():
                         columns.append({

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -102,6 +102,8 @@ class DynamoDBSQL(BaseSQLQueryRunner):
 
             columns = []
             rows = []
+            if isinstance(result, basestring):
+                result = [{"value": result}]
             for item in res_dict:
 
                 if not columns:


### PR DESCRIPTION
This is pull request to fix below problem.

## Problem

- When I send a query as "SCAN Count(*) FROM Foobar;", an error message is shown (`Error running query: 'str' object has no attribute 'iteritems'`)

## Expected

- When I send above query, it returns counted result.
- Without "count" function ("SCAN * FROM Foobar;"), it works.
- According to Dynamo DB spec (DQL), count is defined.
https://dql.readthedocs.io/en/latest/topics/queries/select.html

## Route cause

- `count(*)` is not correctly handled in `dynamo_sql.py`

## Related issue

https://discuss.redash.io/t/dynamodb-count-query/385
This issue reports same issue, I guess.