### PR TITLE
Layout fixes (mainly schema browser)

### DIFF
--- a/client/app/components/app-header/app-header.html
+++ b/client/app/components/app-header/app-header.html
@@ -41,8 +41,8 @@
           Create <span class="caret caret--nav"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="create-button">
-          <li role="menuitem"><a ng-show="$ctrl.currentUser.hasPermission('create_dashboard')" ng-click="$ctrl.newDashboard()">Dashboard</a></li>
           <li role="menuitem" ng-show="$ctrl.showNewQueryMenu"><a href="queries/new">Query</a></li>
+          <li role="menuitem"><a ng-show="$ctrl.currentUser.hasPermission('create_dashboard')" ng-click="$ctrl.newDashboard()">Dashboard</a></li>
           <li role="menuitem"><a href="alerts/new">Alert</a></li>
         </ul>
       </div>

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -16,7 +16,7 @@
           <ul class="dropdown-menu pull-right" uib-dropdown-menu style="z-index:1000000">
             <li ng-class="{'disabled': $ctrl.queryResult.isEmpty()}"><a ng-href="{{$ctrl.queryResult.getLink($ctrl.query.id, 'csv')}}" download="{{$ctrl.queryResult.getName($ctrl.query.name, 'csv')}}" target="_self">Download as CSV File</a></li>
             <li ng-class="{'disabled': $ctrl.queryResult.isEmpty()}"><a ng-href="{{$ctrl.queryResult.getLink($ctrl.query.id, 'xlsx')}}" download="{{$ctrl.queryResult.getName($ctrl.query.name, 'xlsx')}}" target="_self">Download as Excel File</a></li>
-            <li><a ng-href="queries/{{$ctrl.query.id}}#{{$ctrl.widget.visualization.id}}" ng-show="$ctrl.canViewQuery">View Query</a></li>
+            <li><a ng-href="{{$ctrl.query.getUrl(true, $ctrl.widget.visualization.id)}}" ng-show="$ctrl.canViewQuery">View Query</a></li>
             <li><a ng-show="$ctrl.dashboard.canEdit()" ng-click="$ctrl.deleteWidget()">Remove From Dashboard</a></li>
           </ul>
         </div>

--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -72,8 +72,10 @@ function queryEditor(QuerySnippet) {
 
             $scope.$watch('schema', (newSchema, oldSchema) => {
               if (newSchema !== oldSchema) {
-                const tokensCount =
-                  newSchema.reduce((totalLength, table) => totalLength + table.columns.length, 0);
+                if (newSchema === undefined) {
+                  return;
+                }
+                const tokensCount = newSchema.reduce((totalLength, table) => totalLength + table.columns.length, 0);
                 // If there are too many tokens we disable live autocomplete,
                 // as it makes typing slower.
                 if (tokensCount > 5000) {
@@ -91,7 +93,6 @@ function queryEditor(QuerySnippet) {
             editor.focus();
           },
         };
-
 
         const schemaCompleter = {
           getCompletions(state, session, pos, prefix, callback) {
@@ -112,18 +113,16 @@ function queryEditor(QuerySnippet) {
                 });
               });
 
-              $scope.schema.keywords = map(keywords, (v, k) =>
-                ({
-                  name: k,
-                  value: k,
-                  score: 0,
-                  meta: v,
-                }));
+              $scope.schema.keywords = map(keywords, (v, k) => ({
+                name: k,
+                value: k,
+                score: 0,
+                meta: v,
+              }));
             }
             callback(null, $scope.schema.keywords);
           },
         };
-
 
         window.ace.acequire(['ace/ext/language_tools'], (langTools) => {
           langTools.addCompleter(schemaCompleter);

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -1,6 +1,6 @@
 <div class="schema-container">
   <div class="schema-control">
-    <input type="text" placeholder="Search schema..." class="form-control" ng-model="$ctrl.schemaFilter">
+    <input type="text" placeholder="Search schema..." class="form-control" ng-model="$ctrl.schemaFilter" ng-disabled="$ctrl.isEmpty()">
     <button class="btn btn-default"
             title="Refresh Schema"
             ng-click="$ctrl.onRefresh()">

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -1,4 +1,4 @@
-<div class="schema-container">
+<div class="schema-container" ng-if="$ctrl.schema">
   <div class="schema-control">
     <input type="text" placeholder="Search schema..." class="form-control" ng-model="$ctrl.schemaFilter" ng-disabled="$ctrl.isEmpty()">
     <button class="btn btn-default"

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -17,6 +17,10 @@ function SchemaBrowserCtrl($scope) {
 
     return size;
   };
+
+  this.isEmpty = function isEmpty() {
+    return this.schema === undefined || this.schema.length === 0;
+  };
 }
 
 const SchemaBrowser = {

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -75,7 +75,6 @@
         }
       }
 
