### PR TITLE
Add: angular-ui-grid based visualization

### DIFF
--- a/client/app/index.js
+++ b/client/app/index.js
@@ -8,6 +8,7 @@ import 'angular-toastr/dist/angular-toastr.css';
 import 'angular-resizable/src/angular-resizable.css';
 import 'angular-gridster/dist/angular-gridster.css';
 import 'pace-progress/themes/blue/pace-theme-minimal.css';
+import 'angular-ui-grid/ui-grid.css';
 
 import 'pace-progress';
 import debug from 'debug';
@@ -27,6 +28,7 @@ import 'angular-ui-ace';
 import 'angular-resizable';
 import ngGridster from 'angular-gridster';
 import { each } from 'underscore';
+import 'angular-ui-grid';
 
 import './sortable';
 
@@ -47,7 +49,7 @@ const logger = debug('redash');
 
 const requirements = [
   ngRoute, ngResource, ngSanitize, uiBootstrap, ngMessages, uiSelect, 'angularMoment', toastr, 'ui.ace',
-  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name,
+  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name, 'ui.grid', 'ui.grid.pinning', 'ui.grid.resizeColumns',
 ];
 
 const ngModule = angular.module('app', requirements);

--- a/client/app/visualizations/index.js
+++ b/client/app/visualizations/index.js
@@ -4,6 +4,7 @@ import { isEmpty, isArray, reduce } from 'underscore';
 import registerEditVisualizationDialog from './edit-visualization-dialog';
 import counterVisualization from './counter';
 import tableVisualization from './table';
+import uiGridVisualization from './uigrid';
 import chartVisualization from './chart';
 import sunburstVisualization from './sunburst';
 import sankeyVisualization from './sankey';
@@ -161,4 +162,5 @@ export default function (ngModule) {
   mapVisualization(ngModule);
   pivotVisualization(ngModule);
   tableVisualization(ngModule);
+  uiGridVisualization(ngModule);
 }

--- a/client/app/visualizations/uigrid/index.js
+++ b/client/app/visualizations/uigrid/index.js
@@ -31,8 +31,8 @@ function UiGridRenderer() {
             pinRight = true;
           }
           let minw = 50;
