### PR TITLE
Replace invalid date time strings

### DIFF
--- a/client/app/filters/datetime.js
+++ b/client/app/filters/datetime.js
@@ -5,7 +5,7 @@ export default function init(ngModule) {
 
   ngModule.filter('dateTime', clientConfig =>
     function dateTime(value) {
-      if (!value || !value.isValid()) {
+      if (!value || !moment(value).isValid()) {
         return '-';
       }
 

--- a/client/app/filters/datetime.js
+++ b/client/app/filters/datetime.js
@@ -5,10 +5,16 @@ export default function init(ngModule) {
 
   ngModule.filter('dateTime', clientConfig =>
     function dateTime(value) {
-      if (!value || !moment(value).isValid()) {
-        return '-';
+      if (!value) {
+        return ''; 
       }
-
-      return moment(value).format(clientConfig.dateTimeFormat);
+    
+      const parsed = moment(value);
+    
+      if (!parsed.isValid()) {
+        return '-'; 
+      }
+      
+      return parsed.format(clientConfig.dateTimeFormat);
     });
 }

--- a/client/app/filters/datetime.js
+++ b/client/app/filters/datetime.js
@@ -5,7 +5,7 @@ export default function init(ngModule) {
 
   ngModule.filter('dateTime', clientConfig =>
     function dateTime(value) {
-      if (!value) {
+      if (!value || !value.isValid()) {
         return '-';
       }
 


### PR DESCRIPTION
When `dateTime` filter got invalid date value, it returned `Invalid date`.

Screenshot when a query has not executed is the following, for example.

<img width="520" alt="before_datetime" src="https://user-images.githubusercontent.com/3317191/33805438-54b1bed6-ddfc-11e7-9408-ce57114b7b5b.png">

I believe the date value is not valid in this situation. This PR make `dateTime` filter to return `-`. 

<img width="520" alt="after_datetime" src="https://user-images.githubusercontent.com/3317191/33805468-d84fedc6-ddfc-11e7-8d51-682558ebd5e5.png">

Invalid date is too.