### PR TITLE
Add: docker-entrypoint for manage.py's commands.

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -35,6 +35,7 @@ help() {
   echo "shell -- open shell"
   echo "dev_server -- start Flask development server with debugger and auto reload"
   echo "create_db -- create database tables"
+  echo "manage -- CLI to manage redash"
 }
 
 tests() {
@@ -63,6 +64,10 @@ case "$1" in
     ;;
   create_db)
     exec /app/manage.py database create_tables
+    ;;
+  manage)
+    shift
+    exec /app/manage.py $*
     ;;
   tests)
     tests


### PR DESCRIPTION
I want use `./bin/run manage.py users list` with docker.

```
$ docker-compose run --rm server manage
Usage: manage.py [OPTIONS] COMMAND [ARGS]...

  Management script for Redash

Options:
  --help  Show this message and exit.

Commands:
  check_settings  Show the settings as Redash sees them (useful...
  database        Manage the database (create/drop tables).
  db              Perform database migrations.
  ds              Data sources management commands.
  groups          Groups management commands.
  org             Organization management commands.
  run             Runs a development server.
  runserver       Runs a development server.
  send_test_mail  Send test message to EMAIL (default: the...
  shell           Runs a shell in the app context.
  status
  users           Users management commands.
  version         Displays Redash version.
```

```
$ docker-compose run --rm server manage users list
Id: 1
Name: Akira Yumiyama
Email: test@example.com
Organization: Test
```