### PR TITLE
Add link to query page from admin view

### DIFF
--- a/client/app/pages/admin/tasks/tasks.html
+++ b/client/app/pages/admin/tasks/tasks.html
@@ -35,7 +35,7 @@
         <td>{{row.data_source_id}}</td>
         <td>{{row.username}}</td>
         <td>{{row.state}} <span ng-if="row.state === 'failed'" uib-popover="{{row.error}}" popover-trigger="mouseenter" class="zmdi zmdi-help"></span></td>
-        <td>{{row.query_id}}</td>
+        <td><a href="queries/{{row.query_id}}">{{row.query_id}}</a></td>
         <td>{{row.query_hash}}</td>
         <td>{{row.run_time | durationHumanize}}</td>
         <td>{{row.created_at | toMilliseconds | dateTime }}</td>


### PR DESCRIPTION
When we have a long0running query, it is useful to look up what that
query definition is. Having a link directly from the admin page cuts
down on the manual step of opying the query id and pasting that into the
address bar.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>