### PR TITLE
Fix: remove unneeded calls to app_context()

### DIFF
--- a/redash/destinations/email.py
+++ b/redash/destinations/email.py
@@ -40,16 +40,15 @@ class Email(BaseDestination):
         logging.debug("Notifying: %s", recipients)
 
         try:
-            with app.app_context():
-                alert_name = alert.name.encode('utf-8', 'ignore')
-                state = new_state.upper()
-                subject_template = options.get('subject_template', settings.ALERTS_DEFAULT_MAIL_SUBJECT_TEMPLATE)
-                message = Message(
-                    recipients=recipients,
-                    subject=subject_template.format(alert_name=alert_name, state=state),
-                    html=html
-                )
-                mail.send(message)
+            alert_name = alert.name.encode('utf-8', 'ignore')
+            state = new_state.upper()
+            subject_template = options.get('subject_template', settings.ALERTS_DEFAULT_MAIL_SUBJECT_TEMPLATE)
+            message = Message(
+                recipients=recipients,
+                subject=subject_template.format(alert_name=alert_name, state=state),
+                html=html
+            )
+            mail.send(message)
         except Exception:
             logging.exception("Mail send error.")
 

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -1,9 +1,10 @@
 import requests
+
 from celery.utils.log import get_task_logger
 from flask_mail import Message
-from redash.worker import celery
+from redash import mail, models, settings
 from redash.version_check import run_version_check
-from redash import models, mail, settings
+from redash.worker import celery
 
 logger = get_task_logger(__name__)
 
@@ -50,12 +51,11 @@ def send_mail(to, subject, html, text):
     from redash.wsgi import app
 
     try:
-        with app.app_context():
-            message = Message(recipients=to,
-                              subject=subject,
-                              html=html,
-                              body=text)
+        message = Message(recipients=to,
+                          subject=subject,
+                          html=html,
+                          body=text)
 
-            mail.send(message)
+        mail.send(message)
     except Exception:
         logger.exception('Failed sending message: %s', message.subject)


### PR DESCRIPTION
When the extra app_context was popped from the stack, it was triggering flask-sqlalchemy's teardown handler, which was removing the session causing objects to become detached before they should be.

Closes #1725.