### PR TITLE
[JIRA JQL] Change: change default max results limit from 50 to 1000

### DIFF
--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -183,6 +183,8 @@ class JiraJQL(BaseQueryRunner):
             if query_type == 'count':
                 query['maxResults'] = 1
                 query['fields'] = ''
+            else:
+                query['maxResults'] = 1000
 
             response = requests.get(jql_url, params=query, auth=(self.configuration.get('username'), self.configuration.get('password')))
 


### PR DESCRIPTION
The current JQL implementation is limited to the default returned items by JIRA which is only 50 issues. This is unsuited for most purposes so this PR raises the limit to 1000 issues returned. The count query works correctly.

To fully solve the limit, multiple queries should be made to JIRA with different startAt parameter. This PR does not implement this, as I didn't have time for that. Therefore I have raised issue #1720.