### PR TITLE
Renamed to "Elasticsearch"

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -271,7 +271,7 @@ class BaseElasticSearch(BaseQueryRunner):
 
                 result_rows.append(row)
         else:
-            raise Exception("Redash failed to parse the results it got from ElasticSearch.")
+            raise Exception("Redash failed to parse the results it got from Elasticsearch.")
 
     def test_connection(self):
         try:
@@ -394,6 +394,10 @@ class ElasticSearch(BaseElasticSearch):
     @classmethod
     def annotate_query(cls):
         return False
+
+    @classmethod
+    def name(cls):
+        return 'Elasticsearch'
 
     def run_query(self, query, user):
         try:


### PR DESCRIPTION
# WHAT IS THIS

Hi, `Elasticsearch` is the correct spelling, NOT `ElasticSearch` and `Elastic Search`.

- https://www.elastic.co/products/elasticsearch

So, I renamed to `Elasticsearch`.
( Please review together -> https://github.com/getredash/website/pull/62 :octocat: )

![_2018-01-12_16_46_37 3](https://user-images.githubusercontent.com/1573290/34865765-4833098c-f7bd-11e7-9dfd-8bc68a5542d9.png)

( After renamed )

Thank you 👍 