-      .dynamic-table-container,
       .sunburst-visualization-container,
       .sankey-visualization-container,
       .map-visualization-container,

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -250,10 +250,6 @@
                 <div ng-if="!query.visualizations.length">
                   <filters filters="filters"></filters>
                   <grid-renderer query-result="queryResult" items-per-page="50"></grid-renderer>
-                  <!-- the ng-repeat is a lame hack to find the table visualization... -->
-                  <div class="p-15" ng-repeat="vis in query.visualizations" ng-if="vis.type == 'TABLE'">
-                    <button class="btn btn-default" ng-if="!query.isNew()" ng-click="showEmbedDialog(query, vis)"><i class="zmdi zmdi-code"></i> Embed</button>
-                  </div>
                 </div>
                 <div ng-if="selectedTab == vis.id" ng-repeat="vis in query.visualizations">
                   <visualization-renderer visualization="vis" query-result="queryResult"></visualization-renderer>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -237,11 +237,9 @@
             <div class="row">
               <div class="col-lg-12">
                 <ul class="tab-nav">
-                  <rd-tab tab-id="table" name="Table" base-path="query.getUrl(sourceMode)"></rd-tab>
-                  <rd-tab tab-id="{{vis.id}}" name="{{vis.name}}" ng-if="vis.type!='TABLE'" base-path="query.getUrl(sourceMode)"
-                          ng-repeat="vis in query.visualizations">
-                          <span class="remove" ng-click="deleteVisualization($event, vis)"
-                                ng-show="canEdit"> &times;</span>
+                  <rd-tab ng-if="!query.visualizations.length" tab-id="table" name="Table" base-path="query.getUrl(sourceMode)"></rd-tab>
+                  <rd-tab tab-id="{{vis.id}}" name="{{vis.name}}" base-path="query.getUrl(sourceMode)" ng-repeat="vis in query.visualizations | orderBy:'id'">
+                    <span class="remove" ng-click="deleteVisualization($event, vis)" ng-if="canEdit && !($first && (vis.type === 'TABLE'))"> &times;</span>
                   </rd-tab>
                   <li class="rd-tab"><a ng-click="openVisualizationEditor()" ng-if="sourceMode && canEdit">&plus; New Visualization</a></li>
                 </ul>
@@ -249,7 +247,7 @@
             </div>
             <div class="row">
               <div class="col-lg-12">
-                <div ng-show="selectedTab == 'table'">
+                <div ng-if="!query.visualizations.length">
                   <filters filters="filters"></filters>
                   <grid-renderer query-result="queryResult" items-per-page="50"></grid-renderer>
                   <!-- the ng-repeat is a lame hack to find the table visualization... -->

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -87,12 +87,11 @@
 
           <schema-browser class="schema-container"
                           schema="schema"
-                          on-refresh="refreshSchema()"
-                          ng-show="hasSchema">
+                          on-refresh="refreshSchema()">
           </schema-browser>
         </div>
 
