### PR TITLE
Cohort visualization improvements

### DIFF
--- a/client/app/assets/less/inc/visualizations/cohort.less
+++ b/client/app/assets/less/inc/visualizations/cohort.less
@@ -1,10 +1,28 @@
 cohort-renderer {
   display: block;
-  text-align: center;
 }
 
 .cornelius-container {
-  display: inline-block;
   padding: 0;
-  margin: 0 10px;
+  margin: 0;
+
+  .cornelius-table {
+    width: 100%;
+    margin: 0;
+    box-shadow: none;
+    border-radius: 0;
+    background: transparent;
+
+    tr, th, td {
+      border-color: @table-border-color;
+    }
+
+    td {
+      border-radius: 0 !important;
+    }
+
+    .cornelius-time, .cornelius-label, .cornelius-people {
+      background-color: fade(@redash-gray, 3%) !important;
+    }
+  }
 }

--- a/client/app/visualizations/cohort/cohort-editor.html
+++ b/client/app/visualizations/cohort/cohort-editor.html
@@ -1,9 +1,9 @@
 <ul class="tab-nav">
-  <li ng-class="{active: currentTab == 'options'}">
-    <a ng-click="setCurrentTab('options')">Options</a>
-  </li>
   <li ng-class="{active: currentTab == 'columns'}">
     <a ng-click="setCurrentTab('columns')">Columns</a>
+  </li>
+  <li ng-class="{active: currentTab == 'options'}">
+    <a ng-click="setCurrentTab('options')">Options</a>
   </li>
 </ul>
 
@@ -20,33 +20,33 @@
   <div class="form-group">
     <label class="control-label">Mode</label>
     <select class="form-control" ng-model="visualization.options.mode">
-      <option value="diagonal">Diagonal</option>
-      <option value="simple">Simple</option>
+      <option value="diagonal">Fill gaps with zeros</option>
+      <option value="simple">Show data as is</option>
     </select>
   </div>
 </div>
 
 <div ng-if="currentTab == 'columns'" class="m-t-10 m-b-10">
   <div class="form-group">
-    <label class="control-label">Date</label>
+    <label class="control-label">Date (Bucket)</label>
     <select class="form-control" ng-model="visualization.options.dateColumn"
       ng-options="column for column in columnNames"></select>
   </div>
 
   <div class="form-group">
-    <label class="control-label">Day Number</label>
-    <select class="form-control" ng-model="visualization.options.dayNumberColumn"
+    <label class="control-label">Stage</label>
+    <select class="form-control" ng-model="visualization.options.stageColumn"
       ng-options="column for column in columnNames"></select>
   </div>
 
   <div class="form-group">
-    <label class="control-label">Total</label>
+    <label class="control-label">Bucket Population Size</label>
     <select class="form-control" ng-model="visualization.options.totalColumn"
       ng-options="column for column in columnNames"></select>
   </div>
 
   <div class="form-group">
-    <label class="control-label">Value</label>
+    <label class="control-label">Stage Value</label>
     <select class="form-control" ng-model="visualization.options.valueColumn"
       ng-options="column for column in columnNames"></select>
   </div>

--- a/client/app/visualizations/cohort/cohort-editor.html
+++ b/client/app/visualizations/cohort/cohort-editor.html
@@ -1,8 +1,53 @@
-<div class="form-group">
+<ul class="tab-nav">
+  <li ng-class="{active: currentTab == 'options'}">
+    <a ng-click="setCurrentTab('options')">Options</a>
+  </li>
+  <li ng-class="{active: currentTab == 'columns'}">
+    <a ng-click="setCurrentTab('columns')">Columns</a>
+  </li>
+</ul>
+
+<div ng-if="currentTab == 'options'" class="m-t-10 m-b-10">
+  <div class="form-group">
     <label class="control-label">Time Interval</label>
     <select class="form-control" ng-model="visualization.options.timeInterval">
       <option value="daily">Daily</option>
       <option value="weekly">Weekly</option>
       <option value="monthly">Monthly</option>
     </select>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label">Mode</label>
+    <select class="form-control" ng-model="visualization.options.mode">
+      <option value="diagonal">Diagonal</option>
+      <option value="simple">Simple</option>
+    </select>
+  </div>
+</div>
+
+<div ng-if="currentTab == 'columns'" class="m-t-10 m-b-10">
+  <div class="form-group">
+    <label class="control-label">Date</label>
+    <select class="form-control" ng-model="visualization.options.dateColumn"
+      ng-options="column for column in columnNames"></select>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label">Day Number</label>
+    <select class="form-control" ng-model="visualization.options.dayNumberColumn"
+      ng-options="column for column in columnNames"></select>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label">Total</label>
+    <select class="form-control" ng-model="visualization.options.totalColumn"
+      ng-options="column for column in columnNames"></select>
+  </div>
+
+  <div class="form-group">
+    <label class="control-label">Value</label>
+    <select class="form-control" ng-model="visualization.options.valueColumn"
+      ng-options="column for column in columnNames"></select>
+  </div>
 </div>

