### PR TITLE
Athena updates: bring back ability to disable annotations and disable formatter

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 from redash.query_runner import *
 from redash.settings import parse_boolean

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -1,9 +1,8 @@
-import logging
 import json
+import logging
 
-from redash.utils import JSONEncoder
 from redash.query_runner import *
-
+from redash.utils import JSONEncoder
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +30,11 @@ _TYPE_MAPPINGS = {
     'row': TYPE_STRING,
     'decimal': TYPE_FLOAT,
 }
+
+
+class SimpleFormatter(object):
+    def format(self, operation, parameters=None):
+        return operation
 
 
 class Athena(BaseQueryRunner):
@@ -119,7 +123,8 @@ class Athena(BaseQueryRunner):
             aws_secret_access_key=self.configuration.get('aws_secret_key', None),
             schema_name=self.configuration.get('schema', 'default'),
             encryption_option=self.configuration.get('encryption_option', None),
-            kms_key=self.configuration.get('kms_key', None)).cursor()
+            kms_key=self.configuration.get('kms_key', None),
+            formatter=SimpleFormatter()).cursor()
 
         try:
             cursor.execute(query)

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -2,10 +2,11 @@ import json
 import logging
 
 from redash.query_runner import *
+from redash.settings import parse_boolean
 from redash.utils import JSONEncoder
 
 logger = logging.getLogger(__name__)
-
+ANNOTATE_QUERY = parse_boolean(os.environ.get('ATHENA_ANNOTATE_QUERY', 'true'))
 
 try:
     import pyathena
@@ -86,6 +87,10 @@ class Athena(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return enabled
+
+    @classmethod
+    def annotate_query(cls):
+        return ANNOTATE_QUERY
 
     @classmethod
     def type(cls):


### PR DESCRIPTION
* use simple formatter to avoid the need to escape "%" character.
* bring back the option to disable query annotations.