### PR TITLE
Fixing filter headers mixed

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -204,6 +204,10 @@ page-header, .page-header--new {
   }
 }
 
+.filter-container {
+  margin-bottom: 5px;
+}
+
 // Navigation
 .caret--nav {
   border-top: none;

--- a/client/app/components/filters.html
+++ b/client/app/components/filters.html
@@ -1,11 +1,8 @@
 <div class="container bg-white p-b-15" ng-show="$ctrl.filters | notEmpty">
   <div class="row">
-    <div class="col-sm-6 p-l-0" ng-repeat="filter in $ctrl.filters">
+    <div class="col-sm-6 p-l-0 filter-container" ng-repeat="filter in $ctrl.filters">
       <label>{{filter.friendlyName}}</label>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-6 p-l-0" ng-repeat="filter in $ctrl.filters">
+
       <ui-select ng-model="filter.current" ng-if="!filter.multiple" on-select="$ctrl.filterChangeListener(filter, $model)" on-remove="$ctrl.filterChangeListener(filter, $model)"
         remove-selected="false">
         <ui-select-match placeholder="Select value for {{filter.friendlyName}}...">{{$select.selected | filterValue:filter}}</ui-select-match>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -248,7 +248,7 @@
             </div>
             <div class="row">
               <div class="col-lg-12">
-                <div ng-if="!query.visualizations.length">
+                <div ng-if="!query.visualizations.length" class="query__vis col-md-12 p-b-15">
                   <filters filters="filters"></filters>
                   <grid-renderer query-result="queryResult" items-per-page="50"></grid-renderer>
                 </div>


### PR DESCRIPTION
Fixing issue #2183 

From now on, we won't mix filter headers. Everything is properly placed.

![screenshot 2018-01-03 20 16 32](https://user-images.githubusercontent.com/2378022/34535697-03f26ce6-f0c3-11e7-8a72-bf23745422f7.png)

This PR also fixes misplaced filters on unsaved queries and improves #2199 previous commit.