### PR TITLE
Fix: make errors from Presto runner JSON-serializable

### DIFF
--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -121,6 +121,8 @@ class Presto(BaseQueryRunner):
         except Exception, ex:
             json_data = None
             error = ex.message
+            if not isinstance(error, basestring):
+                error = unicode(error)
 
         return json_data, error
 


### PR DESCRIPTION
Errors from Presto can be exceptions raised by `requests`, which can have exception objects as the `message` attribute of the exceptions they raise:

    TypeError: MaxRetryError("HTTPConnectionPool(host='ec2-45-224-206-100.us-west-2.compute.amazonaws.com', port=8889): Max retries exceeded with url: /v1/statement (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7fc4b3ed2c10>: Failed to establish a new connection: [Errno 111] Connection refused',))",) is not JSON serializable
      File "celery/app/trace.py", line 240, in trace_task
        R = retval = fun(*args, **kwargs)
      File "redash/tasks/base.py", line 18, in __call__
        return super(BaseTask, self).__call__(*args, **kwargs)
      File "celery/app/trace.py", line 438, in __protected_call__
        return self.run(*args, **kwargs)
      File "redash/tasks/queries.py", line 470, in execute_query
        return QueryExecutor(self, query, data_source_id, user_id, metadata).run()
      File "redash/tasks/queries.py", line 419, in run
        self.tracker.update(error=error, run_time=run_time, state='saving_results')
      File "redash/tasks/queries.py", line 69, in update
        self.save()
      File "redash/tasks/queries.py", line 59, in save
        connection.set(key_name, utils.json_dumps(self.data))
      File "redash/utils/__init__.py", line 77, in json_dumps
        return json.dumps(data, cls=JSONEncoder)
      File "json/__init__.py", line 251, in dumps
        sort_keys=sort_keys, **kw).encode(obj)
      File "json/encoder.py", line 207, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "json/encoder.py", line 270, in iterencode
        return _iterencode(o, 0)
      File "redash/utils/__init__.py", line 73, in default
        super(JSONEncoder, self).default(o)
      File "json/encoder.py", line 184, in default
        raise TypeError(repr(o) + " is not JSON serializable")

