### PR TITLE
Fixed monitoring metrics for Redis

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -4,7 +4,8 @@ from redash import redis_connection, models, __version__, settings
 def get_status():
     status = {}
     info = redis_connection.info()
-    status['redis_used_memory'] = info['used_memory_human']
+    status['redis_used_memory'] = info['used_memory']
+    status['redis_used_memory_human'] = info['used_memory_human']
     status['version'] = __version__
     status['queries_count'] = models.db.session.query(models.Query).count()
     if settings.FEATURE_SHOW_QUERY_RESULTS_COUNT:


### PR DESCRIPTION
# What is this

In the monitoring endpoint `/status.json`, I think that `redis_used_memory` metric is little tricky.

Because `redis_used_memory` metric is set `used_memory_human` NOT `used_memory`, and it is unfriendly for monitoring service (like Zabbix, etc).

So, I fixed metrics like this.

- `redis_used_memory` = ~~`info['used_memory_human']`~~ `info['used_memory']`
- `redis_used_memory_human` = `info['used_memory_human']`
    - Added new metric 🆕 

# Here are sample metrics

```
$ /usr/local/bin/redis-cli info | grep 'memory'
used_memory:2041448
used_memory_human:1.95M
used_memory_rss:9203712
used_memory_peak:2388032
used_memory_peak_human:2.28M
used_memory_lua:33792
```

# Sample of my Zabbix

After that, I can visualize metrics using Zabbix.

![chart](https://cloud.githubusercontent.com/assets/1573290/24391687/7e4d4130-13cb-11e7-8a06-709af1d99539.png)

# Will fix documents

If this PR can be merged, I will fix documents soon.

- [Ongoing Maintenance and Basic Operations · Redash Help Center](https://redash.io/help-onpremise/maintenance/ongoing-maintenance-and-basic-operations.html)
	- `Monitoring` Section


Please review, thanks ! 👍 