### PR TITLE
Fix: query embed dialog close button wasn't working

### DIFF
--- a/client/app/pages/queries/embed-code-dialog.html
+++ b/client/app/pages/queries/embed-code-dialog.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <button type="button" class="close" aria-label="Close" ng-click="close()"><span aria-hidden="true">&times;</span></button>
+    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.close()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Embed Code</h4>
 </div>
 <div class="modal-body">


### PR DESCRIPTION
The `x` button on the query embed modal was not working. This fixes it.

![screen shot 2017-03-04 at 2 52 09 pm](https://cloud.githubusercontent.com/assets/1858004/23582897/3c2d636e-00ea-11e7-9056-df7473f29475.png)
