### PR TITLE
Change: Sort dashboard-list in /dashboards

### DIFF
--- a/client/app/pages/dashboards/dashboard-list.js
+++ b/client/app/pages/dashboards/dashboard-list.js
@@ -46,6 +46,7 @@ function DashboardListCtrl(Dashboard, $location, clientConfig) {
 
   this.update = () => {
     this.dashboards.$promise.then((data) => {
+      data = _.sortBy(data, 'name');
       const filteredDashboards = data.map((dashboard) => {
         dashboard.tags = (dashboard.name.match(TAGS_REGEX) || []).map(tag => tag.replace(/:$/, ''));
         dashboard.untagged_name = dashboard.name.replace(TAGS_REGEX, '').trim();


### PR DESCRIPTION
This PR sorts the dashboards listed in /dashboards page by name.

Top page `'/'` has recent dashboards, so I thought `/dashboards` page can have different sort order and structure. Sorting dashboards by name, I can have dashboards structured like

- `Sales`  1. Daily
- `Sales`  2. Weekly
- `Revenue`  1. Daily
- `Revenue`  2. Weekly

And even if I edit something, such as the third dashboard, I can keep showing the same structure to the user so that they can easily navigate through the long list of dashboards. Now the third dashboard will be pushed to the top.

This also might be of some help to those who miss Tree-style Dashboard Menu.