### PR TITLE
Add utf8 column name support for query result data source

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -1,3 +1,5 @@
+#-*- coding: utf-8 -*-
+
 import json
 import logging
 import numbers
@@ -76,14 +78,22 @@ def create_tables_from_query_ids(user, connection, query_ids):
         create_table(connection, table_name, results)
 
 
-def fix_column_name(name):
-    return name.replace(':', '_').replace('.', '_').replace(' ', '_')
+def is_ascii(string):
+    for c in string:
+        if ord(c) >= 128:
+            return False
+    return True
+
+def fix_column_name(i, name):
+    if is_ascii(name):
+        return name.replace(':', '_').replace('.', '_').replace(' ', '_')
+    return 'column_{}'.format(i+1)
 
 
 def create_table(connection, table_name, query_results):
     columns = [column['name']
                for column in query_results['columns']]
-    safe_columns = [fix_column_name(column) for column in columns]
+    safe_columns = [fix_column_name(i, column) for (i, column) in enumerate(columns)]
 
     column_list = ", ".join(safe_columns)
     create_table = "CREATE TABLE {table_name} ({column_list})".format(

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 import json
 import logging
@@ -83,6 +83,7 @@ def is_ascii(string):
         if ord(c) >= 128:
             return False
     return True
+
 
 def fix_column_name(i, name):
     if is_ascii(name):

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -1,3 +1,5 @@
+#-*- coding: utf-8 -*-
+
 import json
 import logging
 import signal

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 import json
 import logging

--- a/tests/query_runner/test_query_results.py
+++ b/tests/query_runner/test_query_results.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 import sqlite3
 from unittest import TestCase

--- a/tests/query_runner/test_query_results.py
+++ b/tests/query_runner/test_query_results.py
@@ -1,3 +1,5 @@
+#-*- coding: utf-8 -*-
+
 import sqlite3
 from unittest import TestCase
 
@@ -56,6 +58,17 @@ class TestCreateTable(TestCase):
         table_name = 'query_123'
         create_table(connection, table_name, results)
         connection.execute('SELECT 1 FROM query_123')
+
+    def test_creates_table_with_non_ascii_in_column_name(self):
+        connection = sqlite3.connect(':memory:')
+        results = {'columns': [{'name': '日の일'}, {'name': 'normal'}], 'rows': [
+            {'日の일': 1, 'normal': 2}]}
+        table_name = 'query_123'
+        expected_column_names = ['column_1', 'normal']
+        create_table(connection, table_name, results)
+        table_description = connection.execute('SELECT * FROM query_123').description
+        actual_column_names = [x[0] for x in table_description]
+        self.assertEquals(actual_column_names, expected_column_names)
 
     def test_loads_results(self):
         connection = sqlite3.connect(':memory:')


### PR DESCRIPTION
# Problem
When the column name contains non ASCII character, using query result as data source.

### The original query result
<img width="883" alt="image" src="https://user-images.githubusercontent.com/16881036/33796585-a77fe222-dd3a-11e7-8871-d48849b4bf83.png">

### Error when executing query from the query result
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/16881036/33796609-76b8428c-dd3b-11e7-9e67-d25f4485c173.png">

# Use case
For original data source such as Google spread sheet, it is quite propable that sheet column was in non-ASCII language.

# Implementation
Change non-ASCII column name into `"column_{}".format(column_number)`
<img width="881" alt="image" src="https://user-images.githubusercontent.com/16881036/33796599-3b789b36-dd3b-11e7-92db-aebb17e44e5d.png">

Though this doesn't seem to be a fundamental solution, a better one might bring more influence to other data source. 