### PR TITLE
improve Salesforce error message

### DIFF
--- a/redash/query_runner/salesforce.py
+++ b/redash/query_runner/salesforce.py
@@ -159,7 +159,7 @@ class Salesforce(BaseQueryRunner):
             data = {'columns': columns, 'rows': rows}
             json_data = json_dumps(data)
         except SalesforceError as err:
-            error = err.message
+            error = err.content
             json_data = None
         return json_data, error
 


### PR DESCRIPTION
In Salesforce datasource, the error message is:

> Error running query: Malformed request {url}. Response content: {content}

![image](https://cloud.githubusercontent.com/assets/807671/25136697/a61678aa-2490-11e7-957c-fa9f8951a7c2.png)

----

changes to:

> Error running query: [{"errorCode":"INVALID_FIELD","message":"\n CreatedDate >= '2017-01-01'\n ^\nERROR at Row:8:Column:5\nvalue of filter criterion for field 'CreatedDate' must be of type dateTime and should not be enclosed in quotes"}]

![image](https://cloud.githubusercontent.com/assets/807671/25136746/cab7281c-2490-11e7-83be-47ee5f9a8a5b.png)
