### PR TITLE
Display profile image to each page

### DIFF
--- a/client/app/assets/css/redash.css
+++ b/client/app/assets/css/redash.css
@@ -53,6 +53,11 @@ a.navbar-brand img {
   height: 40px;
 }
 
+.avatar-mini img {
+  width: 20px;
+  height: 20px;
+}
+
 #logout {
   color: white;
   position: relative;

--- a/client/app/assets/css/redash.css
+++ b/client/app/assets/css/redash.css
@@ -53,11 +53,6 @@ a.navbar-brand img {
   height: 40px;
 }
 
-.avatar-mini img {
-  width: 20px;
-  height: 20px;
-}
-
 #logout {
   color: white;
   position: relative;

--- a/client/app/assets/less/redash-newstyle.less
+++ b/client/app/assets/less/redash-newstyle.less
@@ -257,6 +257,14 @@ edit-in-place p.editable:hover {
   margin-top: -2px;
 }
 
+.profile__image_thumb {
+  border-radius: 100%;
+  margin-right: 3px;
+  margin-top: -2px;
+  width: 20px;
+  height: 20px;
+}
+
 .btn__new {
   margin-left: 15px;
 }

--- a/client/app/components/app-header/app-header.html
+++ b/client/app/components/app-header/app-header.html
@@ -57,7 +57,7 @@
         <!--</li>-->
         <li class="dropdown" uib-dropdown>
           <a href="#" class="dropdown-toggle dropdown--profile" uib-dropdown-toggle>
-            <img ng-src="{{$ctrl.currentUser.gravatar_url}}" class="profile__image--navbar" width="20"/>
+            <img ng-src="{{$ctrl.currentUser.profile_image_url}}" class="profile__image--navbar" width="20"/>
             <span class="dropdown--profile__username" ng-bind="$ctrl.currentUser.name"></span> <span
             class="caret caret--nav"></span></a>
           <ul class="dropdown-menu dropdown-menu--profile">

--- a/client/app/components/permissions-editor/permissions-editor.html
+++ b/client/app/components/permissions-editor/permissions-editor.html
@@ -11,7 +11,7 @@
                          refresh-delay="0"
                          ui-disable-choice="user.alreadyGrantee">
         <div>
-          <img ng-src="{{user.gravatar_url}}" height="24px">&nbsp;{{user.name}}
+          <img ng-src="{{user.profile_image_url}}" height="24px">&nbsp;{{user.name}}
           <small ng-if="user.alreadyGrantee">(already has permission)</small>
         </div>
        </ui-select-choices>
@@ -28,7 +28,7 @@
         </thead>
         <tbody>
         <tr ng-repeat="grantee in $ctrl.grantees">
-          <td width="50px"><img ng-src="{{grantee.gravatar_url}}" height="40px"/></td>
+          <td width="50px"><img ng-src="{{grantee.profile_image_url}}" height="40px"/></td>
           <td>{{grantee.name}} </td>
           <td>{{grantee.access_type}}</td>
           <td><button class="pull-right btn btn-sm btn-danger" ng-click="$ctrl.removeGrantee(grantee)">Remove</button></td>

--- a/client/app/pages/groups/show.html
+++ b/client/app/pages/groups/show.html
@@ -17,7 +17,7 @@
                            refresh-delay="0"
                            ui-disable-choice="user.alreadyMember">
           <div>
-            <img ng-src="{{user.gravatar_url}}" height="24px">&nbsp;{{user.name}}
+            <img ng-src="{{user.profile_image_url}}" height="24px">&nbsp;{{user.name}}
             <small ng-if="user.alreadyMember">(already member in this group)</small>
           </div>
         </ui-select-choices>
@@ -29,7 +29,7 @@
       <table class="table table-condensed table-hover" ng-show="members">
         <tbody>
         <tr ng-repeat="member in members">
