### PR TITLE
DB2 Support for Redash 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install && npm run build && rm -rf node_modules
 RUN chown -R redash /app
 USER redash
 
-ENTRYPOINT ["/app/bin/docker-entrypoint"]
+ENTRYPOINT ["bin/docker-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM redash/base:latest
 # change.
 COPY requirements.txt requirements_dev.txt requirements_all_ds.txt ./
 RUN pip install -r requirements.txt -r requirements_dev.txt -r requirements_all_ds.txt
+RUN apt-get update
+RUN apt-get install -y apt-transport-https
+RUN apt-get -y build-dep python-lxml
 
 COPY . ./
 RUN npm install && npm run build && rm -rf node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5000:5000"
     volumes:
-      - ".:/app"
+      - ".:/client/app"
     environment:
       PYTHONUNBUFFERED: 0
       REDASH_LOG_LEVEL: "INFO"

--- a/redash/query_runner/DB2.py
+++ b/redash/query_runner/DB2.py
@@ -11,11 +11,11 @@ try:
     import ibm_db
 
     types_map = {
-       ibm_db_dbi.FLOAT: TYPE_FLOAT,
-       ibm_db_dbi.NUMBER: TYPE_INTEGER,
-       ibm_db_dbi.STRING: TYPE_STRING,
-       ibm_db_dbi.DATE: TYPE_DATE,
-       ibm_db_dbi.DATETIME: TYPE_DATETIME,
+        ibm_db_dbi.FLOAT: TYPE_FLOAT,
+        ibm_db_dbi.NUMBER: TYPE_INTEGER,
+        ibm_db_dbi.STRING: TYPE_STRING,
+        ibm_db_dbi.DATE: TYPE_DATE,
+        ibm_db_dbi.DATETIME: TYPE_DATETIME,
     }
     ENABLED = True
 except ImportError:
@@ -33,7 +33,7 @@ class Db2(BaseSQLQueryRunner):
 
     @classmethod
     def name(cls):
-        return "IBM DB2"        
+        return "IBM DB2"
 
     @classmethod
     def configuration_schema(cls):
@@ -60,13 +60,11 @@ class Db2(BaseSQLQueryRunner):
                 "read_timeout": {
                     "type": "number",
                     "title": "Read Timeout"
-                },                                
+                },
             },
             'required': ['database'],
             'secret': ['password']
         }
-
-
 
     def __init__(self, configuration):
         super(Db2, self).__init__(configuration)
@@ -82,7 +80,8 @@ class Db2(BaseSQLQueryRunner):
         results = json.loads(results)
 
         for row in results['rows']:
-            table_name = '{}.{}'.format(row['TBCREATOR'].strip(), row['TBNAME'])
+            table_name = '{}.{}'.format(
+                row['TBCREATOR'].strip(), row['TBNAME'])
 
             if table_name not in schema:
                 schema[table_name] = {'name': table_name, 'columns': []}
@@ -108,7 +107,7 @@ class Db2(BaseSQLQueryRunner):
                 self.configuration.get('user', ''),
                 self.configuration.get('password', ''))
 
-            connection = ibm_db_dbi.connect(conn_info,"","")
+            connection = ibm_db_dbi.connect(conn_info, "", "")
 
             logger.debug("DB2 running query: %s", query)
             cursor = connection.cursor()
@@ -116,7 +115,8 @@ class Db2(BaseSQLQueryRunner):
             if cursor.description is not None:
                 columns_data = [(i[0], i[1]) for i in cursor.description]
 
-                rows = [dict(zip((c[0] for c in columns_data), row)) for row in cursor.fetchall()]
+                rows = [dict(zip((c[0] for c in columns_data), row))
+                        for row in cursor.fetchall()]
                 columns = [{'name': col[0],
                             'friendly_name': col[0],
                             'type': types_map.get(col[1], None)} for col in columns_data]
@@ -136,7 +136,6 @@ class Db2(BaseSQLQueryRunner):
         finally:
             if connection:
                 connection.close()
-
         return json_data, error
 
 register(Db2)

