### PR TITLE
fix: commit saml user group assignment to the database

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -515,6 +515,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
         groups.append(self.org.default_group)
         self.group_ids = [g.id for g in groups]
         db.session.add(self)
+        db.session.commit()
 
     def has_access(self, obj, access_type):
         return AccessPermission.exists(obj, access_type, grantee=self)

--- a/tests/models/test_users.py
+++ b/tests/models/test_users.py
@@ -1,12 +1,14 @@
 from tests import BaseTestCase
 
-from redash.models import User
+from redash.models import User, db
 
 class TestUserUpdateGroupAssignments(BaseTestCase):
     def test_default_group_always_added(self):
         user = self.factory.create_user()
 
         user.update_group_assignments(["g_unknown"])
+        db.session.refresh(user)
+
         self.assertItemsEqual([user.org.default_group.id], user.group_ids)
 
     def test_update_group_assignments(self):
@@ -14,6 +16,8 @@ class TestUserUpdateGroupAssignments(BaseTestCase):
         new_group = self.factory.create_group(name="g1")
 
         user.update_group_assignments(["g1"])
+        db.session.refresh(user)
+
         self.assertItemsEqual([user.org.default_group.id, new_group.id], user.group_ids)
 
 


### PR DESCRIPTION
Relevant tests were also modified to reload the user
object from the database before asserting that the
user belongs to correct groups.

Fixes #1668.