### PR TITLE
Added RPM specfiles for building Redash

### DIFF
--- a/setup/fedora/redash-runner.py
+++ b/setup/fedora/redash-runner.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+from ConfigParser import ConfigParser
+import os
+import argparse
+import sys
+
+LIST_OPTS = [
+    'enabled_query_runners',
+    'enabled_destinations'
+]
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c','--config', default='/etc/redash.cfg')
+    parser.add_argument('-p','--installpath', default='/opt/redash')
+    parser.add_argument('-v','--virtualenv', default='/opt/redash/venv')
+    parser.add_argument('command',
+                    choices=['manage','api','worker','scheduler'])
+    parser.add_argument('arguments', nargs='*')
+    args = parser.parse_args()
+    conf = ConfigParser()
+    conf.readfp(open(args.config))
+
+    paths = os.environ['PATH']
+    os.environ['PATH'] = '%s/bin/:%s/bin/:%s' % (args.installpath,
+            args.virtualenv, paths)
+
+    os.chdir(args.installpath)
+    for opt in conf.options('config'):
+        if opt not in LIST_OPTS:
+            val = conf.get('config', opt)
+            if val:
+                os.environ['REDASH_%s' % opt.upper()] = val
+
+    for opt in LIST_OPTS:
+        os.environ['REDASH_%s' % opt.upper()] = ','.join(
+            conf.get('config', opt).split()
+        )
+
+    for section in conf.sections():
+        if section in ['config', 'daemon']:
+            continue
+
+        for opt in conf.options(section):
+            val = conf.get(section, opt).strip()
+            if val:
+                os.environ['REDASH_%s' % opt.upper()] = val
+
+    command = args.command
+
+    listen_address = conf.get('daemon','http_address')
+    workers = conf.get('daemon', 'http_workers')
+    max_requests = conf.get('daemon', 'http_max_requests')
+    concurrency = conf.get('daemon','celery_concurrency')
+    tasks_per_child = conf.get('daemon','celery_tasks_per_child')
+
+    cmd = []
+    if command == 'manage':
+        cmd = ['./manage.py']
+    elif command == 'api':
+        cmd = ['gunicorn','-b',listen_address,
+                '--name','redash','-w', workers ,'--max-requests',
+                max_requests, 'redash.wsgi:app']
+    elif command == 'worker':
+        cmd = ['celery', 'worker', '--app=redash.worker', '--beat',
+                '-c%s' % concurrency, '-Qqueries,celery', 
+                '--maxtasksperchild=%s' % tasks_per_child, '-Ofair']
+    elif command == 'scheduler':
+        cmd = ['celery','worker','--app=redash.worker','-c%s' % concurrency,
+                '-Qscheduled_queries', 
+                '--maxtasksperchild=%s' % tasks_per_child, '-Ofair']
+    else:
+        raise ValueError(command)
+
+    if cmd:
+        os.system(' '.join(cmd + args.arguments))
+
+if __name__ == '__main__':
+    main()

--- a/setup/fedora/redash-supervisor.conf
+++ b/setup/fedora/redash-supervisor.conf
@@ -1,0 +1,36 @@
+[program:redash_server]
+command=/usr/bin/redash api
+process_name=redash_server
+user=redash
+numprocs=1
+priority=999
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/redash/redash.log
+stderr_logfile=/var/log/redash/redash_errors.log
+
+# There are two queue types here: one for ad-hoc queries, and one for the refresh of scheduled queries
+# (note that "scheduled_queries" appears only in the queue list of "redash_celery_scheduled").
+# The default concurrency level for each is 2 (-c2), you can increase based on your machine's resources.
+
+[program:redash_worker]
+command=/usr/bin/redash worker
+process_name=redash_worker
+user=redash
+numprocs=1
+priority=999
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/redash/worker.log
+stderr_logfile=/var/log/redash/worker_errors.log
+
+[program:redash_scheduler]
+command=/usr/bin/redash scheduler
+process_name=redash_scheduler
+user=redash
+numprocs=1
+priority=999
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/redash/scheduler.log
+stderr_logfile=/var/log/redash/scheduler_errors.log

--- a/setup/fedora/redash.cfg
+++ b/setup/fedora/redash.cfg
@@ -12,8 +12,6 @@ logo_url = /images/redash_icon_small.png
 redis_url = redis://localhost:6379/0
 proxies_count = 1
 
-listen_address = 127.0.0.1:5000
-
 database_url = postgresql://postgres@localhost:5432/redash
 celery_task_result_expires = 3600
 