--- a/redash/query_runner/DB2.py
+++ b/redash/query_runner/DB2.py
@@ -1,0 +1,170 @@
+import sys
+import json
+import logging
+
+from redash.utils import JSONEncoder
+from redash.query_runner import *
+
+logger = logging.getLogger(__name__)
+
+"""
+ NAME                  	TYPEID	REDASH TYPE 
+ --------------------- 	------	 
+FLOAT - DECFLOAT             	4 : TYPE_FLOAT,
+FLOAT - DOUBLE               	8 :	TYPE_FLOAT,
+FLOAT - REAL                 	10 : TYPE_FLOAT,
+DECIMAL -  DECIMAL             	16 : TYPE_FLOAT,
+BIGINT - BIGINT               	20 : TYPE_INTEGER,
+NUMBER - INTEGER              	24 : TYPE_INTEGER,
+NUMBER - SMALLINT             	28 : TYPE_INTEGER,
+STRING - LONG VARCHAR         	52 : TYPE_STRING,
+STRING - VARCHAR              	56 : TYPE_STRING,
+STRING - CHARACTER            	60 : TYPE_STRING,
+DATE -  DATE                 	100 : TYPE_DATE,
+DATETIME - TIMESTAM            	108 : TYPE_DATETIME,
+			BOOLEAN            	112 : TYPE_BOOLEAN 
+"""
+types_map = {
+ 	ibm_db_dbi.FLOAT : TYPE_FLOAT,
+ 	ibm_db_dbi.NUMBER : TYPE_INTEGER,
+ 	ibm_db_dbi.STRING : TYPE_STRING,
+ 	ibm_db_dbi.DATE : TYPE_DATE,
+ 	ibm_db_dbi.DATETIME : TYPE_DATETIME
+	#ibm_db_dbi. : TYPE_BOOLEAN 
+}
+
+
+class DB2(BaseSQLQueryRunner):
+    noop_query = "SELECT 1 FROM sysibm.sysdummy1 "
+
+    @classmethod
+    def configuration_schema(cls):
+        return {
+            'type': 'object',
+            'properties': {
+                'host': {
+                    'type': 'string'
+                },
+                'user': {
+                    'type': 'string'
+                },
+                'password': {
+                    'type': 'string',
+                    'title': 'Password'
+                },
+                'database': {
+                    'type': 'string',
+                    'title': 'Database name'
+                },
+                "port": {
+                    "type": "number"
+                },
+                "read_timeout": {
+                    "type": "number",
+                    "title": "Read Timeout"
+                },                                
+            },
+            'required': ['database'],
+            'secret': ['password']
+        }
+
+    @classmethod
+    def enabled(cls):
+        try:
+            import ibm_db
+        except ImportError:
+            return False
+
+        return True
+
+    def __init__(self, configuration):
+        super(DB2, self).__init__(configuration)
+
+    def _get_tables(self, schema):
+        query = """
+        Select 
+			t.creator table_schema,
+			t.name table_name,
+			c.name column_name   
+		FROM 
+			sysibm.systables t
+		INNER JOIN sysibm.syscolumns  c 
+			on t.name=c.tbname 
+			and t.creator=c.tbcreator
+		WHERE 
+			t.creator NOT LIKE 'SYS%';
+        """
+
+        results, error = self.run_query(query, None)
+
+        if error is not None:
+            raise Exception("Failed getting schema.")
+
+        results = json.loads(results)
+
+        for row in results['rows']:
+            table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
+
+            if table_name not in schema:
+                schema[table_name] = {'name': table_name, 'columns': []}
+
+            schema[table_name]['columns'].append(row['column_name'])
+
+        return schema.values()
+
+    def run_query(self, query, user):
+        import ibm_db_dbi
+
+        if query == "":
+            json_data = None
+            error = "Query is empty"
+            return json_data, error
+
+        connection = None
+        try:
+            conn_info = 
+				"DATABASE={};HOSTNAME={};PORT={};PROTOCOL=TCPIP;UID={};PWD{}".format(
+					self.configuration.get('database', ''),
+					self.configuration.get('host', ''),
+					self.configuration.get('port', 60000),
+					self.configuration.get('user', ''),
+					self.configuration.get('password', ''))
+            connection = ibm_db_dbi.connect(conn_info,"","")
+			logger.debug("DB2 running query: %s", query)
+            cursor = connection.cursor()
+			cursor.execute(sql)
+            # Process results
+			result = ibm_db.fetch_both(statement)
+			
+			# Get Column Data
+			results.keys()
+			
+			# Loop over data
+            if cursor.description is not None:
+                columns_data = [(i[0], i[1]) for i in cursor.description]
+
+                rows = [dict(zip((c[0] for c in columns_data), row)) for row in cursor.fetchall()]
+                columns = [{'name': col[0],
+                            'friendly_name': col[0],
+                            'type': types_map.get(col[1], None)} for col in columns_data]
+
+                data = {'columns': columns, 'rows': rows}
+                json_data = json.dumps(data, cls=JSONEncoder)
+                error = None
+            else:
+                json_data = None
+                error = "No data was returned."
+
+            cursor.close()
+        except KeyboardInterrupt:
+            error = "Query cancelled by user."
+            json_data = None
+        except Exception as e:
+            raise sys.exc_info()[1], None, sys.exc_info()[2]
+        finally:
+            if connection:
+                connection.close()
+
+        return json_data, error
+
+register(DB2)