-        <div ng-class="editorSize" style="height:100%;">
+        <div class="col-md-9 p-r-0" style="height:100%;">
           <div class="editor__control">
             <div class="form-inline">
               <div class="text-right">

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -43,7 +43,10 @@ function QueryViewCtrl(
   }
 
   function getSchema(refresh = undefined) {
-    DataSource.getSchema({ id: $scope.query.data_source_id, refresh }, (data) => {
+    // TODO: is it possible this will be called before dataSource is set?
+    $scope.schema = [];
+    $scope.dataSource.getSchema(refresh).then((data) => {
+      data = data.data;
       const hasPrevSchema = refresh ? ($scope.schema && ($scope.schema.length > 0)) : false;
       const hasSchema = data && (data.length > 0);
 
@@ -56,10 +59,6 @@ function QueryViewCtrl(
         toastr.error('Schema refresh failed. Please try again later.');
       }
     });
-  }
-
-  function updateSchema() {
-    getSchema();
   }
 
   $scope.refreshSchema = () => getSchema(true);
@@ -82,7 +81,7 @@ function QueryViewCtrl(
 
     $scope.canCreateQuery = any(dataSources, ds => !ds.view_only);
 
-    updateSchema();
+    getSchema();
   }
 
   $scope.executeQuery = () => {
@@ -251,8 +250,8 @@ function QueryViewCtrl(
       });
     }
 
-    updateSchema();
     $scope.dataSource = find($scope.dataSources, ds => ds.id === $scope.query.data_source_id);
+    getSchema();
     $scope.executeQuery();
   };
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -42,11 +42,6 @@ function QueryViewCtrl(
     return dataSourceId;
   }
 
-  function toggleSchemaBrowser(hasSchema) {
-    $scope.hasSchema = hasSchema;
-    $scope.editorSize = hasSchema ? 'col-md-9 p-r-0' : 'col-md-9 p-r-0';
-  }
-
   function getSchema(refresh = undefined) {
     DataSource.getSchema({ id: $scope.query.data_source_id, refresh }, (data) => {
       const hasPrevSchema = refresh ? ($scope.schema && ($scope.schema.length > 0)) : false;
@@ -60,13 +55,10 @@ function QueryViewCtrl(
       } else if (hasPrevSchema) {
         toastr.error('Schema refresh failed. Please try again later.');
       }
-
-      toggleSchemaBrowser(hasSchema || hasPrevSchema);
     });
   }
 
   function updateSchema() {
-    toggleSchemaBrowser(false);
     getSchema();
   }
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -1,10 +1,25 @@
 import { pick, any, some, find, min, isObject } from 'underscore';