-          <td width="50px"><img ng-src="{{member.gravatar_url}}" height="40px"/></td>
+          <td width="50px"><img ng-src="{{member.profile_image_url}}" height="40px"/></td>
           <td>{{member.name}} <button class="pull-right btn btn-sm btn-danger" ng-click="removeMember(member)" ng-if="currentUser.isAdmin">Remove</button></td>
         </tr>
         </tbody>

--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -17,7 +17,10 @@
       <tbody>
       <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
         <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
-        <td>{{query.user.name}}</td>
+        <td>
+          <span class="avatar-mini"><img ng-src="{{query.user.gravatar_url}}"/></span>
+          {{query.user.name}}
+        </td>
         <td>{{query.created_at | dateTime}}</td>
         <td>{{query.runtime | durationHumanize}}</td>
         <td>{{query.retrieved_at | dateTime}}</td>

--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -18,7 +18,7 @@
       <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
         <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
         <td>
-          <img ng-src="{{query.user.gravatar_url}}" class="profile__image_thumb"/>
+          <img ng-src="{{query.user.profile_image_url}}" class="profile__image_thumb"/>
           {{query.user.name}}
         </td>
         <td>{{query.created_at | dateTime}}</td>

--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -18,7 +18,7 @@
       <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
         <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
         <td>
-          <span class="avatar-mini"><img ng-src="{{query.user.gravatar_url}}"/></span>
+          <img ng-src="{{query.user.gravatar_url}}" class="profile__image_thumb"/>
           {{query.user.name}}
         </td>
         <td>{{query.created_at | dateTime}}</td>

--- a/client/app/pages/queries/queries-search-results-page.html
+++ b/client/app/pages/queries/queries-search-results-page.html
@@ -24,7 +24,9 @@
         <tbody>
           <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
             <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
-            <td>{{query.user.name}}</td>
+            <td>
+              <span class="avatar-mini"><img ng-src="{{query.user.gravatar_url}}"/></span>
+              {{query.user.name}}</td>
             <td>{{query.created_at | dateTime}}</td>
             <td>{{query.schedule | scheduleHumanize}}</td>
           </tr>

--- a/client/app/pages/queries/queries-search-results-page.html
+++ b/client/app/pages/queries/queries-search-results-page.html
@@ -25,7 +25,7 @@
           <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
             <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
             <td>
-              <img ng-src="{{query.user.gravatar_url}}" class="profile__image_thumb"/>
+              <img ng-src="{{query.user.profile_image_url}}" class="profile__image_thumb"/>
               {{query.user.name}}</td>
             <td>{{query.created_at | dateTime}}</td>
             <td>{{query.schedule | scheduleHumanize}}</td>

--- a/client/app/pages/queries/queries-search-results-page.html
+++ b/client/app/pages/queries/queries-search-results-page.html
@@ -25,7 +25,7 @@
           <tr ng-repeat="query in $ctrl.paginator.getPageRows()">
             <td><a href="queries/{{query.id}}">{{query.name}}</a> <span class="label label-default" ng-if="query.is_draft">Unpublished</span></td>
             <td>
-              <span class="avatar-mini"><img ng-src="{{query.user.gravatar_url}}"/></span>
+              <img ng-src="{{query.user.gravatar_url}}" class="profile__image_thumb"/>
               {{query.user.name}}</td>
             <td>{{query.created_at | dateTime}}</td>
             <td>{{query.schedule | scheduleHumanize}}</td>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -40,6 +40,7 @@
         <li>
           <span class="zmdi zmdi-account"></span>
           <span class="text-muted">Created By </span>
+          <span class="avatar-mini"><img ng-src="{{query.user.gravatar_url}}"/></span>
           <strong>{{query.user.name}}</strong>
         </li>
         <li ng-if="query.last_modified_by && query.user.id != query.last_modified_by.id">

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -40,7 +40,7 @@
         <li>
           <span class="zmdi zmdi-account"></span>
           <span class="text-muted">Created By </span>
