### PR TITLE
Improvements to background jobs

### DIFF
--- a/redash/handlers/admin.py
+++ b/redash/handlers/admin.py
@@ -37,9 +37,9 @@ def queries_tasks():
     done = QueryTaskTracker.all(QueryTaskTracker.DONE_LIST, limit=50)
 
     response = {
-        'waiting': [t.data for t in waiting],
-        'in_progress': [t.data for t in in_progress],
-        'done': [t.data for t in done]
+        'waiting': [t.data for t in waiting if t is not None],
+        'in_progress': [t.data for t in in_progress if t is not Non],
+        'done': [t.data for t in done if t is not Non]
     }
 
     return json_response(response)

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -276,8 +276,8 @@ def refresh_queries():
                               scheduled_query=query,
                               metadata={'Query ID': query.id, 'Username': 'Scheduled'})
 
-            query_ids.append(query.id)
-            outdated_queries_count += 1
+                query_ids.append(query.id)
+                outdated_queries_count += 1
 
     statsd_client.gauge('manager.outdated_queries', outdated_queries_count)
 


### PR DESCRIPTION
* Fix: don't remove locks for queries with task status of PENDING. It's possible the Celery metadata object was expired, but the task is still running (which will result in PENDING status when querying the AsyncResult object).
* Put a limit on how many keys we remove at a time to make sure it can handle large lists.
* Include Celery task name in statsd metrics.
* Don't include paused datasource's queries in outdated queries count.
* Handle the case when the task object might not exist.