### PR TITLE
Insert schema node into editor by click

### DIFF
--- a/client/app/assets/less/inc/schema-browser.less
+++ b/client/app/assets/less/inc/schema-browser.less
@@ -30,6 +30,11 @@ div.table-name {
 
   .table-open {
     padding-left: 26px;
+    cursor: pointer;
+
+    &:hover {
+      background: fade(@redash-gray, 10%);
+    }
   }
 }
 

--- a/client/app/assets/less/inc/schema-browser.less
+++ b/client/app/assets/less/inc/schema-browser.less
@@ -3,11 +3,20 @@ div.table-name {
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
-  padding: 2px 10px;
+  padding: 2px 22px 2px 10px;
   border-radius: @redash-radius;
+  position: relative;
+
+  .copy-to-editor {
+    display: none;
+  }
 
   &:hover {
     background: fade(@redash-gray, 10%);
+
+    .copy-to-editor {
+      display: flex;
+    }
   }
 }
 
@@ -28,12 +37,34 @@ div.table-name {
     background: transparent;
   }
 
-  .table-open {
-    padding-left: 26px;
+  .copy-to-editor {
+    color: fade(@redash-gray, 90%);
     cursor: pointer;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .table-open {
+    padding: 0 22px 0 26px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    position: relative;
+
+    .copy-to-editor {
+      display: none;
+    }
 
     &:hover {
-      background: fade(@redash-gray, 10%);
+      .copy-to-editor {
+        display: flex;
+      }
     }
   }
 }

--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -42,6 +42,10 @@ function queryEditor(QuerySnippet) {
             autoScrollEditorIntoView: true,
           },
           onLoad(editor) {
+            $scope.$on('schema-browser-select', ($event, hierarchy) => {
+              editor.session.doc.replace(editor.selection.getRange(), hierarchy.join('.'));
+            });
+
             // Release Cmd/Ctrl+L to the browser
             editor.commands.bindKey('Cmd+L', null);
             editor.commands.bindKey('Ctrl+L', null);

--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -42,8 +42,8 @@ function queryEditor(QuerySnippet) {
             autoScrollEditorIntoView: true,
           },
           onLoad(editor) {
-            $scope.$on('schema-browser-select', ($event, hierarchy) => {
-              editor.session.doc.replace(editor.selection.getRange(), hierarchy.join('.'));
+            $scope.$on('query-editor.paste', ($event, text) => {
+              editor.session.doc.replace(editor.selection.getRange(), text);
             });
 
             // Release Cmd/Ctrl+L to the browser

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -10,17 +10,20 @@
 
   <div class="schema-browser" vs-repeat vs-size="$ctrl.getSize(table)">
     <div ng-repeat="table in $ctrl.schema | filter:$ctrl.schemaFilter track by table.name">
-      <div class="table-name" ng-click="$ctrl.showTable(table)"
-        ng-dblclick="$ctrl.itemSelected([table.name])">
+      <div class="table-name" ng-click="$ctrl.showTable(table)">
         <i class="fa fa-table"></i>
         <strong>
           <span title="{{table.name}}">{{table.name}}</span>
           <span ng-if="table.size !== undefined"> ({{table.size}})</span>
         </strong>
+        <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
+          ng-click="$ctrl.itemSelected($event, [table.name])"></i>
       </div>
       <div uib-collapse="table.collapsed">
-        <div ng-repeat="column in table.columns track by column" class="table-open"
-          ng-dblclick="$ctrl.itemSelected([table.name, column])">{{column}}</div>
+        <div ng-repeat="column in table.columns track by column" class="table-open">{{column}}
+          <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
+            ng-click="$ctrl.itemSelected($event, [table.name, column])"></i>
+        </div>
       </div>
     </div>
   </div>

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -10,7 +10,8 @@
 
   <div class="schema-browser" vs-repeat vs-size="$ctrl.getSize(table)">
     <div ng-repeat="table in $ctrl.schema | filter:$ctrl.schemaFilter track by table.name">
-      <div class="table-name" ng-click="$ctrl.showTable(table)">
+      <div class="table-name" ng-click="$ctrl.showTable(table)"
+        ng-dblclick="$ctrl.itemSelected([table.name])">
         <i class="fa fa-table"></i>
         <strong>
           <span title="{{table.name}}">{{table.name}}</span>
@@ -18,7 +19,8 @@
         </strong>
       </div>
       <div uib-collapse="table.collapsed">
-        <div ng-repeat="column in table.columns track by column" class="table-open">{{column}}</div>
+        <div ng-repeat="column in table.columns track by column" class="table-open"
+          ng-dblclick="$ctrl.itemSelected([table.name, column])">{{column}}</div>
       </div>
     </div>
   </div>

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -22,9 +22,10 @@ function SchemaBrowserCtrl($rootScope, $scope) {
     return this.schema === undefined || this.schema.length === 0;
   };
 
-  this.itemSelected = (hierarchy) => {
+  this.itemSelected = ($event, hierarchy) => {
     $rootScope.$broadcast('schema-browser-select', hierarchy);
-    window.getSelection().removeAllRanges();
+    $event.preventDefault();
+    $event.stopPropagation();
   };
 }
 

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -1,6 +1,6 @@
 import template from './schema-browser.html';
 
-function SchemaBrowserCtrl($scope) {
+function SchemaBrowserCtrl($rootScope, $scope) {
   'ngInject';
 
   this.showTable = (table) => {
@@ -20,6 +20,11 @@ function SchemaBrowserCtrl($scope) {
 
   this.isEmpty = function isEmpty() {
     return this.schema === undefined || this.schema.length === 0;
+  };
+
+  this.itemSelected = (hierarchy) => {
+    $rootScope.$broadcast('schema-browser-select', hierarchy);
+    window.getSelection().removeAllRanges();
   };
 }
 

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -23,7 +23,7 @@ function SchemaBrowserCtrl($rootScope, $scope) {
   };
 
   this.itemSelected = ($event, hierarchy) => {
-    $rootScope.$broadcast('schema-browser-select', hierarchy);
+    $rootScope.$broadcast('query-editor.paste', hierarchy.join('.'));
     $event.preventDefault();
     $event.stopPropagation();
   };

--- a/client/app/pages/queries/queries-search-results-page.js
+++ b/client/app/pages/queries/queries-search-results-page.js
@@ -25,15 +25,15 @@ function QuerySearchCtrl($location, $filter, currentUser, Events, Query) {
 
   this.createdAtSort = row => row.created_at.valueOf();
   this.createdBySort = row => row.user.name;
-  this.scheduleSort = function (row) {
+  this.scheduleSort = (row) => {
     if (!row.schedule) {
       return null;
     }
     if (row.schedule.match(/\d\d:\d\d/) !== null) {
       const parts = row.schedule.split(':');
       const localTime = moment.utc()
-            .hour(parts[0])
-            .minute(parts[1]);
+        .hour(parts[0])
+        .minute(parts[1]);
       return localTime.valueOf();
     }
     return parseInt(row.schedule, 10);


### PR DESCRIPTION
When user clicks an icon near each node in schema browser, insert selected node name at current position (or replace selection) in query editor.