### PR TITLE
Fix query cancellation condition for Athena query runner

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -130,11 +130,13 @@ class Athena(BaseQueryRunner):
             json_data = json.dumps(data, cls=JSONEncoder)
             error = None
         except KeyboardInterrupt:
-            cursor.cancel()
+            if cursor.query_id:
+                cursor.cancel()
             error = "Query cancelled by user."
             json_data = None
         except Exception, ex:
-            cursor.cancel()
+            if cursor.query_id:
+                cursor.cancel()
             error = ex.message
             json_data = None
 


### PR DESCRIPTION
Even if there is a syntax error or typo in the query, the following error occurs and I do not know the details of the error.
```
Unexpected error while running query:
Traceback (most recent call last):
File "/app/redash/tasks/queries.py", line 421, in run
data, error = query_runner.run_query(annotated_query, self.user)
File "/app/redash/query_runner/athena.py", line 137, in run_query
cursor.cancel()
File "/usr/local/lib/python2.7/dist-packages/pyathena/util.py", line 29, in _wrapper
return wrapped(*args, **kwargs)
File "/usr/local/lib/python2.7/dist-packages/pyathena/cursor.py", line 241, in cancel
raise ProgrammingError('QueryExecutionId is none or empty.')
ProgrammingError: QueryExecutionId is none or empty.
```
So I fixed it to cancel the query only if the query ID is not None.