### PR TITLE
Show query editor's Archive/Publish Query drop-down only on saved queries

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -114,7 +114,7 @@
                   <span class="fa fa-floppy-o"> </span> Save<span
                   ng-show="isDirty">&#42;</span>
                 </button>
-                <div class="btn-group" role="group" uib-dropdown>
+                <div ng-if="query.id != undefined" class="btn-group" role="group" uib-dropdown>
                   <button class="btn btn-default btn-sm dropdown-toggle" uib-dropdown-toggle>
                     <span class="zmdi zmdi-more"></span>
                   </button>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1846416/31673758-b06d359c-b37d-11e7-9d32-8259c7062fc6.png)
changes to 
![image](https://user-images.githubusercontent.com/1846416/31673796-c4835df4-b37d-11e7-9126-24d031e2df29.png)

--
The drop-down shows up for saved queries as normal.