### PR TITLE
Table visualization: "Image" column type

### DIFF
--- a/client/app/assets/less/redash/redash-table.less
+++ b/client/app/assets/less/redash/redash-table.less
@@ -18,7 +18,7 @@
     font-weight: 500;
     color: #333;
     border-width: 1px;
-    text-transform: capitalize;
+    text-transform: none;
     padding: 15px 10px;
   }
 

--- a/client/app/components/dynamic-table/dynamic-table.html
+++ b/client/app/components/dynamic-table/dynamic-table.html
@@ -4,7 +4,7 @@
       <tr>
         <th ng-repeat="column in $ctrl.columns" ng-click="$ctrl.onColumnHeaderClick($event, column)"
           class="sortable-column" ng-class="'content-align-' + column.alignContent"
-          width="{{ ['number', 'boolean', 'datetime'].indexOf(column.displayAs) >= 0 ? '1%' : undefined }}">
+          width="{{ ['number', 'boolean', 'datetime', 'image'].indexOf(column.displayAs) >= 0 ? '1%' : undefined }}">
           <span ng-if="($ctrl.orderBy.length > 1) && ($ctrl.orderByColumnsIndex[column.name] > 0)"
             class="sort-order-indicator">{{ $ctrl.orderByColumnsIndex[column.name] }}</span>
           <span>{{column.title}}</span>
@@ -19,7 +19,7 @@
       </tr>
     </thead>
     <thead ng-if="$ctrl.searchColumns.length > 0">
-      <th class="p-t-10 p-b-10 p-l-15 p-r-15" colspan="{{ $ctrl.columns.length }}">
+      <th class="p-t-10 p-b-10 p-l-15 p-r-15" colspan="{{ $ctrl.columns.length + 1 }}">
         <input type="text" class="form-control" placeholder="Search..."
           ng-model="$ctrl.searchTerm" ng-model-options="{ allowInvalid: true, debounce: 200 }"
           ng-change="$ctrl.onSearchTermChanged()">

--- a/client/app/components/dynamic-table/image-cell/index.js
+++ b/client/app/components/dynamic-table/image-cell/index.js
@@ -1,0 +1,66 @@
+import { isUndefined } from 'underscore';
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function trim(str) {
+  return str.replace(/^\s+|\s+$/g, '');
+}
+
+function processTags(template, data, defaultColumn) {
+  return template.replace(/{{\s*([^\s]+)\s*}}/g, (match, column) => {
+    if (column === '@') {
+      column = defaultColumn;
+    }
+    if (hasOwnProperty.call(data, column) && !isUndefined(data[column])) {
+      return data[column];
+    }
+    return match;
+  });
+}
+
+function buildImgTag(column, row) {
+  const url = trim(processTags(column.imageUrlTemplate, row, column.name));
+  const width = parseInt(processTags(column.imageWidth, row, column.name), 10);
+  const height = parseInt(processTags(column.imageHeight, row, column.name), 10);
+  const title = trim(processTags(column.imageTitleTemplate, row, column.name));
+
+  const result = [];
+  if (url !== '') {
+    result.push('<img src="' + url + '"');
+
+    if (isFinite(width) && (width > 0)) {
+      result.push('width="' + width + '"');
+    }
+    if (isFinite(height) && (height > 0)) {
+      result.push('height="' + height + '"');
+    }
+    if (title !== '') {
+      result.push('title="' + title + '"');
+    }
+
+    result.push('>');
+  }
+
+  return result.join(' ');
+}
+
+export default function init(ngModule) {
+  ngModule.directive('dynamicTableImageCell', $sanitize => ({
+    template: '<td ng-bind-html="value"></td>',
+    restrict: 'E',
+    replace: true,
+    scope: {
+      column: '=',
+      row: '=',
+    },
+    link: ($scope) => {
+      $scope.value = $sanitize(buildImgTag($scope.column, $scope.row));
+
+      $scope.$watch('row', (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          $scope.value = $sanitize(buildImgTag($scope.column, $scope.row));
+        }
+      });
+    },
+  }));
+}