+import { SCHEMA_NOT_SUPPORTED, SCHEMA_LOAD_ERROR } from '@/services/data-source';
 import template from './query.html';
 
 function QueryViewCtrl(
-  $scope, Events, $route, $routeParams, $location, $window, $q,
-  KeyboardShortcuts, Title, AlertDialog, Notifications, clientConfig, toastr, $uibModal,
-  currentUser, Query, DataSource,
+  $scope,
+  Events,
+  $route,
+  $routeParams,
+  $location,
+  $window,
+  $q,
+  KeyboardShortcuts,
+  Title,
+  AlertDialog,
+  Notifications,
+  clientConfig,
+  toastr,
+  $uibModal,
+  currentUser,
+  Query,
+  DataSource,
 ) {
   function getQueryResult(maxAge) {
     if (maxAge === undefined) {
@@ -31,8 +46,7 @@ function QueryViewCtrl(
 
     // If we had an invalid value in localStorage (e.g. nothing, deleted source),
     // then use the first data source
-    const isValidDataSourceId = !isNaN(dataSourceId) && some($scope.dataSources, ds =>
-      ds.id === dataSourceId);
+    const isValidDataSourceId = !isNaN(dataSourceId) && some($scope.dataSources, ds => ds.id === dataSourceId);
 
     if (!isValidDataSourceId) {
       dataSourceId = $scope.dataSources[0].id;
@@ -46,16 +60,16 @@ function QueryViewCtrl(
     // TODO: is it possible this will be called before dataSource is set?
     $scope.schema = [];
     $scope.dataSource.getSchema(refresh).then((data) => {
-      data = data.data;
-      const hasPrevSchema = refresh ? ($scope.schema && ($scope.schema.length > 0)) : false;
-      const hasSchema = data && (data.length > 0);
-
-      if (hasSchema) {
-        $scope.schema = data;
-        data.forEach((table) => {
+      if (data.schema) {
+        $scope.schema = data.schema;
+        $scope.schema.forEach((table) => {
           table.collapsed = true;
         });
-      } else if (hasPrevSchema) {
+      } else if (data.error.code === SCHEMA_NOT_SUPPORTED) {
+        $scope.schema = undefined;
+      } else if (data.error.code === SCHEMA_LOAD_ERROR) {
+        toastr.error('Schema refresh failed. Please try again later.');
+      } else {
         toastr.error('Schema refresh failed. Please try again later.');
       }
     });
@@ -65,8 +79,10 @@ function QueryViewCtrl(
 
   function updateDataSources(dataSources) {
     // Filter out data sources the user can't query (or used by current query):
-    $scope.dataSources = dataSources.filter(dataSource =>
-      !dataSource.view_only || dataSource.id === $scope.query.data_source_id);
+    function canUseDataSource(dataSource) {
+      return !dataSource.view_only || dataSource.id === $scope.query.data_source_id;
+    }
+    $scope.dataSources = dataSources.filter(canUseDataSource);
 
     if ($scope.dataSources.length === 0) {
       $scope.noDataSources = true;
@@ -123,7 +139,7 @@ function QueryViewCtrl(
   }
   $scope.queryExecuting = false;
 
-  $scope.isQueryOwner = (currentUser.id === $scope.query.user.id) || currentUser.hasPermission('admin');
+  $scope.isQueryOwner = currentUser.id === $scope.query.user.id || currentUser.hasPermission('admin');
   $scope.canEdit = currentUser.canEdit($scope.query) || $scope.query.can_edit;
   $scope.canViewSource = currentUser.hasPermission('view_source');
 
@@ -167,25 +183,47 @@ function QueryViewCtrl(
       request.id = $scope.query.id;
       request.version = $scope.query.version;
     } else {
-      request = pick($scope.query, ['schedule', 'query', 'id', 'description', 'name', 'data_source_id', 'options', 'latest_query_data_id', 'version', 'is_draft']);
+      request = pick($scope.query, [
+        'schedule',
+        'query',
+        'id',
+        'description',
+        'name',
+        'data_source_id',
+        'options',
+        'latest_query_data_id',
+        'version',
+        'is_draft',
+      ]);
     }
 
-    const options = Object.assign({}, {
-      successMessage: 'Query saved',
-      errorMessage: 'Query could not be saved',
-    }, customOptions);
+    const options = Object.assign(
+      {},
+      {
+        successMessage: 'Query saved',
+        errorMessage: 'Query could not be saved',
+      },
+      customOptions,
+    );
 
-    return Query.save(request, (updatedQuery) => {
-      toastr.success(options.successMessage);
-      $scope.query.version = updatedQuery.version;
-    }, (error) => {
-      if (error.status === 409) {
-        toastr.error('It seems like the query has been modified by another user. ' +
-          'Please copy/backup your changes and reload this page.', { autoDismiss: false });
-      } else {
-        toastr.error(options.errorMessage);
-      }
-    }).$promise;
+    return Query.save(
+      request,
+      (updatedQuery) => {
+        toastr.success(options.successMessage);
+        $scope.query.version = updatedQuery.version;
+      },
+      (error) => {
+        if (error.status === 409) {
+          toastr.error(
+            'It seems like the query has been modified by another user. ' +
+              'Please copy/backup your changes and reload this page.',
+            { autoDismiss: false },
+          );
+        } else {
+          toastr.error(options.errorMessage);
+        }
+      },
+    ).$promise;
   };
 
   // toastr.success('It seems like the query has been modified by another user. ' +
@@ -220,16 +258,21 @@ function QueryViewCtrl(
 
   $scope.archiveQuery = () => {
     function archive() {
-      Query.delete({ id: $scope.query.id }, () => {
-        $scope.query.is_archived = true;
-        $scope.query.schedule = null;
-      }, () => {
-        toastr.error('Query could not be archived.');
-      });
+      Query.delete(
+        { id: $scope.query.id },
+        () => {
+          $scope.query.is_archived = true;
+          $scope.query.schedule = null;
+        },
+        () => {
+          toastr.error('Query could not be archived.');
+        },
+      );
     }
 
     const title = 'Archive Query';
-    const message = 'Are you sure you want to archive this query?<br/> All alerts and dashboard widgets created with its visualizations will be deleted.';
+    const message =
+      'Are you sure you want to archive this query?<br/> All alerts and dashboard widgets created with its visualizations will be deleted.';
     const confirm = { class: 'btn-warning', title: 'Archive' };
 
     AlertDialog.open(title, message, confirm).then(archive);

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -1,30 +1,46 @@
-function DataSource($resource, $http) {
-  const actions = {
-    get: { method: 'GET', cache: false, isArray: false },
-    query: { method: 'GET', cache: false, isArray: true },
-    test: {
-      method: 'POST', cache: false, isArray: false, url: 'api/data_sources/:id/test',
-    },
-    // getSchema: {
-    //   method: 'GET', cache: false, isArray: true, url: 'api/data_sources/:id/schema',
-    // },
-  };
+export const SCHEMA_NOT_SUPPORTED = 1;
+export const SCHEMA_LOAD_ERROR = 2;
 
-  const DataSourceResource = $resource('api/data_sources/:id', { id: '@id' }, actions);
-
-  DataSourceResource.prototype.getSchema = function getSchema(refresh = false) {
+function DataSource($q, $resource, $http) {
+  function fetchSchema(dataSourceId, refresh = false) {
     const params = {};
 
     if (refresh) {
       params.refresh = true;
     }
 
-    return $http.get(`api/data_sources/${this.id}/schema`, { params });
+    return $http.get(`api/data_sources/${dataSourceId}/schema`, { params });
+  }
+
+  const actions = {
+    get: { method: 'GET', cache: false, isArray: false },
+    query: { method: 'GET', cache: false, isArray: true },
+    test: {
+      method: 'POST',
+      cache: false,
+      isArray: false,
+      url: 'api/data_sources/:id/test',
+    },
+  };
+
+  const DataSourceResource = $resource('api/data_sources/:id', { id: '@id' }, actions);
+
+  DataSourceResource.prototype.getSchema = function getSchema(refresh = false) {
+    if (this._schema === undefined || refresh) {
+      return fetchSchema(this.id, refresh).then((response) => {
+        const data = response.data;
+
+        this._schema = data;
+
+        return data;
+      });
+    }
+
+    return $q.resolve(this._schema);
   };
 
   return DataSourceResource;
 }
-
 
 export default function init(ngModule) {
   ngModule.factory('DataSource', DataSource);

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -1,16 +1,26 @@
-function DataSource($resource) {
+function DataSource($resource, $http) {
   const actions = {
     get: { method: 'GET', cache: false, isArray: false },
     query: { method: 'GET', cache: false, isArray: true },
     test: {
       method: 'POST', cache: false, isArray: false, url: 'api/data_sources/:id/test',
     },
-    getSchema: {
-      method: 'GET', cache: false, isArray: true, url: 'api/data_sources/:id/schema',
-    },
+    // getSchema: {
+    //   method: 'GET', cache: false, isArray: true, url: 'api/data_sources/:id/schema',
+    // },
   };
 
   const DataSourceResource = $resource('api/data_sources/:id', { id: '@id' }, actions);
+
+  DataSourceResource.prototype.getSchema = function getSchema(refresh = false) {
+    const params = {};
+
+    if (refresh) {
+      params.refresh = true;
+    }
+
+    return $http.get(`api/data_sources/${this.id}/schema`, { params });
+  };
 
   return DataSourceResource;
 }

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -45,6 +45,10 @@ class InterruptException(Exception):
     pass
 
 
+class NotSupported(Exception):
+    pass
+
+
 class BaseQueryRunner(object):
     noop_query = None
 
@@ -102,7 +106,7 @@ class BaseQueryRunner(object):
         return new_columns
 
     def get_schema(self, get_stats=False):
-        return []
+        raise NotSupported()
 
     def _run_query_internal(self, query):
         results, error = self.run_query(query, None)


### PR DESCRIPTION
* Maintain consistent size of query editor, regardless of availability of the schema.
* Change order of Create menu (Query is first now).
* "View Query" menu item in widget's menu is now linking to the query source view.
* Fix some accidental issues in the UI.

The 3 states of schema browser:
![3tgjdpdsqw](https://user-images.githubusercontent.com/71468/33720389-7b3853c2-db6c-11e7-9504-f07853a61e5d.gif)

* Showing
* Hidden (when not supported)
* Showing but empty (when failed to load)