### PR TITLE
WIP: Counter value formatting

### DIFF
--- a/client/app/index.js
+++ b/client/app/index.js
@@ -26,6 +26,7 @@ import 'brace';
 import 'angular-ui-ace';
 import 'angular-resizable';
 import ngGridster from 'angular-gridster';
+import 'angular-dynamic-locale/dist/tmhDynamicLocale';
 import { each } from 'underscore';
 
 import './sortable';
@@ -42,12 +43,14 @@ import registerDirectives from './directives';
 import registerVisualizations from './visualizations';
 import markdownFilter from './filters/markdown';
 import dateTimeFilter from './filters/datetime';
+import customCurrencyFilter from './filters/customCurrency';
+import customNumberFilter from './filters/customNumber';
 
 const logger = debug('redash');
 
 const requirements = [
   ngRoute, ngResource, ngSanitize, uiBootstrap, ngMessages, uiSelect, 'angularMoment', toastr, 'ui.ace',
-  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name,
+  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name, 'tmh.dynamicLocale',
 ];
 
 const ngModule = angular.module('app', requirements);
@@ -94,12 +97,14 @@ registerServices();
 registerFilters();
 markdownFilter(ngModule);
 dateTimeFilter(ngModule);
+customCurrencyFilter(ngModule);
+customNumberFilter(ngModule);
 registerComponents();
 registerPages();
 registerVisualizations(ngModule);
 
 ngModule.config(($routeProvider, $locationProvider, $compileProvider,
-  uiSelectConfig, toastrConfig) => {
+  uiSelectConfig, toastrConfig, tmhDynamicLocaleProvider) => {
   $compileProvider.debugInfoEnabled(false);
   $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|http|data):/);
   $locationProvider.html5Mode(true);
@@ -109,6 +114,8 @@ ngModule.config(($routeProvider, $locationProvider, $compileProvider,
     positionClass: 'toast-bottom-right',
     timeOut: 2000,
   });
+
+  tmhDynamicLocaleProvider.localeLocationPattern('./locales/angular-locale_{{locale}}.js');
 });
 
 // Update ui-select's template to use Font-Awesome instead of glyphicon.

--- a/client/app/visualizations/counter/counter-editor.html
+++ b/client/app/visualizations/counter/counter-editor.html
@@ -26,6 +26,32 @@
     </div>
   </div>
   <div class="form-group">
+    <label class="col-lg-6">Format</label>
+    <div class="col-lg-6">
+      <select ng-options="c as c for c in formattingOptions" ng-model="visualization.options.format" class="form-control">
+      </select>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Format locale</label>
+    <div class="col-lg-6">
+      <select ng-options="key as value.name for (key, value) in localeOptions" ng-model="visualization.options.counterLocale" class="form-control">
+      </select>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Format suffix</label>
+    <div class="col-lg-6">
+      <input type="text" ng-model="visualization.options.suffix" class="form-control">
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Format Decimal Places</label>
+    <div class="col-lg-6">
+      <input type="number" ng-model="visualization.options.fractionSize" class="form-control">
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-lg-6">
       <input type="checkbox" ng-model="visualization.options.countRow">
       <i class="input-helper"></i> Count Rows

--- a/client/app/visualizations/counter/counter.html
+++ b/client/app/visualizations/counter/counter.html
@@ -1,5 +1,6 @@
 <counter ng-class="{'positive': targetValue && trendPositive, 'negative': targetValue && !trendPositive}">
-  <value>{{counterValue|number}}</value>
+  <value ng-if="format == 'Number'">{{counterValue|number:fractionSize}}{{suffix}}</value>
+  <value ng-if="format == 'Currency'">{{counterValue|currency:undefined:fractionSize}}{{suffix}}</value>
   <counter-target ng-if="targetValue">({{targetValue|number}})</counter-target>
   <counter-name>{{visualization.name}}</counter-name>
 </counter>

--- a/client/app/visualizations/counter/index.js
+++ b/client/app/visualizations/counter/index.js
@@ -1,5 +1,8 @@
+import 'angular-dynamic-locale/dist/tmhDynamicLocale';
+
 import counterTemplate from './counter.html';
 import counterEditorTemplate from './counter-editor.html';
