### PR TITLE
Fix redirect to /setup on the last setup step

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -93,9 +93,9 @@ def forgot_password(org_slug=None):
 def login(org_slug=None):
     # We intentionally use == as otherwise it won't actually use the proxy. So weird :O
     # noinspection PyComparisonWithNone
-    if current_org is None and not settings.MULTI_ORG:
+    if current_org == None and not settings.MULTI_ORG:
         return redirect('/setup')
-    elif current_org is None:
+    elif current_org == None:
         return redirect('/')
 
     index_url = url_for("redash.index", org_slug=org_slug)

--- a/redash/handlers/setup.py
+++ b/redash/handlers/setup.py
@@ -38,7 +38,7 @@ def create_org(org_name, user_name, email, password):
 
 @routes.route('/setup', methods=['GET', 'POST'])
 def setup():
-    if current_org is not None or settings.MULTI_ORG:
+    if current_org != None or settings.MULTI_ORG:
         return redirect('/')
 
     form = SetupForm(request.form)


### PR DESCRIPTION
If you try to set up developer environment from master branch, you'll get redirect to `http://localhost:8080/login?next=/` instead of `http://localhost:8080/setup` on the last step.

Seems like it caused by `current_org is not None` check.

PS: I'm not sure these changes are 100% correct (I'm not a python developer). Maybe there is a better way to fix problem.