### PR TITLE
Fix: Setting series color for boxplot

### DIFF
--- a/client/app/visualizations/chart/plotly.js
+++ b/client/app/visualizations/chart/plotly.js
@@ -363,15 +363,13 @@ const PlotlyChart = () => {
           if (seriesOptions.type === 'box') {
             plotlySeries.boxpoints = 'outliers';
             plotlySeries.marker = {
+              color: seriesColor,
               size: 3,
             };
             if (scope.options.showpoints) {
               plotlySeries.boxpoints = 'all';
               plotlySeries.jitter = 0.3;
               plotlySeries.pointpos = -1.8;
-              plotlySeries.marker = {
-                size: 3,
-              };
             }
           }
 


### PR DESCRIPTION
This PR fixes #1991, and allows you to change series color of your boxplots.