### PR TITLE
Upgraded dql version to 0.5.24

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -10,7 +10,7 @@ pyOpenSSL==16.2.0
 vertica-python==0.5.1
 td-client==0.8.0
 pymssql==2.1.3
-dql==0.5.16
+dql==0.5.24
 dynamo3==0.4.7
 botocore==1.5.72
 sasl>=0.1.3


### PR DESCRIPTION
This allows querying tables in dynamo DB which have keys with dashes in the name. 

Please see more here about this bug report on DQL: https://github.com/stevearc/dql/issues/12