### PR TITLE
Prevent line breaks in EditInPlace description when using Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can try out the demo instance: http://demo.redash.io/ (login with any Google
 ## Reporting Bugs and Contributing Code
 
 * Want to report a bug or request a feature? Please open [an issue](https://github.com/getredash/redash/issues/new).
-* Want to help us build **_Redash_**? Fork the project, edit in a [dev environment](https://redash.io/help-onpremise/setup/setting-up-development-environment-using-vagrant.html), and make a pull request. We need all the help we can get!
+* Want to help us build **_Redash_**? Fork the project, edit in a [dev environment](https://redash.io/help-onpremise/dev/guide.html), and make a pull request. We need all the help we can get!
 
 ## License
 

--- a/client/app/components/edit-in-place.js
+++ b/client/app/components/edit-in-place.js
@@ -33,6 +33,8 @@ function EditInPlace() {
     link($scope, element) {
       // Let's get a reference to the input element, as we'll want to reference it.
       const inputElement = $(element.children()[2]);
+      const keycodeEnter = 13;
+      const keycodeEscape = 27;
 
       // This directive should have a set class so we can style it.
       element.addClass('edit-in-place');
@@ -74,9 +76,9 @@ function EditInPlace() {
       $(inputElement).keydown((e) => {
         // 'return' or 'enter' key pressed
         // allow 'shift' to break lines
-        if (e.which === 13 && !e.shiftKey) {
+        if (e.which === keycodeEnter && !e.shiftKey) {
           save();
-        } else if (e.which === 27) {
+        } else if (e.which === keycodeEscape) {
           $scope.value = $scope.oldValue;
           $scope.$apply(() => {
             $(inputElement[0]).blur();

--- a/client/app/components/edit-in-place.js
+++ b/client/app/components/edit-in-place.js
@@ -77,6 +77,7 @@ function EditInPlace() {
         // 'return' or 'enter' key pressed
         // allow 'shift' to break lines
         if (e.which === keycodeEnter && !e.shiftKey) {
+          e.preventDefault();
           save();
         } else if (e.which === keycodeEscape) {
           $scope.value = $scope.oldValue;


### PR DESCRIPTION
Before this change, pressing enter in Firefox 55 would insert a line break into the description field and then save it.

This change prevents the line break from being inserted before saving.

There's no change to Chrome's behaviour from this change.