### PR TITLE
UnicodeWriter errors code to environment

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -19,6 +19,7 @@ from redash import settings
 
 COMMENTS_REGEX = re.compile("/\*.*?\*/")
 WRITER_ENCODING = os.environ.get('REDASH_CSV_WRITER_ENCODING', 'utf-8')
+WRITER_ERRORS = os.environ.get('REDASH_CSV_WRITER_ERRORS', 'strict')
 
 
 def utcnow():
@@ -113,7 +114,7 @@ class UnicodeWriter:
 
     def _encode_utf8(self, val):
         if isinstance(val, (unicode, str)):
-            return val.encode(WRITER_ENCODING)
+            return val.encode(WRITER_ENCODING, WRITER_ERRORS)
 
         return val
 


### PR DESCRIPTION
Hello,

This enables .env config file to accept `WRITER_ERRORS` variable which is expected to be used in the encoding function, inspired by https://github.com/getredash/redash/pull/1839

Best Regards,
Tsukasa Endo

```
$ grep REDASH_CSV /opt/redash/current/.env
export REDASH_CSV_WRITER_ENCODING="cp932"
export REDASH_CSV_WRITER_ERRORS="ignore"
```