### PR TITLE
Change: auto publish named queries

### DIFF
--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -211,7 +211,12 @@ function QueryViewCtrl($scope, Events, $route, $routeParams, $location, $window,
 
   $scope.saveName = () => {
     Events.record('edit_name', 'query', $scope.query.id);
-    $scope.saveQuery(undefined, { name: $scope.query.name });
+
+    if ($scope.query.is_draft && clientConfig.autoPublishNamedQueries && $scope.query.name !== 'New Query') {
+      $scope.query.is_draft = false;
+    }
+
+    $scope.saveQuery(undefined, { name: $scope.query.name, is_draft: $scope.query.is_draft });
   };
 
   $scope.cancelExecution = () => {

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -228,6 +228,7 @@ FEATURE_SHOW_QUERY_RESULTS_COUNT = parse_boolean(os.environ.get("REDASH_FEATURE_
 FEATURE_SHOW_PERMISSIONS_CONTROL = parse_boolean(os.environ.get("REDASH_FEATURE_SHOW_PERMISSIONS_CONTROL", "false"))
 FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS = parse_boolean(os.environ.get("REDASH_FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS", "false"))
 FEATURE_DUMB_RECENTS = parse_boolean(os.environ.get("REDASH_FEATURE_DUMB_RECENTS", "false"))
+FEATURE_AUTO_PUBLISH_NAMED_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_AUTO_PUBLISH_NAMED_QUERIES", "true"))
 
 # BigQuery
 BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"))
@@ -244,6 +245,7 @@ COMMON_CLIENT_CONFIG = {
     'allowScriptsInUserInput': ALLOW_SCRIPTS_IN_USER_INPUT,
     'showPermissionsControl': FEATURE_SHOW_PERMISSIONS_CONTROL,
     'allowCustomJSVisualizations': FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS,
+    'autoPublishNamedQueries': FEATURE_AUTO_PUBLISH_NAMED_QUERIES,
     'dateFormat': DATE_FORMAT,
     'dateTimeFormat': "{0} HH:mm".format(DATE_FORMAT),
     'allowAllToEditQueries': FEATURE_ALLOW_ALL_TO_EDIT_QUERIES,


### PR DESCRIPTION
This is a feature flag, so if you prefer the explicit publish workflow you can preserve it by setting `REDASH_FEATURE_AUTO_PUBLISH_NAMED_QUERIES` to `false`.