### PR TITLE
Fix multiple alert subscription detached

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -1104,18 +1104,20 @@ class Alert(TimestampMixin, db.Model):
 
     def evaluate(self):
         data = json.loads(self.query_rel.latest_query_data.data)
-        # todo: safe guard for empty
-        value = data['rows'][0][self.options['column']]
-        op = self.options['op']
+        if data['rows']:
+            value = data['rows'][0][self.options['column']]
+            op = self.options['op']
 
-        if op == 'greater than' and value > self.options['value']:
-            new_state = self.TRIGGERED_STATE
-        elif op == 'less than' and value < self.options['value']:
-            new_state = self.TRIGGERED_STATE
-        elif op == 'equals' and value == self.options['value']:
-            new_state = self.TRIGGERED_STATE
+            if op == 'greater than' and value > self.options['value']:
+                new_state = self.TRIGGERED_STATE
+            elif op == 'less than' and value < self.options['value']:
+                new_state = self.TRIGGERED_STATE
+            elif op == 'equals' and value == self.options['value']:
+                new_state = self.TRIGGERED_STATE
+            else:
+                new_state = self.OK_STATE
         else:
-            new_state = self.OK_STATE
+            new_state = self.state
 
         return new_state
 

--- a/redash/tasks/alerts.py
+++ b/redash/tasks/alerts.py
@@ -18,7 +18,7 @@ def base_url(org):
 
 def notify_subscriptions(alert, new_state):
     host = base_url(alert.query_rel.org)
-    for subscription in alert.subscriptions:
+    for subscription in models.AlertSubscription.all(alert.id):
         try:
             subscription.notify(alert, alert.query_rel, subscription.user, new_state, current_app, host)
         except Exception as e:


### PR DESCRIPTION
references #1725 

When a triggered Alert had more than 1 AlertSubscription it could fail
firing the second subscription (and subsequent) due to the
`alert.subscriptions` being detached from the `models.db.session`.

We avoid the problem by explicitely loading the subscriptions by id.

Also implemented a safeguard for alerts when the query result is empty (it assumes alert state is unchanged).