### PR TITLE
Fix template variable typo

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -129,7 +129,7 @@ def login(org_slug=None):
     return render_template("login.html",
                            org_slug=org_slug,
                            next=next_path,
-                           username=request.form.get('username', ''),
+                           email=request.form.get('email', ''),
                            show_google_openid=settings.GOOGLE_OAUTH_ENABLED,
                            google_auth_url=google_auth_url,
                            show_saml_login=settings.SAML_LOGIN_ENABLED,


### PR DESCRIPTION
Should be email instead of username (see redash/templates/login.html:47)