### PR TITLE
Fix upgrade script for ci channel

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -3,6 +3,7 @@ import argparse
 import os
 import subprocess
 import sys
+import urllib
 from collections import namedtuple
 from fnmatch import fnmatch
 
@@ -81,6 +82,7 @@ def get_latest_release_from_ci():
 
     tarball_asset = filter(lambda asset: asset['url'].endswith('.tar.gz'), response.json())[0]
     filename = tarball_asset['pretty_path'].replace('$CIRCLE_ARTIFACTS/', '')
+    filename = os.path.basename(urllib.unquote(filename))
     version = filename.replace('redash.', '').replace('.tar.gz', '')
 
     release = Release(version, tarball_asset['url'], filename, '')


### PR DESCRIPTION
bin/upgrade --channel ci broke with the following error
ValueError: tmp/circle-artifacts.69TScQG/4.0.0%2Bb3384 is not valid SemVer string

