### PR TITLE
[FIX] Revoke permission should respect to given grantee and access type.

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -1041,13 +1041,13 @@ class AccessPermission(GFKBase, db.Model):
                              cls.object_type == obj.__tablename__)
 
         if access_type:
-            q.filter(AccessPermission.access_type == access_type)
+            q = q.filter(AccessPermission.access_type == access_type)
 
         if grantee:
-            q.filter(AccessPermission.grantee == grantee)
+            q = q.filter(AccessPermission.grantee == grantee)
 
         if grantor:
-            q.filter(AccessPermission.grantor == grantor)
+            q = q.filter(AccessPermission.grantor == grantor)
 
         return q
 

--- a/tests/models/test_permissions.py
+++ b/tests/models/test_permissions.py
@@ -40,6 +40,25 @@ class TestAccessPermissionRevoke(BaseTestCase):
                                             grantee=self.factory.user)
         self.assertEqual(1, AccessPermission.revoke(q, self.factory.user, ACCESS_TYPE_MODIFY))
 
+    def test_deletes_permission_for_only_given_grantee_on_given_grant_type(self):
+        q = self.factory.create_query()
+        first_user  = self.factory.create_user()
+        second_user = self.factory.create_user()
+
+        AccessPermission.grant(obj=q, access_type=ACCESS_TYPE_MODIFY,
+                               grantor=self.factory.user,
+                               grantee=first_user)
+
+        AccessPermission.grant(obj=q, access_type=ACCESS_TYPE_MODIFY,
+                               grantor=self.factory.user,
+                               grantee=second_user)
+
+        AccessPermission.grant(obj=q, access_type=ACCESS_TYPE_VIEW,
+                               grantor=self.factory.user,
+                               grantee=second_user)
+
+        self.assertEqual(1, AccessPermission.revoke(q, second_user, ACCESS_TYPE_VIEW))
+
     def test_deletes_all_permissions_if_no_type_given(self):
         q = self.factory.create_query()
 


### PR DESCRIPTION
The issue is, if you try to revoke the permission of a user from an
object, all the permissions on this object get removed. The fix is
assigning filtered query object to it's own reference.

According to SQLAlchemy documentation, `filter` method applies to
the **copy** of the query object which means calling filter doesn't
affect the object receiving filter call. For more information;
http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.filter