### PR TITLE
[Athena] Fix: queries throwing errors except for SELECT

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -40,6 +40,9 @@ class Athena(BaseQueryRunner):
             'secret': ['aws_secret_key']
         }
 
+    @classmethod
+    def annotate_query(cls):
+        return False
 
     def get_schema(self, get_stats=False):
         schema = {}

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -4,8 +4,10 @@ import os
 import requests
 
 from redash.query_runner import BaseQueryRunner, register
+from redash.settings import parse_boolean
 
 PROXY_URL = os.environ.get('ATHENA_PROXY_URL')
+ANNOTATE_QUERY = parse_boolean(os.environ.get('ATHENA_ANNOTATE_QUERY', 'true'))
 
 class Athena(BaseQueryRunner):
     noop_query = 'SELECT 1'
@@ -42,7 +44,7 @@ class Athena(BaseQueryRunner):
 
     @classmethod
     def annotate_query(cls):
-        return False
+        return ANNOTATE_QUERY
 
     def get_schema(self, get_stats=False):
         schema = {}


### PR DESCRIPTION
When post query to Athena via re:dash, like CREATE TABLE or DESCRIBE,
a following error occurs.

```
Error running query: FAILED: ParseException line 1:0 cannot recognize input near '/' '*' 'Username'
```
In Athena, re:dash annotation format (`/* ~ */`) fails with many Hive DDL except for SELECT.

In this PR, I disable annotations in Athena query runner to solve the problem.