### PR TITLE
Disable Format/Execute button when body of query is blank

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -130,7 +130,7 @@
                     schema="schema"
                     syntax="dataSource.syntax"></query-editor>
 
-                  <button type="button" class="btn btn-default btn-s btn__format pull-right" ng-click="formatQuery()" title="Format">
+                  <button type="button" class="btn btn-default btn-s btn__format pull-right" ng-disabled="!query.query" ng-click="formatQuery()" title="Format">
                     <span class="zmdi zmdi-format-indent-increase"></span>
                   </button>
                 </p>
@@ -151,7 +151,7 @@
                             ng-show="isDirty">&#42;</span>
                         </button>
 
-                        <button type="button" class="btn btn-primary" ng-disabled="queryExecuting || !canExecuteQuery()" ng-click="executeQuery()">
+                        <button type="button" class="btn btn-primary" ng-disabled="!query.query || queryExecuting || !canExecuteQuery()" ng-click="executeQuery()">
                           <span class="zmdi zmdi-play"></span>
                           <span class="hidden-xs">Execute</span>
                         </button>


### PR DESCRIPTION
# Summary

"Format/Execute button" should be disabled if the body of the query is blank like a "Download Dataset" button.

# Screenshot

<img width="662" alt="after_disable_button" src="https://user-images.githubusercontent.com/3317191/34383549-352d9714-eb59-11e7-846a-f6438d915cc6.png">

<img width="621" alt="after_disable_button2" src="https://user-images.githubusercontent.com/3317191/34383571-5c153cc4-eb59-11e7-91ec-7a987189c111.png">

