### PR TITLE
Fix ldap url mail

### DIFF
--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -36,7 +36,12 @@ def login(org_slug=None):
         user = auth_ldap_user(request.form['email'], request.form['password'])
 
         if user is not None:
-            create_and_login_user(current_org, user[settings.LDAP_DISPLAY_NAME_KEY][0], user[settings.LDAP_EMAIL_KEY][0])
+            email = ''
+            if settings.LDAP_CUSTOM_MAIL_DOMAIN:
+                email = '{}@{}'.format(user[settings.LDAP_EMAIL_KEY][0], settings.LDAP_CUSTOM_MAIL_DOMAIN)
+            else:
+                email = user[settings.LDAP_EMAIL_KEY][0]
+            create_and_login_user(current_org, user[settings.LDAP_DISPLAY_NAME_KEY][0], email)
             return redirect(next_path or url_for('redash.index'))
         else:
             flash("Incorrect credentials.")

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -151,6 +151,8 @@ LDAP_CUSTOM_USERNAME_PROMPT = os.environ.get('REDASH_LDAP_CUSTOM_USERNAME_PROMPT
 LDAP_SEARCH_TEMPLATE = os.environ.get('REDASH_LDAP_SEARCH_TEMPLATE', '(cn=%(username)s)')
 # The schema to bind to (ex. cn=users,dc=ORG,dc=local)
 LDAP_SEARCH_DN = os.environ.get('REDASH_SEARCH_DN', None)
+# Custom email domain
+LDAP_CUSTOM_MAIL_DOMAIN = os.environ.get('REDASH_LDAP_CUSTOM_MAIL_DOMAIN', None)
 
 
 # Usually it will be a single path, but we allow to specify additional ones to override the default assets. Only the

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -43,7 +43,7 @@
 
   {% if show_ldap_login %}
   <div class="row">
-    <a href="/ldap_auth/login">LDAP/SSO Login</a>
+    <a href="/ldap/login">LDAP/SSO Login</a>
   </div>
 
   <div class="login-or">


### PR DESCRIPTION
When the LDAP user has no email entered in the mail attribute, login is
not possible due to the fact that the current implementation uses the
email field.

Therefore, the email needs to be composed from other fields.
For this, we need to get the username of the user and the company
domain, concatenate the values and use the resulting email.

e.g.
To get the username, we make use of  the already existing key, but ask
it to query the ldap server for the “uid” attribute:
LDAP_EMAIL_KEY = “uid” —> johndoe

To get the company domain we add an optional environment key read in
the settings file.
The enviromnent key would hold the domain name:
export REDASH_LDAP_CUSTOM_MAIL_DOMAIN=“redash.com"

The end result is: johndoe@redash.com

When the key is not defined, the flow is not changed.