### PR TITLE
Fix: Appearance collapse of outdated-queries.

### DIFF
--- a/client/app/pages/admin/outdated-queries/outdated-queries.html
+++ b/client/app/pages/admin/outdated-queries/outdated-queries.html
@@ -13,6 +13,7 @@
       <table class="table table-condensed table-hover">
         <thead>
         <tr>
+          <th>Id</th>
           <th>Name</th>
           <th>Created By</th>
           <th>Runtime</th>


### PR DESCRIPTION
There seems to be no `<th>` element for Id of "out dated queries", so I fixed it.


before:

<img width="1280" alt="bb" src="https://user-images.githubusercontent.com/8569015/33857820-b044eb82-df10-11e7-951f-f9a40d225b34.png">


after:

<img width="1279" alt="aft" src="https://user-images.githubusercontent.com/8569015/33857694-1adf00c8-df10-11e7-9899-3a56252c5029.png">



