### PR TITLE
Change: pivottable design to match other components

### DIFF
--- a/client/app/visualizations/pivot/index.js
+++ b/client/app/visualizations/pivot/index.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import $ from 'jquery';
 import 'pivottable';
 import 'pivottable/dist/pivot.css';
+import './pivot-ext.css';
 
 import editorTemplate from './pivottable-editor.html';
 

--- a/client/app/visualizations/pivot/pivot-ext.css
+++ b/client/app/visualizations/pivot/pivot-ext.css
@@ -1,0 +1,11 @@
+
+/* pivot-ext.css */
+/* match body */
+table.pvtTable { font-size: 13px; }
+
+/* match table visualization header */
+table.pvtTable thead tr th, table.pvtTable tbody tr th { background-color: #FAFAFA; font-size: 13px; }
+
+/* match table visualization value */
+table.pvtTable tbody tr td { color: #767676; }
+


### PR DESCRIPTION
This PR changes css for pivot table to make it blend in better with other components.

![pivot-css](https://user-images.githubusercontent.com/1698635/28770973-0dbfbd0e-761c-11e7-94d7-e8c69ec6b1ea.png)

Too monotonous?