### PR TITLE
Align numbers right in table

### DIFF
--- a/client/app/components/dynamic-table/dynamic-table.css
+++ b/client/app/components/dynamic-table/dynamic-table.css
@@ -1,3 +1,7 @@
 th.sortable-column {
   cursor: pointer;
 }
+
+.number-column {
+  text-align: right;
+}

--- a/client/app/components/dynamic-table/dynamic-table.html
+++ b/client/app/components/dynamic-table/dynamic-table.html
@@ -2,7 +2,7 @@
   <table class="table table-condensed table-hover">
     <thead>
     <tr>
-      <th ng-repeat="column in $ctrl.columns" ng-click="$ctrl.orderBy(column)" class="sortable-column">
+      <th ng-repeat="column in $ctrl.columns" ng-click="$ctrl.orderBy(column)" class="sortable-column {{column.className}}">
         {{column.title}} <span ng-if="$ctrl.sortIcon(column)"><i class="fa fa-sort-{{$ctrl.sortIcon(column)}}"></i></span>
       </th>
     </tr>
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
     <tr ng-repeat="row in $ctrl.rowsToDisplay">
-      <td ng-repeat="column in $ctrl.columns" ng-bind-html="$ctrl.sanitize(column.formatFunction(row[column.name]))">
+      <td ng-repeat="column in $ctrl.columns" ng-bind-html="$ctrl.sanitize(column.formatFunction(row[column.name]))" class="{{column.className}}">
       </td>
     </tr>
     </tbody>

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -65,6 +65,7 @@ function GridRenderer(clientConfig) {
           columns.forEach((col) => {
             col.title = getColumnCleanName(col.name);
             col.formatFunction = partial(formatValue, $filter, clientConfig, _, col.type);
+            col.className = col.type === 'integer' || col.type === 'float' ? 'number-column' : 'string-column';
           });
 
           $scope.gridRows = $scope.queryResult.getData();


### PR DESCRIPTION
I'd like to align numbers right in result list.

Numbers are integer and float. Other types are same as before.

# Screenshot

## before
![align_before](https://user-images.githubusercontent.com/3317191/33240191-94767c9e-d2f5-11e7-8692-fc40d087c835.png)

## after
![align_after](https://user-images.githubusercontent.com/3317191/33240194-9b5665f6-d2f5-11e7-928a-de41b3bbf607.png)


