### PR TITLE
Table visualization: "Link" column type

### DIFF
--- a/client/app/components/dynamic-table/default-cell/index.js
+++ b/client/app/components/dynamic-table/default-cell/index.js
@@ -1,3 +1,5 @@
+import { contains } from 'underscore';
+import { renderDefault, renderImage, renderLink } from './utils';
 import template from './template.html';
 
 export default function init(ngModule) {
@@ -7,10 +9,35 @@ export default function init(ngModule) {
     replace: true,
     scope: {
       column: '=',
-      value: '=',
+      row: '=',
     },
     link: ($scope) => {
-      $scope.sanitize = value => $sanitize(value);
+      // `dynamicTable` will recreate all table cells if some columns changed.
+      // This means two things:
+      // 1. `column` object will be always "fresh" - no need to watch it.
+      // 2. we will always have a column object already available in `link` function.
+      // Note that `row` may change during this directive's lifetime.
+
+      if ($scope.column.displayAs === 'string') {
+        $scope.allowHTML = $scope.column.allowHTML;
+      } else {
+        $scope.allowHTML = contains(['image', 'link'], $scope.column.displayAs);
+      }
+
+      let renderValue;
+      switch ($scope.column.displayAs) {
+        case 'image': renderValue = renderImage; break;
+        case 'link': renderValue = renderLink; break;
+        default: renderValue = renderDefault; break;
+      }
+
+      $scope.value = $sanitize(renderValue($scope.column, $scope.row));
+
+      $scope.$watch('row', (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          $scope.value = $sanitize(renderValue($scope.column, $scope.row));
+        }
+      });
     },
   }));
 }

--- a/client/app/components/dynamic-table/default-cell/index.js
+++ b/client/app/components/dynamic-table/default-cell/index.js
@@ -2,6 +2,11 @@ import { contains } from 'underscore';
 import { renderDefault, renderImage, renderLink } from './utils';
 import template from './template.html';
 
+const renderFunctions = {
+  image: renderImage,
+  link: renderLink,
+};
+
 export default function init(ngModule) {
   ngModule.directive('dynamicTableDefaultCell', $sanitize => ({
     template,
@@ -24,12 +29,7 @@ export default function init(ngModule) {
         $scope.allowHTML = contains(['image', 'link'], $scope.column.displayAs);
       }
 
-      let renderValue;
-      switch ($scope.column.displayAs) {
-        case 'image': renderValue = renderImage; break;
-        case 'link': renderValue = renderLink; break;
-        default: renderValue = renderDefault; break;
-      }
+      const renderValue = renderFunctions[$scope.column.displayAs] || renderDefault;
 
       $scope.value = $sanitize(renderValue($scope.column, $scope.row));
 

--- a/client/app/components/dynamic-table/default-cell/template.html
+++ b/client/app/components/dynamic-table/default-cell/template.html
@@ -1,4 +1,4 @@
 <td ng-class="'content-align-' + column.alignContent">
-  <div ng-if="column.allowHTML" ng-bind-html="sanitize(column.formatFunction(value))"></div>
-  <div ng-if="!column.allowHTML" ng-bind="column.formatFunction(value)"></div>
+  <div ng-if="allowHTML" ng-bind-html="value"></div>
+  <div ng-if="!allowHTML" ng-bind="value"></div>
 </td>

--- a/client/app/components/dynamic-table/index.js
+++ b/client/app/components/dynamic-table/index.js
@@ -65,18 +65,14 @@ function createRowRenderTemplate(columns, $compile) {
     switch (column.displayAs) {
       case 'json':
         return `
-            <dynamic-table-json-cell column="columns[${index}]" 
-              value="row[columns[${index}].name]"></dynamic-table-json-cell>
-          `;
-      case 'image':
-        return `
-            <dynamic-table-image-cell column="columns[${index}]" row="row"></dynamic-table-image-cell>
-          `;
+          <dynamic-table-json-cell column="columns[${index}]" 
+            value="row[columns[${index}].name]"></dynamic-table-json-cell>
+        `;
       default:
         return `
-            <dynamic-table-default-cell column="columns[${index}]" 
-              value="row[columns[${index}].name]"></dynamic-table-default-cell>
-          `;
+          <dynamic-table-default-cell column="columns[${index}]" 
+            row="row"></dynamic-table-default-cell>
+        `;
     }
   }).join('');
   return $compile(rowTemplate);

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -14,6 +14,7 @@ const DISPLAY_AS_OPTIONS = [
   { name: 'Boolean', value: 'boolean' },
   { name: 'JSON', value: 'json' },
   { name: 'Image', value: 'image' },
+  { name: 'Link', value: 'link' },
 ];
 
 const DEFAULT_OPTIONS = {
@@ -44,13 +45,10 @@ function getDefaultColumnsOptions(columns) {
     order: 100000 + index,
     title: getColumnCleanName(col.name),
     allowSearch: false,
+    alignContent: getColumnContentAlignment(col.type),
+    // `string` cell options
     allowHTML: false,
     highlightLinks: false,
-    alignContent: getColumnContentAlignment(col.type),
-    imageUrlTemplate: '{{ @ }}',
-    imageTitleTemplate: '{{ @ }}',
-    imageWidth: '',
-    imageHeight: '',
   }));
 }
 
@@ -67,6 +65,16 @@ function getDefaultFormatOptions(column, clientConfig) {
     dateTimeFormat: dateTimeFormat[column.type],
     numberFormat: numberFormat[column.type],
     booleanValues: clientConfig.booleanValues || ['false', 'true'],
+    // `image` cell options
+    imageUrlTemplate: '{{ @ }}',
+    imageTitleTemplate: '{{ @ }}',
+    imageWidth: '',
+    imageHeight: '',
+    // `link` cell options
+    linkUrlTemplate: '{{ @ }}',
+    linkTextTemplate: '{{ @ }}',
+    linkTitleTemplate: '{{ @ }}',
+    linkOpenInNewTab: true,
   };
 }
 
