### PR TITLE
Make queries list page faster

### DIFF
--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -17,7 +17,7 @@
       <tbody>
       <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
         <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
-        <td>{{query.user.name}}</td>
+        <td>{{query.created_by}}</td>
         <td>{{query.created_at | dateTime}}</td>
         <td>{{query.runtime | durationHumanize}}</td>
         <td>{{query.retrieved_at | dateTime}}</td>

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -136,11 +136,11 @@ class QueryListResource(BaseResource):
 
         Responds with an array of :ref:`query <query-response-label>` objects.
         """
-        
+
         results = models.Query.all_queries(self.current_user.group_ids, self.current_user.id)
         page = request.args.get('page', 1, type=int)
         page_size = request.args.get('page_size', 25, type=int)
-        return paginate(results, page, page_size, lambda q: q.to_dict(with_stats=True, with_last_modified_by=False))
+        return paginate(results, page, page_size, lambda q: q._asdict())
 
 
 class MyQueriesResource(BaseResource):
@@ -158,7 +158,7 @@ class MyQueriesResource(BaseResource):
         results = models.Query.by_user(self.current_user)
         page = request.args.get('page', 1, type=int)
         page_size = request.args.get('page_size', 25, type=int)
-        return paginate(results, page, page_size, lambda q: q.to_dict(with_stats=True, with_last_modified_by=False))
+        return paginate(results, page, page_size, lambda q: q._asdict())
 
 
 class QueryResource(BaseResource):

--- a/redash/models.py
+++ b/redash/models.py
@@ -807,14 +807,14 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     @classmethod
     def all_queries(cls, group_ids, user_id=None, drafts=False):
         select_columns = [
-            Query.id
-            , Query.name
-            , Query.created_at
-            , Query.schedule
-            , Query.is_draft
-            , User.name.label("created_by")
-            , QueryResult.retrieved_at
-            , QueryResult.runtime
+            Query.id,
+            Query.name,
+            Query.created_at,
+            Query.schedule,
+            Query.is_draft,
+            User.name.label("created_by"),
+            QueryResult.retrieved_at,
+            QueryResult.runtime
             ]
         q = (db.Query(select_columns, session=SignallingSession(db))
             .join(User, Query.user_id == User.id)

--- a/redash/models.py
+++ b/redash/models.py
@@ -9,7 +9,7 @@ import csv
 import xlsxwriter
 
 from funcy import project
-from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy, SignallingSession
 from flask_login import UserMixin, AnonymousUserMixin
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.event import listens_for
@@ -806,7 +806,18 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def all_queries(cls, group_ids, user_id=None, drafts=False):
-        q = (cls.query.join(User, Query.user_id == User.id)
+        select_columns = [
+            Query.id
+            , Query.name
+            , Query.created_at
+            , Query.schedule
+            , Query.is_draft
+            , User.name.label("created_by")
+            , QueryResult.retrieved_at
+            , QueryResult.runtime
+            ]
+        q = (db.Query(select_columns, session=SignallingSession(db))
+            .join(User, Query.user_id == User.id)
             .outerjoin(QueryResult)
             .join(DataSourceGroup, Query.data_source_id == DataSourceGroup.data_source_id)
             .filter(Query.is_archived == False)


### PR DESCRIPTION
For https://github.com/getredash/redash/issues/1697

This PR is to reduce number of admin SQL and amount of data send from admin DB to App server when `/api/queries` or `/api/queries/my` is requested.

There are two reasons which make those two API slow.

- Executing extra admin SQL for each queries to be responded(listed) (N+1)
- Retrieving non-required data for query listing from DB to App server ( large query result data )

This PR solves both.

Changes on `Query#all_queries` is the main part. Before the change, it only retrieves columns of `queries` table. `query_results` and `users` are retrieved on succeeding process (N+1 part).
And also all columns are retrieved from admin DB to App server which will be slow with large query result data.

After the change, it retrieved minimal data for query listing with 1 SQL.