### PR TITLE
Feature: Add an unarchive query button

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -22,7 +22,7 @@
       <h3>
         <edit-in-place editable="canEdit" done="saveName" ignore-blanks="true" value="query.name"></edit-in-place>
         <span class="label label-default" ng-if="query.is_draft && !query.is_archived">Unpublished</span>
-        <span class="label label-warning" ng-if="query.is_archived && !(isQueryOwner || currentUser.hasPermission('admin'))" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
+        <span class="label label-warning" ng-if="query.is_archived" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
         <button type="button" class="btn btn-warning" ng-click="unarchiveQuery()" ng-if="query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))" tooltip="Unarchive this query or won't appear in dashbords and search results.">
           Unarchive
         </button>
@@ -59,6 +59,7 @@
             <li class="divider"></li>
             <li ng-if="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))"><a ng-click="archiveQuery()">Archive</a></li>
             <li ng-if="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin')) && showPermissionsControl"><a ng-click="showManagePermissionsModal()">Manage Permissions</a></li>
+            <li ng-if="query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))"><a ng-click="unarchiveQuery()">Unarchive</a></li>
             <li ng-if="!query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))"><a ng-click="togglePublished()">Unpublish</a></li>
             <li class="divider"></li>
             <li ng-if="query.id != undefined"><a ng-click="showApiKey()">Show API Key</a></li>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -22,7 +22,10 @@
       <h3>
         <edit-in-place editable="canEdit" done="saveName" ignore-blanks="true" value="query.name"></edit-in-place>
         <span class="label label-default" ng-if="query.is_draft && !query.is_archived">Unpublished</span>
-        <span class="label label-warning" ng-if="query.is_archived" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
+        <span class="label label-warning" ng-if="query.is_archived && !(isQueryOwner || currentUser.hasPermission('admin'))" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
+        <button type="button" class="btn btn-warning" ng-click="unarchiveQuery()" ng-if="query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))" tooltip="Unarchive this query or won't appear in dashbords and search results.">
+          Unarchive
+        </button>
       </h3>
 
       <em>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -23,9 +23,6 @@
         <edit-in-place editable="canEdit" done="saveName" ignore-blanks="true" value="query.name"></edit-in-place>
         <span class="label label-default" ng-if="query.is_draft && !query.is_archived">Unpublished</span>
         <span class="label label-warning" ng-if="query.is_archived" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
