### PR TITLE
 Fix: require full access to the data source to fork a query.

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -107,7 +107,7 @@
                 <button class="btn btn-s btn-default" ng-click="togglePublished()" ng-if="query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
                   <span class="fa fa-paper-plane"></span> Publish
                 </button>
-                <button class="btn btn-s btn-default" ng-click="duplicateQuery()" ng-disabled="query.id === undefined">
+                <button class="btn btn-s btn-default" ng-click="duplicateQuery()" ng-disabled="query.id === undefined || !canForkQuery()">
                   <span class="zmdi zmdi-arrow-split"></span> Fork
                 </button>
                 <button class="btn btn-default" ng-show="canEdit" ng-click="saveQuery()">

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -44,6 +44,8 @@ function QuerySourceCtrl(
     KeyboardShortcuts.unbind(shortcuts);
   });
 
+  $scope.canForkQuery = () => currentUser.hasPermission('edit_query') && !$scope.dataSource.view_only;
+
   // @override
   $scope.saveQuery = (options, data) => {
     const savePromise = saveQuery(options, data);

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -251,6 +251,7 @@ class QueryForkResource(BaseResource):
         Responds with created :ref:`query <query-response-label>` object.
         """
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
+        require_access(query.data_source.groups, self.current_user, not_view_only)
         forked_query = query.fork(self.current_user)
         models.db.session.commit()
         return forked_query.to_dict(with_visualizations=True)

--- a/tests/handlers/test_queries.py
+++ b/tests/handlers/test_queries.py
@@ -158,3 +158,21 @@ class QueryRefreshTest(BaseTestCase):
         user = self.factory.create_user(group_ids=[group.id])
         response = self.make_request('post', self.path, user=user)
         self.assertEqual(403, response.status_code)
+
+
+class TestQueryForkResourcePost(BaseTestCase):
+    def test_forks_a_query(self):
+        ds = self.factory.create_data_source(group=self.factory.org.default_group, view_only=False)
+        query = self.factory.create_query(data_source=ds)
+
+        rv = self.make_request('post', '/api/queries/{}/fork'.format(query.id))
+
+        self.assertEqual(rv.status_code, 200)
+
+    def test_must_have_full_access_to_data_source(self):
+        ds = self.factory.create_data_source(group=self.factory.org.default_group, view_only=True)
+        query = self.factory.create_query(data_source=ds)
+
+        rv = self.make_request('post', '/api/queries/{}/fork'.format(query.id))
+
+        self.assertEqual(rv.status_code, 403)


### PR DESCRIPTION
Closes #1825.