### PR TITLE
Add copy clipboard link

### DIFF
--- a/client/app/assets/css/redash.css
+++ b/client/app/assets/css/redash.css
@@ -134,6 +134,14 @@ a.navbar-brand img {
   display: block;
 }
 
+.copy-link {
+  text-align: right;
+}
+
+.copy-link > a {
+  cursor: pointer;
+}
+
 /* angular-growl */
 .growl {
   position: fixed;

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -27,6 +27,7 @@ import 'angular-ui-ace';
 import 'angular-resizable';
 import ngGridster from 'angular-gridster';
 import { each } from 'underscore';
+import clipboardModule from 'angular-clipboard';
 
 import './sortable';
 
@@ -47,7 +48,7 @@ const logger = debug('redash');
 
 const requirements = [
   ngRoute, ngResource, ngSanitize, uiBootstrap, ngMessages, uiSelect, 'angularMoment', toastr, 'ui.ace',
-  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name,
+  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name, clipboardModule.name,
 ];
 
 const ngModule = angular.module('app', requirements);

--- a/client/app/pages/queries/api-key-dialog.js
+++ b/client/app/pages/queries/api-key-dialog.js
@@ -1,3 +1,5 @@
+import { CopyClipboard } from '../../utils';
+
 const ApiKeyDialog = {
   template: `<div class="modal-header">
     <button type="button" class="close" aria-label="Close" ng-click="$ctrl.close()"><span aria-hidden="true">&times;</span></button>
@@ -5,6 +7,9 @@ const ApiKeyDialog = {
 <div class="modal-body">
     <h5>API Key</h5>
     <pre>{{$ctrl.apiKey}}</pre>
+    <div class="copy-link">
+      <a clipboard supported="supported" text="$ctrl.apiKey" on-copied="$ctrl.copySuccess()" on-error="$ctrl.copyFail(err)">Copy</a>
+    </div>
 
     <h5>Example API Calls:</h5>
 
@@ -12,18 +17,33 @@ const ApiKeyDialog = {
         Results in CSV format:
 
         <pre>{{$ctrl.csvUrl}}</pre>
+        <div class="copy-link">
+          <a clipboard supported="supported" text="$ctrl.csvUrl" on-copied="$ctrl.copySuccess()" on-error="$ctrl.copyFail(err)">Copy</a>
+        </div>
 
         Results in JSON format:
 
         <pre>{{$ctrl.jsonUrl}}</pre>
+        <div class="copy-link">
+          <a clipboard supported="supported" text="$ctrl.jsonUrl" on-copied="$ctrl.copySuccess()" on-error="$ctrl.copyFail(err)">Copy</a>
+        </div>
     </div>
 </div>`,
-  controller(clientConfig) {
+  controller(clientConfig, toastr) {
     'ngInject';
 
     this.apiKey = this.resolve.query.api_key;
     this.csvUrl = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.csv?api_key=${this.apiKey}`;
     this.jsonUrl = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.json?api_key=${this.apiKey}`;
+    this.copyClipboard = new CopyClipboard(toastr);
+
+    this.copySuccess = () => {
+      this.copyClipboard.success();
+    };
+
+    this.copyFail = (err) => {
+      this.copyClipboard.fail(err);
+    };
   },
   bindings: {
     resolve: '<',

--- a/client/app/pages/users/show.html
+++ b/client/app/pages/users/show.html
@@ -44,7 +44,10 @@
   </div>
   <div ng-show="selectedTab == 'apiKey'" class="p-10">
     API Key:
-    <input type="text" value="{{user.api_key}}" size="44" readonly/>
+    <pre>{{user.api_key}}</pre>
+    <div class="copy-link">
+      <a clipboard supported="supported" text="user.api_key" on-copied="copySuccess()" on-error="copyFail(err)">Copy</a>
+    </div>
   </div>
   <div ng-show="selectedTab == 'settings'" class="p-10">
     <div class="col-md-6">

--- a/client/app/pages/users/show.js
+++ b/client/app/pages/users/show.js
@@ -1,5 +1,6 @@
 import { each } from 'underscore';
 import template from './show.html';
+import { CopyClipboard } from '../../utils';
 
 function UserCtrl(
   $scope, $routeParams, $http, $location, toastr,
@@ -102,6 +103,16 @@ function UserCtrl(
       $scope.disablePasswordResetButton = false;
       $scope.passwordResetLink = data.reset_link;
     });
+  };
+
+  this.copyClipboard = new CopyClipboard(toastr);
+
+  $scope.copySuccess = () => {
+    this.copyClipboard.success();
+  };
+
+  $scope.copyFail = (err) => {
+    this.copyClipboard.fail(err);
   };
 }
 

--- a/client/app/utils/copy-clipboard.js
+++ b/client/app/utils/copy-clipboard.js
@@ -1,0 +1,14 @@
+export default class CopyClipboard {
+  constructor(toastr) {
+    this.toastr = toastr;
+  }
+
+  success() {
+    this.toastr.success('Copied.');
+  }
+
+  fail(err) {
+    this.toastr.error('Unable to copy. ' + err);
+  }
+}
+

--- a/client/app/utils/index.js
+++ b/client/app/utils/index.js
@@ -1,2 +1,3 @@
 export { default as Paginator } from './paginator';
 export { default as LivePaginator } from './live-paginator';
+export { default as CopyClipboard } from './copy-clipboard';

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,11 @@
       "resolved": "https://registry.npmjs.org/angular-base64-upload/-/angular-base64-upload-0.1.23.tgz",
       "integrity": "sha512-vRSY+7/pag2hEdTSB90LTvT5rU5XPxBNMA1WGz60pNSpChRUzf+h5FR9lObRcGg1WUOvlYinnvoPTD6Nktcx1g=="
     },
+    "angular-clipboard": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/angular-clipboard/-/angular-clipboard-1.6.2.tgz",
+      "integrity": "sha512-T5kK6X6fFigLPd2szxW8ETEOLNW9z/9RqdlXtLAY7nakrI62BH8FGOxIes36tvAP/9numwokEWKVLy0WpNkB7w=="
+    },
     "angular-gridster": {
       "version": "0.13.14",
       "resolved": "https://registry.npmjs.org/angular-gridster/-/angular-gridster-0.13.14.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "angular": "~1.5.8",
     "angular-base64-upload": "^0.1.23",
+    "angular-clipboard": "^1.6.2",
     "angular-gridster": "^0.13.14",
     "angular-messages": "~1.5.8",
     "angular-moment": "^1.1.0",


### PR DESCRIPTION
To improve user experience, add link to copy clipboard.

The package [angular-clipboard](https://github.com/omichelsen/angular-clipboard) using  Selection API and Clipboard API, and supports Chrome 43+, Firefox 41+, Opera 29+, IE10+, Safari 10+ and Mobile Safari 10+.

# Screenshot
## Before
Query:
![before_query](https://user-images.githubusercontent.com/3317191/31849689-6dc39f2c-b681-11e7-8fc7-d7dd9e716817.png)

User Settings:
![before_api](https://user-images.githubusercontent.com/3317191/31849700-9d61d078-b681-11e7-9853-cbbcff3f4902.png)

## After
Query:
![copied_in_query](https://user-images.githubusercontent.com/3317191/31849679-3542141c-b681-11e7-9f57-6a3cb869846f.png)

User Settings:
![api_key_copied](https://user-images.githubusercontent.com/3317191/31849658-99cc3a44-b680-11e7-9538-10583397a348.png)

# Test Environment

The following are OK.

- Chrome 62.0.3202.62 (Official Build) (64-bit) on macOS Sierra 10.12.4
- Safari 10.1 (12603.1.30.0.34) on macOS Sierra 10.12.4
- Internet Explorer 11.0.9600.18792 on Windows 7 Service Pack1
- Edge 40.15063.0.0 on Windows 10 Enterprise Evaluation 1703
- Chrome 62.0.3202.60 on iOS 11.0.3

The following is NG because angular-clipboard isn't support.

- Firefox 40.0 on macOS Sierra 10.12.4