### PR TITLE
Query editor insert node from schema browser update ngModel

### DIFF
--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -44,6 +44,7 @@ function queryEditor(QuerySnippet) {
           onLoad(editor) {
             $scope.$on('query-editor.paste', ($event, text) => {
               editor.session.doc.replace(editor.selection.getRange(), text);
+              $scope.query.query = editor.session.getValue();
             });
 
             // Release Cmd/Ctrl+L to the browser


### PR DESCRIPTION
[This PR](https://github.com/getredash/redash/pull/2225) added new feature - ability to insert schema node into query editor by click in schema browser. But editor did not update ngModel value immediately - only on blur or user input. This PR fixes that bug.

Probably related to issue getredash/redash/issues/2241