### PR TITLE
Do not extract the topmost directory from tarball

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -65,7 +65,7 @@ create_directories() {
 extract_redash_sources() {
     sudo -u redash wget "$LATEST_URL" -O "$REDASH_TARBALL"
     sudo -u redash mkdir "$VERSION_DIR"
-    sudo -u redash tar -C "$VERSION_DIR" -xvf "$REDASH_TARBALL"
+    sudo -u redash tar -C "$VERSION_DIR" -xvf "$REDASH_TARBALL" --strip 1
     ln -nfs "$VERSION_DIR" $REDASH_BASE_PATH/current
     ln -nfs $REDASH_BASE_PATH/.env $REDASH_BASE_PATH/current/.env
 }


### PR DESCRIPTION
The bootstrap script was creating a bit odd directory tree when I've called it, something like `~/redash/redash.3.0.0/redash-3.0.0`. Though I was using not an AWS link, but one of Github's release URLs.