### PR TITLE
New user layout improvement

### DIFF
--- a/client/app/pages/users/new.html
+++ b/client/app/pages/users/new.html
@@ -1,33 +1,34 @@
 <settings-screen>
   <email-settings-warning function="'invite emails'"></email-settings-warning>
-  <form class="form" name="$ctrl.userForm" ng-submit="saveUser()" novalidate>
-    <div class="form-group required" ng-class="{ 'has-error':  ($ctrl.userForm.name | showError )}">
-      <label class="control-label">Name</label>
-      <input type="text" name="name" class="form-control" ng-model="user.name" ng-disabled="user.created" required/ autofocus>
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4 creation-container">
+      <h3>New User</h3>
+      <form class="form" name="$ctrl.userForm" ng-submit="saveUser()" novalidate>
+        <div class="form-group required" ng-class="{ 'has-error':  ($ctrl.userForm.name | showError )}">
+          <label class="control-label">Name</label>
+          <input type="text" name="name" class="form-control" ng-model="user.name" ng-disabled="user.created" required/ autofocus>
 
-      <error-messages input="$ctrl.userForm.name" form="$ctrl.userForm"></error-messages>
+          <error-messages input="$ctrl.userForm.name" form="$ctrl.userForm"></error-messages>
+        </div>
+
+        <div class="form-group required" ng-class="{ 'has-error': ($ctrl.userForm.email | showError ) }">
+          <label class="control-label">Email</label>
+          <input name="email" type="email" class="form-control" ng-model="user.email" ng-disabled="user.created" required/>
+
+          <error-messages input="$ctrl.userForm.email" form="$ctrl.userForm"></error-messages>
+        </div>
+
+        <div class="form-group" ng-if="!user.created">
+          <button class="btn btn-primary">Create user</button>
+        </div>
+
+
+        <div ng-if="user.created" class="alert alert-success alert-invited">
+          <h4>The user has been created and should receive an invite email soon</h4>
+          <p>You can use the following link to invite them yourself:</p>
+          <textarea class="form-control" rows="2" disabled>{{user.invite_link}}</textarea>
+        </div>
+      </form>
     </div>
-
-    <div class="form-group required" ng-class="{ 'has-error': ($ctrl.userForm.email | showError ) }">
-      <label class="control-label">Email</label>
-      <input name="email" type="email" class="form-control" ng-model="user.email" ng-disabled="user.created" required/>
-
-      <error-messages input="$ctrl.userForm.email" form="$ctrl.userForm"></error-messages>
-    </div>
-
-    <div class="form-group" ng-if="!user.created">
-      <button class="btn btn-primary">Create</button>
-    </div>
-
-
-    <div ng-if="user.created" class="alert alert-success">
-      <p>
-        <strong>The user has been created and should receive an invite email soon.</strong>
-      </p>
-      <p>
-        You can use the following link to invite them yourself:<br/>
-        {{user.invite_link}}
-      </p>
-    </div>
-  </form>
+  </div>
 </settings-screen>

--- a/client/app/pages/users/settings.less
+++ b/client/app/pages/users/settings.less
@@ -8,10 +8,17 @@
   margin: 8px 0 0 0;
 }
 
-.profile__cointainer {
+.profile__container {
   .well {
     .form-group:last-of-type {
       margin-bottom: 0;
     }
+  }
+}
+
+.alert-invited {
+  .form-control {
+    cursor: text !important;
+    background: #fff !important;
   }
 }

--- a/client/app/pages/users/show.html
+++ b/client/app/pages/users/show.html
@@ -3,7 +3,7 @@
 
   <div ng-show="selectedTab == 'profile'">
     <div class="row">
-      <div class="col-md-4 col-md-offset-4 profile__cointainer">
+      <div class="col-md-4 col-md-offset-4 profile__container">
 
         <img ng-src="{{user.profile_image_url}}" class="profile__image"/>
 


### PR DESCRIPTION
I adjusted the New User layout to our new centered narrower design.

- [x] Header added
- [x] col-md-4, centered layout
- [x] Adjust success message and use disabled textarea for the invite link 
- [x] Extra: fix typo in css/markup

<img width="1282" alt="screenshot 2018-02-05 01 51 42" src="https://user-images.githubusercontent.com/2378022/35784402-5c5063e4-0a17-11e8-8a4a-80e2991d1b67.png">