-          <img ng-src="{{query.user.gravatar_url}}" class="profile__image_thumb"/>
+          <img ng-src="{{query.user.profile_image_url}}" class="profile__image_thumb"/>
           <strong>{{query.user.name}}</strong>
         </li>
         <li ng-if="query.last_modified_by && query.user.id != query.last_modified_by.id">

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -40,7 +40,7 @@
         <li>
           <span class="zmdi zmdi-account"></span>
           <span class="text-muted">Created By </span>
-          <span class="avatar-mini"><img ng-src="{{query.user.gravatar_url}}"/></span>
+          <img ng-src="{{query.user.gravatar_url}}" class="profile__image_thumb"/>
           <strong>{{query.user.name}}</strong>
         </li>
         <li ng-if="query.last_modified_by && query.user.id != query.last_modified_by.id">

--- a/client/app/pages/query-snippets/edit.html
+++ b/client/app/pages/query-snippets/edit.html
@@ -22,7 +22,9 @@
         <button class="btn btn-danger" ng-if="$ctrl.snippet.id" ng-click="$ctrl.delete()">Delete</button>
       </div>
       <small ng-if="$ctrl.snippet.user">
-        Created by: {{$ctrl.snippet.user.name}}
+        Created by: 
+        <span class="avatar-mini"><img ng-src="{{$ctrl.snippet.user.gravatar_url}}"/></span>
+        {{$ctrl.snippet.user.name}}
       </small>
     </form>
   </div>

--- a/client/app/pages/query-snippets/edit.html
+++ b/client/app/pages/query-snippets/edit.html
@@ -23,7 +23,7 @@
       </div>
       <small ng-if="$ctrl.snippet.user">
         Created by: 
-        <span class="avatar-mini"><img ng-src="{{$ctrl.snippet.user.gravatar_url}}"/></span>
+        <img ng-src="{{$ctrl.snippet.user.gravatar_url}}" class="profile__image_thumb"/>
         {{$ctrl.snippet.user.name}}
       </small>
     </form>

--- a/client/app/pages/query-snippets/edit.html
+++ b/client/app/pages/query-snippets/edit.html
@@ -23,7 +23,7 @@
       </div>
       <small ng-if="$ctrl.snippet.user">
         Created by: 
-        <img ng-src="{{$ctrl.snippet.user.gravatar_url}}" class="profile__image_thumb"/>
+        <img ng-src="{{$ctrl.snippet.user.profile_image_url}}" class="profile__image_thumb"/>
         {{$ctrl.snippet.user.name}}
       </small>
     </form>

--- a/client/app/pages/query-snippets/list.html
+++ b/client/app/pages/query-snippets/list.html
@@ -27,6 +27,7 @@
                   {{row.snippet}}
                 </td>
                 <td>
+                  <span class="avatar-mini"><img ng-src="{{row.user.gravatar_url}}"/></span>
                   {{row.user.name}}
                 </td>
                 <td>

--- a/client/app/pages/query-snippets/list.html
+++ b/client/app/pages/query-snippets/list.html
@@ -27,7 +27,7 @@
                   {{row.snippet}}
                 </td>
                 <td>
-                  <img ng-src="{{row.user.gravatar_url}}" class="profile__image_thumb"/>
+                  <img ng-src="{{row.user.profile_image_url}}" class="profile__image_thumb"/>
                   {{row.user.name}}
                 </td>
                 <td>

--- a/client/app/pages/query-snippets/list.html
+++ b/client/app/pages/query-snippets/list.html
@@ -27,7 +27,7 @@
                   {{row.snippet}}
                 </td>
                 <td>
-                  <span class="avatar-mini"><img ng-src="{{row.user.gravatar_url}}"/></span>
+                  <img ng-src="{{row.user.gravatar_url}}" class="profile__image_thumb"/>
                   {{row.user.name}}
                 </td>
                 <td>

--- a/client/app/pages/users/list.html
+++ b/client/app/pages/users/list.html
@@ -15,7 +15,7 @@
         <tbody>
           <tr ng-repeat="row in $ctrl.users.getPageRows()">
             <td>
