### PR TITLE
100%-wide results table

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -93,7 +93,6 @@ edit-in-place p.editable:hover {
 
   table {
     border: 1px solid #f0f0f0;
-    width: auto;
   }
 
   .paginator-container {

--- a/client/app/components/dynamic-table/dynamic-table-row.js
+++ b/client/app/components/dynamic-table/dynamic-table-row.js
@@ -16,7 +16,7 @@ export default function init(ngModule) {
       $scope.$watch('render', () => {
         if (isFunction($scope.render)) {
           $scope.render($scope, (clonedElement) => {
-            $element.empty().append(clonedElement);
+            $element.empty().append(clonedElement).append('<td></td>');
           });
         }
       });

--- a/client/app/components/dynamic-table/dynamic-table.html
+++ b/client/app/components/dynamic-table/dynamic-table.html
@@ -3,7 +3,8 @@
     <thead>
       <tr>
         <th ng-repeat="column in $ctrl.columns" ng-click="$ctrl.onColumnHeaderClick($event, column)"
-          class="sortable-column" ng-class="'content-align-' + column.alignContent">
+          class="sortable-column" ng-class="'content-align-' + column.alignContent"
+          width="{{ ['number', 'boolean', 'datetime'].indexOf(column.displayAs) >= 0 ? '1%' : undefined }}">
           <span ng-if="($ctrl.orderBy.length > 1) && ($ctrl.orderByColumnsIndex[column.name] > 0)"
             class="sort-order-indicator">{{ $ctrl.orderByColumnsIndex[column.name] }}</span>
           <span>{{column.title}}</span>
@@ -14,6 +15,7 @@
               'fa-caret-up': $ctrl.orderByColumnsDirection[column.name] < 0
             }"></i>
         </th>
+        <th class="dynamic-table-spacer"></th>
       </tr>
     </thead>
     <thead ng-if="$ctrl.searchColumns.length > 0">

--- a/client/app/components/dynamic-table/dynamic-table.less
+++ b/client/app/components/dynamic-table/dynamic-table.less
@@ -35,4 +35,18 @@
       text-align: center;
     }
   }
+
+  .table {
+    > thead,
+    > tbody,
+    > tfoot {
+      > tr {
+        > th.dynamic-table-spacer,
+        > td.dynamic-table-spacer {
+          padding-left: 0;
+          padding-right: 5px;
+        }
+      }
+    }
+  }
 }

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -9,7 +9,7 @@ function SchemaBrowserCtrl($scope) {
   };
 
   this.getSize = (table) => {
-    let size = 18;
+    let size = 22;
 
     if (!table.collapsed) {
       size += 18 * table.columns.length;


### PR DESCRIPTION
Closes #2215.

Added "spacer" column at the end of table + tweaked data columns width based on data type.

With few columns:
![image](https://user-images.githubusercontent.com/12139186/35093486-2eaa2314-fc4b-11e7-8c52-1c315c48ee6b.png)

With a lot of columns:
![image](https://user-images.githubusercontent.com/12139186/35093521-47348712-fc4b-11e7-9946-83b55d2ae1d6.png)

Scrolling also works:
![image](https://user-images.githubusercontent.com/12139186/35093562-5f5bdb38-fc4b-11e7-863a-823bffd5f4fb.png)