@@ -196,6 +204,12 @@ function GridEditor(clientConfig) {
           );
         }
       });
+
+      $scope.templateHint = `
+        All columns can be referenced using <code>{{ column_name }}</code> syntax.
+        Use <code>{{ @ }}</code> to reference current (this) column.
+        This syntax is applicable to URL, Title and Size options.
+      `;
     },
   };
 }

--- a/client/app/visualizations/table/table-editor.html
+++ b/client/app/visualizations/table/table-editor.html
@@ -130,9 +130,39 @@
 
         <div class="form-group">
           <label class="ui-sortable-bypass text-muted" style="font-weight: normal; cursor: pointer;"
-            uib-popover-html="'All columns can be referenced using <code>\{\{ column_name \}\}</code> syntax.
-            Use <code>\{\{ @ \}\}</code> to reference current (this) column.
-            This syntax is applicable to URL, Title and Size options.'"
+            uib-popover-html="templateHint"
+            popover-trigger="'click outsideClick'" popover-placement="top-left">
+            Format specs <i class="fa fa-question-circle m-l-5"></i>
+          </label>
+        </div>
+      </div>
+
+      <div ng-if="column.displayAs == 'link'">
+        <div class="form-group">
+          <label for="table-editor-{{ column.name }}-link-url-template">URL template</label>
+          <input class="form-control" ng-model="column.linkUrlTemplate" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+            id="table-editor-{{ column.name }}-link-url-template">
+        </div>
+
+        <div class="form-group">
+          <label for="table-editor-{{ column.name }}-link-text-template">Text template</label>
+          <input class="form-control" ng-model="column.linkTextTemplate" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+            id="table-editor-{{ column.name }}-link-text-template">
+        </div>
+
+        <div class="form-group">
+          <label for="table-editor-{{ column.name }}-link-title-template">Title template</label>
+          <input class="form-control" ng-model="column.linkTitleTemplate" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+            id="table-editor-{{ column.name }}-link-title-template">
+        </div>
+
+        <div class="form-group">
+          <label class="ui-sortable-bypass"><input type="checkbox" ng-model="column.linkOpenInNewTab"> Open in new tab</label>
+        </div>
+
+        <div class="form-group">
+          <label class="ui-sortable-bypass text-muted" style="font-weight: normal; cursor: pointer;"
+            uib-popover-html="templateHint"
             popover-trigger="'click outsideClick'" popover-placement="top-left">
             Format specs <i class="fa fa-question-circle m-l-5"></i>
           </label>


### PR DESCRIPTION
Related to this PR getredash/redash/pull/2283 and works in a similar way.

Added new column type ("Link") and several options for it: "URL template", "Text template", "Title template", "Open in new tab" (adds `target="_blank"` attribute) (see screenshots below). All options allows to use values from another columns via `{{ column_name }}` syntax.

![image](https://user-images.githubusercontent.com/12139186/35777841-6e8c4a6e-09bd-11e8-9c78-9b1ae56dd1e2.png)
![image](https://user-images.githubusercontent.com/12139186/35777847-7c109780-09bd-11e8-807d-d045fa2ea5ca.png)
![image](https://user-images.githubusercontent.com/12139186/35777849-82f06bb6-09bd-11e8-916d-910965664b77.png)

P.S. Sorry for a lot of changes comparing to PR getredash/redash/pull/2283 - I moved some code to better place, and somewhere `git` wrongly detected file renaming instead of delete + adding new file.