### PR TITLE
[Salesforce] Change: Sandbox cannot be required or it will force it to be True. 

### DIFF
--- a/redash/query_runner/salesforce.py
+++ b/redash/query_runner/salesforce.py
@@ -56,6 +56,10 @@ class Salesforce(BaseQueryRunner):
         return enabled
 
     @classmethod
+    def annotate_query(cls):
+        return False
+
+    @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
@@ -74,7 +78,7 @@ class Salesforce(BaseQueryRunner):
                     "type": "boolean"
                 }
             },
-            "required": ["username", "password", "token", "sandbox"],
+            "required": ["username", "password", "token"],
             "secret": ["password", "token"]
         }
 


### PR DESCRIPTION
Very minor fixes for the Salesforce query runner:

1) If Sandbox is a required parameter then Redash will require it be True

2) SOQL queries should not be annotated since SOQL does not allow comments