### PR TITLE
Add babel-plugin-transform-object-assign for IE support

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-2"]
+  "presets": ["es2015", "stage-2"],
+  "plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "babel-core": "^6.18.0",
     "babel-loader": "^6.2.7",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "css-loader": "^0.25.0",


### PR DESCRIPTION
This PR adds Babel plugin transform-object-assign.

This is necessary for v1 to work with IE11 (and probably other versions of some older IEs).

This is alternate version of #1610.