### PR TITLE
[BigQuery] Add: maximumBillingTier configuration

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -113,6 +113,10 @@ class BigQuery(BaseQueryRunner):
                 'loadSchema': {
                     "type": "boolean",
                     "title": "Load Schema"
+                },
+                'maximumBillingTier': {
+                    "type": "number",
+                    "title": "Maximum Billing Tier"
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
@@ -173,6 +177,9 @@ class BigQuery(BaseQueryRunner):
             resource_uris = self.configuration["userDefinedFunctionResourceUri"].split(',')
             job_data["configuration"]["query"]["userDefinedFunctionResources"] = map(
                 lambda resource_uri: {"resourceUri": resource_uri}, resource_uris)
+
+        if "maximumBillingTier" in self.configuration:
+            job_data["configuration"]["query"]["maximumBillingTier"] = self.configuration["maximumBillingTier"]
 
         insert_response = jobs.insert(projectId=project_id, body=job_data).execute()
         current_row = 0


### PR DESCRIPTION
Add maximumBillingTier option to BigQuery.
This PR enable Redash to execute a high compute query. 

Referrence:
 - https://cloud.google.com/bigquery/pricing#high-compute
 - https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.maximumBillingTier
