### PR TITLE
update if test for string instead of expecting boolean

### DIFF
--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -27,7 +27,7 @@ def send_static(filename):
 
 
 def render_index():
-    if settings.MULTI_ORG:
+    if settings.MULTI_ORG == "true":
         response = render_template("multi_org.html", base_href=base_href())
     else:
         full_path = safe_join(settings.STATIC_ASSETS_PATHS[-2], 'index.html')


### PR DESCRIPTION
Hi. Right now if the environment variable REDASH_MULTI_ORG is unset the `if settings.MULTI_ORG` statement returns true and can't find the multi_org.html template, generating 5 test suite errors. 

By changing the if statement to look for the string "true" all tests pass regardless of whether REDASH_MULTI_ORG is set to "true", "false", or unset.