### PR TITLE
Change multi-filter behavior and fix dashboard multi-filter bug

### DIFF
--- a/client/app/components/filters.html
+++ b/client/app/components/filters.html
@@ -11,7 +11,7 @@
         </ui-select-choices>
       </ui-select>
 
-      <ui-select ng-model="filter.current" multiple ng-if="filter.multiple" on-select="$ctrl.filterChangeListener(filter, $model)"
+      <ui-select ng-model="filter.current" multiple ng-if="filter.multiple" on-select="$ctrl.multiFilterSelectListener(filter, $model)"
                  on-remove="$ctrl.filterChangeListener(filter, $model)" remove-selected="false">
         <ui-select-match placeholder="Select value for {{filter.friendlyName}}...">{{$item | filterValue:filter}}</ui-select-match>
         <ui-select-choices ui-disable-choice="filter.current[0] == '*' && value != '-'"

--- a/client/app/components/filters.html
+++ b/client/app/components/filters.html
@@ -14,7 +14,8 @@
       <ui-select ng-model="filter.current" multiple ng-if="filter.multiple" on-select="$ctrl.filterChangeListener(filter, $model)"
                  on-remove="$ctrl.filterChangeListener(filter, $model)" remove-selected="false">
         <ui-select-match placeholder="Select value for {{filter.friendlyName}}...">{{$item | filterValue:filter}}</ui-select-match>
-        <ui-select-choices repeat="value in filter.values | filter: $select.search" group-by="$ctrl.itemGroup">
+        <ui-select-choices ui-disable-choice="filter.current[0] == '*' && value != '-'"
+                           repeat="value in filter.values | filter: $select.search" group-by="$ctrl.itemGroup">
           <span ng-if="value == '*'">
             Select All
           </span>

--- a/client/app/components/filters.js
+++ b/client/app/components/filters.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'underscore';
+import { includes, without } from 'underscore';
 import template from './filters.html';
 
 const FiltersComponent = {
@@ -11,24 +11,18 @@ const FiltersComponent = {
     'ngInject';
 
     this.filterChangeListener = (filter, modal) => {
-      if (filter.multiple && !isEmpty(filter.current)) {
-        if (modal === '-') {
-          filter.current = [];
-        } else if (modal === '*') {
-          filter.current = ['*'];
-        }
+      this.onChange({ filter, $modal: modal });
+    };
+
+    this.multiFilterSelectListener = (filter, modal) => {
+      if (includes(['*', '-'], modal)) {
+        filter.current = without([modal], '-');
       }
 
       this.onChange({ filter, $modal: modal });
     };
 
-    this.itemGroup = (item) => {
-      if (item === '*' || item === '-') {
-        return '';
-      }
-
-      return 'Values';
-    };
+    this.itemGroup = item => (includes(['*', '-'], item) ? '' : 'Values');
   },
 };
 

--- a/client/app/components/filters.js
+++ b/client/app/components/filters.js
@@ -1,3 +1,4 @@
+import { isEmpty } from 'underscore';
 import template from './filters.html';
 
 const FiltersComponent = {
@@ -10,6 +11,14 @@ const FiltersComponent = {
     'ngInject';
 
     this.filterChangeListener = (filter, modal) => {
+      if (filter.multiple && !isEmpty(filter.current)) {
+        if (modal === '-') {
+          filter.current = [];
+        } else if (modal === '*') {
+          filter.current = ['*'];
+        }
+      }
+
       this.onChange({ filter, $modal: modal });
     };
 

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import moment from 'moment';
-import { sortBy, uniq, contains, values, some, each, isArray, isNumber, isString, includes } from 'underscore';
+import { sortBy, uniq, contains, values, some, each, isArray, isNumber, isString } from 'underscore';
 
 const logger = debug('redash:services:QueryResult');
 const filterTypes = ['filter', 'multi-filter', 'multiFilter'];
@@ -212,20 +212,14 @@ function QueryResultService($resource, $timeout, $q) {
         this.filterFreeze = filterFreeze;
 
         if (filters) {
-          filters.forEach((filter) => {
-            if (filter.multiple && includes(filter.current, ALL_VALUES)) {
-              filter.current = filter.values.slice(2);
-            }
-
-            if (filter.multiple && includes(filter.current, NONE_VALUES)) {
-              filter.current = [];
-            }
-          });
-
           this.filteredData = this.query_result.data.rows.filter(row =>
             filters.reduce((memo, filter) => {
               if (!isArray(filter.current)) {
                 filter.current = [filter.current];
+              }
+
+              if (filter.current[0] === ALL_VALUES) {
+                return (memo);
               }
 
               return (memo && some(filter.current, (v) => {

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -377,7 +377,7 @@ function QueryResultService($resource, $timeout, $q) {
           filter.values.push(row[filter.name]);
           if (filter.values.length === 1) {
             if (filter.multiple) {
-              filter.current = [row[filter.name]];
+              filter.current = [ALL_VALUES];
             } else {
               filter.current = row[filter.name];
             }


### PR DESCRIPTION
Alternative is here: https://github.com/getredash/redash/pull/2359
I prefer the alternative solution

Before
===
![](https://user-images.githubusercontent.com/16881036/35444321-8afbf730-02f1-11e8-86a2-ac9e64f84bc3.png)
* Dashboard level multi-filter acts weird

After
===
change ALL_VALUES representation
----
![image](https://user-images.githubusercontent.com/16881036/35444625-7d13a16c-02f2-11e8-8733-ac19f98548e3.png)
* Multi-filter shows `*` instead of rendering tags for all options
* All options except `Clear` disabled when `*` is selected
* Dashboard-level multi-filter and queryResult-level multi-filter synced
* Default value for multi-filter becomes ALL_VALUE(`*`)

Related Issues
----
https://github.com/getredash/redash/issues/1952
https://github.com/getredash/redash/issues/608

Related PR
----
https://github.com/getredash/redash/pull/2155
