### PR TITLE
Upgrade to Celery 3.1.25 in preparation to Celery 4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ wsgiref==0.1.2
 honcho==0.5.0
 statsd==2.1.2
 gunicorn==19.7.1
-celery==3.1.23
+celery==3.1.25
 jsonschema==2.4.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0


### PR DESCRIPTION
To prepare for a future Celery upgrade to verson 4.x this upgrades
Redash to 3.1.25 which includes support for Celery's task protocol 2.
It's the first of two steps to get Redash upgraded to Celery 4.x.

More info:
- [3.1.4 release notes](http://docs.celeryproject.org/en/3.1/changelog.html#version-3-1-24) regarding the new task protocol.
- [4.0 release notes](http://docs.celeryproject.org/en/latest/whatsnew-4.0.html#step-1-upgrade-to-celery-3-1-25) regarding the two-step-upgrade approach.