### PR TITLE
Change: add support for filtered data in Pivot table visualization

### DIFF
--- a/client/app/visualizations/pivot/index.js
+++ b/client/app/visualizations/pivot/index.js
@@ -21,7 +21,7 @@ function pivotTableRenderer() {
         if ($scope.queryResult.getData() !== null) {
           // We need to give the pivot table its own copy of the data, because it changes
           // it which interferes with other visualizations.
-          data = angular.copy($scope.queryResult.getRawData());
+          data = angular.copy($scope.queryResult.getData());
           const options = {
             renderers: $.pivotUtilities.renderers,
             onRefresh(config) {

--- a/client/app/visualizations/pivot/index.js
+++ b/client/app/visualizations/pivot/index.js
@@ -1,10 +1,9 @@
+import angular from 'angular';
 import $ from 'jquery';
 import 'pivottable';
 import 'pivottable/dist/pivot.css';
-import { formatValue } from '../table';
-import { getColumnCleanName } from '../../services/query-result';
 
-function pivotTableRenderer(clientConfig, $filter) {
+function pivotTableRenderer() {
   return {
     restrict: 'E',
     scope: {
@@ -22,19 +21,7 @@ function pivotTableRenderer(clientConfig, $filter) {
         if ($scope.queryResult.getData() !== null) {
           // We need to give the pivot table its own copy of the data, because it changes
           // it which interferes with other visualizations.
-          data = [];
-          const columns = $scope.queryResult.getColumns();
-          const rows = $scope.queryResult.getData();
-          rows.forEach((row) => {
-            const rowObj = {};
-            columns.forEach((col) => {
-              const colName = getColumnCleanName(col.name);
-              const value = formatValue($filter, clientConfig, row[col.name], col.type);
-              rowObj[colName] = value;
-            });
-            data.push(rowObj);
-          });
-
+          data = angular.copy($scope.queryResult.getRawData());
           const options = {
             renderers: $.pivotUtilities.renderers,
             onRefresh(config) {

--- a/client/app/visualizations/pivot/index.js
+++ b/client/app/visualizations/pivot/index.js
@@ -1,9 +1,10 @@
-import angular from 'angular';
 import $ from 'jquery';
 import 'pivottable';
 import 'pivottable/dist/pivot.css';
+import { formatValue } from '../table';
+import { getColumnCleanName } from '../../services/query-result';
 
-function pivotTableRenderer() {
+function pivotTableRenderer(clientConfig, $filter) {
   return {
     restrict: 'E',
     scope: {
@@ -21,7 +22,19 @@ function pivotTableRenderer() {
         if ($scope.queryResult.getData() !== null) {
           // We need to give the pivot table its own copy of the data, because it changes
           // it which interferes with other visualizations.
-          data = angular.copy($scope.queryResult.getRawData());
+          data = [];
+          const columns = $scope.queryResult.getColumns();
+          const rows = $scope.queryResult.getData();
+          rows.forEach((row) => {
+            const rowObj = {};
+            columns.forEach((col) => {
+              const colName = getColumnCleanName(col.name);
+              const value = formatValue($filter, clientConfig, row[col.name], col.type);
+              rowObj[colName] = value;
+            });
+            data.push(rowObj);
+          });
+
           const options = {
             renderers: $.pivotUtilities.renderers,
             onRefresh(config) {

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -3,7 +3,7 @@ import { _, partial, isString } from 'underscore';
 import { getColumnCleanName } from '../../services/query-result';
 import template from './table.html';
 
-export function formatValue($filter, clientConfig, value, type) {
+function formatValue($filter, clientConfig, value, type) {
   let formattedValue = value;
   switch (type) {
     case 'integer':

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -3,7 +3,7 @@ import { _, partial, isString } from 'underscore';
 import { getColumnCleanName } from '../../services/query-result';
 import template from './table.html';
 
-function formatValue($filter, clientConfig, value, type) {
+export function formatValue($filter, clientConfig, value, type) {
   let formattedValue = value;
   switch (type) {
     case 'integer':


### PR DESCRIPTION
This PR changes how the `data` fed to pivottable visualization is prepared, and makes pivottable show filtered and formatted data just as you can see in Table visualization.

I have noticed that pivottable visualization:
* does not incorporate query/dashboard filter
* `::filter` annotation appears as part of pivottable attribute name and does not get removed
* date and datetime columns does not respect `REDASH_DATE_FORMAT`

This PR addresses all three points.