### PR TITLE
Set auto focus in first input items

### DIFF
--- a/client/app/components/dynamic-form.html
+++ b/client/app/components/dynamic-form.html
@@ -1,7 +1,7 @@
 <form name="dataSourceForm">
     <div class="form-group">
         <label for="type">Type</label>
-        <select name="type" class="form-control" ng-options="type.type as type.name for type in types" ng-model="target.type"></select>
+        <select name="type" class="form-control" ng-options="type.type as type.name for type in types" ng-model="target.type" autofocus></select>
     </div>
     <div class="form-group">
         <label for="dataSourceName">Name</label>

--- a/client/app/pages/dashboards/dashboard-list.html
+++ b/client/app/pages/dashboards/dashboard-list.html
@@ -2,7 +2,7 @@
   <page-header title="Dashboards"></page-header>
   <div class="col-lg-3">
     <input type='text' class='form-control' placeholder="Search Dashboards..." 
-      ng-change="$ctrl.update()" ng-model="$ctrl.searchText"/>
+      ng-change="$ctrl.update()" ng-model="$ctrl.searchText" autofocus/>
     <div class='list-group m-t-20 tags-list'>
       <a ng-repeat='tag in $ctrl.allTags' ng-class='{"active": $ctrl.tagIsSelected(tag)}'
       class='list-group-item' ng-click='$ctrl.toggleTag($event, tag)'>

--- a/client/app/pages/dashboards/edit-dashboard-dialog.html
+++ b/client/app/pages/dashboards/edit-dashboard-dialog.html
@@ -4,7 +4,7 @@
 </div>
 <div class="modal-body">
   <p>
-    <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name">
+    <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name" autofocus>
   </p>
 
   <p ng-if="$ctrl.dashboard.id">

--- a/client/app/pages/groups/edit-group-dialog.html
+++ b/client/app/pages/groups/edit-group-dialog.html
@@ -3,7 +3,7 @@
 </div>
 <div class="modal-body">
     <form class="form">
-        <input type="text" ng-model="$ctrl.group.name" placeholder="Group Name" class="form-control"/>
+        <input type="text" ng-model="$ctrl.group.name" placeholder="Group Name" class="form-control" autofocus/>
     </form>
 </div>
 <div class="modal-footer">

--- a/client/app/pages/query-snippets/edit.html
+++ b/client/app/pages/query-snippets/edit.html
@@ -3,7 +3,7 @@
     <form name="snippetForm" class="form">
       <div class="form-group">
         <label>Trigger</label>
-        <input type="string" class="form-control" ng-model="$ctrl.snippet.trigger" ng-disabled="!$ctrl.canEdit" required>
+        <input type="string" class="form-control" ng-model="$ctrl.snippet.trigger" ng-disabled="!$ctrl.canEdit" required autofocus>
       </div>
 
       <div class="form-group">

--- a/client/app/pages/users/new.html
+++ b/client/app/pages/users/new.html
@@ -3,7 +3,7 @@
   <form class="form" name="$ctrl.userForm" ng-submit="saveUser()" novalidate>
     <div class="form-group required" ng-class="{ 'has-error':  ($ctrl.userForm.email | showError:$ctrl.userForm )}">
       <label class="control-label">Name</label>
-      <input type="text" name="name" class="form-control" ng-model="user.name" ng-disabled="user.created" required/>
+      <input type="text" name="name" class="form-control" ng-model="user.name" ng-disabled="user.created" required/ autofocus>
 
       <error-messages input="$ctrl.userForm.name" form="$ctrl.userForm"></error-messages>
     </div>


### PR DESCRIPTION
In order to improve user experience, the following items should be focus automatically when they open the page. 

- **Type** in new Data Source form
- **Trigger** in new Query Snippet form
- **Group Name** in new Group dialog
- **User name** in new User form
- **Dashboard name** in edit Dashboard dialog
- **Search box** in Dashboard list

Because they set focus them manually in most cases.