### PR TITLE
Fix docker-compose.production.yml

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -31,8 +31,8 @@ services:
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
       QUEUES: "queries,scheduled_queries,celery"
-    restart: always
       WORKERS_COUNT: 2
+    restart: always
   redis:
     image: redis:3.0-alpine
     restart: always


### PR DESCRIPTION
`docker-compose` fails on my local Windows with this error:

```console
> docker-compose -f docker-compose.production.yml run --rm server create_db
ERROR: yaml.scanner.ScannerError: mapping values are not allowed here
  in ".\docker-compose.production.yml", line 35, column 20
```

It seems #1976 broke `docker-compose.production.yml` by introducing some wrong syntax. This PR fixes the issue as suggested in https://github.com/getredash/redash/pull/1976#commitcomment-24882099.