--- a/client/app/components/dynamic-table/index.js
+++ b/client/app/components/dynamic-table/index.js
@@ -68,6 +68,10 @@ function createRowRenderTemplate(columns, $compile) {
             <dynamic-table-json-cell column="columns[${index}]" 
               value="row[columns[${index}].name]"></dynamic-table-json-cell>
           `;
+      case 'image':
+        return `
+            <dynamic-table-image-cell column="columns[${index}]" row="row"></dynamic-table-image-cell>
+          `;
       default:
         return `
             <dynamic-table-default-cell column="columns[${index}]" 

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -13,6 +13,7 @@ const DISPLAY_AS_OPTIONS = [
   { name: 'Date/Time', value: 'datetime' },
   { name: 'Boolean', value: 'boolean' },
   { name: 'JSON', value: 'json' },
+  { name: 'Image', value: 'image' },
 ];
 
 const DEFAULT_OPTIONS = {
@@ -46,6 +47,10 @@ function getDefaultColumnsOptions(columns) {
     allowHTML: false,
     highlightLinks: false,
     alignContent: getColumnContentAlignment(col.type),
+    imageUrlTemplate: '{{ @ }}',
+    imageTitleTemplate: '{{ @ }}',
+    imageWidth: '',
+    imageHeight: '',
   }));
 }
 

--- a/client/app/visualizations/table/table-editor.html
+++ b/client/app/visualizations/table/table-editor.html
@@ -41,7 +41,7 @@
       </div>
 
       <div class="form-group">
-        <label><input type="checkbox" ng-model="column.allowSearch"> Use for search</label>
+        <label class="ui-sortable-bypass"><input type="checkbox" ng-model="column.allowSearch"> Use for search</label>
       </div>
 
       <div class="form-group">
@@ -96,6 +96,46 @@
           <label for="table-editor-{{ column.name }}-boolean-true">Value for <code>true</code></label>
           <input class="form-control" ng-model="column.booleanValues[1]" ng-model-options="{ allowInvalid: true, debounce: 200 }"
             id="table-editor-{{ column.name }}-boolean-true">
+        </div>
+      </div>
+
+      <div ng-if="column.displayAs == 'image'">
+        <div class="form-group">
+          <label for="table-editor-{{ column.name }}-image-url-template">URL template</label>
+          <input class="form-control" ng-model="column.imageUrlTemplate" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+            id="table-editor-{{ column.name }}-image-url-template">
+        </div>
+
+        <div class="form-group">
+          <label>
+            Size
+            <span class="m-l-5"
+              uib-popover-html="'Any positive integer value that specifies size in pixels. Leave empty to use default value.'"
+              popover-trigger="'click outsideClick'" popover-placement="top-left"><i class="fa fa-question-circle"></i></span>
+          </label>
+          <div class="d-flex">
+            <input class="form-control" ng-model="column.imageWidth" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+              placeholder="Width">
+            <span class="form-control-static m-l-5 m-r-5">&times;</span>
+            <input class="form-control" ng-model="column.imageHeight" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+              placeholder="Height">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="table-editor-{{ column.name }}-image-title-template">Title template</label>
+          <input class="form-control" ng-model="column.imageTitleTemplate" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+            id="table-editor-{{ column.name }}-image-title-template">
+        </div>
+
+        <div class="form-group">
+          <label class="ui-sortable-bypass text-muted" style="font-weight: normal; cursor: pointer;"
+            uib-popover-html="'All columns can be referenced using <code>\{\{ column_name \}\}</code> syntax.
+            Use <code>\{\{ @ \}\}</code> to reference current (this) column.
+            This syntax is applicable to URL, Title and Size options.'"
+            popover-trigger="'click outsideClick'" popover-placement="top-left">
+            Format specs <i class="fa fa-question-circle m-l-5"></i>
+          </label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Issue getredash/redash#2138

Implementation details:

Added new column type ("Image") and several options for it: "URL Template", "Width"/"Height", "Title template" (see screenshots below). All options allows to use values from another columns via `{{ column_name }}` syntax. It allows to construct image URL from many parts, or construct `data:` URLs when image data and MIME type are stored in different columns, etc. Also, it allows to use other columns for image size and `title` attribute.

![image](https://user-images.githubusercontent.com/12139186/35738440-9a02d3fc-0837-11e8-8237-7c35c22f8cbc.png)
![image](https://user-images.githubusercontent.com/12139186/35738459-a793e952-0837-11e8-9108-26683c7da190.png)
![image](https://user-images.githubusercontent.com/12139186/35738492-b90f327c-0837-11e8-9c1b-b969b1c8847d.png)
