### PR TITLE
Fixes Issue: multiple users with the same email

### DIFF
--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -27,7 +27,7 @@ class UserListResource(BaseResource):
     def post(self):
         req = request.get_json(force=True)
         require_fields(req, ('name', 'email'))
-
+        req['email'] = req['email'].lower()
         user = models.User(org=self.current_org,
                            name=req['name'],
                            email=req['email'],


### PR DESCRIPTION
With current code, It is possible for the Admin to create two redash users with the same email-id, for example two users can be, REDASH@REDASH.IO and reDash@redash.io. 
Fixes #1694