### PR TITLE
Fix : User Form displays a incorrect error appearance.

### DIFF
--- a/client/app/filters/index.js
+++ b/client/app/filters/index.js
@@ -92,7 +92,7 @@ export function notEmpty(collection) {
   return !isEmpty(collection);
 }
 
-export function showError(field, form) {
-  return (field.$touched && field.$invalid) || form.$submitted;
+export function showError(field) {
+  return field.$touched && field.$invalid;
 }
 

--- a/client/app/pages/users/new.html
+++ b/client/app/pages/users/new.html
@@ -1,14 +1,14 @@
 <settings-screen>
   <email-settings-warning function="'invite emails'"></email-settings-warning>
   <form class="form" name="$ctrl.userForm" ng-submit="saveUser()" novalidate>
-    <div class="form-group required" ng-class="{ 'has-error':  ($ctrl.userForm.email | showError:$ctrl.userForm )}">
+    <div class="form-group required" ng-class="{ 'has-error':  ($ctrl.userForm.name | showError )}">
       <label class="control-label">Name</label>
       <input type="text" name="name" class="form-control" ng-model="user.name" ng-disabled="user.created" required/ autofocus>
 
       <error-messages input="$ctrl.userForm.name" form="$ctrl.userForm"></error-messages>
     </div>
 
-    <div class="form-group required" ng-class="{ 'has-error': ($ctrl.userForm.email | showError:$ctrl.userForm ) }">
+    <div class="form-group required" ng-class="{ 'has-error': ($ctrl.userForm.email | showError ) }">
       <label class="control-label">Email</label>
       <input name="email" type="email" class="form-control" ng-model="user.email" ng-disabled="user.created" required/>
 

--- a/client/app/pages/users/show.html
+++ b/client/app/pages/users/show.html
@@ -12,12 +12,12 @@
         <hr>
 
         <form class="form" name="userSettingsForm" ng-submit="updateUser(userSettingsForm)" novalidate>
-          <div class="form-group" ng-class="{ 'has-error':  (userSettingsForm.name | showError:userSettingsForm )}">
+          <div class="form-group" ng-class="{ 'has-error':  (userSettingsForm.name | showError )}">
             <label class="control-label" for="name" >Name</label>
             <input name="name" id="name" type="text" class="form-control" ng-model="user.name" required/>
             <error-messages input="userSettingsForm.name" form="userSettingsForm"></error-messages>
           </div>
-          <div class="form-group" ng-class="{ 'has-error':  (userSettingsForm.email | showError:userSettingsForm )}">
+          <div class="form-group" ng-class="{ 'has-error':  (userSettingsForm.email | showError )}">
             <label class="control-label" for="email" >Email</label>
             <input name="email" id="email" type="email" class="form-control" ng-model="user.email" required/>
             <error-messages input="userSettingsForm.email" form="userSettingsForm"></error-messages>


### PR DESCRIPTION
Regardless that user saving or updating is success, each form field of user has `error frame`.

**Image (gif) :**

![before1 mov](https://user-images.githubusercontent.com/8569015/34248049-fb2e4756-e677-11e7-9dc1-aec01769ba0c.gif)


The code which has the problem is in `client/app/filters/index.js`.

In `showError function`, if the `form` is submitted, it assume that there is an error.

I fixed it.

And when calling of `showErorr function`,  it's argument is no longer useless, so I removed it.

**After:**

**gif**
![after1 mov](https://user-images.githubusercontent.com/8569015/34248186-6e2ec046-e678-11e7-8f91-490ee467a65d.gif)

**image (when any error occur)**
<img width="1280" alt="aft1" src="https://user-images.githubusercontent.com/8569015/34248203-8053cda2-e678-11e7-9451-cadebc1d34ad.png">


