### PR TITLE
Url password can have quoted special characters.

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -55,10 +55,8 @@ def create_redis_connection():
         else:
             redis_db = 0
         # Redis passwords might be quoted with special characters
-        redisPassword = ""
-        if redis_url.password is not None:
-            redisPassword = urllib.unquote(redis_url.password)
-        r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redisPassword)
+        redis_password = redis_url.password and urllib.unquote(redis_url.password)
+        r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_password)
 
     return r
 

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -55,7 +55,10 @@ def create_redis_connection():
         else:
             redis_db = 0
         # Redis passwords might be quoted with special characters
-        redisPassword = urllib.unquote(redis_url.password)
+        redisPassword = ""
+        if redis_url.password is not None: 
+            redisPassword = urllib.unquote(redis_url.password)
+        else:
         r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redisPassword)
 
     return r

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 import urlparse
+import urllib
 import redis
 from flask import Flask, safe_join
 from flask_sslify import SSLify
@@ -53,8 +54,9 @@ def create_redis_connection():
             redis_db = redis_url.path[1]
         else:
             redis_db = 0
-
-        r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_url.password)
+        # Redis passwords might be quoted with special characters
+        redisPassword = urllib.unquote(redis_url.password)
+        r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redisPassword)
 
     return r
 

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -56,9 +56,8 @@ def create_redis_connection():
             redis_db = 0
         # Redis passwords might be quoted with special characters
         redisPassword = ""
-        if redis_url.password is not None: 
-            redisPassword = urllib.unquote(redis_url.password)
-        else:
+        if redis_url.password is not None:
+            redisPassword = urllib.unquote(redis_url.password)            
         r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redisPassword)
 
     return r

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -57,7 +57,7 @@ def create_redis_connection():
         # Redis passwords might be quoted with special characters
         redisPassword = ""
         if redis_url.password is not None:
-            redisPassword = urllib.unquote(redis_url.password)            
+            redisPassword = urllib.unquote(redis_url.password)
         r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redisPassword)
 
     return r

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -1,7 +1,6 @@
 import json
 import os
 import urlparse
-import urllib
 
 
 def parse_db_url(url):

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -15,8 +15,7 @@ def parse_db_url(url):
         connection['host'] = url_parts.hostname
         connection['port'] = url_parts.port
         connection['user'] = url_parts.username
-        # Passwords might be quoted with special characters
-        connection['password'] = urllib.unquote(url_parts.password)
+        connection['password'] = url_parts.password
 
     return connection
 

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -17,7 +17,7 @@ def parse_db_url(url):
         connection['user'] = url_parts.username
         # Passwords might be quoted with special characters
         connection['password'] = url_parts.password and urllib.unquote(url_parts.password)
-        
+
     return connection
 
 

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -1,6 +1,7 @@
 import json
 import os
 import urlparse
+import urllib
 
 
 def parse_db_url(url):
@@ -14,8 +15,9 @@ def parse_db_url(url):
         connection['host'] = url_parts.hostname
         connection['port'] = url_parts.port
         connection['user'] = url_parts.username
-        connection['password'] = url_parts.password
-
+        # Passwords might be quoted with special characters
+        connection['password'] = url_parts.password and urllib.unquote(url_parts.password)
+        
     return connection
 
 

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -1,6 +1,7 @@
 import json
 import os
 import urlparse
+import urllib
 
 
 def parse_db_url(url):
@@ -14,7 +15,8 @@ def parse_db_url(url):
         connection['host'] = url_parts.hostname
         connection['port'] = url_parts.port
         connection['user'] = url_parts.username
-        connection['password'] = url_parts.password
+        # Passwords might be quoted with special characters
+        connection['password'] = urllib.unquote(url_parts.password)
 
     return connection
 


### PR DESCRIPTION
As described on this Redash [forum support issue](https://discuss.redash.io/t/redis-quoted-password/1435) password can have special characters and those ones can be `quoted` (encoded). They must be `unquoted ` before being sent otherwise the validation process will fail.  