-          if( $scope.visualization.options.uigridMinColWidths && $scope.visualization.options.uigridMinColWidths[col.name] > 0){
-            minw = $scope.visualization.options.uigridMinColWidths[col.name];
+          if( $scope.visualization.options.uiGridMinColWidths && $scope.visualization.options.uiGridMinColWidths[col.name] > 0){
+            minw = $scope.visualization.options.uiGridMinColWidths[col.name];
           }
         if(col.type == 'integer' || col.type == 'float'){
           columnDefs.push({field: getColumnCleanName(col.name), pinnedLeft: pinLeft, pinnedRight: pinRight, aggregationType: uiGridConstants.aggregationTypes.sum, minWidth: minw});
@@ -93,10 +93,10 @@ export default function (ngModule) {
         '</uigrid-renderer>';
     const editTemplate = '<uigrid-editor></uigrid-editor>';
     const defaultOptions = {
-      uigridShowColumnFooter: true,
-      uigridShowGridFooter: true,
-      uigridEnableFiltering: true,
-      uigridMinColWidths: {},
+      uiGridShowColumnFooter: true,
+      uiGridShowGridFooter: true,
+      uiGridEnableFiltering: true,
+      uiGridMinColWidths: {},
     };
 
     VisualizationProvider.registerVisualization({

--- a/client/app/visualizations/uigrid/index.js
+++ b/client/app/visualizations/uigrid/index.js
@@ -1,0 +1,110 @@
+/* eslint-disable */
+import uiGridTemplate from './uigrid.html';
+import uiGridEditorTemplate from './uigrid-editor.html';
+import { getColumnCleanName } from '../../services/query-result';
+
+function UiGridRenderer() {
+  return {
+    restrict: 'E',
+    template: uiGridTemplate,
+
+    controller($scope, $filter, uiGridConstants) {
+      if ($scope.queryResult.getData() != null) {
+        const showColumnFooter = $scope.visualization.options.uiGridShowColumnFooter;
+        const showGridFooter = $scope.visualization.options.uiGridShowGridFooter;
+        const enableFiltering = $scope.visualization.options.uiGridEnableFiltering;
+        const pinLeftColumn = $scope.visualization.options.uiGridPinLeftColumn;
+        const pinRightColumn = $scope.visualization.options.uiGridPinRightColumn;
+
+
+
+      const columns = $scope.queryResult.getColumns();
+      const columnDefs = [];
+      columns.forEach((col) => {
+        let pinLeft = false;
+          if(col.name == pinLeftColumn){
+            pinLeft = true;
+          }
+
+        let pinRight = false;
+          if(col.name == pinRightColumn){
+            pinRight = true;
+          }
+          let minw = 50;
+          if( $scope.visualization.options.uigridMinColWidths && $scope.visualization.options.uigridMinColWidths[col.name] > 0){
+            minw = $scope.visualization.options.uigridMinColWidths[col.name];
+          }
+        if(col.type == 'integer' || col.type == 'float'){
+          columnDefs.push({field: getColumnCleanName(col.name), pinnedLeft: pinLeft, pinnedRight: pinRight, aggregationType: uiGridConstants.aggregationTypes.sum, minWidth: minw});
+        } else {
+          columnDefs.push({field: getColumnCleanName(col.name), pinnedLeft: pinLeft, pinnedRight: pinRight, groupable: true, minWidth: minw});
+        }
+
+      });
+      $scope.gridOptions = {
+        enableFiltering: enableFiltering,
+        showGridFooter: showGridFooter,
+        showColumnFooter: showColumnFooter,
+        columnDefs: columnDefs,
+
+        enablePinning: true,
+        data: $scope.queryResult.getData(),
+        //pinning?
+      };
+    }
+    },
+
+  };
+}
+
+
+function UiGridEditor() {
+
+
+  return {
+    restrict: 'E',
+    template: uiGridEditorTemplate,
+
+      link(scope) {
+      scope.currentTab = 'general';
+
+      scope.stackingOptions = {
+        Disabled: null,
+        Enabled: 'normal',
+        Percent: 'percent',
+      };
+
+      scope.changeTab = (tab) => {
+        scope.currentTab = tab;
+      };
+}
+};
+}
+
+
+export default function (ngModule) {
+  ngModule.directive('uigridEditor', UiGridEditor);
+  ngModule.directive('uigridRenderer', UiGridRenderer);
+
+  ngModule.config((VisualizationProvider) => {
+    const renderTemplate =
+        '<uigrid-renderer ' +
+        'options="visualization.options" query-result="queryResult">' +
+        '</uigrid-renderer>';
+    const editTemplate = '<uigrid-editor></uigrid-editor>';
+    const defaultOptions = {
+      uigridShowColumnFooter: true,
+      uigridShowGridFooter: true,
+      uigridEnableFiltering: true,
+      uigridMinColWidths: {},
+    };
+
+    VisualizationProvider.registerVisualization({
+      type: 'UIGRID',
+      name: 'UiGrid',
+      renderTemplate,
+      editorTemplate: editTemplate,
+      defaultOptions,
+    });
+  });
+}

--- a/client/app/visualizations/uigrid/uigrid-editor.html
+++ b/client/app/visualizations/uigrid/uigrid-editor.html
@@ -1,0 +1,64 @@
+<div class="form-horizontal">
+
+
+  <ul class="tab-nav">
+    <li ng-class="{active: currentTab == 'general'}">
+      <a ng-click="changeTab('general')">General</a>
+    </li>
+    <li ng-class="{active: currentTab == 'colWidths'}" ng-if="options.globalSeriesType != 'custom'">
+      <a ng-click="changeTab('colWidths')">Column Widths</a>
+    </li>
+  </ul>
+
+<div ng-show="currentTab == 'general'">
+<br>
+  <div class="form-group">
+    <label class="col-lg-6">Pin Column Left</label>
+    <div class="col-lg-6">
+      <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.uiGridPinLeftColumn" class="form-control"></select>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="col-lg-6">Pin Column Right</label>
+    <div class="col-lg-6">
+      <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.uiGridPinRightColumn" class="form-control"></select>
+    </div>
+  </div>
+
+
+  <div class="form-group">
+    <div class="col-lg-6">
+      <input type="checkbox" ng-model="visualization.options.uiGridShowColumnFooter">
+      <i class="input-helper"></i>Show Column Footer
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-lg-6">
+      <input type="checkbox" ng-model="visualization.options.uiGridShowGridFooter">
+      <i class="input-helper"></i>Show Grid Footer
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-lg-6">
+      <input type="checkbox" ng-model="visualization.options.uiGridEnableFiltering">
+      <i class="input-helper"></i>Enable Filtering
+    </div>
+  </div>
+</div>
+
+<div ng-show="currentTab == 'colWidths'">
+  <h4>Minimum width per column </h4>
+  <div ng-repeat="name in queryResult.getColumnNames()" class="form-group">
+    <label class="col-lg-6">{{name}}</label>
+    <div class="col-lg-6">
+      <input type="number" ng-model="visualization.options.uiGridMinColWidths[name]" min="1" class="form-control">
+    </div>
+  </div>
+</div>
+
+
+  <div >
+  {{n}}
+</div>
+</div>

--- a/client/app/visualizations/uigrid/uigrid.html
+++ b/client/app/visualizations/uigrid/uigrid.html
@@ -1,0 +1,3 @@
+<div>
+  <div ui-grid="gridOptions" ui-grid-pinning ui-grid-resize-columns></div>
+</div>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -112,6 +112,11 @@
       "from": "angular-ui-bootstrap@latest",
       "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.2.0.tgz"
     },
+    "angular-ui-grid": {
+      "version": "4.0.4",
+      "from": "angular-ui-grid@>=4.0.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/angular-ui-grid/-/angular-ui-grid-4.0.4.tgz"
+    },
     "angular-vs-repeat": {
       "version": "1.1.7",
       "from": "angular-vs-repeat@latest",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "angular-toastr": "^2.1.1",
     "angular-ui-ace": "^0.2.3",
     "angular-ui-bootstrap": "^2.2.0",
+    "angular-ui-grid": "^4.0.4",
     "angular-vs-repeat": "^1.1.7",
     "brace": "^0.9.0",
     "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",


### PR DESCRIPTION
Adding a new visualization based on ui-grid (http://ui-grid.info). 
This visualization is an endless table with:
* pinning left/right (switch on/off via visualization editor)
* customizable column widths (via visualization editor)
* optional column sum (switch on/off via visualization editor)
* optional record count (switch on/off via visualization editor)
* filtering per column
* multi sorting per column
* vertical and horizontal scrolling (no pagination implemented for now)

<img width="1432" alt="screenshot" src="https://cloud.githubusercontent.com/assets/16962/25091685/b2fb27a2-238a-11e7-9f02-69fd35ba2146.png">
<img width="1426" alt="screenshot" src="https://cloud.githubusercontent.com/assets/16962/25091686/b8b66c38-238a-11e7-9290-d1eadb98fcf4.png">
<img width="1424" alt="screenshot" src="https://cloud.githubusercontent.com/assets/16962/25091689/bc8d70fe-238a-11e7-8b68-9d5cbb0a37f5.png">
<img width="358" alt="screenshot" src="https://cloud.githubusercontent.com/assets/16962/25091691/c12aee3e-238a-11e7-9778-2ea1d2ea4eb9.png">

![uigrid](https://cloud.githubusercontent.com/assets/16962/25091782/1de92460-238b-11e7-9123-f466d995d8a4.gif)

