### PR TITLE
Add a description field to a dashboard

### DIFF
--- a/client/app/components/dashboards/edit-dashboard-dialog.html
+++ b/client/app/components/dashboards/edit-dashboard-dialog.html
@@ -6,6 +6,9 @@
   <p>
     <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name" autofocus>
   </p>
+  <p>
+    <input type="text" class="form-control" placeholder="Dashboard Description" ng-model="$ctrl.dashboard.description">
+  </p>
 
   <p ng-if="$ctrl.dashboard.id">
     <label>

--- a/client/app/components/dashboards/edit-dashboard-dialog.js
+++ b/client/app/components/dashboards/edit-dashboard-dialog.js
@@ -37,6 +37,7 @@ const EditDashboardDialog = {
         const request = {
           slug: this.dashboard.id,
           name: this.dashboard.name,
+          description: this.dashboard.description,
           version: this.dashboard.version,
           dashboard_filters_enabled: this.dashboard.dashboard_filters_enabled,
         };
@@ -59,6 +60,7 @@ const EditDashboardDialog = {
       } else {
         $http.post('api/dashboards', {
           name: this.dashboard.name,
+          description: this.dashboard.description,
         }).success((response) => {
           this.close();
           $location.path(`/dashboard/${response.slug}`).replace();

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -5,6 +5,9 @@
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>
         <span class="label label-warning" ng-if="$ctrl.dashboard.is_archived" uib-popover="This dashboard is archived and and won't appear in the dashboards list or search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
       </h3>
+      <p>
+        <em>{{$ctrl.dashboard.description}}</em>
+      </p>
     </div>
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-5 text-right">
       <h3>

--- a/migrations/versions/0fc534115f9b_.py
+++ b/migrations/versions/0fc534115f9b_.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: 0fc534115f9b
+Revises: d1eae8b9893e
+Create Date: 2017-11-19 19:51:49.843065
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0fc534115f9b'
+down_revision = 'd1eae8b9893e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('dashboards', sa.Column('description', sa.String(),
+                                           nullable=True, server_default=None))
+
+
+def downgrade():
+    op.drop_column('dashboards', 'description')

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -128,7 +128,7 @@ class DashboardResource(BaseResource):
 
         require_object_modify_permission(dashboard, self.current_user)
 
-        updates = project(dashboard_properties, ('name', 'layout', 'version',
+        updates = project(dashboard_properties, ('name', 'description', 'layout', 'version',
                                                  'is_draft', 'dashboard_filters_enabled'))
 
         # SQLAlchemy handles the case where a concurrent transaction beats us

--- a/redash/models.py
+++ b/redash/models.py
@@ -1218,6 +1218,7 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
     org = db.relationship(Organization, backref="dashboards")
     slug = Column(db.String(140), index=True, default=generate_slug)
     name = Column(db.String(100))
+    description = Column(db.String(4096), nullable=True)
     user_id = Column(db.Integer, db.ForeignKey("users.id"))
     user = db.relationship(User)
     # TODO: The layout should dynamically be built from position and size information on each widget.
@@ -1274,6 +1275,7 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
             'id': self.id,
             'slug': self.slug,
             'name': self.name,
+            'description': self.description,
             'user_id': self.user_id,
             'layout': layout,
             'dashboard_filters_enabled': self.dashboard_filters_enabled,


### PR DESCRIPTION
Add a description field to a dashboard like a query's one.

# Screenshot

## Edit dialog

before
![dashboard_before](https://user-images.githubusercontent.com/3317191/32990854-28eb0d36-cd74-11e7-9b73-99185c6f631a.png)

after
![dashboard_after2](https://user-images.githubusercontent.com/3317191/32990899-e5f990be-cd74-11e7-9bd8-fc96e921d52f.png)


## Detail page

| before | after |
| ------ | ----- |
| ![dashboard_detail_before](https://user-images.githubusercontent.com/3317191/32990888-be466ea2-cd74-11e7-9d2e-9bcfad5697a2.png) | ![dashboard_after](https://user-images.githubusercontent.com/3317191/32990871-5245b852-cd74-11e7-9050-acd57003cace.png) | 


