### PR TITLE
Allow multiple requests to JIRA when necessary.

### DIFF
--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -31,7 +31,7 @@ def parse_issue(issue, field_mapping):
     result = OrderedDict()
     result['key'] = issue['key']
 
-    for k, v in issue['fields'].iteritems():#
+    for k, v in issue['fields'].iteritems():
         output_name = field_mapping.get_output_field_name(k)
         member_names = field_mapping.get_dict_members(k)
 
@@ -118,20 +118,20 @@ class FieldMapping:
                 'output_field_name': v
                 })
 
-    def get_output_field_name(cls,field_name):
+    def get_output_field_name(cls, field_name):
         for item in cls.mapping:
             if item['field_name'] == field_name and not item['member_name']:
                 return item['output_field_name']
         return field_name
 
-    def get_dict_members(cls,field_name):
+    def get_dict_members(cls, field_name):
         member_names = []
         for item in cls.mapping:
             if item['field_name'] == field_name and item['member_name']:
                 member_names.append(item['member_name'])
         return member_names
 
-    def get_dict_output_field_name(cls,field_name, member_name):
+    def get_dict_output_field_name(cls, field_name, member_name):
         for item in cls.mapping:
             if item['field_name'] == field_name and item['member_name'] == member_name:
                 return item['output_field_name']
@@ -224,4 +224,3 @@ class JiraJQL(BaseQueryRunner):
             return None, "Query cancelled by user."
 
 register(JiraJQL)
-


### PR DESCRIPTION
Although issue #1721 allowed to use maxResults up to 1k, most of JIRA Cloud instances do not allow maxResults greater than 100, and I think it's impossible to change this limit in JIRA. 

So, I changed to repeat the query increasing the startAt parameter until the defined maxResults is reached. 