### PR TITLE
Improve dashboard editing flow

### DIFF
--- a/client/app/assets/less/inc/schema-browser.less
+++ b/client/app/assets/less/inc/schema-browser.less
@@ -62,6 +62,8 @@ div.table-name {
     }
 
     &:hover {
+      background: fade(@redash-gray, 10%);
+      
       .copy-to-editor {
         display: flex;
       }

--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -79,7 +79,7 @@ edit-in-place p.editable:hover {
 }
 
 .filter-container {
-  margin-bottom: 5px;
+  margin-bottom: 10px;
 }
 
 .editor__control--right {

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -293,6 +293,11 @@ page-header, .page-header--new {
 .label {
   border-radius: 2px;
   padding: 3px 6px 4px;
+  font-weight: 500;
+}
+
+.label-default {
+  background: fade(@redash-gray, 85%);
 }
 
 .tab-nav > li > a {

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -128,14 +128,6 @@ body {
   }
 }
 
-.add-widget-container {
-  background: fade(@redash-gray, 10%);
-  border-radius: @redash-radius;
-  margin-top: 15px;
-  //box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
-  border: 2px dashed fade(@redash-gray, 25%);
-}
-
 .database-source {
   display: inline-flex;
   flex-wrap: wrap;

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -323,6 +323,12 @@ page-header, .page-header--new {
   }
 }
 
+.widget-wrapper {
+  .parameter-container {
+    padding: 0 15px;
+  }
+}
+
 .bg-ace {
   background-color: fade(@redash-gray, 12%) !important;
 }

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -323,6 +323,16 @@ page-header, .page-header--new {
   }
 }
 
+.dashboard-header.fixed {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background: #f6f7f9;
+  z-index: 9999;
+  left: 0;
+  padding: 5px 30px !important;
+}
+
 .widget-wrapper {
   .parameter-container {
     padding: 0 15px;

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -323,14 +323,13 @@ page-header, .page-header--new {
   }
 }
 
-.dashboard-header.fixed {
-  position: fixed;
-  top: 0;
-  width: 100%;
+.dashboard-header {
+  position: -webkit-sticky;  // required for Safari
+  position: sticky;
   background: #f6f7f9;
-  z-index: 9999;
-  left: 0;
-  padding: 5px 30px !important;
+  z-index: 99;
+  width: 100%;
+  top: 0;
 }
 
 .widget-wrapper {

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -76,16 +76,37 @@ body {
 .add-widget-container {
   background: #fff;
   border-radius: @redash-radius;
-  padding: 20px;
+  padding: 15px;
   position: fixed;
-  left: calc(~'50% - 200px');
-  bottom: 25px;
-  width: 400px;
+  left: 15px;
+  bottom: 20px;
+  width: calc(~'100% - 30px');
   z-index: 99;
   box-shadow: fade(@redash-gray, 50%) 0px 7px 29px -3px;
+  display: flex;
+  justify-content: space-between;
 
   h2 {
-    margin-top: 0;
+    margin: 0;
+    font-size: 14px;
+    line-height: 2.1;
+    font-weight: 400;
+
+    .zmdi {
+      margin: 0;
+      margin-right: 5px;
+      font-size: 24px;
+      position: absolute;
+      bottom: 18px;
+    }
+
+    span {
+      padding-left: 30px;
+    }
+  }
+
+  .btn {
+    align-self: center;
   }
 }
 

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -308,6 +308,21 @@ page-header, .page-header--new {
   text-transform: none;
 }
 
+.dashboard-header {
+  position: -webkit-sticky;  // required for Safari
+  position: sticky;
+  background: #f6f7f9;
+  z-index: 99;
+  width: 100%;
+  top: 0;
+}
+
+.widget-wrapper {
+  .parameter-container {
+    padding: 0 15px;
+  }
+}
+
 .dashboard__control {
   margin: 8px 0;
 }

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -73,6 +73,22 @@ body {
   }
 }
 
+.add-widget-container {
+  background: #fff;
+  border-radius: @redash-radius;
+  padding: 20px;
+  position: fixed;
+  left: calc(~'50% - 200px');
+  bottom: 25px;
+  width: 400px;
+  z-index: 99;
+  box-shadow: fade(@redash-gray, 50%) 0px 7px 29px -3px;
+
+  h2 {
+    margin-top: 0;
+  }
+}
+
 body {
   .ace-tm .ace_gutter {
     background: #fff;

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -91,6 +91,14 @@ body {
   }
 }
 
+.add-widget-container {
+  background: fade(@redash-gray, 10%);
+  border-radius: @redash-radius;
+  margin-top: 15px;
+  //box-shadow: fade(@redash-gray, 15%) 0px 4px 9px -3px;
+  border: 2px dashed fade(@redash-gray, 25%);
+}
+
 .database-source {
   display: inline-flex;
   flex-wrap: wrap;

--- a/client/app/components/dashboards/edit-dashboard-dialog.html
+++ b/client/app/components/dashboards/edit-dashboard-dialog.html
@@ -6,13 +6,6 @@
   <p>
     <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name" autofocus>
   </p>
-
-  <p ng-if="$ctrl.dashboard.id">
-    <label>
-        <input name="input" type="checkbox" ng-model="$ctrl.dashboard.dashboard_filters_enabled">
-        Use Dashboard Level Filters
-    </label>
-  </p>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.dismiss()">Close</button>

--- a/client/app/components/dashboards/edit-dashboard-dialog.js
+++ b/client/app/components/dashboards/edit-dashboard-dialog.js
@@ -8,63 +8,28 @@ const EditDashboardDialog = {
     dismiss: '&',
   },
   template,
-  controller($rootScope, $location, $http, toastr, Events, Dashboard) {
+  controller($rootScope, $location, $http, toastr, Events) {
     'ngInject';
 
     this.dashboard = this.resolve.dashboard;
-    this.gridsterOptions = {
-      margins: [5, 5],
-      rowHeight: 100,
-      colWidth: 260,
-      columns: 2,
-      mobileModeEnabled: false,
-      swapping: true,
-      minRows: 1,
-      draggable: {
-        enabled: true,
-      },
-      resizable: {
-        enabled: false,
-      },
-    };
 
     this.isFormValid = () => !isEmpty(this.dashboard.name);
 
     this.saveDashboard = () => {
       this.saveInProgress = true;
 
-      if (this.dashboard.id) {
-        const request = {
-          slug: this.dashboard.id,
+      $http
+        .post('api/dashboards', {
           name: this.dashboard.name,
-          version: this.dashboard.version,
-          dashboard_filters_enabled: this.dashboard.dashboard_filters_enabled,
-        };
-
-        Dashboard.save(request, (dashboard) => {
-          this.dashboard = dashboard;
-          this.saveInProgress = false;
-          this.close({ $value: this.dashboard });
-          $rootScope.$broadcast('reloadDashboards');
-        }, (error) => {
-          this.saveInProgress = false;
-          if (error.status === 403) {
-            toastr.error('Unable to save dashboard: Permission denied.');
-          } else if (error.status === 409) {
-            toastr.error('It seems like the dashboard has been modified by another user. ' +
-                'Please copy/backup your changes and reload this page.', { autoDismiss: false });
-          }
-        });
-        Events.record('edit', 'dashboard', this.dashboard.id);
-      } else {
-        $http.post('api/dashboards', {
-          name: this.dashboard.name,
-        }).success((response) => {
+        })
+        .success((response) => {
           this.close();
-          $location.path(`/dashboard/${response.slug}`).replace();
+          $location
+            .path(`/dashboard/${response.slug}`)
+            .search('edit')
+            .replace();
         });
-        Events.record('create', 'dashboard');
-      }
+      Events.record('create', 'dashboard');
     };
   },
 };

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -82,11 +82,8 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
   Events.record('view', 'widget', this.widget.id);
 
   this.reload = (force) => {
-    let maxAge = $location.search().maxAge;
-    if (force) {
-      maxAge = 0;
-    }
-    this.queryResult = this.query.getQueryResult(maxAge);
+    const maxAge = $location.search().maxAge;
+    this.queryResult = this.widget.getQueryResult(force, maxAge);
   };
 
   if (this.widget.visualization) {

--- a/client/app/components/filters.html
+++ b/client/app/components/filters.html
@@ -1,4 +1,4 @@
-<div class="container bg-white" ng-show="$ctrl.filters | notEmpty">
+<div class="parameter-container container bg-white" ng-show="$ctrl.filters | notEmpty">
   <div class="row">
     <div class="col-sm-6 p-l-0 filter-container" ng-repeat="filter in $ctrl.filters">
       <label>{{filter.friendlyName}}</label>

--- a/client/app/components/filters.html
+++ b/client/app/components/filters.html
@@ -1,4 +1,4 @@
-<div class="container bg-white p-b-15" ng-show="$ctrl.filters | notEmpty">
+<div class="container bg-white" ng-show="$ctrl.filters | notEmpty">
   <div class="row">
     <div class="col-sm-6 p-l-0 filter-container" ng-repeat="filter in $ctrl.filters">
       <label>{{filter.friendlyName}}</label>

--- a/client/app/components/parameters.html
+++ b/client/app/components/parameters.html
@@ -1,4 +1,4 @@
-<div class="form-inline bg-white p-15"
+<div class="parameter-container form-inline bg-white"
      ng-if="parameters | notEmpty"
      ui-sortable="{ 'ui-floating': true, 'disabled': !editable }"
      ng-model="parameters">

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -2,14 +2,14 @@
 
   <div class="row p-l-15 p-r-15 m-b-10 m-l-0 m-r-0 dashboard-header">
     <div class="col-xs-5 col-sm-5 col-lg-5 page-header--new p-l-0">
-      <h3>{{$ctrl.dashboard.name}}
+      <h3>
+        <edit-in-place editable="$ctrl.layoutEditing" done="$ctrl.saveName" ignore-blanks="true" value="$ctrl.dashboard.name"></edit-in-place>
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>
         <span class="label label-warning" ng-if="$ctrl.dashboard.is_archived" uib-popover="This dashboard is archived and and won't appear in the dashboards list or search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
       </h3>
     </div>
     <div class="col-xs-7 col-sm-7 col-lg-7 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
-
           <div class="btn-group">
             <button type="button" class="btn btn-primary btn-sm"
               ng-disabled="$ctrl.isGridDisabled"
@@ -60,9 +60,7 @@
               <span class="zmdi zmdi-more"></span>
             </button>
             <ul class="dropdown-menu pull-right" uib-dropdown-menu>
-              <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.editDashboard()">Edit Dashboard</a></li>
-              <li ng-if="!$ctrl.dashboard.is_archived" ng-class="{hidden: $ctrl.isGridDisabled}"><a ng-click="$ctrl.editLayout(true)">Edit Layout</a></li>
-              <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.addWidget()">Add Widget</a></li>
+              <li ng-if="!$ctrl.dashboard.is_archived" ng-class="{hidden: $ctrl.isGridDisabled}"><a ng-click="$ctrl.editLayout(true)">Edit Dashboard</a></li>
               <li ng-if="$ctrl.showPermissionsControl"><a ng-click="$ctrl.showManagePermissionsModal()">Manage Permissions</a></li>
               <li ng-if="!$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Unpublish Dashboard</a></li>
               <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.archiveDashboard()">Archive Dashboard</a></li>
@@ -71,11 +69,18 @@
     </div>
   </div>
 
+  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.layoutEditing">
+    <label>
+        <input name="input" type="checkbox" ng-model="$ctrl.dashboard.dashboard_filters_enabled">
+        Use Dashboard Level Filters
+    </label>
+  </div>
+
   <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0">
     <parameters parameters="$ctrl.globalParameters" on-change="$ctrl.onGlobalParametersChange()"></parameters>
   </div>
 
-  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.dashboard.dashboard_filters_enabled">
+  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.filters | notEmpty">
     <filters filters="$ctrl.filters" on-change="$ctrl.filtersOnChange(filter, $modal)"></filters>
   </div>
 

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -1,13 +1,13 @@
 <div class="container">
 
   <div class="row p-l-15 p-r-15 m-b-10 m-l-0 m-r-0">
-    <div class="col-xs-12 col-sm-6 col-lg-7 page-header--new p-l-0">
+    <div class="col-xs-5 col-sm-5 col-lg-5 page-header--new p-l-0">
       <h3>{{$ctrl.dashboard.name}}
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>
         <span class="label label-warning" ng-if="$ctrl.dashboard.is_archived" uib-popover="This dashboard is archived and and won't appear in the dashboards list or search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
       </h3>
     </div>
-    <div class="col-xs-12 col-sm-6 col-lg-5 text-right dashboard__control p-r-0">
+    <div class="col-xs-7 col-sm-7 col-lg-7 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
 
           <div class="btn-group">
@@ -24,7 +24,11 @@
             </button>
           </div>
 
-          <div class="btn-group" uib-dropdown>
+          <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.togglePublished()" tooltip="Publish Dashboard" ng-if="$ctrl.dashboard.is_draft">
+            Publish Dashboard
+          </button>
+
+          <div class="btn-group" uib-dropdown ng-if="!$ctrl.dashboard.is_draft">
             <button id="split-button" type="button"
                     ng-class="{'btn-default btn-sm': $ctrl.refreshRate === null,'btn-primary btn-sm':$ctrl.refreshRate !== null}"
                     class="btn btn-sm" ng-click="$ctrl.loadDashboard(true)">
@@ -44,10 +48,10 @@
               </li>
             </ul>
           </div>
-          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.isFullscreen, 'btn-primary': $ctrl.isFullscreen}" tooltip="Enable/Disable Fullscreen display" ng-click="$ctrl.toggleFullscreen()">
+          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.isFullscreen, 'btn-primary': $ctrl.isFullscreen}" tooltip="Enable/Disable Fullscreen display" ng-click="$ctrl.toggleFullscreen()" ng-if="!$ctrl.dashboard.is_draft">
             <span class="zmdi zmdi-fullscreen"></span>
           </button>
-          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.dashboard.publicAccessEnabled, 'btn-primary': $ctrl.dashboard.publicAccessEnabled}" tooltip="Enable/Disable Share URL" ng-click="$ctrl.openShareForm()" ng-if="$ctrl.dashboard.canEdit() || $ctrl.dashboard.publicAccessEnabled">
+          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.dashboard.publicAccessEnabled, 'btn-primary': $ctrl.dashboard.publicAccessEnabled}" tooltip="Enable/Disable Share URL" ng-click="$ctrl.openShareForm()" ng-if="($ctrl.dashboard.canEdit() || $ctrl.dashboard.publicAccessEnabled) && !$ctrl.dashboard.is_draft">
             <span class="zmdi zmdi-share"></span>
           </button>
       </span>
@@ -61,7 +65,6 @@
               <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.addWidget()">Add Widget</a></li>
               <li ng-if="$ctrl.showPermissionsControl"><a ng-click="$ctrl.showManagePermissionsModal()">Manage Permissions</a></li>
               <li ng-if="!$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Unpublish Dashboard</a></li>
-              <li ng-if="$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Publish Dashboard</a></li>
               <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.archiveDashboard()">Archive Dashboard</a></li>
             </ul>
           </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -92,7 +92,7 @@
   <div class="add-widget-container" ng-if="$ctrl.layoutEditing">
     <h2>
       <i class="zmdi zmdi-widgets"></i>
-      <span class="hidden-xs hidden-sm">Widgets are individual query visualisations you can place on your dashboard in various arrangements.</span>
+      <span class="hidden-xs hidden-sm">Widgets are individual query visualizations or text boxes you can place on your dashboard in various arrangements.</span>
     </h2>
     <a class="btn btn-primary" ng-click="$ctrl.addWidget()">Add Widget</a>
   </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -71,8 +71,7 @@
     </div>
   </div>
 
-  <!-- TODO: only show if we have global parameters -->
-  <div class="m-b-10 p-15 bg-white tiled">
+  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0">
     <parameters parameters="$ctrl.globalParameters" on-change="$ctrl.onGlobalParametersChange()"></parameters>
   </div>
 
@@ -80,7 +79,7 @@
     <filters filters="$ctrl.filters" on-change="$ctrl.filtersOnChange(filter, $modal)"></filters>
   </div>
 
-  <div style="overflow: hidden; padding-bottom: 5px;">
+  <div style="overflow: hidden; padding-bottom: 5px;" ng-if="$ctrl.dashboard.widgets.length > 0">
     <div gridster="$ctrl.dashboardGridOptions" class="dashboard-wrapper"
       ng-class="{'preview-mode': !$ctrl.layoutEditing, 'editing-mode': $ctrl.layoutEditing}">
       <div ng-repeat="widget in $ctrl.dashboard.widgets" gridster-item="widget.options.position"

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -24,11 +24,11 @@
             </button>
           </div>
 
-          <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.togglePublished()" tooltip="Publish Dashboard" ng-if="$ctrl.dashboard.is_draft">
+          <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.togglePublished()" tooltip="Publish Dashboard" ng-if="$ctrl.dashboard.is_draft && !$ctrl.layoutEditing">
             Publish Dashboard
           </button>
 
-          <div class="btn-group" uib-dropdown ng-if="!$ctrl.dashboard.is_draft">
+          <div class="btn-group" uib-dropdown ng-if="!$ctrl.layoutEditing">
             <button id="split-button" type="button"
                     ng-class="{'btn-default btn-sm': $ctrl.refreshRate === null,'btn-primary btn-sm':$ctrl.refreshRate !== null}"
                     class="btn btn-sm" ng-click="$ctrl.loadDashboard(true)">
@@ -48,14 +48,14 @@
               </li>
             </ul>
           </div>
-          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.isFullscreen, 'btn-primary': $ctrl.isFullscreen}" tooltip="Enable/Disable Fullscreen display" ng-click="$ctrl.toggleFullscreen()" ng-if="!$ctrl.dashboard.is_draft">
+          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.isFullscreen, 'btn-primary': $ctrl.isFullscreen}" tooltip="Enable/Disable Fullscreen display" ng-click="$ctrl.toggleFullscreen()" ng-if="!$ctrl.dashboard.is_draft && !$ctrl.layoutEditing">
             <span class="zmdi zmdi-fullscreen"></span>
           </button>
-          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.dashboard.publicAccessEnabled, 'btn-primary': $ctrl.dashboard.publicAccessEnabled}" tooltip="Enable/Disable Share URL" ng-click="$ctrl.openShareForm()" ng-if="($ctrl.dashboard.canEdit() || $ctrl.dashboard.publicAccessEnabled) && !$ctrl.dashboard.is_draft">
+          <button type="button" class="btn btn-sm" ng-class="{'btn-default': !$ctrl.dashboard.publicAccessEnabled, 'btn-primary': $ctrl.dashboard.publicAccessEnabled}" tooltip="Enable/Disable Share URL" ng-click="$ctrl.openShareForm()" ng-if="($ctrl.dashboard.canEdit() || $ctrl.dashboard.publicAccessEnabled) && !$ctrl.dashboard.is_draft && !$ctrl.layoutEditing">
             <span class="zmdi zmdi-share"></span>
           </button>
       </span>
-          <div class="btn-group hidden-print" role="group" ng-show="$ctrl.dashboard.canEdit()" uib-dropdown ng-if="!$ctrl.dashboard.is_archived">
+          <div class="btn-group hidden-print" role="group" ng-show="$ctrl.dashboard.canEdit()" uib-dropdown ng-if="!$ctrl.dashboard.is_archived && !$ctrl.layoutEditing">
             <button class="btn btn-default btn-sm dropdown-toggle" uib-dropdown-toggle>
               <span class="zmdi zmdi-more"></span>
             </button>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -71,7 +71,7 @@
 
   <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.layoutEditing">
     <label>
-        <input name="input" type="checkbox" ng-model="$ctrl.dashboard.dashboard_filters_enabled">
+        <input name="input" type="checkbox" ng-model="$ctrl.dashboard.dashboard_filters_enabled" ng-change="$ctrl.updateDashboardFiltersState()">
         Use Dashboard Level Filters
     </label>
   </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -71,12 +71,13 @@
     </div>
   </div>
 
-  <div class="m-b-10 tiled">
+  <!-- TODO: only show if we have global parameters -->
+  <div class="m-b-10 p-15 bg-white tiled">
     <parameters parameters="$ctrl.globalParameters" on-change="$ctrl.onGlobalParametersChange()"></parameters>
   </div>
 
-  <div class="m-b-10 tiled">
-    <filters ng-if="$ctrl.dashboard.dashboard_filters_enabled" filters="$ctrl.filters" on-change="$ctrl.filtersOnChange(filter, $modal)"></filters>
+  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.dashboard.dashboard_filters_enabled">
+    <filters filters="$ctrl.filters" on-change="$ctrl.filtersOnChange(filter, $modal)"></filters>
   </div>
 
   <div style="overflow: hidden; padding-bottom: 5px;">

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -1,17 +1,17 @@
 <div class="container">
 
   <div class="row p-l-15 p-r-15 m-b-10 m-l-0 m-r-0">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-7 page-header--new p-l-0">
+    <div class="col-xs-12 col-sm-6 col-lg-7 page-header--new p-l-0">
       <h3>{{$ctrl.dashboard.name}}
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>
         <span class="label label-warning" ng-if="$ctrl.dashboard.is_archived" uib-popover="This dashboard is archived and and won't appear in the dashboards list or search results." popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
       </h3>
     </div>
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-5 text-right dashboard__control p-r-0">
+    <div class="col-xs-12 col-sm-6 col-lg-5 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
 
           <div class="btn-group">
-            <button type="button" class="btn btn-default btn-sm"
+            <button type="button" class="btn btn-primary btn-sm"
               ng-disabled="$ctrl.isGridDisabled"
               ng-click="$ctrl.editLayout(false, true)" ng-if="$ctrl.layoutEditing">
               <i class="zmdi zmdi-check"></i> Apply Changes
@@ -20,7 +20,7 @@
             <button type="button" class="btn btn-default btn-sm"
               ng-disabled="$ctrl.isGridDisabled"
               ng-click="$ctrl.editLayout(false, false)" ng-if="$ctrl.layoutEditing">
-              Cancel
+              <i class="zmdi zmdi-close"></i> Cancel
             </button>
           </div>
 
@@ -76,12 +76,24 @@
     <filters ng-if="$ctrl.dashboard.dashboard_filters_enabled" filters="$ctrl.filters" on-change="$ctrl.filtersOnChange(filter, $modal)"></filters>
   </div>
 
-  <div style="overflow: hidden">
+  <div style="overflow: hidden; padding-bottom: 5px;">
     <div gridster="$ctrl.dashboardGridOptions" class="dashboard-wrapper"
       ng-class="{'preview-mode': !$ctrl.layoutEditing, 'editing-mode': $ctrl.layoutEditing}">
       <div ng-repeat="widget in $ctrl.dashboard.widgets" gridster-item="widget.options.position"
         gridster-auto-height=".scrollbox, .spinner-container">
         <dashboard-widget widget="widget" dashboard="$ctrl.dashboard" on-delete="$ctrl.removeWidget()"></dashboard-widget>
+      </div>
+    </div>
+  </div>
+
+  <div ng-if="$ctrl.layoutEditing">
+    <div class="col-md-12 text-center add-widget-container">
+      <div class="col-md-4 col-md-offset-4">
+        <br>
+        <h2><i class="zmdi zmdi-widgets"></i></h2>
+        <p>Widgets are individual query visualisations you can place on your dashboard in various arrangements.</p>
+        <a class="btn btn-primary" ng-click="$ctrl.addWidget()">Add Widget</a>
+        <br><br>
       </div>
     </div>
   </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -1,6 +1,6 @@
 <div class="container">
 
-  <div class="row p-l-15 p-r-15 m-b-10 m-l-0 m-r-0">
+  <div class="row p-l-15 p-r-15 m-b-10 m-l-0 m-r-0 dashboard-header">
     <div class="col-xs-5 col-sm-5 col-lg-5 page-header--new p-l-0">
       <h3>{{$ctrl.dashboard.name}}
         <span class="label label-default" ng-if="$ctrl.dashboard.is_draft && !$ctrl.dashboard.is_archived">Unpublished</span>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -89,15 +89,9 @@
     </div>
   </div>
 
-  <div ng-if="$ctrl.layoutEditing">
-    <div class="col-md-12 text-center add-widget-container">
-      <div class="col-md-4 col-md-offset-4">
-        <br>
-        <h2><i class="zmdi zmdi-widgets"></i></h2>
-        <p>Widgets are individual query visualisations you can place on your dashboard in various arrangements.</p>
-        <a class="btn btn-primary" ng-click="$ctrl.addWidget()">Add Widget</a>
-        <br><br>
-      </div>
-    </div>
+  <div class="text-center add-widget-container" ng-if="$ctrl.layoutEditing">
+    <h2><i class="zmdi zmdi-widgets"></i></h2>
+    <p>Widgets are individual query visualisations you can place on your dashboard in various arrangements.</p>
+    <a class="btn btn-primary" ng-click="$ctrl.addWidget()">Add Widget</a>
   </div>
 </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -89,9 +89,11 @@
     </div>
   </div>
 
-  <div class="text-center add-widget-container" ng-if="$ctrl.layoutEditing">
-    <h2><i class="zmdi zmdi-widgets"></i></h2>
-    <p>Widgets are individual query visualisations you can place on your dashboard in various arrangements.</p>
+  <div class="add-widget-container" ng-if="$ctrl.layoutEditing">
+    <h2>
+      <i class="zmdi zmdi-widgets"></i>
+      <span class="hidden-xs hidden-sm">Widgets are individual query visualisations you can place on your dashboard in various arrangements.</span>
+    </h2>
     <a class="btn btn-primary" ng-click="$ctrl.addWidget()">Add Widget</a>
   </div>
 </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -25,7 +25,7 @@
           </div>
 
           <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.togglePublished()" tooltip="Publish Dashboard" ng-if="$ctrl.dashboard.is_draft && !$ctrl.layoutEditing">
-            Publish Dashboard
+            <span class="fa fa-paper-plane"></span> Publish
           </button>
 
           <div class="btn-group" uib-dropdown ng-if="!$ctrl.layoutEditing">
@@ -60,10 +60,10 @@
               <span class="zmdi zmdi-more"></span>
             </button>
             <ul class="dropdown-menu pull-right" uib-dropdown-menu>
-              <li ng-if="!$ctrl.dashboard.is_archived" ng-class="{hidden: $ctrl.isGridDisabled}"><a ng-click="$ctrl.editLayout(true)">Edit Dashboard</a></li>
+              <li ng-if="!$ctrl.dashboard.is_archived" ng-class="{hidden: $ctrl.isGridDisabled}"><a ng-click="$ctrl.editLayout(true)">Edit</a></li>
               <li ng-if="$ctrl.showPermissionsControl"><a ng-click="$ctrl.showManagePermissionsModal()">Manage Permissions</a></li>
-              <li ng-if="!$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Unpublish Dashboard</a></li>
-              <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.archiveDashboard()">Archive Dashboard</a></li>
+              <li ng-if="!$ctrl.dashboard.is_draft"><a ng-click="$ctrl.togglePublished()">Unpublish</a></li>
+              <li ng-if="!$ctrl.dashboard.is_archived"><a ng-click="$ctrl.archiveDashboard()">Archive</a></li>
             </ul>
           </div>
     </div>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -186,7 +186,7 @@
             <div class="t-body">
               <div class="row">
                 <div class="col-lg-12">
-                  <div class="p-t-15 p-b-15">
+                  <div class="p-t-15 p-b-15" ng-if="query.getParametersDefs().length > 0">
                     <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"></parameters>
                   </div>
                   <!-- Query Execution Status -->

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -186,7 +186,9 @@
             <div class="t-body">
               <div class="row">
                 <div class="col-lg-12">
-                  <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"></parameters>
+                  <div class="p-t-15 p-b-15">
+                    <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"></parameters>
+                  </div>
                   <!-- Query Execution Status -->
 
                   <div class="query-alerts">

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -25,6 +25,21 @@ function Widget($resource, $http, Query, Visualization, dashboardGridOptions) {
     return this.query;
   };
 
+  WidgetResource.prototype.getQueryResult = function getQueryResult(force, maxAge) {
+    if (!this.visualization) {
+      return undefined;
+    }
+
+    if (force || this.queryResult === undefined) {
+      if (maxAge === undefined || force) {
+        maxAge = force ? 0 : undefined;
+      }
+      this.queryResult = this.getQuery().getQueryResult(maxAge);
+    }
+
+    return this.queryResult;
+  };
+
   WidgetResource.prototype.getName = function getName() {
     if (this.visualization) {
       return `${this.visualization.query.name} (${this.visualization.name})`;


### PR DESCRIPTION
- [x] Hide Refresh, Share and Fullscreen while Unpublished
- [x] Publish Dashboard should be visible and not hidden under …
- [x] Stick dashboard header to the top
- [x] Show Refresh button when Unpublished
- [x] Hide Refresh, Share, Fullscreen and ... in Edit mode
- [x] Stick Add New Widget to the bottom so it's always visible 
- [x] Hide empty parameter container (on query page) so it stops wasting space @kocsmy
- [x] Finalise widget description: "Widgets are individual query visualisations you can place on your dashboard in various arrangements." @arikfr 
- [x] When creating a new dashboard, it should be in Edit Layout mode by default @arikfr 
- [x] Make Publish button consistent with Query Publish
- [x] Enable filters checkbox should work properly (save its state) @arikfr

#2213 

(until #2185 is merged this pull request contains commits from that branch too)