### PR TITLE
Bugfix: race condition in query task status reporting

### DIFF
--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -155,23 +155,25 @@ class QueryTask(object):
         return self._async_result.id
 
     def to_dict(self):
-        if self._async_result.status == 'STARTED':
-            updated_at = self._async_result.result.get('start_time', 0)
+        task_info = self._async_result._get_task_meta()
+        result, task_status = task_info['result'], task_info['status']
+        if task_status == 'STARTED':
+            updated_at = result.get('start_time', 0)
         else:
             updated_at = 0
 
-        status = self.STATUSES[self._async_result.status]
+        status = self.STATUSES[task_status]
 
-        if isinstance(self._async_result.result, Exception):
-            error = self._async_result.result.message
+        if isinstance(result, Exception):
+            error = result.message
             status = 4
-        elif self._async_result.status == 'REVOKED':
+        elif task_status == 'REVOKED':
             error = 'Query execution cancelled.'
         else:
             error = ''
 
-        if self._async_result.successful() and not error:
-            query_result_id = self._async_result.result
+        if task_status == 'SUCCESS' and not error:
+            query_result_id = result
         else:
             query_result_id = None
 


### PR DESCRIPTION
We encountered this traceback recently:

    AttributeError: 'exceptions.TypeError' object has no attribute 'get'
     File "flask/app.py", line 1639, in full_dispatch_request
       rv = self.dispatch_request()
     File "flask/app.py", line 1625, in dispatch_request
       return self.view_functions[rule.endpoint](**req.view_args)
     File "flask_restful/__init__.py", line 477, in wrapper
       resp = resource(*args, **kwargs)
     File "flask_login/utils.py", line 228, in decorated_view
       return func(*args, **kwargs)
     File "flask/views.py", line 84, in view
       return self.dispatch_request(*args, **kwargs)
     File "redash/handlers/base.py", line 28, in dispatch_request
       return super(BaseResource, self).dispatch_request(*args, **kwargs)
     File "flask_restful/__init__.py", line 587, in dispatch_request
       resp = meth(*args, **kwargs)
     File "redash/handlers/query_results.py", line 233, in get
       return {'job': job.to_dict()}
     File "redash/tasks/queries.py", line 159, in to_dict
       updated_at = self._async_result.result.get('start_time', 0)

I believe this is a result of the task status changing from STARTED to FAILED after the initial status check. This patch changes it to fetch the status info only once.