### PR TITLE
Make invitation token max age configurable

### DIFF
--- a/redash/authentication/account.py
+++ b/redash/authentication/account.py
@@ -31,7 +31,7 @@ def reset_link_for_user(user):
 
 
 def validate_token(token):
-    max_token_age = 60 * 60 * 24 * 7 # 1 week
+    max_token_age = settings.INVITATION_TOKEN_MAX_AGE
     return serializer.loads(token, max_age=max_token_age)
 
 

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -94,6 +94,7 @@ SCHEMAS_REFRESH_SCHEDULE = int(os.environ.get("REDASH_SCHEMAS_REFRESH_SCHEDULE",
 AUTH_TYPE = os.environ.get("REDASH_AUTH_TYPE", "api_key")
 PASSWORD_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_PASSWORD_LOGIN_ENABLED", "true"))
 ENFORCE_HTTPS = parse_boolean(os.environ.get("REDASH_ENFORCE_HTTPS", "false"))
+INVITATION_TOKEN_MAX_AGE = int(os.environ.get("REDASH_INVITATION_TOKEN_MAX_AGE", 60 * 60 * 24 * 7))
 
 MULTI_ORG = parse_boolean(os.environ.get("REDASH_MULTI_ORG", "false"))
 


### PR DESCRIPTION
Allows configuration the max life time of an invitation token which is currently fixed in code for one week.