### PR TITLE
Add the option to configure log stream

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 import urlparse
 import redis
@@ -21,7 +22,7 @@ __version__ = '2.0.0'
 
 
 def setup_logging():
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout if settings.LOG_STDOUT else sys.stderr)
     formatter = logging.Formatter('[%(asctime)s][PID:%(process)d][%(levelname)s][%(name)s] %(message)s')
     handler.setFormatter(formatter)
     logging.getLogger().addHandler(handler)

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -134,6 +134,7 @@ COOKIE_SECRET = os.environ.get("REDASH_COOKIE_SECRET", "c292a0a3aa32397cdb050e23
 SESSION_COOKIE_SECURE = parse_boolean(os.environ.get("REDASH_SESSION_COOKIE_SECURE") or str(ENFORCE_HTTPS))
 
 LOG_LEVEL = os.environ.get("REDASH_LOG_LEVEL", "INFO")
+LOG_STDOUT = parse_boolean(os.environ.get('REDASH_LOG_STDOUT', 'false'))
 
 # Mail settings:
 MAIL_SERVER = os.environ.get('REDASH_MAIL_SERVER', 'localhost')


### PR DESCRIPTION
by default when using python's `logging` module and a `StreamHandler`,
the stream is directed to `sys.stderr`
(https://docs.python.org/2/library/logging.handlers.html)

By setting the `REDASH_LOG_STREAM` environment variable to `"STDOUT"` we
enable the option to stream the logs to `sys.stdout`. Setting this
configuration option to anything else (or leaving it as default) will
initialize the `StreamHandler` to `sys.stderr` - meaning the original
behavior remains unchanged.

fixes #1869 