### PR TITLE
Fix: Set query filter to match dashboard level filters

### DIFF
--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -84,8 +84,7 @@ function DashboardCtrl($rootScope, $routeParams, $location, $timeout, $q, $uibMo
             return;
           }
 
-          if ((hasQueryStringValue || dashboard.dashboard_filters_enabled)) {
-            // Sets query filters to match dashboard fiters when present
+          if (hasQueryStringValue) {
             queryFilter.current = $location.search()[queryFilter.name];
           }
 

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -84,13 +84,15 @@ function DashboardCtrl($rootScope, $routeParams, $location, $timeout, $q, $uibMo
             return;
           }
 
+          if ((hasQueryStringValue || dashboard.dashboard_filters_enabled)) {
+            // Sets query filters to match dashboard fiters when present
+            queryFilter.current = $location.search()[queryFilter.name];
+          }
+
           if (!_.has(filters, queryFilter.name)) {
             const filter = _.extend({}, queryFilter);
             filters[filter.name] = filter;
             filters[filter.name].originFilters = [];
-            if (hasQueryStringValue) {
-              filter.current = $location.search()[filter.name];
-            }
           }
 
           // TODO: merge values.


### PR DESCRIPTION
Added:
When dashboard level parameters are present, we should set to the filter strings to match.

Removed:
Existing code that doesn't seem to work.

Video:
![filter_params](https://cloud.githubusercontent.com/assets/6301118/23777585/e5c4c2de-0589-11e7-8563-fe7828faabc8.gif)
