### PR TITLE
Fix webpack config (server-rendered pages); fix assets URLs

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -6,9 +6,9 @@
     <base href="/">
     <title>Redash</title>
 
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="/images/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/static/images/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
   </head>
 
   <body ng-class="bodyClass">

--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -6,9 +6,9 @@
     <base href="{{base_href}}">
     <title>Redash</title>
 
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="/images/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/static/images/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
   </head>
 
   <body ng-class="bodyClass">

--- a/redash/templates/invite.html
+++ b/redash/templates/invite.html
@@ -19,7 +19,7 @@
 {% endwith %}
 {% if google_auth_url %}
 <div class="row">
-    <a href="{{ google_auth_url }}"><img src="/images/google_login.png" class="login-button"/></a>
+    <a href="{{ google_auth_url }}"><img src="/static/images/google_login.png" class="login-button"/></a>
 </div>
 <div class="login-or">
     <hr class="hr-or">

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -10,7 +10,7 @@
   {% endwith %}
   {% if show_google_openid %}
   <div class="row">
-    <a href="{{ google_auth_url }}"><img src="/images/google_login.png" class="login-button"/></a>
+    <a href="{{ google_auth_url }}"><img src="/static/images/google_login.png" class="login-button"/></a>
   </div>
 
   <div class="login-or">
@@ -71,7 +71,7 @@
       Log In
     </button>
   </form>
-  
+
   {% if not hide_forgot_password %}
     <hr>
     <a href="{{ url_for("redash.forgot_password", org_slug=org_slug) }}">I forgot my password</a>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,15 +52,15 @@ const config = {
       chunks: ['vendor']
     }),
     new HtmlWebpackPlugin({
-      template: './client/app/index.html'
+      template: './client/app/index.html',
+      filename: 'index.html',
     }),
     new HtmlWebpackPlugin({
       template: './client/app/multi_org.html',
-      filename: 'multi_org.html'
+      filename: 'multi_org.html',
     }),
     new ExtractTextPlugin({
       filename: 'styles.[chunkhash].css',
-      publicPath: '/assets/'
     }),
     new ManifestPlugin({
       fileName: 'asset-manifest.json'
@@ -146,17 +146,27 @@ const config = {
     index: '/static/index.html',
     historyApiFallback: {
       index: '/static/index.html',
+      rewrites: [{from: /./, to: '/static/index.html'}],
     },
-    contentBase: path.join(__dirname, 'client', 'dist'),
+    contentBase: false,
     publicPath: '/static/',
-    proxy: [{
-      context: [
-        '/login', '/invite', '/setup', '/images', '/js', '/styles',
-        '/status.json', '/api', '/oauth'],
-      target: redashBackend + '/',
-      changeOrigin: true,
-      secure: false,
-    }],
+    proxy: [
+      {
+        context: ['/login', '/logout', '/invite', '/setup', '/status.json', '/api', '/oauth'],
+        target: redashBackend + '/',
+        changeOrigin: true,
+        secure: false,
+      },
+      {
+        context: (path) => {
+          // CSS/JS for server-rendered pages should be served from backend
+          return /^\/static\/[a-z]+\.[0-9a-fA-F]+\.(css|js)$/.test(path);
+        },
+        target: redashBackend + '/',
+        changeOrigin: true,
+        secure: false,
+      }
+    ],
     stats: {
       modules: false,
       chunkModules: false,
@@ -169,7 +179,6 @@ if (process.env.DEV_SERVER_HOST) {
 }
 
 if (process.env.NODE_ENV === 'production') {
-  config.output.path = __dirname + '/client/dist';
   config.output.filename = '[name].[chunkhash].js';
   config.plugins.push(new webpack.optimize.UglifyJsPlugin({
     sourceMap: true,


### PR DESCRIPTION
Supplements PR getredash/redash/pull/2301

There are some caveats with config in previous PR related to server-rendered pages (like login page, invite user page, etc.). In short: all that pages contains assets URLs with hash (files are built with `npm run build` and are located in `client/dist` folder). Previous webpack config tries to mount that folder as path with static files (`contentBase` option), but it leads to some bugs in a case when `client/dist` folder does not exist (some resources does not load), or filename conflicts (say, there is "virtual" `index.html` generated by `webpack-dev-server`, and also "physical" one in `client/dist`. In some cases WDS serves "physical" one).

This PR fixes that issues in next way:
1. WDS will not serve any static files; everything needed for front-end code is already in WDS's memory and served by it (including fonts, images, etc.).
2. Files needed by server-rendered pages (it's only CSS and JS with "salt" in filename) are proxied to backend and served by it - so no more conflicts between generated and "physical" files.

Also this PR fixes some assets URLs missed in previous one, and removes unnecessary proxy URLs (now all assets are served from '/static', so no need to proxy all that '/styles', '/images' etc.).