### PR TITLE
Fix: Non-ASCII dashboard tag

### DIFF
--- a/client/app/pages/dashboards/dashboard-list.js
+++ b/client/app/pages/dashboards/dashboard-list.js
@@ -6,7 +6,7 @@ import './dashboard-list.css';
 
 
 function DashboardListCtrl(Dashboard, $location, clientConfig) {
-  const TAGS_REGEX = /(^[\w\s]+):|(#[\w-]+)/ig;
+  const TAGS_REGEX = /(^([\w\s]|[^\u0000-\u007F])+):|(#([\w-]|[^\u0000-\u007F])+)/ig;
 
   this.logoUrl = clientConfig.logoUrl;
   const page = parseInt($location.search().page || 1, 10);


### PR DESCRIPTION
Currently dashboard tag can only be activated if the tag (the string before colon of the dashboard name) is all ASCII alphabets.

This PR tries to include characters with umlauts and multi-byte characters to become part of tags.

I know this regexp may not be perfect. Please let me know if you know a better solution.

![non-ascii-dashboard-tags](https://cloud.githubusercontent.com/assets/1698635/24891384/68f37c1a-1eb0-11e7-9085-2a80aef5f93d.png)