### PR TITLE
Add: Trimmed ; from query as it causes trouble when using pyhive

### DIFF
--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -90,6 +90,11 @@ function QueryViewCtrl($scope, Events, $route, $routeParams, $location, $window,
       return;
     }
 
+    // Remove ';' from queries to avoid pyhive errors
+    if ($scope.query.query[$scope.query.query.length - 1] === ';') {
+      $scope.query.query = $scope.query.query.substring(0, $scope.query.query.length - 1);
+    }
+
     if (!$scope.query.query) {
       return;
     }


### PR DESCRIPTION
When using the pyhive connector, queries fail if they have a colon at the end. This can be pretty annoying.

Not sure if this is the best way to fix the problem. Happy to take feedback on the PR.

Thanks