### PR TITLE
Add setting for celery prefetch

### DIFF
--- a/redash/settings.py
+++ b/redash/settings.py
@@ -73,6 +73,8 @@ SQLALCHEMY_ECHO = False
 CELERY_BROKER = os.environ.get("REDASH_CELERY_BROKER", REDIS_URL)
 CELERY_BACKEND = os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER)
 CELERY_TASK_RESULT_EXPIRES = int(os.environ.get('REDASH_CELERY_TASK_RESULT_EXPIRES', 3600))
+CELERYD_PREFETCH_MULTIPLIER = int(os.environ.get('REDASH_CELERYD_PREFETCH_MULTIPLIER', 4))
+CELERY_ACKS_LATE = parse_boolean(os.environ.get('REDASH_CELERY_ACKS_LATE', "false"))
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -47,7 +47,9 @@ if settings.QUERY_RESULTS_CLEANUP_ENABLED:
 celery.conf.update(CELERY_RESULT_BACKEND=settings.CELERY_BACKEND,
                    CELERYBEAT_SCHEDULE=celery_schedule,
                    CELERY_TIMEZONE='UTC',
-                   CELERY_TASK_RESULT_EXPIRES=settings.CELERY_TASK_RESULT_EXPIRES)
+                   CELERY_TASK_RESULT_EXPIRES=settings.CELERY_TASK_RESULT_EXPIRES,
+                   CELERYD_PREFETCH_MULTIPLIER=settings.CELERYD_PREFETCH_MULTIPLIER,
+                   CELERY_ACKS_LATE=settings.CELERY_ACKS_LATE)
 
 if settings.SENTRY_DSN:
     from raven import Client


### PR DESCRIPTION
This PR is for https://github.com/getredash/redash/issues/1782 .

Celery worker fetches four tasks at a time. With long running queries, this cause tasks kept waiting even when there are available workers. I think Number of prefetch should be configurable though setting.

ref. http://docs.celeryproject.org/en/latest/userguide/optimizing.html#reserve-one-task-at-a-time