### PR TITLE
Remove /forgot endpoint if REDASH_PASSWORD_LOGIN_ENABLED is false

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 
-from flask import flash, redirect, render_template, request, url_for
+from flask import abort, flash, redirect, render_template, request, url_for
 
 from flask_login import current_user, login_required, login_user, logout_user
 from redash import __version__, limiter, models, settings
@@ -74,6 +74,9 @@ def reset(token, org_slug=None):
 
 @routes.route(org_scoped_rule('/forgot'), methods=['GET', 'POST'])
 def forgot_password(org_slug=None):
+    if not settings.PASSWORD_LOGIN_ENABLED:
+        abort(404)
+
     submitted = False
     if request.method == 'POST' and request.form['email']:
         submitted = True


### PR DESCRIPTION
Users should not be able to reset their password if `REDASH_PASSWORD_LOGIN_ENABLED` is false. Instead, the `/forgot` endpoint should return a `404`.