### PR TITLE
Send alert ID to UI

### DIFF
--- a/client/app/pages/alerts-list/index.js
+++ b/client/app/pages/alerts-list/index.js
@@ -14,6 +14,7 @@ class AlertsListCtrl {
     this.alerts = new Paginator([], { itemsPerPage: 20 });
     Alert.query((alerts) => {
       this.alerts.updateRows(alerts.map(alert => ({
+        id: alert.id,
         name: alert.name,
         state: alert.state,
         class: stateClass[alert.state],


### PR DESCRIPTION
This will allow alert detail page links on the alert list page to work again.

Fixes bug #1888 