### PR TITLE
[bugfix] Setup a new workers for beat to avoid unpredictable stuck of scheduled queries

### DIFF
--- a/setup/ubuntu/files/supervisord.conf
+++ b/setup/ubuntu/files/supervisord.conf
@@ -10,12 +10,21 @@ numprocs=1
 autostart=true
 autorestart=true
 
-# There are two queue types here: one for ad-hoc queries, and one for the refresh of scheduled queries
+# There are three queue types here: one for celery periodic tasks, one for ad-hoc queries, and one for the refresh of scheduled queries
 # (note that "scheduled_queries" appears only in the queue list of "redash_celery_scheduled").
 # The default concurrency level for each is 2 (-c2), you can increase based on your machine's resources.
 
+[program:redash_celery_beat]
+command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c2 -Qcelery --maxtasksperchild=10 -Ofair
+directory=/opt/redash/current
+process_name=redash_celery_beat
+user=redash
+numprocs=1
+autostart=true
+autorestart=true
+
 [program:redash_celery]
-command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c2 -Qqueries,celery --maxtasksperchild=10 -Ofair
+command=/opt/redash/current/bin/run celery worker --app=redash.worker -c2 -Qqueries --maxtasksperchild=10 -Ofair
 directory=/opt/redash/current
 process_name=redash_celery
 user=redash

--- a/setup/ubuntu/files/supervisord.conf
+++ b/setup/ubuntu/files/supervisord.conf
@@ -15,7 +15,7 @@ autorestart=true
 # The default concurrency level for each is 2 (-c2), you can increase based on your machine's resources.
 
 [program:redash_celery_beat]
-command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c2 -Qcelery --maxtasksperchild=10 -Ofair
+command=/opt/redash/current/bin/run celery worker --app=redash.worker --beat -c1 -Qcelery --maxtasksperchild=10 -Ofair
 directory=/opt/redash/current
 process_name=redash_celery_beat
 user=redash


### PR DESCRIPTION
I think that this PR is close to a bug fix. Because setting up based on https: //redash.io/help-onpremise/setup/setting-up-redash-instance.html causes the problem to be written below.

### Problem

Currently, if redash_celery workers gets stuck, scheduled queries will not be executed either. Even if no redash_celery_scheduled workers are processing the query. Because the redash_celery workers are also responsible for the periodic execution.

### Solution

By delegating periodic execution to the new redash_celery_beat workers, the execution status of the redash_celery workers will not affect the execution of the scheduled query.

I think that this is the behavior expected by the users.