### PR TITLE
Disable "Download Dataset" button when query hasn't been saved

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -245,7 +245,7 @@
 
                     <div class="btn-group dropup" uib-dropdown>
                       <button type="button" class="btn btn-default dropup-toggle"
-                              ng-disabled="queryExecuting || !queryResult.getData()" aria-haspopup="true"
+                              ng-disabled="query.id === undefined || queryExecuting || !queryResult.getData()" aria-haspopup="true"
                               uib-dropdown-toggle aria-expanded="false">
                         Download <span class="hidden-xs">Dataset </span><span class="caret"></span>
                       </button>


### PR DESCRIPTION
Fix #2232

The reason why error raised is the query hasn't had an id. It should be saved before downloading a dataset.

I think this solution is simple and enough for this situation.