### PR TITLE
docker: make gunicorn worker count configurable

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -19,7 +19,7 @@ scheduler() {
 }
 
 server() {
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w4 redash.wsgi:app
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app
 }
 
 help() {

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -20,6 +20,7 @@ services:
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
       REDASH_COOKIE_SECRET: veryverysecret
+      REDASH_WEB_WORKERS: 4
   worker:
     image: redash/redash:latest
     command: scheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
+      REDASH_WEB_WORKERS: 4
   worker:
     build: .
     command: scheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      REDASH_WEB_WORKERS: 4
   worker:
     build: .
     command: scheduler


### PR DESCRIPTION
```
Allow $REDASH_WEB_WORKERS to be set in the environment to change the
number of Gunicorn workers that are started (currently hardcoded to
four).  If not set, the default is four, so this will not affect
existing users at all.

Documentated by example in docker-compose example manifests.
```

Use case: we want to run two copies of the web container for redundancy, but we don't want it to use twice as many resources.  Now we can run two workers per container, giving four in total.