--- a/setup/fedora/redash.cfg
+++ b/setup/fedora/redash.cfg
@@ -1,0 +1,129 @@
+[daemon]
+http_address = 127.0.0.1:5000
+http_workers = 4
+http_max_requests = 1000
+celery_concurrency = 2
+celery_tasks_per_child = 10
+
+
+[config]
+name = Redash
+logo_url = /images/redash_icon_small.png
+redis_url = redis://localhost:6379/0
+proxies_count = 1
+
+listen_address = 127.0.0.1:5000
+
+database_url = postgresql://postgres@localhost:5432/redash
+celery_task_result_expires = 3600
+
+schemas_refresh_schedule = 30
+schema_run_table_size_calculations = false
+
+auth_type = api_key
+password_login_enabled = true
+enforce_https = false
+
+multi_org = false
+
+job_expiry_time = 21600
+cookie_secret = cbee410b48db5078b1397cde0774fa22
+
+log_level = INFO
+
+alerts_default_mail_subject_template = {{state}} {alert_name}
+
+throttle_login_pattern = 50/hour
+
+enabled_query_runners = 
+    redash.query_runner.graphite
+    redash.query_runner.mongodb
+    redash.query_runner.mysql
+    redash.query_runner.pg
+    redash.query_runner.url
+    redash.query_runner.influx_db
+    redash.query_runner.elasticsearch
+    redash.query_runner.presto
+    redash.query_runner.hive_ds
+    redash.query_runner.impala_ds
+    redash.query_runner.vertica
+    redash.query_runner.clickhouse
+    redash.query_runner.treasuredata
+    redash.query_runner.sqlite
+    redash.query_runner.dynamodb_sql
+    redash.query_runner.mssql
+    redash.query_runner.jql
+    redash.query_runner.snowflake
+#    redash.query_runner.google_analytics
+#    redash.query_runner.big_query
+#    redash.query_runner.google_spreadsheets
+
+enabled_destinations = 
+    redash.destinations.email
+    redash.destinations.slack
+    redash.destinations.webhook
+    redash.destinations.hipchat
+
+event_reporting_webhooks = 
+
+sentry_dsn = 
+
+allow_scripts_in_user_input = false
+date_format = YY/MM/DD
+
+allow_all_to_edit = true
+version_check = true
+
+disable_refresh_queries = false
+show_query_results_count = true
+show_permissions_control = false
+allow_custom_js_visualizations = false
+
+allow_parameters_in_embeds = false
+
+[statsd]
+host = 127.0.0.1
+port = 8125
+prefix = redash
+use_tags = false
+
+[query_results]
+cleanup_enabled = true
+cleanup_count = 100
+cleanup_max_age = 7
+
+[google]
+client_id =
+client_secret =
+
+[bigquery]
+http_timeout = 600
+
+[saml]
+entity_id = 
+metadata_url =
+local_metadata_path =
+nameid_format = 
+
+callback_server_name = 
+
+[remote_user]
+login_enabled = false
+header = X-Forwarded-Remote-User
+
+[mail]
+server = localhost
+port = 25
+use_tls = false
+use_ssl = false
+username =
+password = 
+default_sender =
+max_emails =
+ascii_attachments = false
+
+[cors_access_control]
+allow_origin = 
+allow_credentials = false
+request_method = GET, POST, PUT
+allow_headers = Content-Type

