### PR TITLE
[WIP]Enable list query by one character when adding widget on Dashboard

### DIFF
--- a/client/app/components/dashboards/add-widget-dialog.js
+++ b/client/app/components/dashboards/add-widget-dialog.js
@@ -45,7 +45,8 @@ const AddWidgetDialog = {
     };
 
     this.searchQueries = (term) => {
-      if (!term || term.length < 3) {
+      if (!term || term.length === 0) {
+        this.queries = [];
         return;
       }
 


### PR DESCRIPTION
I think it would be better to list queries by one character on "Add Widget" dialog.

Before:
<img width="664" alt="sample dashboard 2018-01-20 12-19-38" src="https://user-images.githubusercontent.com/3317191/35179363-3c131262-fddc-11e7-9d39-045c163de756.png">

After:
<img width="666" alt="sample dashboard 2018-01-20 12-14-22" src="https://user-images.githubusercontent.com/3317191/35179330-8499d1f2-fddb-11e7-8325-bc8c90dc160e.png">

This change will lead to increase search access. Another solution is delay refresh, or defining this behavior as Settings.