### PR TITLE
feat: make SAML signature requirements configurable

### DIFF
--- a/client/app/pages/settings/organization.html
+++ b/client/app/pages/settings/organization.html
@@ -45,6 +45,26 @@
                         <input name="input" type="string" class="form-control" ng-model="$ctrl.settings.auth_saml_nameid_format" accesskey="tab"
                                ng-change="$ctrl.update('auth_saml_metadata_nameid_format')">
                     </div>
+
+                    <label>SAML Response Signing Settings</label>
+                    <p ng-class="{'text-danger': !$ctrl.validateSamlSigningSettings(), 'help-block': $ctrl.validateSamlSigningSettings()}">
+                        Depending on your SAML IDP, you must require the IDP to sign
+                        assertions, whole response or both.
+                    </p>
+                    <div class="form-group">
+                        <label>
+                            <input name="input" type="checkbox" ng-model="$ctrl.settings.auth_saml_want_assertions_signed"
+                                ng-change="$ctrl.update('auth_saml_want_assertions_signed')" accesskey="tab">
+                            Require Signed Assertions
+                        </label>
+                    </div>
+                    <div class="form-group">
+                        <label>
+                            <input name="input" type="checkbox" ng-model="$ctrl.settings.auth_saml_want_response_signed"
+                                ng-change="$ctrl.update('auth_saml_want_response_signed')" accesskey="tab">
+                            Require Signed Response
+                        </label>
+                    </div>
                 </div>
             </p>
         </div>

--- a/client/app/pages/settings/organization.js
+++ b/client/app/pages/settings/organization.js
@@ -10,6 +10,10 @@ function OrganizationSettingsCtrl($http, toastr, Events) {
   });
 
   this.update = (key) => {
+    if (!this.validateSamlSigningSettings()) {
+      return;
+    }
+
     $http.post('api/settings/organization', { [key]: this.settings[key] }).then((response) => {
       this.settings = response.data.settings;
       toastr.success('Settings changes saved.');
@@ -17,6 +21,11 @@ function OrganizationSettingsCtrl($http, toastr, Events) {
       toastr.error('Failed saving changes.');
     });
   };
+
+  this.validateSamlSigningSettings = () =>
+    // One of these must be enabled for secure SAML authentication
+    this.settings.auth_saml_want_response_signed ||
+    this.settings.auth_saml_want_assertions_signed;
 }
 
 export default function init(ngModule) {

--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -43,8 +43,8 @@ def get_saml_client(org):
                 # sense in a situation where you control both the SP and IdP
                 'authn_requests_signed': False,
                 'logout_requests_signed': True,
-                'want_assertions_signed': True,
-                'want_response_signed': False,
+                'want_assertions_signed': org.get_setting("auth_saml_want_assertions_signed"),
+                'want_response_signed': org.get_setting("auth_saml_want_response_signed"),
             },
         },
     }

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -46,6 +46,7 @@ def int_or_none(value):
 
     return int(value)
 