--- a/setup/fedora/redash.spec
+++ b/setup/fedora/redash.spec
@@ -1,0 +1,80 @@
+%global _python_bytecompile_errors_terminate_build 0
+%global __python_requires %{nil}
+%global __python_requires %{nil}
+%define debug_package %{nil}
+%define redash_version 1.0.0-rc.1
+%define redash_installdir /opt/redash/
+
+Name:	    redash
+Version:	1.0.0rc1
+Release:	1%{?dist}
+Summary:	Web based dashboard builder
+
+Group:		Applications/Publishing
+License:	BSD
+URL:		http://redash.io
+Source0:	https://github.com/getredash/redash/archive/v%{redash_version}.tar.gz
+Source1:    %{name}-runner.py
+Source2:    %{name}.conf
+Source3:    %{name}-supervisor.conf
+BuildRequires: python-virtualenv cyrus-sasl-devel openssl-devel
+BuildRequires: postgresql-devel python-devel mariadb-devel freetds-devel
+BuildRequires: xmlsec1 xmlsec1-devel npm gcc gcc-c++
+Requires:	python-virtualenv redis supervisor xmlsec1
+Requires(pre): shadow-utils
+
+%description
+Redash provides a web based dashboarding platform for easily visualizing and
+sharing your data
+
+%prep
+%setup -q -n %{name}-%{redash_version}
+
+
+%build
+echo $PWD
+virtualenv venv/
+./venv/bin/pip install -r requirements.txt
+./venv/bin/pip install -r requirements_all_ds.txt
+npm install
+npm run build
+
+%install
+mkdir -p %{buildroot}/%{redash_installdir}
+cp -r * %{buildroot}/%{redash_installdir}
+virtualenv --relocatable %{buildroot}/opt/redash/venv
+grep -lrZF "#!%{buildroot}" %{buildroot} | xargs \
+  -r -0 perl -p -i -e "s|%{buildroot}|%{redash_installdir}|g"
+grep -lrZF "#!%{_builddir}/%{name}-%{redash_version}" %{buildroot} | xargs \
+  -r -0 perl -p -i -e "s|%{_builddir}/%{name}-%{redash_version}|%{redash_installdir}|g"
+
+perl -p -i -e "s|%{buildroot}|%{redash_installdir}|g" \
+     %{buildroot}/%{redash_installdir}/venv/bin/activate
+perl -p -i -e "s|%{_builddir}/%{name}-%{redash_version}|%{redash_installdir}|g" \
+     %{buildroot}/%{redash_installdir}/venv/bin/activate
+
+mkdir -p %{buildroot}/%{_bindir}
+cp %{SOURCE1} %{buildroot}/%{_bindir}/redash
+mkdir -p %{buildroot}/%{_sysconfdir}/
+cp %{SOURCE2} %{buildroot}/%{_sysconfdir}/%{name}.conf
+mkdir -p %{buildroot}/etc/supervisord.d/
+cp %{SOURCE3} %{buildroot}/etc/supervisord.d/%{name}.conf
+mkdir -p %{buildroot}/%{_var}/log/%{name}
+
+%pre
+getent group redash >/dev/null || groupadd -r redash
+getent passwd redash >/dev/null || \
+    useradd -r -g redash -d /opt/redash -s /sbin/nologin \
+    -c "Redash user" redash
+exit 0
+
+%files
+%defattr(-,redash,redash)
+%attr(755,redash,redash) %{_bindir}/%{name}
+%config %{_sysconfdir}/%{name}.conf
+/opt/redash
+%{_var}/log/redash/
+
+%changelog
+* 2017-03-03 Izhar Firdaus <kagesenshi.87@gmail.com> 1.0.0rc1-1
+- Initial package

--- a/setup/fedora/redash.spec
+++ b/setup/fedora/redash.spec
@@ -15,7 +15,7 @@ License:	BSD
 URL:		http://redash.io
 Source0:	https://github.com/getredash/redash/archive/v%{redash_version}.tar.gz
 Source1:    %{name}-runner.py
-Source2:    %{name}.conf
+Source2:    %{name}.cfg
 Source3:    %{name}-supervisor.conf
 BuildRequires: python-virtualenv cyrus-sasl-devel openssl-devel
 BuildRequires: postgresql-devel python-devel mariadb-devel freetds-devel
@@ -56,9 +56,9 @@ perl -p -i -e "s|%{_builddir}/%{name}-%{redash_version}|%{redash_installdir}|g" 
 mkdir -p %{buildroot}/%{_bindir}
 cp %{SOURCE1} %{buildroot}/%{_bindir}/redash
 mkdir -p %{buildroot}/%{_sysconfdir}/
-cp %{SOURCE2} %{buildroot}/%{_sysconfdir}/%{name}.conf
-mkdir -p %{buildroot}/etc/supervisord.d/
-cp %{SOURCE3} %{buildroot}/etc/supervisord.d/%{name}.conf
+cp %{SOURCE2} %{buildroot}/%{_sysconfdir}/%{name}.cfg
+mkdir -p %{buildroot}/%{_sysconfdir}/supervisord.d/
+cp %{SOURCE3} %{buildroot}/%{_sysconfdir}/supervisord.d/%{name}.ini
 mkdir -p %{buildroot}/%{_var}/log/%{name}
 
 %pre
@@ -71,10 +71,11 @@ exit 0
 %files
 %defattr(-,redash,redash)
 %attr(755,redash,redash) %{_bindir}/%{name}
-%config %{_sysconfdir}/%{name}.conf
+%config %{_sysconfdir}/%{name}.cfg
+%config %{_sysconfdir}/supervisord.d/%{name}.ini
 /opt/redash
 %{_var}/log/redash/
 
 %changelog
-* 2017-03-03 Izhar Firdaus <kagesenshi.87@gmail.com> 1.0.0rc1-1
+* Fri Mar 3 2017 Izhar Firdaus <kagesenshi.87@gmail.com> 1.0.0rc1-1
 - Initial package


### PR DESCRIPTION
Built and tested in Fedora25

installs redash in /opt/redash/
uses config file for configuring redash /etc/redash.cfg
includes a runner script for executing manage.py and daemons using the configured environment variables /usr/bin/redash 
installs supervisor config in /etc/supervisord.d/
logs in /var/log/redash/