-              <img ng-src="{{row.gravatar_url}}" height="40px"/> <a href="users/{{row.id}}">{{row.name}}</a>
+              <img ng-src="{{row.profile_image_url}}" height="40px"/> <a href="users/{{row.id}}">{{row.name}}</a>
             </td>
             <td>
               <span am-time-ago="row.created_at"></span>

--- a/client/app/pages/users/show.html
+++ b/client/app/pages/users/show.html
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col-md-4 col-md-offset-4 profile__cointainer">
 
-        <img ng-src="{{user.gravatar_url}}" class="profile__image"/>
+        <img ng-src="{{user.profile_image_url}}" class="profile__image"/>
 
         <h3 class="profile__h3">{{user.name}}</h3>
 

--- a/migrations/versions/7671dca4e604_.py
+++ b/migrations/versions/7671dca4e604_.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: 7671dca4e604
+Revises: d1eae8b9893e
+Create Date: 2017-11-22 22:20:25.166045
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7671dca4e604'
+down_revision = 'd1eae8b9893e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('image_url', sa.String(),
+                                     nullable=True, server_default=None))
+
+
+def downgrade():
+    op.drop_column('users', 'image_url')

--- a/migrations/versions/7671dca4e604_.py
+++ b/migrations/versions/7671dca4e604_.py
@@ -17,9 +17,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('users', sa.Column('image_url', sa.String(),
+    op.add_column('users', sa.Column('profile_image_url', sa.String(),
                                      nullable=True, server_default=None))
 
 
 def downgrade():
-    op.drop_column('users', 'image_url')
+    op.drop_column('users', 'profile_image_url')

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -58,7 +58,7 @@ def verify_profile(org, profile):
     return False
 
 
-def create_and_login_user(org, name, email):
+def create_and_login_user(org, name, email, picture):
     try:
         user_object = models.User.get_by_email_and_org(email, org)
         if user_object.name != name:
@@ -67,7 +67,7 @@ def create_and_login_user(org, name, email):
             models.db.session.commit()
     except NoResultFound:
         logger.debug("Creating user object (%r)", name)
-        user_object = models.User(org=org, name=name, email=email, group_ids=[org.default_group.id])
+        user_object = models.User(org=org, name=name, email=email, image_url=picture, group_ids=[org.default_group.id])
         models.db.session.add(user_object)
         models.db.session.commit()
 
@@ -116,7 +116,7 @@ def authorized():
         flash("Your Google Apps account ({}) isn't allowed.".format(profile['email']))
         return redirect(url_for('redash.login', org_slug=org.slug))
 
-    create_and_login_user(org, profile['name'], profile['email'])
+    create_and_login_user(org, profile['name'], profile['email'], profile['picture'])
 
     next_path = request.args.get('state') or url_for("redash.index", org_slug=org.slug)
 

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -58,7 +58,7 @@ def verify_profile(org, profile):
     return False
 
 
-def create_and_login_user(org, name, email, picture):
+def create_and_login_user(org, name, email, picture=None):
     try:
         user_object = models.User.get_by_email_and_org(email, org)
         if user_object.name != name:

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -116,7 +116,8 @@ def authorized():
         flash("Your Google Apps account ({}) isn't allowed.".format(profile['email']))
         return redirect(url_for('redash.login', org_slug=org.slug))
 
-    create_and_login_user(org, profile['name'], profile['email'], profile['picture'])
+    picture_url = "%s?sz=40" % profile['picture']
+    create_and_login_user(org, profile['name'], profile['email'], picture_url)
 
     next_path = request.args.get('state') or url_for("redash.index", org_slug=org.slug)
 

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -67,7 +67,8 @@ def create_and_login_user(org, name, email, picture=None):
             models.db.session.commit()
     except NoResultFound:
         logger.debug("Creating user object (%r)", name)
-        user_object = models.User(org=org, name=name, email=email, image_url=picture, group_ids=[org.default_group.id])
+        user_object = models.User(org=org, name=name, email=email, _profile_image_url=picture,
+                                  group_ids=[org.default_group.id])
         models.db.session.add(user_object)
         models.db.session.commit()
 

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -191,11 +191,8 @@ def session(org_slug=None):
             'apiKey': current_user.id
         }
     else:
-        email_md5 = hashlib.md5(current_user.email.lower()).hexdigest()
-        gravatar_url = "https://www.gravatar.com/avatar/%s?s=40" % email_md5
-
         user = {
-            'gravatar_url': gravatar_url,
+            'profile_image_url': current_user.profile_image_url,
             'id': current_user.id,
             'name': current_user.name,
             'email': current_user.email,

--- a/redash/models.py
+++ b/redash/models.py
@@ -395,7 +395,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
     org = db.relationship(Organization, backref=db.backref("users", lazy="dynamic"))
     name = Column(db.String(320))
     email = Column(LowercasedString)
-    image_url = Column(db.String(320), nullable=True)
+    _profile_image_url = Column('profile_image_url', db.String(320), nullable=True)
     password_hash = Column(db.String(128), nullable=True)
     # XXX replace with association table
     group_ids = Column('groups', MutableList.as_mutable(postgresql.ARRAY(db.Integer)), nullable=True)
@@ -416,7 +416,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
             'id': self.id,
             'name': self.name,
             'email': self.email,
-            'gravatar_url': self.gravatar_url,
+            'profile_image_url': self.profile_image_url,
             'groups': self.group_ids,
             'updated_at': self.updated_at,
             'created_at': self.created_at
@@ -436,9 +436,9 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
         return False
 
     @property
-    def gravatar_url(self):
-        if self.image_url is not None:
-            return self.image_url
+    def profile_image_url(self):
+        if self._profile_image_url is not None:
+            return self._profile_image_url
 
         email_md5 = hashlib.md5(self.email.lower()).hexdigest()
         return "https://www.gravatar.com/avatar/%s?s=40" % email_md5

--- a/redash/models.py
+++ b/redash/models.py
@@ -395,6 +395,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
     org = db.relationship(Organization, backref=db.backref("users", lazy="dynamic"))
     name = Column(db.String(320))
     email = Column(LowercasedString)
+    image_url = Column(db.String(320))
     password_hash = Column(db.String(128), nullable=True)
     # XXX replace with association table
     group_ids = Column('groups', MutableList.as_mutable(postgresql.ARRAY(db.Integer)), nullable=True)
@@ -436,6 +437,9 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
 
     @property
     def gravatar_url(self):
+        if self.image_url is not None:
+            return self.image_url
+
         email_md5 = hashlib.md5(self.email.lower()).hexdigest()
         return "https://www.gravatar.com/avatar/%s?s=40" % email_md5
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -395,7 +395,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
     org = db.relationship(Organization, backref=db.backref("users", lazy="dynamic"))
     name = Column(db.String(320))
     email = Column(LowercasedString)
-    image_url = Column(db.String(320))
+    image_url = Column(db.String(320), nullable=True)
     password_hash = Column(db.String(128), nullable=True)
     # XXX replace with association table
     group_ids = Column('groups', MutableList.as_mutable(postgresql.ARRAY(db.Integer)), nullable=True)


### PR DESCRIPTION
To increase visibility, I think it would be better to display image next to user name.

# Screenshot

 Queries list, for example.

## before
![before_670320](https://user-images.githubusercontent.com/3317191/33157116-fe2f4f4a-d042-11e7-93ff-eaaeb0f1ca65.png)

## after
![after_670320](https://user-images.githubusercontent.com/3317191/33157115-fdf86f48-d042-11e7-9b15-ba67626b9407.png)

# List of all changed page

- queries list
- queries search result list
- query detail
- query snippets list
- query snippet edit

# Other

Add `image_url` field to `User` model. If user logged in via Google Authentication, then picture url got as a callback will save as image_url and return as `gravatar_url`. Otherwise, Gravatar url will return as `gravatar_url`.

BTW a classname `profile__image_thumb` may not be appropriate.