### PR TITLE
fix: update correct settings in saml settings form

### DIFF
--- a/client/app/pages/settings/organization.html
+++ b/client/app/pages/settings/organization.html
@@ -34,17 +34,17 @@
                     <div class="form-group">
                         <label>SAML Metadata URL</label>
                         <input name="input" type="string" class="form-control" ng-model="$ctrl.settings.auth_saml_metadata_url" accesskey="tab"
-                               ng-change="$ctrl.update('auth_saml_metadata_url')">
+                               ng-change="$ctrl.update('auth_saml_metadata_url')" ng-model-options="{ debounce: 200 }">
                     </div>
                     <div class="form-group">
                         <label>SAML Entity ID</label>
                         <input name="input" type="string" class="form-control" ng-model="$ctrl.settings.auth_saml_entity_id" accesskey="tab"
-                               ng-change="$ctrl.update('auth_saml_metadata_entity_id')">
+                               ng-change="$ctrl.update('auth_saml_entity_id')" ng-model-options="{ debounce: 200 }">
                     </div>
                     <div class="form-group">
                         <label>SAML NameID Format</label>
                         <input name="input" type="string" class="form-control" ng-model="$ctrl.settings.auth_saml_nameid_format" accesskey="tab"
-                               ng-change="$ctrl.update('auth_saml_metadata_nameid_format')">
+                               ng-change="$ctrl.update('auth_saml_nameid_format')" ng-model-options="{ debounce: 200 }">
                     </div>
                 </div>
             </p>


### PR DESCRIPTION
The entity_id and nameid_format form fields didn't work as they
tried to save a setting with an incorrect name. This has now
been fixed and the form can be used to configure these values.

A short debounce delay was also added to the form to avoid
saving the value after every keystroke (if values are inputted
manually).