### PR TITLE
Fix: SQLite utf-8 error messages

### DIFF
--- a/redash/query_runner/sqlite.py
+++ b/redash/query_runner/sqlite.py
@@ -83,7 +83,11 @@ class Sqlite(BaseSQLQueryRunner):
             error = "Query cancelled by user."
             json_data = None
         except Exception as e:
-            raise sys.exc_info()[1], None, sys.exc_info()[2]
+            # handle unicode error message
+            err_class = sys.exc_info()[1].__class__
+            err_args = [arg.decode('utf-8') for arg in sys.exc_info()[1].args]
+            unicode_err = err_class(*err_args)
+            raise unicode_err, None, sys.exc_info()[2]
         finally:
             connection.close()
         return json_data, error


### PR DESCRIPTION
### Issue
SQLite does not show error message when error message contain unicode character.

With SQL like

`select 名称 from user`,

 we get

`raised unexpected: UnicodeDecodeError('ascii', 'no such column: \xe5\x90\x8d\xe7\xa7\xb0', 16, 17, 'ordinal not in range(128)')`

in log, and nothing on screen.

### Fix
Since the error instance is immutable, 

`sqlite3.OperationalError('no such column: \xe5\x90\x8d\xe7\xa7\xb0',)`

I had to create a new instance with utf-8 decoded arguments of the original error instance to get 

`sqlite3.OperationalError('no such column: \u540d\u79f0',)`.

Then we can see 'no such column: 名称' as on screen error.
