### PR TITLE
Fix #1843: Remove deprecated cx_Oracle types

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -14,18 +14,14 @@ try:
         cx_Oracle.LOB: TYPE_STRING,
         cx_Oracle.FIXED_CHAR: TYPE_STRING,
         cx_Oracle.FIXED_NCHAR: TYPE_STRING,
-        cx_Oracle.FIXED_UNICODE: TYPE_STRING,
         cx_Oracle.INTERVAL: TYPE_DATETIME,
-        cx_Oracle.LONG_NCHAR: TYPE_STRING,
         cx_Oracle.LONG_STRING: TYPE_STRING,
-        cx_Oracle.LONG_UNICODE: TYPE_STRING,
         cx_Oracle.NATIVE_FLOAT: TYPE_FLOAT,
         cx_Oracle.NCHAR: TYPE_STRING,
         cx_Oracle.NUMBER: TYPE_FLOAT,
         cx_Oracle.ROWID: TYPE_INTEGER,
         cx_Oracle.STRING: TYPE_STRING,
         cx_Oracle.TIMESTAMP: TYPE_DATETIME,
-        cx_Oracle.UNICODE: TYPE_STRING,
     }
 
 

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -1,4 +1,4 @@
 # Requires installation of, or similar versions of:
-#    oracle-instantclient12.1-basic_12.1.0.2.0-2_amd64.deb
-#    oracle-instantclient12.1-devel_12.1.0.2.0-2_amd64.deb
+#    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
+#    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm
 cx_Oracle==5.3

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -1,4 +1,4 @@
 # Requires installation of, or similar versions of:
 #    oracle-instantclient12.1-basic_12.1.0.2.0-2_amd64.deb
 #    oracle-instantclient12.1-devel_12.1.0.2.0-2_amd64.deb
-cx_Oracle==5.2
+cx_Oracle==5.3


### PR DESCRIPTION
FIXED_UNICODE, LONG_NCHAR, LONG_UNICODE and UNICODE have been removed
from cx_Oracle version 5.3 and should be removed from the TYPES_MAP.

Closes #1843.