+
 
 function getRowNumber(index, size) {
   if (index >= 0) {
@@ -13,7 +16,8 @@ function getRowNumber(index, size) {
   return size + index;
 }
 
-function CounterRenderer() {
+
+function CounterRenderer(tmhDynamicLocale) {
   return {
     restrict: 'E',
     template: counterTemplate,
@@ -21,6 +25,12 @@ function CounterRenderer() {
       const refreshData = () => {
         const queryData = $scope.queryResult.getData();
         if (queryData) {
+          tmhDynamicLocale.set($scope.visualization.options.counterLocale);
+          $scope.counterLocale = $scope.visualization.options.counterLocale;
+          $scope.fractionSize = $scope.visualization.options.fractionSize;
+          $scope.suffix = $scope.visualization.options.suffix;
+          $scope.format = $scope.visualization.options.format;
+
           const rowNumber = getRowNumber($scope.visualization.options.rowNumber, queryData.length);
           const targetRowNumber =
             getRowNumber($scope.visualization.options.targetRowNumber, queryData.length);
@@ -55,9 +65,174 @@ function CounterEditor() {
   return {
     restrict: 'E',
     template: counterEditorTemplate,
+    link(scope) {
+      scope.formattingOptions = ['Number', 'Currency'];
+      scope.localeOptions = {
+        af: { name: 'Afrikaans' },
+        sq: { name: 'Albanian' },
+        'ar-dz': { name: 'Arabic (Algeria)' },
+        'ar-bh': { name: 'Arabic (Bahrain)' },
+        'ar-eg': { name: 'Arabic (Egypt)' },
+        'ar-iq': { name: 'Arabic (Iraq)' },
+        'ar-jo': { name: 'Arabic (Jordan)' },
+        'ar-kw': { name: 'Arabic (Kuwait)' },
+        'ar-lb': { name: 'Arabic (Lebanon)' },
+        'ar-ly': { name: 'Arabic (Libya)' },
+        'ar-ma': { name: 'Arabic (Morocco)' },
+        'ar-om': { name: 'Arabic (Oman)' },
+        'ar-qa': { name: 'Arabic (Qatar)' },
+        'ar-sa': { name: 'Arabic (Saudi Arabia)' },
+        ar: { name: 'Arabic (Standard)' },
+        'ar-sy': { name: 'Arabic (Syria)' },
+        'ar-tn': { name: 'Arabic (Tunisia)' },
+        'ar-ae': { name: 'Arabic (U.A.E.)' },
+        'ar-ye': { name: 'Arabic (Yemen)' },
+        hy: { name: 'Armenian' },
+        as: { name: 'Assamese' },
+        ast: { name: 'Asturian' },
+        az: { name: 'Azerbaijani' },
+        eu: { name: 'Basque' },
+        be: { name: 'Belarusian' },
+        bn: { name: 'Bengali' },
+        bs: { name: 'Bosnian' },
+        br: { name: 'Breton' },
+        bg: { name: 'Bulgarian' },
+        my: { name: 'Burmese' },
+        ca: { name: 'Catalan' },
+        ce: { name: 'Chechen' },
+        'zh-hk': { name: 'Chinese (Hong Kong)' },
+        'zh-cn': { name: 'Chinese (PRC)' },
+        'zh-tw': { name: 'Chinese (Taiwan)' },
+        zh: { name: 'Chinese' },
+        hr: { name: 'Croatian' },
+        cs: { name: 'Czech' },
+        da: { name: 'Danish' },
+        'nl-be': { name: 'Dutch (Belgian)' },
+        nl: { name: 'Dutch (Standard)' },
+        'en-au': { name: 'English (Australia)' },
+        'en-bz': { name: 'English (Belize)' },
+        'en-ca': { name: 'English (Canada)' },
+        'en-ie': { name: 'English (Ireland)' },
+        'en-jm': { name: 'English (Jamaica)' },
+        'en-nz': { name: 'English (New Zealand)' },
+        'en-ph': { name: 'English (Philippines)' },
+        'en-za': { name: 'English (South Africa)' },
+        'en-tt': { name: 'English (Trinidad & Tobago)' },
+        'en-gb': { name: 'English (United Kingdom)' },
+        'en-us': { name: 'English (United States)' },
+        'en-zw': { name: 'English (Zimbabwe)' },
+        en: { name: 'English' },
+        eo: { name: 'Esperanto' },
+        et: { name: 'Estonian' },
+        fo: { name: 'Faeroese' },
+        fa: { name: 'Farsi' },
+        fi: { name: 'Finnish' },
+        'fr-be': { name: 'French (Belgium)' },
+        'fr-ca': { name: 'French (Canada)' },
+        'fr-fr': { name: 'French (France)' },
+        'fr-lu': { name: 'French (Luxembourg)' },
+        'fr-mc': { name: 'French (Monaco)' },
+        fr: { name: 'French (Standard)' },
+        'fr-ch': { name: 'French (Switzerland)' },
+        fy: { name: 'Frisian' },
+        fur: { name: 'Friulian' },
+        mk: { name: 'FYRO Macedonian' },
+        gd: { name: 'Gaelic (Scots)' },
+        gl: { name: 'Galacian' },
+        ka: { name: 'Georgian' },
+        'de-at': { name: 'German (Austria)' },
+        'de-de': { name: 'German (Germany)' },
+        'de-li': { name: 'German (Liechtenstein)' },
+        'de-lu': { name: 'German (Luxembourg)' },
+        de: { name: 'German (Standard)' },
+        'de-ch': { name: 'German (Switzerland)' },
+        el: { name: 'Greek' },
+        gu: { name: 'Gujurati' },
+        he: { name: 'Hebrew' },
+        hi: { name: 'Hindi' },
+        hu: { name: 'Hungarian' },
+        is: { name: 'Icelandic' },
+        id: { name: 'Indonesian' },
+        ga: { name: 'Irish' },
+        it: { name: 'Italian (Standard)' },
+        'it-ch': { name: 'Italian (Switzerland)' },
+        ja: { name: 'Japanese' },
+        kn: { name: 'Kannada' },
+        ks: { name: 'Kashmiri' },
+        kk: { name: 'Kazakh' },
+        km: { name: 'Khmer' },
+        ky: { name: 'Kirghiz' },
+        'ko-kp': { name: 'Korean (North Korea)' },
+        'ko-kr': { name: 'Korean (South Korea)' },
+        ko: { name: 'Korean' },
+        lv: { name: 'Latvian' },
+        lt: { name: 'Lithuanian' },
+        lb: { name: 'Luxembourgish' },
+        ms: { name: 'Malay' },
+        ml: { name: 'Malayalam' },
+        mt: { name: 'Maltese' },
+        mr: { name: 'Marathi' },
+        mo: { name: 'Moldavian' },
+        ne: { name: 'Nepali' },
+        nb: { name: 'Norwegian (Bokmal)' },
+        nn: { name: 'Norwegian (Nynorsk)' },
+        no: { name: 'Norwegian' },
+        or: { name: 'Oriya' },
+        om: { name: 'Oromo' },
+        'fa-ir': { name: 'Persian/Iran' },
+        pl: { name: 'Polish' },
+        'pt-br': { name: 'Portuguese (Brazil)' },
+        pt: { name: 'Portuguese' },
+        pa: { name: 'Punjabi' },
+        qu: { name: 'Quechua' },
+        rm: { name: 'Rhaeto-Romanic' },
+        ro: { name: 'Romanian' },
+        ru: { name: 'Russian' },
+        sg: { name: 'Sango' },
+        sr: { name: 'Serbian' },
+        si: { name: 'Singhalese' },
+        sk: { name: 'Slovak' },
+        sl: { name: 'Slovenian' },
+        so: { name: 'Somani' },
+        'es-ar': { name: 'Spanish (Argentina)' },
+        'es-bo': { name: 'Spanish (Bolivia)' },
+        'es-cl': { name: 'Spanish (Chile)' },
+        'es-co': { name: 'Spanish (Colombia)' },
+        'es-cr': { name: 'Spanish (Costa Rica)' },
+        'es-do': { name: 'Spanish (Dominican Republic)' },
+        'es-ec': { name: 'Spanish (Ecuador)' },
+        'es-sv': { name: 'Spanish (El Salvador)' },
+        'es-gt': { name: 'Spanish (Guatemala)' },
+        'es-hn': { name: 'Spanish (Honduras)' },
+        'es-mx': { name: 'Spanish (Mexico)' },
+        'es-ni': { name: 'Spanish (Nicaragua)' },
+        'es-pa': { name: 'Spanish (Panama)' },
+        'es-py': { name: 'Spanish (Paraguay)' },
+        'es-pe': { name: 'Spanish (Peru)' },
+        'es-pr': { name: 'Spanish (Puerto Rico)' },
+        'es-es': { name: 'Spanish (Spain)' },
+        'es-uy': { name: 'Spanish (Uruguay)' },
+        'es-ve': { name: 'Spanish (Venezuela)' },
+        es: { name: 'Spanish' },
+        sw: { name: 'Swahili' },
+        'sv-fi': { name: 'Swedish (Finland)' },
+        sv: { name: 'Swedish' },
+        ta: { name: 'Tamil' },
+        te: { name: 'Teluga' },
+        th: { name: 'Thai' },
+        tr: { name: 'Turkish' },
+        tk: { name: 'Turkmen' },
+        uk: { name: 'Ukrainian' },
+        hsb: { name: 'Upper Sorbian' },
+        ur: { name: 'Urdu' },
+        vi: { name: 'Vietnamese' },
+        vo: { name: 'Volapuk' },
+        cy: { name: 'Welsh' },
+        zu: { name: 'Zulu' },
+      };
+    },
   };
 }
-
 
 export default function (ngModule) {
   ngModule.directive('counterEditor', CounterEditor);
@@ -74,6 +249,8 @@ export default function (ngModule) {
       counterColName: 'counter',
       rowNumber: 1,
       targetRowNumber: 1,
+      format: 'Number',
+      counterLocale: 'en-us',
     };
 
     VisualizationProvider.registerVisualization({

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -67,10 +67,20 @@
       "from": "angular-base64-upload@latest",
       "resolved": "https://registry.npmjs.org/angular-base64-upload/-/angular-base64-upload-0.1.19.tgz"
     },
+    "angular-dynamic-locale": {
+      "version": "0.1.32",
+      "from": "angular-dynamic-locale@latest",
+      "resolved": "https://registry.npmjs.org/angular-dynamic-locale/-/angular-dynamic-locale-0.1.32.tgz"
+    },
     "angular-gridster": {
       "version": "0.13.14",
-      "from": "angular-gridster@>=0.13.14 <0.14.0",
+      "from": "angular-gridster@latest",
       "resolved": "https://registry.npmjs.org/angular-gridster/-/angular-gridster-0.13.14.tgz"
+    },
+    "angular-i18n": {
+      "version": "1.6.5",
+      "from": "angular-i18n@latest",
+      "resolved": "https://registry.npmjs.org/angular-i18n/-/angular-i18n-1.6.5.tgz"
     },
     "angular-messages": {
       "version": "1.5.8",
@@ -84,7 +94,7 @@
     },
     "angular-resizable": {
       "version": "1.2.0",
-      "from": "angular-resizable@>=1.2.0 <2.0.0",
+      "from": "angular-resizable@latest",
       "resolved": "https://registry.npmjs.org/angular-resizable/-/angular-resizable-1.2.0.tgz"
     },
     "angular-resource": {
@@ -104,12 +114,12 @@
     },
     "angular-toastr": {
       "version": "2.1.1",
-      "from": "angular-toastr@>=2.1.1 <3.0.0",
+      "from": "angular-toastr@latest",
       "resolved": "https://registry.npmjs.org/angular-toastr/-/angular-toastr-2.1.1.tgz"
     },
     "angular-ui-ace": {
       "version": "0.2.3",
-      "from": "angular-ui-ace@>=0.2.3 <0.3.0",
+      "from": "angular-ui-ace@latest",
       "resolved": "https://registry.npmjs.org/angular-ui-ace/-/angular-ui-ace-0.2.3.tgz"
     },
     "angular-ui-bootstrap": {
@@ -119,7 +129,7 @@
     },
     "angular-vs-repeat": {
       "version": "1.1.7",
-      "from": "angular-vs-repeat@>=1.1.7 <2.0.0",
+      "from": "angular-vs-repeat@latest",
       "resolved": "https://registry.npmjs.org/angular-vs-repeat/-/angular-vs-repeat-1.1.7.tgz"
     },
     "ansi-regex": {
@@ -134,7 +144,7 @@
     },
     "arraytools": {
       "version": "1.1.2",
-      "from": "arraytools@>=1.1.2 <2.0.0",
+      "from": "arraytools@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/arraytools/-/arraytools-1.1.2.tgz"
     },
     "asn1": {
@@ -377,7 +387,7 @@
     },
     "color-name": {
       "version": "1.1.2",
-      "from": "color-name@>=1.0.0 <2.0.0",
+      "from": "color-name@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
     },
     "color-parse": {
@@ -516,7 +526,7 @@
     },
     "d3": {
       "version": "3.5.17",
-      "from": "d3@>=3.5.17 <4.0.0",
+      "from": "d3@>=3.5.6 <3.6.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
     },
     "d3-cloud": {
@@ -568,7 +578,7 @@
     },
     "defined": {
       "version": "1.0.0",
-      "from": "defined@>=1.0.0 <1.1.0",
+      "from": "defined@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
     },
     "delaunay-triangulate": {
@@ -689,7 +699,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "from": "events@>=1.0.2 <2.0.0",
+      "from": "events@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
     },
     "extend": {
@@ -768,7 +778,7 @@
     },
     "font-awesome": {
       "version": "4.7.0",
-      "from": "font-awesome@>=4.7.0 <5.0.0",
+      "from": "font-awesome@latest",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz"
     },
     "for-each": {
@@ -798,7 +808,7 @@
     },
     "function-bind": {
       "version": "1.1.0",
-      "from": "function-bind@>=1.1.0 <1.2.0",
+      "from": "function-bind@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "functional-red-black-tree": {
@@ -1158,7 +1168,7 @@
     },
     "gl-plot2d": {
       "version": "1.2.0",
-      "from": "gl-plot2d@>=1.2.0 <2.0.0",
+      "from": "gl-plot2d@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.2.0.tgz",
       "dependencies": {
         "binary-search-bounds": {
@@ -1519,7 +1529,7 @@
     },
     "gl-surface3d": {
       "version": "1.3.0",
-      "from": "gl-surface3d@>=1.3.0 <2.0.0",
+      "from": "gl-surface3d@>=1.2.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.3.0.tgz",
       "dependencies": {
         "bl": {
@@ -1561,7 +1571,7 @@
     },
     "gl-vao": {
       "version": "1.3.0",
-      "from": "gl-vao@>=1.3.0 <2.0.0",
+      "from": "gl-vao@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/gl-vao/-/gl-vao-1.3.0.tgz"
     },
     "gl-vec3": {
@@ -1720,7 +1730,7 @@
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@>=1.0.1 <1.1.0",
+      "from": "has@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
@@ -1755,7 +1765,7 @@
     },
     "ieee754": {
       "version": "1.1.8",
-      "from": "ieee754@>=1.1.6 <2.0.0",
+      "from": "ieee754@>=1.1.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "incremental-convex-hull": {
@@ -1770,7 +1780,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.3 <2.1.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "interval-tree-1d": {
@@ -1820,7 +1830,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "from": "is-plain-obj@>=1.1.0 <2.0.0",
+      "from": "is-plain-obj@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
     },
     "is-property": {
@@ -1866,7 +1876,7 @@
     },
     "jquery-ui": {
       "version": "1.12.1",
-      "from": "jquery-ui@>=1.12.1 <2.0.0",
+      "from": "jquery-ui@latest",
       "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz"
     },
     "jsbn": {
@@ -1907,7 +1917,7 @@
     },
     "kdbush": {
       "version": "1.0.1",
-      "from": "kdbush@>=1.0.1 <2.0.0",
+      "from": "kdbush@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz"
     },
     "kind-of": {
@@ -2026,7 +2036,7 @@
     },
     "marked": {
       "version": "0.3.6",
-      "from": "marked@>=0.3.6 <0.4.0",
+      "from": "marked@latest",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
     },
     "mat4-decompose": {
@@ -2046,7 +2056,7 @@
     },
     "material-design-iconic-font": {
       "version": "2.2.0",
-      "from": "material-design-iconic-font@>=2.2.0 <3.0.0",
+      "from": "material-design-iconic-font@latest",
       "resolved": "https://registry.npmjs.org/material-design-iconic-font/-/material-design-iconic-font-2.2.0.tgz"
     },
     "matrix-camera-controller": {
@@ -2086,7 +2096,7 @@
     },
     "mouse-change": {
       "version": "1.4.0",
-      "from": "mouse-change@>=1.4.0 <2.0.0",
+      "from": "mouse-change@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz"
     },
     "mouse-event": {
@@ -2150,7 +2160,7 @@
     },
     "ndarray": {
       "version": "1.0.18",
-      "from": "ndarray@>=1.0.18 <2.0.0",
+      "from": "ndarray@>=1.0.16 <2.0.0",
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz"
     },
     "ndarray-extract-contour": {
@@ -2272,7 +2282,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.1 <0.9.0",
+      "from": "optionator@>=0.8.2 <0.9.0",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "dependencies": {
         "wordwrap": {
@@ -2389,7 +2399,7 @@
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.4.1 <2.0.0",
+      "from": "punycode@>=1.2.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "quat-slerp": {
@@ -2456,7 +2466,7 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@>=1.3.0 <2.0.0",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
     },
     "request": {
@@ -2478,7 +2488,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "from": "resolve@>=1.1.7 <1.2.0",
+      "from": "resolve@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-protobuf-schema": {
@@ -2793,7 +2803,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.8 <2.4.0",
+      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -2886,7 +2896,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.6 <0.0.7",
+      "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "typedarray-pool": {
@@ -2953,12 +2963,12 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@>=1.8.3 <2.0.0",
+      "from": "underscore@latest",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "underscore.string": {
       "version": "3.3.4",
-      "from": "underscore.string@>=3.3.4 <4.0.0",
+      "from": "underscore.string@latest",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz"
     },
     "union-find": {
@@ -3053,7 +3063,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0-0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "angular": "~1.5.8",
     "angular-base64-upload": "^0.1.19",
+    "angular-dynamic-locale": "^0.1.32",
     "angular-gridster": "^0.13.14",
+    "angular-i18n": "^1.6.5",
     "angular-messages": "~1.5.8",
     "angular-moment": "^1.0.0",
     "angular-resizable": "^1.2.0",


### PR DESCRIPTION
This PR is still WIP, and I seek for your advise around handling locales.

I am trying to add a feature to specify locale for counter value. I am planning to use [`angular-dynamic-locale`](https://github.com/lgalfaso/angular-dynamic-locale) to change locale at runtime. However I have been facing two issues.

![counter](https://user-images.githubusercontent.com/1698635/28411520-e5eb8400-6d7b-11e7-83c2-be8f9bc7febf.png)
![counter-editor](https://user-images.githubusercontent.com/1698635/28411529-ea63211e-6d7b-11e7-817c-62f7040d7390.png)


1. I cannot mix locales in one dashboard.
When I try to place multiple counter widgets with multiple locales in one dashboard, locales for counter widgets are not displayed correctly. This is due to the nature of angular-dynamic-locale, where `tmhDynamicLocale.set()` sets locales asynchronously. This is fine in individual visualization and counter-editor, but loading multiple counter widgets with different locales in dashboard results in 'single locale for all widgets'. For example, if default locale was en-US:
* USD widget loads => USD currency shown as USD => EUR widget loads => EUR currency shown as USD => locale set to USD => locale set to EUR
　
This will not become a problem if a user sticks to 'one locale per dashboard', but would like to do something to allow one locale per widget. Do you have any idea how to handle this?

2. How to handle installation of angular-i18n.
Running `npm install -S angular-i18n` places locale javascript files under node_modules/angular-i18n/. The files in this directory has to be moved somehow to client/app folder to be able to be seen by angular-dynamic-locale via HTTP get. For now I create `locales` folder under client/app and copy the locale files manually. Does `mkdir locales && cp  node_modules/angular-i18n/* locales` in Dockerfile make sense to you for installation? Is it too much to copy all 801 locale files? Is this against the Webpack way?