### PR TITLE
Extend the Prometheus query runner to support the range query

### DIFF
--- a/redash/query_runner/prometheus.py
+++ b/redash/query_runner/prometheus.py
@@ -56,10 +56,6 @@ class Prometheus(BaseQueryRunner):
     def annotate_query(cls):
         return False
 
-    @classmethod
-    def type(cls):
-        return "Prometheus"
-
     def test_connection(self):
         resp = requests.get(self.configuration.get("url", None))
         return resp.ok

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -55,8 +55,8 @@ class Python(BaseQueryRunner):
                     'type': 'string',
                     'title': 'Modules to import prior to running the script'
                 },
-                'additionalModulesPaths' : {
-                    'type' : 'string'
+                'additionalModulesPaths': {
+                    'type': 'string'
                 }
             },
         }

--- a/tests/query_runner/test_prometheus.py
+++ b/tests/query_runner/test_prometheus.py
@@ -1,0 +1,98 @@
+import datetime
+import json
+from unittest import TestCase
+from redash.query_runner.prometheus import get_instant_rows, get_range_rows
+
+
+class TestPrometheus(TestCase):
+    def setUp(self):
+        self.instant_query_result = [
+            {
+                "metric": {
+                    "name": "example_metric_name",
+                    "foo_bar": "foo",
+                },
+                "value": [1516937400.781, "7400_foo"]
+            },
+            {
+                "metric": {
+                    "name": "example_metric_name",
+                    "foo_bar": "bar",
+                },
+                "value": [1516937400.781, "7400_bar"]
+            }
+        ]
+
+        self.range_query_result = [
+            {
+                "metric": {
+                    "name": "example_metric_name",
+                    "foo_bar": "foo",
+                },
+                "values": [
+                    [1516937400.781, "7400_foo"],
+                    [1516938000.781, "8000_foo"],
+                ]
+            },
+            {
+                "metric": {
+                    "name": "example_metric_name",
+                    "foo_bar": "bar",
+                },
+                "values": [
+                    [1516937400.781, "7400_bar"],
+                    [1516938000.781, "8000_bar"],
+                ]
+            }
+        ]
+
+    def test_get_instant_rows(self):
+        instant_rows = [
+            {
+                "name": "example_metric_name",
+                "foo_bar": "foo",
+                "timestamp": datetime.datetime.fromtimestamp(1516937400.781),
+                "value": "7400_foo"
+            },
+            {
+                "name": "example_metric_name",
+                "foo_bar": "bar",
+                "timestamp": datetime.datetime.fromtimestamp(1516937400.781),
+                "value": "7400_bar"
+            },
+        ]
+
+        rows = get_instant_rows(self.instant_query_result)
+        self.assertEqual(instant_rows, rows)
+
+    def test_get_range_rows(self):
+
+        range_rows = [
+            {
+                "name": "example_metric_name",
+                "foo_bar": "foo",
+                "timestamp": datetime.datetime.fromtimestamp(1516937400.781),
+                "value": "7400_foo"
+            },
+            {
+                "name": "example_metric_name",
+                "foo_bar": "foo",
+                "timestamp": datetime.datetime.fromtimestamp(1516938000.781),
+                "value": "8000_foo"
+            },
+            {
+                "name": "example_metric_name",
+                "foo_bar": "bar",
+                "timestamp": datetime.datetime.fromtimestamp(1516937400.781),
+                "value": "7400_bar"
+            },
+            {
+                "name": "example_metric_name",
+                "foo_bar": "bar",
+                "timestamp": datetime.datetime.fromtimestamp(1516938000.781),
+                "value": "8000_bar"
+            },
+        ]
+
+        rows = get_range_rows(self.range_query_result)
+        self.assertEqual(range_rows, rows)


### PR DESCRIPTION
The Prometheus HTTP API supports the two type of expression queries, [instant queries](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries) and [range queries](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries)
But the current Prometheus query runner only supports the `instant` query which means that we can **NOT** visualize the time series metrics for the period of time.

This PR will help to meet it.