-        <button type="button" class="btn btn-warning" ng-click="unarchiveQuery()" ng-if="query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))" tooltip="Unarchive this query or won't appear in dashbords and search results.">
-          Unarchive
-        </button>
       </h3>
 
       <em>

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -288,6 +288,7 @@ function QueryViewCtrl(
       },
       () => {
         $scope.query.is_archived = false;
+        toastr.success('Query unarchived');
       },
       () => {
         toastr.error('Query could not be unarchived.');

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -282,21 +282,12 @@ function QueryViewCtrl(
   $scope.unarchiveQuery = () => {
     const queryId = $scope.query.id;
     const url = `api/queries/${queryId}/unarchive`;
-    const unarchive = () => {
-      Events.record('unarhive', 'queries', queryId);
-      $http.patch(url).success(() => {
-        $scope.query.is_archived = false;
-      }).error(() => {
-        toastr.error('Query could not be unarchived.');
-      });
-    };
-
-    const title = 'Unarchive Query';
-    const message =
-      'Are you sure you want to unarchive this query?';
-    const confirm = { class: 'btn-warning', title: 'Unarchive' };
-
-    AlertDialog.open(title, message, confirm).then(unarchive);
+    Events.record('unarhive', 'queries', queryId);
+    $http.patch(url).success(() => {
+      $scope.query.is_archived = false;
+    }).error(() => {
+      toastr.error('Query could not be unarchived.');
+    });
   };
 
   $scope.updateDataSource = () => {

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -10,6 +10,7 @@ function QueryViewCtrl(
   $location,
   $window,
   $q,
+  $http,
   KeyboardShortcuts,
   Title,
   AlertDialog,
@@ -276,6 +277,26 @@ function QueryViewCtrl(
     const confirm = { class: 'btn-warning', title: 'Archive' };
 
     AlertDialog.open(title, message, confirm).then(archive);
+  };
+
+  $scope.unarchiveQuery = () => {
+    const queryId = $scope.query.id;
+    const url = `api/queries/${queryId}/unarchive`;
+    const unarchive = () => {
+      Events.record('unarhive', 'queries', queryId);
+      $http.patch(url).success(() => {
+        $scope.query.is_archived = false;
+      }).error(() => {
+        toastr.error('Query could not be unarchived.');
+      });
+    };
+
+    const title = 'Unarchive Query';
+    const message =
+      'Are you sure you want to unarchive this query?';
+    const confirm = { class: 'btn-warning', title: 'Unarchive' };
+
+    AlertDialog.open(title, message, confirm).then(unarchive);
   };
 
   $scope.updateDataSource = () => {

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -282,7 +282,10 @@ function QueryViewCtrl(
     const queryId = $scope.query.id;
     Events.record('unarhive', 'queries', queryId);
     Query.unarchive(
-      { id: queryId },
+      {
+        id: queryId,
+        is_archived: false,
+      },
       () => {
         $scope.query.is_archived = false;
       },

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -10,7 +10,6 @@ function QueryViewCtrl(
   $location,
   $window,
   $q,
-  $http,
   KeyboardShortcuts,
   Title,
   AlertDialog,
@@ -281,13 +280,16 @@ function QueryViewCtrl(
 
   $scope.unarchiveQuery = () => {
     const queryId = $scope.query.id;
-    const url = `api/queries/${queryId}/unarchive`;
     Events.record('unarhive', 'queries', queryId);
-    $http.patch(url).success(() => {
-      $scope.query.is_archived = false;
-    }).error(() => {
-      toastr.error('Query could not be unarchived.');
-    });
+    Query.unarchive(
+      { id: queryId },
+      () => {
+        $scope.query.is_archived = false;
+      },
+      () => {
+        toastr.error('Query could not be unarchived.');
+      },
+    );
   };
 
   $scope.updateDataSource = () => {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -201,6 +201,11 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
         isArray: false,
         url: 'api/queries/:id/results.json',
       },
+      unarchive: {
+        method: 'post',
+        isArray: false,
+        url: 'api/queries/:id/unarchive',
+      },
     },
   );
 

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -72,7 +72,9 @@ api.add_org_resource(QueryRecentResource, '/api/queries/recent', endpoint='recen
 api.add_org_resource(QueryListResource, '/api/queries', endpoint='queries')
 api.add_org_resource(MyQueriesResource, '/api/queries/my', endpoint='my_queries')
 api.add_org_resource(QueryRefreshResource, '/api/queries/<query_id>/refresh', endpoint='query_refresh')
-api.add_org_resource(QueryResource, '/api/queries/<query_id>', endpoint='query')
+api.add_org_resource(QueryResource, '/api/queries/<query_id>',
+                                    '/api/queries/<query_id>/unarchive',
+                                    endpoint='query')
 api.add_org_resource(QueryForkResource, '/api/queries/<query_id>/fork', endpoint='query_fork')
 
 api.add_org_resource(ObjectPermissionsListResource, '/api/<object_type>/<object_id>/acl', endpoint='object_permissions')

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -246,17 +246,6 @@ class QueryResource(BaseResource):
         query.archive(self.current_user)
         models.db.session.commit()
 
-    def patch(self, query_id):
-        """
-        Unarchives a query.
-
-        :param query_id: ID of query to unarchive
-        """
-        query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
-        require_admin_or_owner(query.user_id)
-        query.unarchive(self.current_user)
-        models.db.session.commit()
-
 
 class QueryForkResource(BaseResource):
     @require_permission('edit_query')

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -246,6 +246,17 @@ class QueryResource(BaseResource):
         query.archive(self.current_user)
         models.db.session.commit()
 
+    def patch(self, query_id):
+        """
+        Unarchives a query.
+
+        :param query_id: ID of query to unarchive
+        """
+        query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
+        require_admin_or_owner(query.user_id)
+        query.unarchive(self.current_user)
+        models.db.session.commit()
+
 
 class QueryForkResource(BaseResource):
     @require_permission('edit_query')

--- a/redash/models.py
+++ b/redash/models.py
@@ -930,6 +930,14 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         if user:
             self.record_changes(user)
 
+    def unarchive(self, user=None):
+        db.session.add(self)
+        self.is_archived = False
+        self.schedule = None
+
+        if user:
+            self.record_changes(user)
+
     @classmethod
     def create(cls, **kwargs):
         query = cls(**kwargs)


### PR DESCRIPTION
Similar to #2180.

This is a query version.

# Screenshot

Confirm dialog:
<img width="632" alt="unarchive_query_dialog" src="https://user-images.githubusercontent.com/3317191/34323839-a19ba954-e89d-11e7-9353-d1d5fb80855e.png">

## Unarchive button

I can't make up my mind which one to choose where the button should be placed.

### Plan A(current version)

Same as #2180. Next to the query name.
<img width="773" alt="unarchive_query_button" src="https://user-images.githubusercontent.com/3317191/34323840-cc7c8a26-e89d-11e7-8799-2cf738f02344.png">

### Plan B

By the control button area.
<img width="769" alt="unarchive_query_button2" src="https://user-images.githubusercontent.com/3317191/34323793-f2e73438-e89b-11e7-821f-3b494357321b.png">

### Plan C

Inside the botton group.
<img width="774" alt="unarchive_query_botton3" src="https://user-images.githubusercontent.com/3317191/34323800-3aa2d0de-e89c-11e7-889b-5d59921ca52a.png">
