### PR TITLE
Fix bottom spacing for widget parameter section

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -346,12 +346,6 @@ page-header, .page-header--new {
   top: 0;
 }
 
-.widget-wrapper {
-  .parameter-container {
-    padding: 0 15px;
-  }
-}
-
 .dashboard__control {
   margin: 8px 0;
 }

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -33,7 +33,9 @@
           <div class="text-muted query--description" ng-bind-html="$ctrl.query.description | markdown"></div>
         </div>
       </div>
-      <parameters parameters="$ctrl.localParametersDefs()"></parameters>
+      <div class="m-b-10" ng-if="$ctrl.localParametersDefs().length > 0">
+        <parameters parameters="$ctrl.localParametersDefs()"></parameters>
+      </div>
     </div>
 
     <div ng-switch-when="failed" class="body-row-auto scrollbox">


### PR DESCRIPTION
Add margin-bottom: 10px for widget parameters so it won't stay super close to the following content.