### PR TITLE
replaced -y option since it didn't perform any action with -qq

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -37,7 +37,7 @@ create_redash_user() {
 }
 
 install_system_packages() {
-    apt-get -y update
+    apt-get -qq update
     # Base packages
     apt install -y python-pip python-dev nginx curl build-essential pwgen
     # Data sources dependencies:


### PR DESCRIPTION
Replaced -y option since it didn't perform any action with the apt-get update command; the -qq option will only display errors and warning when updating the repositories.

Thanks.