### PR TITLE
Configure supervisor.conf logging to /opt/redash/logs/redash.log…

### DIFF
--- a/setup/ubuntu/files/supervisord.conf
+++ b/setup/ubuntu/files/supervisord.conf
@@ -9,6 +9,10 @@ user=redash
 numprocs=1
 autostart=true
 autorestart=true
+stdout_logfile=/opt/redash/logs/redash.log
+stdout_logfile_maxbytes=100MB
+stderr_logfile=/opt/redash/logs/redash.log
+stderr_logfile_maxbytes=100MB
 
 # There are two queue types here: one for ad-hoc queries, and one for the refresh of scheduled queries
 # (note that "scheduled_queries" appears only in the queue list of "redash_celery_scheduled").
@@ -22,6 +26,10 @@ user=redash
 numprocs=1
 autostart=true
 autorestart=true
+stdout_logfile=/opt/redash/logs/redash.log
+stdout_logfile_maxbytes=100MB
+stderr_logfile=/opt/redash/logs/redash.log
+stderr_logfile_maxbytes=100MB
 
 [program:redash_celery_scheduled]
 command=/opt/redash/current/bin/run celery worker --app=redash.worker -c2 -Qscheduled_queries --maxtasksperchild=10 -Ofair
@@ -31,3 +39,7 @@ user=redash
 numprocs=1
 autostart=true
 autorestart=true
+stdout_logfile=/opt/redash/logs/redash.log
+stdout_logfile_maxbytes=100MB
+stderr_logfile=/opt/redash/logs/redash.log
+stderr_logfile_maxbytes=100MB


### PR DESCRIPTION
… with a rollover at 100MB.

I couldn't get production logging to work until I added this configuration.