+
 def check_saml_settings_security(settings):
     """Check SAML authentication for insecure settings.
 
@@ -61,7 +62,7 @@ def check_saml_settings_security(settings):
     # signatures, anyone can craft a valid and trusted SAML
     # response with arbitrary information
     if not settings.get("auth_saml_want_response_signed") and \
-        not settings.get("auth_saml_want_assertions_signed"):
+            not settings.get("auth_saml_want_assertions_signed"):
         raise Exception("SAML configuration must require signed responses, signed assertions or both.")
 
     # All good

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -45,3 +45,24 @@ def int_or_none(value):
         return value
 
     return int(value)
+
+def check_saml_settings_security(settings):
+    """Check SAML authentication for insecure settings.
+
+    Raises Exception with a human readable message if settings are
+    not secure.
+    """
+    if not settings.get("auth_saml_enabled"):
+        # SAML not enabled. All good.
+        return True
+
+    # We must require that the IDP signs the entire response or
+    # individual assertions (or both). If we don't require any
+    # signatures, anyone can craft a valid and trusted SAML
+    # response with arbitrary information
+    if not settings.get("auth_saml_want_response_signed") and \
+        not settings.get("auth_saml_want_assertions_signed"):
+        raise Exception("SAML configuration must require signed responses, signed assertions or both.")
+
+    # All good
+    return True

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -1,5 +1,5 @@
 import os
-from .helpers import parse_boolean
+from .helpers import parse_boolean, check_saml_settings_security
 
 if os.environ.get("REDASH_SAML_LOCAL_METADATA_PATH") is not None:
     print "DEPRECATION NOTICE:\n"
@@ -13,6 +13,8 @@ PASSWORD_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_PASSWORD_LOGIN_ENA
 SAML_METADATA_URL = os.environ.get("REDASH_SAML_METADATA_URL", "")
 SAML_ENTITY_ID = os.environ.get("REDASH_SAML_ENTITY_ID", "")
 SAML_NAMEID_FORMAT = os.environ.get("REDASH_SAML_NAMEID_FORMAT", "")
+SAML_WANT_ASSERTIONS_SIGNED = parse_boolean(os.environ.get("REDASH_SAML_WANT_ASSERTIONS_SIGNED", "true"))
+SAML_WANT_RESPONSE_SIGNED = parse_boolean(os.environ.get("REDASH_SAML_WANT_RESPONSE_SIGNED", "false"))
 SAML_LOGIN_ENABLED = SAML_METADATA_URL != ""
 
 DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
@@ -23,5 +25,17 @@ settings = {
     "auth_saml_entity_id": SAML_ENTITY_ID,
     "auth_saml_metadata_url": SAML_METADATA_URL,
     "auth_saml_nameid_format": SAML_NAMEID_FORMAT,
+    "auth_saml_want_assertions_signed": SAML_WANT_ASSERTIONS_SIGNED,
+    "auth_saml_want_response_signed": SAML_WANT_RESPONSE_SIGNED,
     "date_format": DATE_FORMAT
 }
+
+try:
+    check_saml_settings_security(settings)
+except Exception as e:
+    print(e)
+    print('One of the following options must be enabled for secure SAML authentication:')
+    print('- REDASH_SAML_WANT_ASSERTIONS_SIGNED')
+    print('- REDASH_SAML_WANT_RESPONSE_SIGNED')
+    print('Enable one or both options according to your IDP configuration and restart Redash')
+    raise SystemExit(1)

--- a/tests/handlers/test_settings.py
+++ b/tests/handlers/test_settings.py
@@ -13,3 +13,20 @@ class TestOrganizationSettings(BaseTestCase):
         updated_org = Organization.get_by_slug(self.factory.org.slug)
         self.assertEqual(rv.json['settings']['auth_password_login_enabled'], True)
         self.assertEqual(updated_org.settings['settings']['auth_password_login_enabled'], True)
+
+    def test_saml_signature_settings_validation(self):
+        admin = self.factory.create_admin()
+        data = {
+            'auth_saml_enabled': True,
+            'auth_saml_want_response_signed': False,
+            'auth_saml_want_assertions_signed': False
+        }
+
+        rv = self.make_request('post', '/api/settings/organization', data=data, user=admin)
+        self.assertEqual(rv.status_code, 400, 'Endpoint rejected the update')
+
+        # Check that this invalid configuration did not persist
+        updated_org = Organization.get_by_slug(self.factory.org.slug)
+        check_sigs = updated_org.get_setting('auth_saml_want_response_signed') or \
+            updated_org.get_setting('auth_saml_want_assertions_signed')
+        self.assertEqual(check_sigs, True)

--- a/tests/models/test_organization.py
+++ b/tests/models/test_organization.py
@@ -1,0 +1,12 @@
+from tests import BaseTestCase
+from redash.models import ApiKey
+
+class TestOrganization(BaseTestCase):
+    def test_saml_signature_default_settings(self):
+        # Previously, these two settings were hard-coded into the codebase
+        # and thus it's important that the defaults never change (that could
+        # break existing installations). The old values were:
+        # - want_assertions_signed: True
+        # - want_response_signed: False
+        self.assertTrue(self.factory.org.get_setting('auth_saml_want_assertions_signed'))
+        self.assertFalse(self.factory.org.get_setting('auth_saml_want_response_signed'))

--- a/tests/settings/test_helpers.py
+++ b/tests/settings/test_helpers.py
@@ -1,0 +1,31 @@
+from redash.settings import helpers
+from unittest import TestCase
+
+class TestSettingsHelpers(TestCase):
+    def test_saml_settings_check_saml_disabled(self):
+        settings = {
+            'auth_saml_enabled': False,
+            'auth_saml_want_response_signed': False,
+            'auth_saml_want_assertions_signed': False
+        }
+
+        self.assertEqual(helpers.check_saml_settings_security(settings), True)
+
+    def test_saml_settings_check_valid_config(self):
+        settings = {
+            'auth_saml_enabled': True,
+            'auth_saml_want_response_signed': True,
+            'auth_saml_want_assertions_signed': False
+        }
+
+        self.assertEqual(helpers.check_saml_settings_security(settings), True)
+
+    def test_saml_settings_check_invalid_config(self):
+        settings = {
+            'auth_saml_enabled': True,
+            'auth_saml_want_response_signed': False,
+            'auth_saml_want_assertions_signed': False
+        }
+
+        with self.assertRaisesRegexp(Exception, 'must require signed responses'):
+            helpers.check_saml_settings_security(settings)

--- a/tests/settings/test_organization.py
+++ b/tests/settings/test_organization.py
@@ -1,0 +1,21 @@
+import mock
+import os
+from unittest import TestCase
+
+from redash.settings import organization
+
+class TestOrganizationSettings(TestCase):
+    def test_exit_if_saml_config_invalid(self):
+        overrides = {
+            'REDASH_SAML_METADATA_URL': 'http://example.com/saml-metadata.xml',
+            'REDASH_SAML_WANT_ASSERTIONS_SIGNED': 'false',
+            'REDASH_SAML_WANT_RESPONSE_SIGNED': 'false'
+        }
+
+        # Make sure the configuration is reloaded without these
+        # modifications once we are done
+        self.addCleanup(lambda: reload(organization))
+
+        with mock.patch.dict('os.environ', overrides):
+            with self.assertRaises(SystemExit):
+                reload(organization)


### PR DESCRIPTION
These changes make it possible to configure if the SAML based authentication requires the IDP to sign individual assertions, whole response or both. These values can be configured both globally via environmental variables or through organization specific settings from the Admin UI / API.

The two environmental variables provide global defaults for these values:

* REDASH_SAML_WANT_ASSERTIONS_SIGNED
* REDASH_SAML_WANT_RESPONSE_SIGNED

If these variables are not present, they default to the previously hardcoded values (want_signed_assertions = True and want_response_signed = False). This is done to ensure existing installations do not break on upgrade. A test has been written to ensure this behavior persists.

Alternatively, these two variables can be modified on per-organization basis from the Admin UI. These configurations override the global defaults set via the environment.

Special care has been taken to ensure that it's not possible to disable signing requirements completely. If the two environmental variables are both disabled while SAML is enabled, the server will instruct the user to enable at least signing requirement and refuse to start. Similarly, the UI will not let the user to disable both signing requirements and the API will return a 400 response if signing requirements are going to be disabled.

Tests have also been written to test the backend functionality.

Closes #1669.