### PR TITLE
Feature: Add an unarchive dashboard button

### DIFF
--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -4,7 +4,9 @@
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-7 page-header--new p-l-0">
       <h3>{{$ctrl.dashboard.name}}
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>
-        <span class="label label-warning" ng-if="$ctrl.dashboard.is_archived" uib-popover="This dashboard is archived and and won't appear in the dashboards list or search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
+        <button type="button" class="btn btn-warning" ng-if="$ctrl.dashboard.is_archived" ng-click="$ctrl.unArchiveDashboard()" tooltip="Unarchive this dashboard or won't appear in the dashboards list or search results.">
+          Unarchive
+        </span>
       </h3>
     </div>
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-5 text-right dashboard__control p-r-0">

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -4,9 +4,7 @@
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-7 page-header--new p-l-0">
       <h3>{{$ctrl.dashboard.name}}
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>
-        <button type="button" class="btn btn-warning" ng-if="$ctrl.dashboard.is_archived" ng-click="$ctrl.unArchiveDashboard()" tooltip="Unarchive this dashboard or won't appear in the dashboards list or search results.">
-          Unarchive
-        </span>
+        <span class="label label-warning" ng-if="$ctrl.dashboard.is_archived" uib-popover="This dashboard is archived and and won't appear in the dashboards list or search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
       </h3>
     </div>
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-5 text-right dashboard__control p-r-0">
@@ -53,7 +51,7 @@
             <span class="zmdi zmdi-share"></span>
           </button>
       </span>
-          <div class="btn-group hidden-print" role="group" ng-show="$ctrl.dashboard.canEdit()" uib-dropdown ng-if="!$ctrl.dashboard.is_archived">
+          <div class="btn-group hidden-print" role="group" ng-show="$ctrl.dashboard.canEdit()" uib-dropdown>
             <button class="btn btn-default btn-sm dropdown-toggle" uib-dropdown-toggle>
               <span class="zmdi zmdi-more"></span>
             </button>
@@ -62,8 +60,9 @@
               <li ng-if="!$ctrl.dashboard.is_archived" ng-class="{hidden: $ctrl.isGridDisabled}"><a ng-click="$ctrl.editLayout(true)">Edit Layout</a></li>
               <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.addWidget()">Add Widget</a></li>
               <li ng-if="$ctrl.showPermissionsControl"><a ng-click="$ctrl.showManagePermissionsModal()">Manage Permissions</a></li>
