### PR TITLE
Upgrade psycopg2 for support PostgreSQL 10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Flask-Limiter==0.9.3
 passlib==1.6.2
 aniso8601==1.1.0
 blinker==1.3
-psycopg2==2.5.2
+psycopg2==2.7.3.1
 python-dateutil==2.4.2
 pytz==2016.7
 redis==2.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Flask-Limiter==0.9.3
 passlib==1.6.2
 aniso8601==1.1.0
 blinker==1.3
-psycopg2==2.7.3.1
+psycopg2==2.7.3.2
 python-dateutil==2.4.2
 pytz==2016.7
 redis==2.10.5


### PR DESCRIPTION
Run `pip install` after install PostgreSQL 10.0, the following error has occurred.

```
% pip install -r requirements.txt -r requirements_dev.txt
Collecting psycopg2==2.5.2 (from -r requirements.txt (line 21))
  Using cached psycopg2-2.5.2.tar.gz
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found

    Error: could not determine PostgreSQL version from '10.1'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/_4/_g1sfpnx2tzf_nck0dqzc7xh0000gp/T/pip-build-wEEbyQ/psycopg2/
```

According to psycopg/psycopg2#489, psycopg2 already fixed this issue.

How about upgrading psycopg2 version. Or with Docker image.