### PR TITLE
Elasticsearch: Collect doc_count field from aggregation

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -219,7 +219,7 @@ class BaseElasticSearch(BaseQueryRunner):
                     result_row = get_row(rows, row)
                     collect_aggregations(mappings, rows, parent_key, value, result_row, result_columns, result_columns_index)
                     if 'doc_count' in value:
-                        collect_value(mappings, result_row, 'doc_count', value['doc_count'], 'long')
+                        collect_value(mappings, result_row, 'doc_count', value['doc_count'], 'integer')
                     if 'key' in value:
                         if 'key_as_string' in value:
                             collect_value(mappings, result_row, parent_key, value['key_as_string'], 'string')

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -218,6 +218,8 @@ class BaseElasticSearch(BaseQueryRunner):
                 for value in data:
                     result_row = get_row(rows, row)
                     collect_aggregations(mappings, rows, parent_key, value, result_row, result_columns, result_columns_index)
+                    if 'doc_count' in value:
+                        collect_value(mappings, result_row, 'doc_count', value['doc_count'], 'long')
                     if 'key' in value:
                         if 'key_as_string' in value:
                             collect_value(mappings, result_row, parent_key, value['key_as_string'], 'string')


### PR DESCRIPTION
The `doc_count` field, which is part of the Elasticsearch aggregation result, was ignored.
This fix makes the following class of queries return a `doc_count` column, which then can be used for histograms and the like:

```
{
    "aggs": {
        "sessions": {
            "date_histogram": {
                "field": "start_time",
                "interval": "day"
            }
        }
    },
    "size": 0
}
```