--- a/redash/query_runner/DB2.py
+++ b/redash/query_runner/DB2.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 import json
 import logging
@@ -5,37 +6,34 @@ import logging
 from redash.utils import JSONEncoder
 from redash.query_runner import *
 
+try:
+    import ibm_db_dbi
+    import ibm_db
+
+    types_map = {
+       ibm_db_dbi.FLOAT: TYPE_FLOAT,
+       ibm_db_dbi.NUMBER: TYPE_INTEGER,
+       ibm_db_dbi.STRING: TYPE_STRING,
+       ibm_db_dbi.DATE: TYPE_DATE,
+       ibm_db_dbi.DATETIME: TYPE_DATETIME,
+    }
+    ENABLED = True
+except ImportError:
+    ENABLED = False
+
 logger = logging.getLogger(__name__)
 
-"""
- NAME                  	TYPEID	REDASH TYPE 
- --------------------- 	------	 
-FLOAT - DECFLOAT             	4 : TYPE_FLOAT,
-FLOAT - DOUBLE               	8 :	TYPE_FLOAT,
-FLOAT - REAL                 	10 : TYPE_FLOAT,
-DECIMAL -  DECIMAL             	16 : TYPE_FLOAT,
-BIGINT - BIGINT               	20 : TYPE_INTEGER,
-NUMBER - INTEGER              	24 : TYPE_INTEGER,
-NUMBER - SMALLINT             	28 : TYPE_INTEGER,
-STRING - LONG VARCHAR         	52 : TYPE_STRING,
-STRING - VARCHAR              	56 : TYPE_STRING,
-STRING - CHARACTER            	60 : TYPE_STRING,
-DATE -  DATE                 	100 : TYPE_DATE,
-DATETIME - TIMESTAM            	108 : TYPE_DATETIME,
-			BOOLEAN            	112 : TYPE_BOOLEAN 
-"""
-types_map = {
- 	ibm_db_dbi.FLOAT : TYPE_FLOAT,
- 	ibm_db_dbi.NUMBER : TYPE_INTEGER,
- 	ibm_db_dbi.STRING : TYPE_STRING,
- 	ibm_db_dbi.DATE : TYPE_DATE,
- 	ibm_db_dbi.DATETIME : TYPE_DATETIME
-	#ibm_db_dbi. : TYPE_BOOLEAN 
-}
 
-
-class DB2(BaseSQLQueryRunner):
+class Db2(BaseSQLQueryRunner):
     noop_query = "SELECT 1 FROM sysibm.sysdummy1 "
+
+    @classmethod
+    def enabled(cls):
+        return True
+
+    @classmethod
+    def name(cls):
+        return "IBM DB2"        
 
     @classmethod
     def configuration_schema(cls):
@@ -68,32 +66,13 @@ class DB2(BaseSQLQueryRunner):
             'secret': ['password']
         }
 
-    @classmethod
-    def enabled(cls):
-        try:
-            import ibm_db
-        except ImportError:
-            return False
 
-        return True
 
     def __init__(self, configuration):
-        super(DB2, self).__init__(configuration)
+        super(Db2, self).__init__(configuration)
 
     def _get_tables(self, schema):
-        query = """
-        Select 
-			t.creator table_schema,
-			t.name table_name,
-			c.name column_name   
-		FROM 
-			sysibm.systables t
-		INNER JOIN sysibm.syscolumns  c 
-			on t.name=c.tbname 
-			and t.creator=c.tbcreator
-		WHERE 
-			t.creator NOT LIKE 'SYS%';
-        """
+        query = "select NAME,TBNAME,TBCREATOR from sysibm.syscolumns WHERE TBCREATOR NOT LIKE 'SYS%'"
 
         results, error = self.run_query(query, None)
 
