### PR TITLE
Fix error when adding widget to dashboard

### DIFF
--- a/redash/handlers/widgets.py
+++ b/redash/handlers/widgets.py
@@ -53,7 +53,7 @@ class WidgetListResource(BaseResource):
             layout.append([widget.id])
         elif len(layout[-1]) == 1:
             neighbour_widget = models.Widget.query.get(layout[-1][0])
-            if neighbour_widget.width == 1:
+            if not (neighbour_widget is None) and neighbour_widget.width == 1:
                 layout[-1].append(widget.id)
                 new_row = False
             else:

--- a/redash/models.py
+++ b/redash/models.py
@@ -827,6 +827,22 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         self.is_archived = True
         self.schedule = None
 
+        dashboards = Dashboard.all(self.org, self.user.group_ids, self.user_id)
+        for dashboard in dashboards:
+            widget_list = Widget.query.filter(Widget.dashboard == dashboard)
+            target_widget_ids = []
+            for widget in widget_list:
+                if self.id == widget.visualization.query_id:
+                    target_widget_ids.append(widget.id)
+
+            if len(target_widget_ids) == 0:
+                continue
+
+            new_layout = map(lambda row: filter(lambda w: w not in target_widget_ids, row), layout)
+            new_layout = filter(lambda row: len(row) > 0, new_layout)
+            dashboard.layout = json.dumps(new_layout)
+            db.session.add(dashboard)
+
         for vis in self.visualizations:
             for w in vis.widgets:
                 db.session.delete(w)


### PR DESCRIPTION
A detail of this error is #1883.

I changed that delete widgets containing a query from dashboard layouts when deleting the query.

And, check `neighbour_widget` exists or not for existing users who have a dashboard generated by this bug when they try to add new widget.