### PR TITLE
Fix "custom visualization" code box behavior

### DIFF
--- a/client/app/visualizations/chart/index.js
+++ b/client/app/visualizations/chart/index.js
@@ -87,7 +87,7 @@ function ChartEditor(ColorPalette, clientConfig) {
 
       scope.showSizeColumnPicker = () => some(scope.options.seriesOptions, options => options.type === 'bubble');
 
-      scope.options.customCode = `// Available variables are x, ys, element, and Plotly
+      scope.options.customCode = scope.options.customCode || `// Available variables are x, ys, element, and Plotly
 // Type console.log(x, ys); for more info about x and ys
 // To plot your graph call Plotly.plot(element, ...)
 // Plotly examples and docs: https://plot.ly/javascript/`;


### PR DESCRIPTION
Only set the code box to the default string if it doesn't already have code entered already. It was blowing away the previously-entered code on load.