### PR TITLE
Fix error when exporting list data as Excel file

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -738,7 +738,10 @@ class QueryResult(db.Model, BelongsToOrgMixin):
 
         for (r, row) in enumerate(query_data['rows']):
             for (c, name) in enumerate(column_names):
-                sheet.write(r + 1, c, row.get(name))
+                v = row.get(name)
+                if isinstance(v, list):
+                    v = str(v).encode('utf-8')
+                sheet.write(r + 1, c, v)
 
         book.close()
 


### PR DESCRIPTION
About #2051.

XlsxWriter's `.write()` is not support list data. My solution is convert to string.

And, I have already checked the following BSON Types in MongoDB is OK.

- Arrays
- String
- Integer
- Boolean
- Object
- Date
- Timestamp
- Symbol