### PR TITLE
Remove loading indicator when updating query parameter value (before executing)

### DIFF
--- a/client/app/config/index.js
+++ b/client/app/config/index.js
@@ -1,7 +1,7 @@
 // This polyfill is needed to support PhantomJS which we use to generate PNGs from embeds.
 import 'core-js/fn/typed/array-buffer';
 
-import 'pace-progress';
+import * as Pace from 'pace-progress';
 import debug from 'debug';
 import angular from 'angular';
 import ngSanitize from 'angular-sanitize';
@@ -29,6 +29,14 @@ import dateTimeFilter from '@/filters/datetime';
 import dashboardGridOptions from './dashboard-grid-options';
 
 const logger = debug('redash:config');
+
+Pace.options.shouldHandlePushState = (prevUrl, newUrl) => {
+  // Show pace progress bar only if URL path changed; when query params
+  // or hash changed - ignore that history event
+  const [prevPrefix] = prevUrl.split('?');
+  const [newPrefix] = newUrl.split('?');
+  return prevPrefix !== newPrefix;
+};
 
 const requirements = [
   ngRoute,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9372,7 +9372,7 @@
       "dev": true
     },
     "pace-progress": {
-      "version": "git+https://github.com/getredash/pace.git#9edab5c9102aef9f24dd3687de2728bbc419751e"
+      "version": "git+https://github.com/getredash/pace.git#1011f6d0d7c32f8bc89ea1a04b7ffa43d5a301b4"
     },
     "pad-left": {
       "version": "1.0.2",


### PR DESCRIPTION
Issue getredash/redash#2161

When history event occurs (`pushState` or `replaceState`) do not show progress bar if only query or hash changed; show it only if URL path changed.

Depends on: https://github.com/getredash/pace/pull/1