### PR TITLE
Copy parameters value when forking a query

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -967,7 +967,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     def fork(self, user):
         forked_list = ['org', 'data_source', 'latest_query_data', 'description',
-                       'query_text', 'query_hash']
+                       'query_text', 'query_hash', 'options']
         kwargs = {a: getattr(self, a) for a in forked_list}
         forked_query = Query.create(name=u'Copy of (#{}) {}'.format(self.id, self.name),
                                     user=user, **kwargs)


### PR DESCRIPTION
Fix #2036.

Now, new query does not have their parameters value  when forking a query. I would like to copy the parameters value from an original query.