### PR TITLE
Don't escape values in non-html mode

### DIFF
--- a/client/app/components/dynamic-table/default-cell/index.js
+++ b/client/app/components/dynamic-table/default-cell/index.js
@@ -1,4 +1,4 @@
-import { contains } from 'underscore';
+import { contains, identity } from 'underscore';
 import { renderDefault, renderImage, renderLink } from './utils';
 import template from './template.html';
 
@@ -29,13 +29,15 @@ export default function init(ngModule) {
         $scope.allowHTML = contains(['image', 'link'], $scope.column.displayAs);
       }
 
+      const sanitize = $scope.allowHTML ? $sanitize : identity;
+
       const renderValue = renderFunctions[$scope.column.displayAs] || renderDefault;
 
-      $scope.value = $sanitize(renderValue($scope.column, $scope.row));
+      $scope.value = sanitize(renderValue($scope.column, $scope.row));
 
       $scope.$watch('row', (newValue, oldValue) => {
         if (newValue !== oldValue) {
-          $scope.value = $sanitize(renderValue($scope.column, $scope.row));
+          $scope.value = sanitize(renderValue($scope.column, $scope.row));
         }
       });
     },


### PR DESCRIPTION
Closes getredash/redash#1731.

`$sanitize` service strips everything that looks like html tag, and escaped all html entities like `<`, `>`, `&` etc. When using it with `ng-bind`, data is displayed wrong, because `ng-bind` updates text contents of node, not `innerHTML`, therefore there is no need to use `$sanitize` in non-html mode (when updating `textContent` browser ignores any king of markup and displays text as-is, escapes everything by itself).