### PR TITLE
Insert schema node by click - fixes

### DIFF
--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -18,7 +18,7 @@ defineDummySnippets('python');
 defineDummySnippets('sql');
 defineDummySnippets('json');
 
-function queryEditor(QuerySnippet) {
+function queryEditor(QuerySnippet, $timeout) {
   return {
     restrict: 'E',
     scope: {
@@ -44,7 +44,11 @@ function queryEditor(QuerySnippet) {
           onLoad(editor) {
             $scope.$on('query-editor.paste', ($event, text) => {
               editor.session.doc.replace(editor.selection.getRange(), text);
+              const range = editor.selection.getRange();
               $scope.query.query = editor.session.getValue();
+              $timeout(() => {
+                editor.selection.setRange(range);
+              });
             });
 
             // Release Cmd/Ctrl+L to the browser

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -22,7 +22,7 @@
       <div uib-collapse="table.collapsed">
         <div ng-repeat="column in table.columns track by column" class="table-open">{{column}}
           <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
-            ng-click="$ctrl.itemSelected($event, [table.name, column])"></i>
+            ng-click="$ctrl.itemSelected($event, [column])"></i>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes related to getredash/redash/pull/2275

- Insert only column name (without table name) - discussed with @arikfr.
- Save cursor position after table/column name inserted.