### PR TITLE
Fix Hive and Impala data sources for use with Cloudera's CDH versions (#1969)

### DIFF
--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -38,24 +38,47 @@ class Hive(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
 
     @classmethod
+    def name(cls):
+        return "Hive via PyHive"
+
+    @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
             "properties": {
                 "host": {
-                    "type": "string"
+                    "type": "string",
+                    "title": "Host: The hostname for the Hive Metastore."
                 },
                 "port": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 10000,
+                    "title": "Port: Hive default is 10000."
                 },
                 "database": {
-                    "type": "string"
+                    "type": "string",
+                    "title": "Default Database: The default database name."
                 },
                 "username": {
-                    "type": "string"
+                    "type": "string",
+                    "title": "Username: The username used for connection."
+                },
+                "auth": {
+                    "type": "string",
+                    "title": "Auth: The value of hive.server2.authentication used by HiveServer2. Either 'NOSASL', 'LDAP', 'KERBEROS', or 'NONE'."
+                },
+                "kerberos_service_name": {
+                    "type": "string",
+                    "title": "Kerberos Service Name: Use with `auth='KERBEROS'` only."
+                },
+                "password": {
+                    "type": "string",
+                    "title": "Password: Use with `auth='LDAP'` only."
                 }
             },
-            "required": ["host"]
+            "order": ["host","port","database","username","auth","kerberos_service_name","password"],
+            "required": ["host"],
+            "secret": ["password"]
         }
 
     @classmethod

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,6 +1,6 @@
 google-api-python-client==1.5.1
 gspread==0.6.2
-impyla==0.10.0
+impyla==0.14.0
 influxdb==2.7.1
 MySQL-python==1.2.5
 oauth2client==3.0.0
@@ -14,7 +14,7 @@ dql==0.5.24
 dynamo3==0.4.7
 botocore==1.5.72
 sasl>=0.1.3
-thrift>=0.8.0
+thrift==0.9.3
 thrift_sasl>=0.1.0
 cassandra-driver==3.1.1
 memsql==2.16.0


### PR DESCRIPTION
Allow Hive and Impala data sources to work with Cloudera CDH clusters (#1969).