### PR TITLE
Snowflake support is no longer enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Update to Webpack 2. @44px
 - Remove /forgot endpoint if REDASH_PASSWORD_LOGIN_ENABLED is false. @amarjayr
 - Docker: make Gunicorn worker count configurable. @unixwitch
+- Snowflake support is no longer enabled by default.
 
 ### Fixed
 

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -198,7 +198,6 @@ default_query_runners = [
     'redash.query_runner.memsql_ds',
     'redash.query_runner.jql',
     'redash.query_runner.google_analytics',
-    'redash.query_runner.snowflake',
     'redash.query_runner.axibase_tsd',
     'redash.query_runner.salesforce'
 ]

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -18,9 +18,12 @@ thrift>=0.8.0
 thrift_sasl>=0.1.0
 cassandra-driver==3.1.1
 memsql==2.16.0
-snowflake_connector_python==1.3.16
 atsd_client==2.0.12
 simple_salesforce==0.72.2
 PyAthena>=1.0.0
 # certifi is needed to support MongoDB and SSL:
 certifi
+# We don't install snowflake connector by default, as it's causing conflicts with
+# other packages. To properly support it we probably need to switch from pyOpenSSL
+# to the other package snowflake is using (that's compatible with it).
+# snowflake_connector_python==1.3.16


### PR DESCRIPTION
We don't install snowflake connector by default, as it's causing conflicts with
other packages. To properly support it we probably need to switch from pyOpenSSL
to the other package snowflake is using (that's compatible with it).