### PR TITLE
Add full text search for queries based on the Postgres tsvector type.

### DIFF
--- a/client/app/pages/queries-list/index.js
+++ b/client/app/pages/queries-list/index.js
@@ -48,6 +48,7 @@ class QueriesListCtrl {
     this.tabs = [
       { path: 'queries', name: 'All Queries', isActive: path => path === '/queries' },
       { name: 'My Queries', path: 'queries/my' },
+      { name: 'Search', path: 'queries/search' },
     ];
   }
 }

--- a/client/app/pages/queries/queries-search-results-page.html
+++ b/client/app/pages/queries/queries-search-results-page.html
@@ -1,4 +1,6 @@
 <div class="container">
+    <page-header title="Queries"></page-header>
+    <tab-nav tabs="$ctrl.tabs"></tab-nav>
     <div class="bg-white tiled p-5 m-t-10 m-b-10">
       <form class="form-inline" role="form" ng-submit="$ctrl.search()">
         <div class="input-group">
@@ -15,10 +17,10 @@
       <table class="table table-condensed table-hover">
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Created By</th>
-            <th>Created At</th>
-            <th>Update Schedule</th>
+            <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('name')">Name <sort-icon column="'name'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
+            <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('created_by')">Created By <sort-icon column="'created_by'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
+            <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('created_at')">Created At <sort-icon column="'created_at'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
+            <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('schedule')">Update Schedule <sort-icon column="'schedule'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
           </tr>
         </thead>
         <tbody>
@@ -29,6 +31,9 @@
               {{query.user.name}}</td>
             <td>{{query.created_at | dateTime}}</td>
             <td>{{query.schedule | scheduleHumanize}}</td>
+          </tr>
+          <tr ng-if="$ctrl.paginator.rows.length == 0">
+            <td>No results found.</td>
           </tr>
         </tbody>
       </table>

--- a/client/app/pages/queries/queries-search-results-page.js
+++ b/client/app/pages/queries/queries-search-results-page.js
@@ -8,6 +8,12 @@ function QuerySearchCtrl($location, $filter, currentUser, Events, Query) {
   this.term = $location.search().q;
   this.paginator = new Paginator([], { itemsPerPage: 20 });
 
+  this.tabs = [
+    { path: 'queries', name: 'All Queries', isActive: path => path === '/queries' },
+    { name: 'My Queries', path: 'queries/my' },
+    { name: 'Search', path: 'queries/search' },
+  ];
+
   Query.search({ q: this.term, include_drafts: true }, (results) => {
     const queries = results.map((query) => {
       query.created_at = moment(query.created_at);

--- a/migrations/versions/5ec5c84ba61e_.py
+++ b/migrations/versions/5ec5c84ba61e_.py
@@ -1,0 +1,35 @@
+"""Add Query.search_vector field for full text search.
+
+Revision ID: 5ec5c84ba61e
+Revises: 7671dca4e604
+Create Date: 2017-10-17 18:21:00.174015
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils as su
+import sqlalchemy_searchable as ss
+
+
+# revision identifiers, used by Alembic.
+revision = '5ec5c84ba61e'
+down_revision = '7671dca4e604'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    op.add_column('queries', sa.Column('search_vector', su.TSVectorType()))
+    op.create_index('ix_queries_search_vector', 'queries', ['search_vector'],
+                    unique=False, postgresql_using='gin')
+    ss.sync_trigger(conn, 'queries', 'search_vector',
+                    ['name', 'description', 'query'])
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    ss.drop_trigger(conn, 'queries', 'search_vector')
+    op.drop_index('ix_queries_search_vector', table_name='queries')
+    op.drop_column('queries', 'search_vector')

--- a/migrations/versions/6b5be7e0a0ef_.py
+++ b/migrations/versions/6b5be7e0a0ef_.py
@@ -1,0 +1,48 @@
+"""Re-index Query.search_vector with existing queries.
+
+Revision ID: 6b5be7e0a0ef
+Revises: 5ec5c84ba61e
+Create Date: 2017-11-02 20:42:13.356360
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_searchable as ss
+
+
+# revision identifiers, used by Alembic.
+revision = '6b5be7e0a0ef'
+down_revision = '5ec5c84ba61e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    ss.vectorizer.clear()
+
+    conn = op.get_bind()
+
+    metadata = sa.MetaData(bind=conn)
+    queries = sa.Table('queries', metadata, autoload=True)
+
+    @ss.vectorizer(queries.c.id)
+    def integer_vectorizer(column):
+        return sa.func.cast(column, sa.Text)
+
+    ss.sync_trigger(
+        conn,
+        'queries',
+        'search_vector',
+        ['id', 'name', 'description', 'query'],
+        metadata=metadata
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    ss.drop_trigger(conn, 'queries', 'search_vector')
+    op.drop_index('ix_queries_search_vector', table_name='queries')
+    op.create_index('ix_queries_search_vector', 'queries', ['search_vector'],
+                    unique=False, postgresql_using='gin')
+    ss.sync_trigger(conn, 'queries', 'search_vector',
+                    ['name', 'description', 'query'])

--- a/redash/admin.py
+++ b/redash/admin.py
@@ -55,7 +55,8 @@ class QueryResultModelView(BaseModelView):
 
 class QueryModelView(BaseModelView):
     column_exclude_list = ('latest_query_data',)
-    form_excluded_columns = ('version', 'visualizations', 'alerts', 'org', 'created_at', 'updated_at', 'latest_query_data')
+    form_excluded_columns = ('version', 'visualizations', 'alerts', 'org', 'created_at',
+                             'updated_at', 'latest_query_data', 'search_vector')
 
 
 class DashboardModelView(BaseModelView):

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -37,16 +37,23 @@ class QuerySearchResource(BaseResource):
     @require_permission('view_query')
     def get(self):
         """
-        Search query text, titles, and descriptions.
+        Search query text, names, and descriptions.
 
         :qparam string q: Search term
 
         Responds with a list of :ref:`query <query-response-label>` objects.
         """
         term = request.args.get('q', '')
+        if not term:
+            return []
+
         include_drafts = request.args.get('include_drafts') is not None
 
-        return [q.to_dict(with_last_modified_by=False) for q in models.Query.search(term, self.current_user.group_ids, include_drafts=include_drafts)]
+        return [q.to_dict(with_last_modified_by=False)
+                for q in models.Query.search(term,
+                                             self.current_user.group_ids,
+                                             include_drafts=include_drafts,
+                                             limit=None)]
 
 
 class QueryRecentResource(BaseResource):

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ redis==2.10.5
 requests==2.11.1
 six==1.10.0
 SQLAlchemy==1.1.4
+SQLAlchemy-Searchable==0.10.6
+SQLAlchemy-Utils>=0.29.0
 sqlparse==0.1.8
 wsgiref==0.1.2
 honcho==0.5.0
@@ -46,4 +48,3 @@ simplejson==3.10.0
 # Uncomment the requirement for ldap3 if using ldap.
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
-


### PR DESCRIPTION
This needs some more tests with a prod like database and probably another
look for someone with more experience with custom alembic migrations.

This is related to #1400 of course and uses [SQLAlchemy-searchable](https://sqlalchemy-searchable.readthedocs.io/en/latest/).