### PR TITLE
Textbox editing fix

### DIFF
--- a/client/app/pages/dashboards/add-widget-dialog.js
+++ b/client/app/pages/dashboards/add-widget-dialog.js
@@ -17,6 +17,7 @@ const AddWidgetDialog = {
     this.query = {};
     this.selected_query = undefined;
     this.text = '';
+    this.existing_text = '';
     this.widgetSizes = [{
       name: 'Regular',
       value: 1,

--- a/client/app/pages/dashboards/add-widget-dialog.js
+++ b/client/app/pages/dashboards/add-widget-dialog.js
@@ -18,6 +18,7 @@ const AddWidgetDialog = {
     this.selected_query = undefined;
     this.text = '';
     this.existing_text = '';
+    this.new_text = '';
     this.widgetSizes = [{
       name: 'Regular',
       value: 1,

--- a/client/app/pages/dashboards/edit-text-box.html
+++ b/client/app/pages/dashboards/edit-text-box.html
@@ -1,18 +1,18 @@
 <div class="modal-header">
-  <button type="button" class="close" aria-label="Close" ng-click="$ctrl.closeWithoutSave()"><span aria-hidden="true">&times;</span></button>
+  <button type="button" class="close" aria-label="Close" ng-click="$ctrl.close()"><span aria-hidden="true">&times;</span></button>
   <h4 class="modal-title">Edit TextBox</h4>
 </div>
 <div class="modal-body">
   <div class="form-group">
-    <textarea class="form-control" ng-model="$ctrl.widget.text" rows="3"></textarea>
+    <textarea class="form-control" ng-model="$ctrl.widget.new_text" rows="3"></textarea>
   </div>
-  <div ng-show="$ctrl.widget.text">
+  <div ng-show="$ctrl.widget.new_text">
     <strong>Preview:</strong>
-    <p ng-bind-html="$ctrl.widget.text | markdown"></p>
+    <p ng-bind-html="$ctrl.widget.new_text | markdown"></p>
   </div>
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.closeWithoutSave()">Close</button>
+  <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.close()">Close</button>
   <button type="button" class="btn btn-primary" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.saveWidget()">Save</button>
 </div>

--- a/client/app/pages/dashboards/edit-text-box.html
+++ b/client/app/pages/dashboards/edit-text-box.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <button type="button" class="close" aria-label="Close" ng-click="$ctrl.close()"><span aria-hidden="true">&times;</span></button>
+  <button type="button" class="close" aria-label="Close" ng-click="$ctrl.closeWithoutSave()"><span aria-hidden="true">&times;</span></button>
   <h4 class="modal-title">Edit TextBox</h4>
 </div>
 <div class="modal-body">
@@ -13,6 +13,6 @@
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.close()">Close</button>
+  <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.closeWithoutSave()">Close</button>
   <button type="button" class="btn btn-primary" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.saveWidget()">Save</button>
 </div>

--- a/client/app/pages/dashboards/widget.js
+++ b/client/app/pages/dashboards/widget.js
@@ -8,7 +8,7 @@ const EditTextBoxComponent = {
     close: '&',
     dismiss: '&',
   },
-  controller(toastr) {
+  controller($rootScope, $location, $http, toastr) {
     'ngInject';
 
     this.saveInProgress = false;
@@ -23,6 +23,10 @@ const EditTextBoxComponent = {
         this.saveInProgress = false;
       });
     };
+    this.closeWithoutSave = () => {
+      this.widget.text = this.widget.existing_text;
+      this.close();
+    };
   },
 };
 
@@ -30,11 +34,14 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
   this.canViewQuery = currentUser.hasPermission('view_query');
 
   this.editTextBox = () => {
+    this.widget.existing_text = this.widget.text;
     $uibModal.open({
       component: 'editTextBox',
       resolve: {
         widget: this.widget,
       },
+      backdrop: 'static',
+      keyboard: false,
     });
   };
 

--- a/client/app/pages/dashboards/widget.js
+++ b/client/app/pages/dashboards/widget.js
@@ -8,24 +8,25 @@ const EditTextBoxComponent = {
     close: '&',
     dismiss: '&',
   },
-  controller($rootScope, $location, $http, toastr) {
+  controller(toastr) {
     'ngInject';
 
     this.saveInProgress = false;
     this.widget = this.resolve.widget;
     this.saveWidget = () => {
       this.saveInProgress = true;
-      this.widget.$save().then(() => {
+      if (this.widget.new_text !== this.widget.existing_text) {
+        this.widget.text = this.widget.new_text;
+        this.widget.$save().then(() => {
+          this.close();
+        }).catch(() => {
+          toastr.error('Widget can not be updated');
+        }).finally(() => {
+          this.saveInProgress = false;
+        });
+      } else {
         this.close();
-      }).catch(() => {
-        toastr.error('Widget can not be updated');
-      }).finally(() => {
-        this.saveInProgress = false;
-      });
-    };
-    this.closeWithoutSave = () => {
-      this.widget.text = this.widget.existing_text;
-      this.close();
+      }
     };
   },
 };
@@ -35,13 +36,12 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
 
   this.editTextBox = () => {
     this.widget.existing_text = this.widget.text;
+    this.widget.new_text = this.widget.text;
     $uibModal.open({
       component: 'editTextBox',
       resolve: {
         widget: this.widget,
       },
-      backdrop: 'static',
-      keyboard: false,
     });
   };
 


### PR DESCRIPTION
Combines mozilla/redash PR’s 86 and 95.

There was a bug that saved textbox content on a dashboard when you
tried to close without saving. This fixes it.