@@ -103,12 +82,12 @@ class DB2(BaseSQLQueryRunner):
         results = json.loads(results)
 
         for row in results['rows']:
-            table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
+            table_name = '{}.{}'.format(row['TBCREATOR'].rstrip(), row['TBNAME'])
 
             if table_name not in schema:
                 schema[table_name] = {'name': table_name, 'columns': []}
 
-            schema[table_name]['columns'].append(row['column_name'])
+            schema[table_name]['columns'].append(row['NAME'])
 
         return schema.values()
 
@@ -122,24 +101,18 @@ class DB2(BaseSQLQueryRunner):
 
         connection = None
         try:
-            conn_info = 
-				"DATABASE={};HOSTNAME={};PORT={};PROTOCOL=TCPIP;UID={};PWD{}".format(
-					self.configuration.get('database', ''),
-					self.configuration.get('host', ''),
-					self.configuration.get('port', 60000),
-					self.configuration.get('user', ''),
-					self.configuration.get('password', ''))
+            conn_info = "DATABASE={};HOSTNAME={};PORT={};PROTOCOL=TCPIP;UID={};PWD={}".format(
+                self.configuration.get('database', ''),
+                self.configuration.get('host', ''),
+                self.configuration.get('port', 60000),
+                self.configuration.get('user', ''),
+                self.configuration.get('password', ''))
+
             connection = ibm_db_dbi.connect(conn_info,"","")
-			logger.debug("DB2 running query: %s", query)
+
+            logger.debug("DB2 running query: %s", query)
             cursor = connection.cursor()
-			cursor.execute(sql)
-            # Process results
-			result = ibm_db.fetch_both(statement)
-			
-			# Get Column Data
-			results.keys()
-			
-			# Loop over data
+            cursor.execute(query)
             if cursor.description is not None:
                 columns_data = [(i[0], i[1]) for i in cursor.description]
 
@@ -154,7 +127,6 @@ class DB2(BaseSQLQueryRunner):
             else:
                 json_data = None
                 error = "No data was returned."
-
             cursor.close()
         except KeyboardInterrupt:
             error = "Query cancelled by user."
@@ -167,4 +139,4 @@ class DB2(BaseSQLQueryRunner):
 
         return json_data, error
 
-register(DB2)
+register(Db2)

--- a/redash/query_runner/DB2.py
+++ b/redash/query_runner/DB2.py
@@ -82,7 +82,7 @@ class Db2(BaseSQLQueryRunner):
         results = json.loads(results)
 
         for row in results['rows']:
-            table_name = '{}.{}'.format(row['TBCREATOR'].rstrip(), row['TBNAME'])
+            table_name = '{}.{}'.format(row['TBCREATOR'].strip(), row['TBNAME'])
 
             if table_name not in schema:
                 schema[table_name] = {'name': table_name, 'columns': []}

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -187,7 +187,8 @@ default_query_runners = [
     'redash.query_runner.google_analytics',
     'redash.query_runner.snowflake',
     'redash.query_runner.axibase_tsd',
-    'redash.query_runner.salesforce'
+    'redash.query_runner.salesforce',
+    'redash.query_runner.DB2'
 ]
 
 enabled_query_runners = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS", ",".join(default_query_runners)))

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -20,5 +20,6 @@ cassandra-driver==3.1.1
 snowflake_connector_python==1.3.7
 atsd_client==2.0.11
 simple_salesforce==0.72.2
+ibm_db==2.0.7
 # certifi is needed to support MongoDB and SSL:
 certifi


### PR DESCRIPTION
Added DB2 Support for re-dash.  Implemented the DB2 Query runner . Tested this on DB2-LUW v 11 . 
Boolean  Types and other esoteric types (CLOB,BLOB) etc are not supported . Will implement them in future . Also plan to add DB2 for Mainframe (z/OS) soon . 

Note
This required additional libxml dependencies ( Will have to add RUN apt-get -y build-dep python-lxml ) to the DockerFile  . 

(Ignore the Docker Files Changes, I had  to do change it to this running on windows docker) . 