--- a/client/app/visualizations/cohort/index.js
+++ b/client/app/visualizations/cohort/index.js
@@ -1,7 +1,6 @@
 /* global Cornelius */
 import _ from 'underscore';
 import moment from 'moment';
-import angular from 'angular';
 import 'cornelius/src/cornelius';
 import 'cornelius/src/cornelius.css';
 
@@ -13,46 +12,118 @@ const momentInterval = {
   monthly: 'months',
 };
 
-function prepareData(rawData, timeInterval) {
-  const sortedData = _.sortBy(rawData, r => r.date + parseInt(r.day_number, 10));
-  const grouped = _.groupBy(sortedData, 'date');
-  const initialDate = moment(sortedData[0].date).toDate();
-  const lastDate = moment(sortedData[sortedData.length - 1].date);
-  const zeroBased = _.min(_.pluck(rawData, 'day_number')) === 0;
+const DEFAULT_OPTIONS = {
+  timeInterval: 'daily',
+  mode: 'diagonal',
+  dateColumn: 'date',
+  dayNumberColumn: 'day_number',
+  totalColumn: 'total',
+  valueColumn: 'value',
+};
+
+function groupData(sortedData) {
+  const result = {};
+
+  _.each(sortedData, (item) => {
+    const groupKey = item.date + 0;
+    result[groupKey] = result[groupKey] || {
+      date: item.date,
+      total: parseInt(item.total, 10),
+      values: {},
+    };
+    result[groupKey].values[item.dayNumber] = parseInt(item.value, 10);
+  });
+
+  return _.values(result);
+}
+
+function prepareDiagonalData(sortedData, options) {
+  const timeInterval = options.timeInterval;
+  const grouped = groupData(sortedData);
+  const firstDayNumber = _.min(_.pluck(sortedData, 'dayNumber'));
+  const dayCount = moment(_.last(grouped).date).diff(_.first(grouped).date, momentInterval[timeInterval]);
+  let lastDayNumber = firstDayNumber + dayCount;
 
   let previousDay = null;
-  const data = [];
 
-  _.each(grouped, (values) => {
+  const data = [];
+  _.each(grouped, (group) => {
     if (previousDay !== null) {
-      let diff = Math.abs(previousDay.diff(values[0].date, momentInterval[timeInterval]));
+      let diff = Math.abs(previousDay.diff(group.date, momentInterval[timeInterval]));
+      while (diff > 1) {
+        const row = [0];
+        for (let dayNumber = firstDayNumber; dayNumber <= lastDayNumber; dayNumber += 1) {
+          row.push(group.values[dayNumber] || 0);
+        }
+        data.push(row);
+        // It should be diagonal, so decrease count of days for each next row
+        lastDayNumber -= 1;
+        diff -= 1;
+      }
+    }
+
+    previousDay = group.date;
+
+    const row = [group.total];
+    for (let dayNumber = firstDayNumber; dayNumber <= lastDayNumber; dayNumber += 1) {
+      row.push(group.values[dayNumber] || 0);
+    }
+    // It should be diagonal, so decrease count of days for each next row
+    lastDayNumber -= 1;
+
+    data.push(row);
+  });
+
+  return data;
+}
+
+function prepareSimpleData(sortedData, options) {
+  const timeInterval = options.timeInterval;
+  const grouped = groupData(sortedData);
+  const dayNumbers = _.pluck(sortedData, 'dayNumber');
+  const firstDayNumber = _.min(dayNumbers);
+  const lastDayNumber = _.max(dayNumbers);
+
+  let previousDay = null;
+
+  const data = [];
+  _.each(grouped, (group) => {
+    if (previousDay !== null) {
+      let diff = Math.abs(previousDay.diff(group.date, momentInterval[timeInterval]));
       while (diff > 1) {
         data.push([0]);
         diff -= 1;
       }
     }
 
-    previousDay = moment(values[0].date);
+    previousDay = group.date;
 
-    const row = [parseInt(values[0].total, 10)];
-    let maxDays = lastDate.diff(moment(values[0].date), momentInterval[timeInterval]);
-    if (zeroBased) {
-      maxDays += 1;
-    }
-
-    _.each(values, (value) => {
-      const index = zeroBased ? value.day_number + 1 : value.day_number;
-      row[index] = parseInt(value.value, 10);
-    });
-
-    for (let i = 0; i <= maxDays; i += 1) {
-      if (row[i] === undefined) {
-        row[i] = 0;
-      }
+    const row = [group.total];
+    for (let dayNumber = firstDayNumber; dayNumber <= lastDayNumber; dayNumber += 1) {
+      row.push(group.values[dayNumber]);
     }
 
     data.push(row);
   });
+
+  return data;
+}
+
+function prepareData(rawData, options) {
+  rawData = _.map(rawData, item => ({
+    date: item[options.dateColumn],
+    dayNumber: item[options.dayNumberColumn],
+    total: item[options.totalColumn],
+    value: item[options.valueColumn],
+  }));
+  const sortedData = _.sortBy(rawData, r => r.date + parseInt(r.dayNumber, 10));
+  const initialDate = moment(sortedData[0].date).toDate();
+
+  let data;
+  switch (options.mode) {
+    case 'simple': data = prepareSimpleData(sortedData, options); break;
+    default: data = prepareDiagonalData(sortedData, options); break;
+  }
 
   return { data, initialDate };
 }
@@ -67,23 +138,33 @@ function cohortRenderer() {
     template: '',
     replace: false,
     link($scope, element) {
-      $scope.options.timeInterval = $scope.options.timeInterval || 'daily';
+      $scope.options = _.extend({}, DEFAULT_OPTIONS, $scope.options);
 
       function updateCohort() {
+        element.empty();
+
         if ($scope.queryResult.getData() === null) {
+          return;
+        }
+
+        const columnNames = _.pluck($scope.queryResult.getColumns(), 'name');
+        if (
+          !_.contains(columnNames, $scope.options.dateColumn) ||
+          !_.contains(columnNames, $scope.options.dayNumberColumn) ||
+          !_.contains(columnNames, $scope.options.totalColumn) ||
+          !_.contains(columnNames, $scope.options.valueColumn)
+        ) {
           return;
         }
 
         const { data, initialDate } = prepareData(
           $scope.queryResult.getData(),
-          $scope.options.timeInterval,
+          $scope.options,
         );
-
-        const container = angular.element(element)[0];
 
         Cornelius.draw({
           initialDate,
-          container,
+          container: element[0],
           cohort: data,
           title: null,
           timeInterval: $scope.options.timeInterval,
@@ -96,7 +177,7 @@ function cohortRenderer() {
       }
 
       $scope.$watch('queryResult && queryResult.getData()', updateCohort);
-      $scope.$watch('options.timeInterval', updateCohort);
+      $scope.$watch('options', updateCohort, true);
     },
   };
 }
@@ -105,6 +186,32 @@ function cohortEditor() {
   return {
     restrict: 'E',
     template: editorTemplate,
+    link: ($scope) => {
+      $scope.visualization.options = _.extend({}, DEFAULT_OPTIONS, $scope.visualization.options);
+
+      $scope.currentTab = 'options';
+      $scope.setCurrentTab = (tab) => {
+        $scope.currentTab = tab;
+      };
+
+      function refreshColumns() {
+        $scope.columns = $scope.queryResult.getColumns();
+        $scope.columnNames = _.pluck($scope.columns, 'name');
+      }
+
+      refreshColumns();
+
+      $scope.$watch(
+        () => [$scope.queryResult.getId(), $scope.queryResult.status],
+        (changed) => {
+          if (!changed[0] || changed[1] !== 'done') {
+            return;
+          }
+          refreshColumns();
+        },
+        true,
+      );
+    },
   };
 }
 


### PR DESCRIPTION
Related to issue getredash/redash/issues/2163

- Added Mode option and two rendering modes (display "diagonal" cohort data - existed before this PR, and simply display data with minimum preprocessing aka "Simple" mode); 
- Options to choose query columns for each cohort dimension;
- UI tweaks.

All new options are backward-compatible.

Screenshots:

![image](https://user-images.githubusercontent.com/12139186/35689535-6bfd0998-077c-11e8-9563-8966e1bd2eeb.png)
![image](https://user-images.githubusercontent.com/12139186/35689538-71a3f67c-077c-11e8-8f0d-41cb02224bb8.png)
![image](https://user-images.githubusercontent.com/12139186/35689549-7bdc9504-077c-11e8-8edd-af86fd510c21.png)
