### PR TITLE
feat: make trusted header authentication compatible with multiorg mode

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,17 +91,17 @@ class BaseTestCase(TestCase):
 
         return response
 
-    def get_request(self, path, org=None):
+    def get_request(self, path, org=None, headers=None):
         if org:
             path = "/{}{}".format(org.slug, path)
 
-        return self.client.get(path)
+        return self.client.get(path, headers=headers)
 
-    def post_request(self, path, data=None, org=None):
+    def post_request(self, path, data=None, org=None, headers=None):
         if org:
             path = "/{}{}".format(org.slug, path)
 
-        return self.client.post(path, data=data)
+        return self.client.post(path, data=data, headers=headers)
 
     def assertResponseEqual(self, expected, actual):
         for k, v in expected.iteritems():

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,7 +1,9 @@
+import os
 import time
 
 from flask import request
 from mock import patch
+from sqlalchemy.orm.exc import NoResultFound
 from tests import BaseTestCase
 
 from redash import models, settings
@@ -181,3 +183,88 @@ class TestGetLoginUrl(BaseTestCase):
     def test_when_multi_org_enabled_and_org_doesnt_exist(self):
         with self.app.test_request_context('/{}_notexists/'.format(self.factory.org.slug)):
             self.assertEqual(get_login_url(next=None), '/')
+
+class TestRemoteUserAuth(BaseTestCase):
+    DEFAULT_SETTING_OVERRIDES = {
+        'REDASH_REMOTE_USER_LOGIN_ENABLED': 'true'
+    }
+
+    def setUp(self):
+        # Apply default setting overrides to every test
+        self.overrideSettings(None)
+
+        super(TestRemoteUserAuth, self).setUp()
+
+    def overrideSettings(self, overrides):
+        """Override settings for testing purposes.
+
+        This helper method can be used to override specific environmental
+        variables to enable / disable Re:Dash features for the duration
+        of the test.
+
+        Note that these overrides only affect code that checks the value of
+        the setting at runtime. It doesn't affect code that only checks the
+        value during program initialization.
+
+        :param dict overrides: a dict of environmental variables to override
+            when the settings are reloaded
+        """
+        variables = self.DEFAULT_SETTING_OVERRIDES.copy()
+        variables.update(overrides or {})
+        with patch.dict(os.environ, variables):
+            reload(settings)
+
+        # Queue a cleanup routine that reloads the settings without overrides
+        # once the test ends
+        self.addCleanup(lambda: reload(settings))
+
+    def assertCorrectUserAttributes(self, user, email='test@example.com', name='test@example.com', groups=None, org=None):
+        """Helper to assert that the user attributes are correct."""
+        groups = groups or []
+        if self.factory.org.default_group.id not in groups:
+            groups.append(self.factory.org.default_group.id)
+
+        self.assertIsNotNone(user)
+        self.assertEqual(user.email, email)
+        self.assertEqual(user.name, name)
+        self.assertEqual(user.org, org or self.factory.org)
+        self.assertItemsEqual(user.group_ids, groups)
+
+    def getTestUser(self, email='test@example.com', org=None):
+        """Helper to fetch an user from the database."""
+
+        # Expire all cached objects to ensure these values are read directly
+        # from the database.
+        models.db.session.expire_all()
+
+        return models.User.get_by_email_and_org(email, org or self.factory.org)
+
+    def test_remote_login_disabled(self):
+        self.overrideSettings({
+            'REDASH_REMOTE_USER_LOGIN_ENABLED': 'false'
+        })
+
+        self.get_request('/remote_user/login', org=self.factory.org, headers={
+            'X-Forwarded-Remote-User': 'test@example.com'
+        })
+
+        with self.assertRaises(NoResultFound):
+            self.getTestUser()
+
+    def test_remote_login_default_header(self):
+        self.get_request('/remote_user/login', org=self.factory.org, headers={
+            'X-Forwarded-Remote-User': 'test@example.com'
+        })
+
+        self.assertCorrectUserAttributes(self.getTestUser())
+
+    def test_remote_login_custom_header(self):
+        self.overrideSettings({
+            'REDASH_REMOTE_USER_HEADER': 'X-Custom-User'
+        })
+
+        self.get_request('/remote_user/login', org=self.factory.org, headers={
+            'X-Custom-User': 'test@example.com'
+        })
+
+        self.assertCorrectUserAttributes(self.getTestUser())

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -191,11 +191,11 @@ class TestRemoteUserAuth(BaseTestCase):
 
     def setUp(self):
         # Apply default setting overrides to every test
-        self.overrideSettings(None)
+        self.override_settings(None)
 
         super(TestRemoteUserAuth, self).setUp()
 
-    def overrideSettings(self, overrides):
+    def override_settings(self, overrides):
         """Override settings for testing purposes.
 
         This helper method can be used to override specific environmental
@@ -218,7 +218,7 @@ class TestRemoteUserAuth(BaseTestCase):
         # once the test ends
         self.addCleanup(lambda: reload(settings))
 
-    def assertCorrectUserAttributes(self, user, email='test@example.com', name='test@example.com', groups=None, org=None):
+    def assert_correct_user_attributes(self, user, email='test@example.com', name='test@example.com', groups=None, org=None):
         """Helper to assert that the user attributes are correct."""
         groups = groups or []
         if self.factory.org.default_group.id not in groups:
@@ -230,7 +230,7 @@ class TestRemoteUserAuth(BaseTestCase):
         self.assertEqual(user.org, org or self.factory.org)
         self.assertItemsEqual(user.group_ids, groups)
 
-    def getTestUser(self, email='test@example.com', org=None):
+    def get_test_user(self, email='test@example.com', org=None):
         """Helper to fetch an user from the database."""
 
         # Expire all cached objects to ensure these values are read directly
@@ -240,7 +240,7 @@ class TestRemoteUserAuth(BaseTestCase):
         return models.User.get_by_email_and_org(email, org or self.factory.org)
 
     def test_remote_login_disabled(self):
-        self.overrideSettings({
+        self.override_settings({
             'REDASH_REMOTE_USER_LOGIN_ENABLED': 'false'
         })
 
@@ -249,17 +249,17 @@ class TestRemoteUserAuth(BaseTestCase):
         })
 
         with self.assertRaises(NoResultFound):
-            self.getTestUser()
+            self.get_test_user()
 
     def test_remote_login_default_header(self):
         self.get_request('/remote_user/login', org=self.factory.org, headers={
             'X-Forwarded-Remote-User': 'test@example.com'
         })
 
-        self.assertCorrectUserAttributes(self.getTestUser())
+        self.assert_correct_user_attributes(self.get_test_user())
 
     def test_remote_login_custom_header(self):
-        self.overrideSettings({
+        self.override_settings({
             'REDASH_REMOTE_USER_HEADER': 'X-Custom-User'
         })
 
@@ -267,4 +267,4 @@ class TestRemoteUserAuth(BaseTestCase):
             'X-Custom-User': 'test@example.com'
         })
 
-        self.assertCorrectUserAttributes(self.getTestUser())
+        self.assert_correct_user_attributes(self.get_test_user())


### PR DESCRIPTION
The previous implementation of remote header login did not
support the multiorg mode of Re:Dash. These changes modify
the trusted header authentication to expose a per-organization
login endpoint that logs users in the specified organization.

The feature itself is not that interesting as multiorg is pretty
much impossible to use in a standalone Re:Dash installation. What's
more interesting is that all tests are executed in multiorg mode. It's
not possible to write tests for the trusted header authentication if
the method does not support multiorg mode.

To make benefits of these changes more concrete, some tests were
written to test the basic functionality of trusted header
authentication.