### PR TITLE
Delete waste space above show/hide source button

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -30,12 +30,6 @@ edit-in-place p.editable:hover {
   min-height: 105px;
 }
 
-.btn--showhide {
-  position: absolute;
-  right: 0;
-  bottom: 5px;
-}
-
 .ace_editor.ace_autocomplete .ace_completion-highlight {
   text-shadow: none !important;
   background: #ffff005e;

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -18,7 +18,7 @@
   <alert-unsaved-changes ng-if="canEdit" is-dirty="isDirty"></alert-unsaved-changes>
 
   <div class="row bg-white tiled p-10 p-l-15 p-r-15 m-b-10 m-l-0 m-r-0 page-header--new">
-    <div class="col-sm-9 p-l-0">
+    <div class="p-l-0">
       <h3>
         <edit-in-place editable="canEdit" done="saveName" ignore-blanks="true" value="query.name"></edit-in-place>
         <span class="label label-default" ng-if="query.is_draft && !query.is_archived">Unpublished</span>
@@ -36,44 +36,48 @@
         </edit-in-place>
       </em>
 
-      <ul class="list-inline m-t-20">
-        <li>
-          <span class="zmdi zmdi-account"></span>
-          <span class="text-muted">Created By </span>
-          <img ng-src="{{query.user.profile_image_url}}" class="profile__image_thumb"/>
-          <strong>{{query.user.name}}</strong>
-        </li>
-        <li ng-if="query.last_modified_by && query.user.id != query.last_modified_by.id">
-          <span class="zmdi zmdi-account"></span>
-          <span class="text-muted">Last Modified By </span>
-          <strong>{{query.last_modified_by.name}}</strong>
-        </li>
-        <li>
-          <i class="zmdi zmdi-time-restore"></i>
-          <span class="text-muted">Updated at </span>
-          <strong>
-            <rd-time-ago value="query.updated_at"></rd-time-ago>
-          </strong>
-        </li>
-        <li>
-          <span class="zmdi zmdi-time"></span>
-          <span class="text-muted">Created at </span>
-          <strong>
-            <rd-time-ago value="query.created_at"></rd-time-ago>
-          </strong>
-        </li>
-      </ul>
+      <div class="row">
+        <div class="col-sm-9">
+          <ul class="list-inline m-t-20">
+            <li>
+              <span class="zmdi zmdi-account"></span>
+              <span class="text-muted">Created By </span>
+              <img ng-src="{{query.user.profile_image_url}}" class="profile__image_thumb"/>
+              <strong>{{query.user.name}}</strong>
+            </li>
+            <li ng-if="query.last_modified_by && query.user.id != query.last_modified_by.id">
+              <span class="zmdi zmdi-account"></span>
+              <span class="text-muted">Last Modified By </span>
+              <strong>{{query.last_modified_by.name}}</strong>
+            </li>
+            <li>
+              <i class="zmdi zmdi-time-restore"></i>
+              <span class="text-muted">Updated at </span>
+              <strong>
+                <rd-time-ago value="query.updated_at"></rd-time-ago>
+              </strong>
+            </li>
+            <li>
+              <span class="zmdi zmdi-time"></span>
+              <span class="text-muted">Created at </span>
+              <strong>
+                <rd-time-ago value="query.created_at"></rd-time-ago>
+              </strong>
+            </li>
+          </ul>
+        </div>
+        <div class="col-sm-3 text-right">
+           <span ng-show="query.id && canViewSource">
+              <a ng-show="!sourceMode"
+                 ng-href="{{query.getUrl(true, selectedTab)}}" class="btn btn-default"><i class="fa fa-eye" aria-hidden="true"></i> Show Source</i>
+              </a>
+              <a ng-show="sourceMode"
+                 ng-href="{{query.getUrl(false, selectedTab)}}" class="btn btn-default"><i class="fa fa-eye-slash" aria-hidden="true"></i> Hide Source</i>
+              </a>
+            </span>
+        </div>
+      </div>
 
-    </div>
-    <div class="col-sm-3 text-right p-r-0 source-control">
-       <span ng-show="query.id && canViewSource">
-          <a ng-show="!sourceMode"
-             ng-href="{{query.getUrl(true, selectedTab)}}" class="btn btn-default btn--showhide"><i class="fa fa-eye" aria-hidden="true"></i> Show Source</i>
-          </a>
-          <a ng-show="sourceMode"
-             ng-href="{{query.getUrl(false, selectedTab)}}" class="btn btn-default btn--showhide"><i class="fa fa-eye-slash" aria-hidden="true"></i> Hide Source</i>
-          </a>
-        </span>
     </div>
   </div>
 


### PR DESCRIPTION
# Summary

Delete waste space above **Show/Hide Source** button at query page when page width is narrow.

<img width="685" alt="waste_space" src="https://user-images.githubusercontent.com/3317191/34325018-d8b8656e-e8c8-11e7-9b94-bdbc02047b59.png">

# Screencasts

## Before
![before_source_button_layout mov](https://user-images.githubusercontent.com/3317191/34325031-6d35907c-e8c9-11e7-83c2-6857013361ee.gif)

## After
![after_source_button_layout mov](https://user-images.githubusercontent.com/3317191/34324997-5ebc8efc-e8c8-11e7-8817-2ba27d3ae7d9.gif)
