### PR TITLE
prevent remove self

### DIFF
--- a/client/app/pages/groups/show.html
+++ b/client/app/pages/groups/show.html
@@ -30,7 +30,7 @@
         <tbody>
         <tr ng-repeat="member in members">
           <td width="50px"><img ng-src="{{member.gravatar_url}}" height="40px"/></td>
-          <td>{{member.name}} <button class="pull-right btn btn-sm btn-danger" ng-click="removeMember(member)" ng-if="currentUser.isAdmin">Remove</button></td>
+          <td>{{member.name}} <button class="pull-right btn btn-sm btn-danger" ng-click="removeMember(member)" ng-if="currentUser.isAdmin && (group.type != 'builtin' || currentUser.id != member.id)">Remove</button></td>
         </tr>
         </tbody>
       </table>


### PR DESCRIPTION
If an administrator mistakenly removed him/herself from a built-in group, it can not recover.
In order to prevent this, the administrator made it impossible to remove him/herself from the built-in group.

・current built-in group view
![current view](https://user-images.githubusercontent.com/1894032/33592383-16e9e20e-d9ce-11e7-9d3a-06e20156b7e9.png)

・built-in group view after change
![after_built-in_group](https://user-images.githubusercontent.com/1894032/33592392-201901a2-d9ce-11e7-9713-743b70822e6a.png)

・regular group view after change
![after_regular_group](https://user-images.githubusercontent.com/1894032/33592398-2936d962-d9ce-11e7-808c-986789d144fb.png)
