### PR TITLE
Make Redshift sslmode configurable

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -191,7 +191,7 @@ class Redshift(PostgreSQL):
                                       host=self.configuration.get('host'),
                                       port=self.configuration.get('port'),
                                       dbname=self.configuration.get('dbname'),
-                                      sslmode='prefer',
+                                      sslmode=self.configuration.get('sslmode', 'prefer'),
                                       sslrootcert=sslrootcert_path,
                                       async=True)
 
@@ -218,6 +218,11 @@ class Redshift(PostgreSQL):
                 "dbname": {
                     "type": "string",
                     "title": "Database Name"
+                },
+                "sslmode": {
+                   "type": "string",
+                   "title": "SSL Mode",
+                   "default": "prefer"
                 }
             },
             "order": ['host', 'port', 'user', 'password'],


### PR DESCRIPTION
This makes it possible to configure Redash to require TLS and verify the certificate Redshift presents.

The setting works similarly to that of the PostgreSQL source except that Redshift explicitly passes 'prefer' to psycopg2 if sslmode is not configured (for compatibility).