-              <li ng-if="!$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Unpublish Dashboard</a></li>
-              <li ng-if="$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Publish Dashboard</a></li>
+              <li ng-if="$ctrl.dashboard.is_archived"><a ng-click="$ctrl.unArchiveDashboard()">Unarchive Dashboard</a></li>
+              <li ng-if="!$ctrl.dashboard.is_archived && $ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Publish Dashboard</a></li>
+              <li ng-if="!$ctrl.dashboard.is_archived && !$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Unpublish Dashboard</a></li>
               <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.archiveDashboard()">Archive Dashboard</a></li>
             </ul>
           </div>

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -205,6 +205,7 @@ function DashboardCtrl(
       },
       () => {
         this.loadDashboard();
+        toastr.success('Dashboard unarchived');
       },
       () => {
         toastr.error('Dashboard could not be unarchived.');

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -198,20 +198,12 @@ function DashboardCtrl(
 
   this.unArchiveDashboard = () => {
     const url = `api/dashboards/${this.dashboard.slug}/unarchive`;
-    const unarchive = () => {
-      Events.record('unarchive', 'dashboard', this.dashboard.id);
-      $http.patch(url).success(() => {
-        this.loadDashboard();
-      }).error(() => {
-        toastr.error('Dashboard could not be unarchived.');
-      });
-    };
-
-    const title = 'Unarchive Dashboard';
-    const message = `Are you sure you want to unarchive the "${this.dashboard.name}" dashboard?`;
-    const confirm = { class: 'btn-warning', title: 'Unarchive' };
-
-    AlertDialog.open(title, message, confirm).then(unarchive);
+    Events.record('unarchive', 'dashboard', this.dashboard.id);
+    $http.patch(url).success(() => {
+      this.loadDashboard();
+    }).error(() => {
+      toastr.error('Dashboard could not be unarchived.');
+    });
   };
 
   this.showManagePermissionsModal = () => {

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -4,7 +4,7 @@ import shareDashboardTemplate from './share-dashboard.html';
 import './dashboard.less';
 
 function DashboardCtrl(
-  $rootScope, $routeParams, $location, $timeout, $q, $uibModal, $http,
+  $rootScope, $routeParams, $location, $timeout, $q, $uibModal,
   Title, AlertDialog, Dashboard, currentUser, clientConfig, Events,
   dashboardGridOptions, toastr,
 ) {
@@ -197,13 +197,19 @@ function DashboardCtrl(
   };
 
   this.unArchiveDashboard = () => {
-    const url = `api/dashboards/${this.dashboard.slug}/unarchive`;
     Events.record('unarchive', 'dashboard', this.dashboard.id);
-    $http.patch(url).success(() => {
-      this.loadDashboard();
-    }).error(() => {
-      toastr.error('Dashboard could not be unarchived.');
-    });
+    Dashboard.unarchive(
+      {
+        slug: this.dashboard.id,
+        is_archived: false,
+      },
+      () => {
+        this.loadDashboard();
+      },
+      () => {
+        toastr.error('Dashboard could not be unarchived.');
+      },
+    );
   };
 
   this.showManagePermissionsModal = () => {

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -4,7 +4,7 @@ import shareDashboardTemplate from './share-dashboard.html';
 import './dashboard.less';
 
 function DashboardCtrl(
-  $rootScope, $routeParams, $location, $timeout, $q, $uibModal,
+  $rootScope, $routeParams, $location, $timeout, $q, $uibModal, $http,
   Title, AlertDialog, Dashboard, currentUser, clientConfig, Events,
   dashboardGridOptions, toastr,
 ) {
@@ -194,6 +194,22 @@ function DashboardCtrl(
     const confirm = { class: 'btn-warning', title: 'Archive' };
 
     AlertDialog.open(title, message, confirm).then(archive);
+  };
+
+  this.unArchiveDashboard = () => {
+    const url = `api/dashboards/${this.dashboard.slug}/unarchive`;
+    const unarchive = () => {
+      Events.record('unarchive', 'dashboard', this.dashboard.id);
+      $http.patch(url).success(() => {
+        this.loadDashboard();
+      });
+    };
+
+    const title = 'Unarchive Dashboard';
+    const message = `Are you sure you want to unarchive the "${this.dashboard.name}" dashboard?`;
+    const confirm = { class: 'btn-warning', title: 'Unarchive' };
+
+    AlertDialog.open(title, message, confirm).then(unarchive);
   };
 
   this.showManagePermissionsModal = () => {

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -202,6 +202,8 @@ function DashboardCtrl(
       Events.record('unarchive', 'dashboard', this.dashboard.id);
       $http.patch(url).success(() => {
         this.loadDashboard();
+      }).error(() => {
+        toastr.error('Dashboard could not be unarchived.');
       });
     };
 

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -50,6 +50,11 @@ function Dashboard($resource, $http, currentUser, Widget, dashboardGridOptions) 
       url: 'api/dashboards/recent',
       transformResponse: transform,
     },
+    unarchive: {
+      method: 'POST',
+      transformResponse: transform,
+      url: 'api/dashboards/:slug/unarchive',
+    },
   });
 
   resource.prototype.canEdit = function canEdit() {

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -46,7 +46,9 @@ api.add_org_resource(AlertListResource, '/api/alerts', endpoint='alerts')
 
 api.add_org_resource(DashboardListResource, '/api/dashboards', endpoint='dashboards')
 api.add_org_resource(RecentDashboardsResource, '/api/dashboards/recent', endpoint='recent_dashboards')
-api.add_org_resource(DashboardResource, '/api/dashboards/<dashboard_slug>', endpoint='dashboard')
+api.add_org_resource(DashboardResource, '/api/dashboards/<dashboard_slug>',
+                                        '/api/dashboards/<dashboard_slug>/unarchive',
+                                        endpoint='dashboard')
 api.add_org_resource(PublicDashboardResource, '/api/dashboards/public/<token>', endpoint='public_dashboard')
 api.add_org_resource(DashboardShareResource, '/api/dashboards/<dashboard_id>/share', endpoint='dashboard_share')
 

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -166,6 +166,23 @@ class DashboardResource(BaseResource):
         models.db.session.commit()
         return d
 
+    @require_permission('edit_dashboard')
+    def patch(self, dashboard_slug):
+        """
+        Unarchives a dashboard.
+
+        :qparam string slug: Slug of dashboard to retrieve.
+
+        Responds with the archived :ref:`dashboard <dashboard-response-label>`.
+        """
+        dashboard = models.Dashboard.get_by_slug_and_org(dashboard_slug, self.current_org)
+        dashboard.is_archived = False
+        dashboard.record_changes(changed_by=self.current_user)
+        models.db.session.add(dashboard)
+        d = dashboard.to_dict(with_widgets=True, user=self.current_user)
+        models.db.session.commit()
+        return d
+
 
 class PublicDashboardResource(BaseResource):
     def get(self, token):

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -129,7 +129,8 @@ class DashboardResource(BaseResource):
         require_object_modify_permission(dashboard, self.current_user)
 
         updates = project(dashboard_properties, ('name', 'layout', 'version',
-                                                 'is_draft', 'dashboard_filters_enabled'))
+                                                 'is_draft', 'dashboard_filters_enabled',
+                                                 'is_archived'))
 
         # SQLAlchemy handles the case where a concurrent transaction beats us
         # to the update. But we still have to make sure that we're not starting
@@ -160,23 +161,6 @@ class DashboardResource(BaseResource):
         """
         dashboard = models.Dashboard.get_by_slug_and_org(dashboard_slug, self.current_org)
         dashboard.is_archived = True
-        dashboard.record_changes(changed_by=self.current_user)
-        models.db.session.add(dashboard)
-        d = dashboard.to_dict(with_widgets=True, user=self.current_user)
-        models.db.session.commit()
-        return d
-
-    @require_permission('edit_dashboard')
-    def patch(self, dashboard_slug):
-        """
-        Unarchives a dashboard.
-
-        :qparam string slug: Slug of dashboard to retrieve.
-
-        Responds with the archived :ref:`dashboard <dashboard-response-label>`.
-        """
-        dashboard = models.Dashboard.get_by_slug_and_org(dashboard_slug, self.current_org)
-        dashboard.is_archived = False
         dashboard.record_changes(changed_by=self.current_user)
         models.db.session.add(dashboard)
         d = dashboard.to_dict(with_widgets=True, user=self.current_user)


### PR DESCRIPTION
Fix #982.

It would be easy to restore without directly updating DB :relaxed:

# Screenshot

Replaced "archived" label to "Unarchive" button.
<img width="500" alt="unarchive_button" src="https://user-images.githubusercontent.com/3317191/34320008-d642c4d2-e832-11e7-81b1-0bedbcead721.png">

Confirm modal:
<img width="633" alt="unarchive_dialog" src="https://user-images.githubusercontent.com/3317191/34320010-df4bb0de-e832-11e7-9afa-7d24fa950cb8.png">

