### PR TITLE
Add Widget Dialog UX Update

### DIFF
--- a/client/app/assets/less/inc/modal.less
+++ b/client/app/assets/less/inc/modal.less
@@ -11,7 +11,7 @@
 }
 
 .modal-footer {
-    padding: 20px 22px;
+    padding: 20px 26px;
 }
 
 .modal-xl {

--- a/client/app/components/dashboards/add-widget-dialog.html
+++ b/client/app/components/dashboards/add-widget-dialog.html
@@ -10,7 +10,7 @@
 
   <div ng-show="$ctrl.isTextBox">
     <div class="form-group">
-      <textarea class="form-control" ng-model="$ctrl.text" ng-model-options="{ debounce: 200 }" rows="3"></textarea>
+      <textarea class="form-control" ng-model="$ctrl.text" ng-model-options="{ debounce: 200 }" rows="3" autofocus></textarea>
     </div>
     <div ng-show="$ctrl.text">
       <strong>Preview:</strong>
@@ -20,9 +20,8 @@
 
   <div ng-show="$ctrl.isVisualization">
     <div class="form-group">
-      <input type="text" placeholder="Search a query by name" class="form-control" autofocus="autofocus"
-        ng-if="!$ctrl.selectedQuery" ng-change="$ctrl.searchQueries($ctrl.searchTerm)"
-        ng-model="$ctrl.searchTerm" ng-model-options="{ debounce: 200 }">
+      <input type="text" placeholder="Search a query by name" class="form-control" autofocus
+        ng-if="!$ctrl.selectedQuery" ng-model="$ctrl.searchTerm" ng-change="$ctrl.searchQueries($ctrl.searchTerm)">
       <div ng-if="$ctrl.selectedQuery" class="p-relative">
         <input type="text" class="form-control bg-white"
           ng-value="$ctrl.selectedQuery.name" readonly="readonly">
@@ -33,34 +32,30 @@
       </div>
     </div>
 
-    <div ng-if="!$ctrl.selectedQuery && ($ctrl.searchTerm == '')" class="scrollbox" style="max-height: 50vh">
-      <div class="list-group" ng-if="$ctrl.recentQueries.length > 0">
-        <a href="javascript:void(0)" class="list-group-item"
-          ng-repeat="query in $ctrl.recentQueries" ng-click="$ctrl.selectQuery(query.id)"
-        >
-          <span>{{query.name}}</span>
-          <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
-        </a>
+    <div ng-if="!$ctrl.selectedQuery" class="scrollbox" style="max-height: 50vh">
+      <div ng-if="$ctrl.searchTerm == ''">
+        <div class="list-group" ng-if="$ctrl.recentQueries.length > 0">
+          <a class="list-group-item" ng-repeat="query in $ctrl.recentQueries"
+            ng-click="$ctrl.selectQuery(query.id)">{{query.name}}</a>
+        </div>
       </div>
-    </div>
 
-    <div ng-if="!$ctrl.selectedQuery && ($ctrl.searchTerm != '')" class="scrollbox" style="max-height: 50vh">
-      <div ng-if="$ctrl.searchedQueries.length == 0" class="text-muted">
-        No results matching search term.
-      </div>
-      <div class="list-group" ng-if="$ctrl.searchedQueries.length > 0">
-        <a href="javascript:void(0)" class="list-group-item"
-          ng-repeat="query in $ctrl.searchedQueries" ng-click="$ctrl.selectQuery(query.id)"
-        >
-          <span ng-bind-html="$ctrl.trustAsHtml(query.name | highlight: $ctrl.searchTerm)"></span>
-          <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
-        </a>
+      <div ng-if="$ctrl.searchTerm != ''">
+        <div ng-if="$ctrl.searchedQueries.length == 0" class="text-muted">
+          No results matching search term.
+        </div>
+        <div class="list-group" ng-if="$ctrl.searchedQueries.length > 0">
+          <a class="list-group-item"
+            ng-repeat="query in $ctrl.searchedQueries" ng-click="$ctrl.selectQuery(query.id)"
+            ng-bind-html="$ctrl.trustAsHtml(query.name | highlight: $ctrl.searchTerm)"
+          ></a>
+        </div>
       </div>
     </div>
 
     <div ng-show="$ctrl.selectedQuery">
       <div class="form-group">
-        <label for="">Choose Visualization</label>
+        <label>Choose Visualization</label>
         <select ng-model="$ctrl.selectedVis" class="form-control"
           ng-options="vis as vis.name group by vis.type for vis in $ctrl.selectedQuery.visualizations"></select>
       </div>

--- a/client/app/components/dashboards/add-widget-dialog.html
+++ b/client/app/components/dashboards/add-widget-dialog.html
@@ -4,46 +4,75 @@
 </div>
 <div class="modal-body">
   <p class="btn-group">
-      <button type="button" class="btn btn-default" ng-class="{active: $ctrl.isVisualization()}" ng-click="$ctrl.setType('visualization')">Visualization</button>
-      <button type="button" class="btn btn-default" ng-class="{active: $ctrl.isTextBox()}" ng-click="$ctrl.setType('textbox')">Text Box</button>
+    <button type="button" class="btn btn-default" ng-class="{active: $ctrl.isVisualization}" ng-click="$ctrl.setType('visualization')">Visualization</button>
+    <button type="button" class="btn btn-default" ng-class="{active: $ctrl.isTextBox}" ng-click="$ctrl.setType('textbox')">Text Box</button>
   </p>
 
-  <div ng-show="$ctrl.isTextBox()">
-      <div class="form-group">
-          <textarea class="form-control" ng-model="$ctrl.text" rows="3"></textarea>
-      </div>
-      <div ng-show="$ctrl.text">
-          <strong>Preview:</strong>
-          <p ng-bind-html="$ctrl.text | markdown"></p>
-      </div>
+  <div ng-show="$ctrl.isTextBox">
+    <div class="form-group">
+      <textarea class="form-control" ng-model="$ctrl.text" ng-model-options="{ debounce: 200 }" rows="3"></textarea>
+    </div>
+    <div ng-show="$ctrl.text">
+      <strong>Preview:</strong>
+      <p ng-bind-html="$ctrl.text | markdown"></p>
+    </div>
   </div>
 
-  <div ng-show="$ctrl.isVisualization()">
-      <div class="form-group">
-          <ui-select ng-model="$ctrl.query.selected" theme="bootstrap" reset-search-input="false" on-select="$ctrl.onQuerySelect($item, $model)">
-              <ui-select-match placeholder="Search a query by name">{{$select.selected.name}}</ui-select-match>
-              <ui-select-choices repeat="q in $ctrl.queries"
-                                 refresh="$ctrl.searchQueries($select.search)"
-                                 refresh-delay="0">
-                  <div ng-bind-html="$ctrl.trustAsHtml(q.name | highlight: $select.search)"></div>
-              </ui-select-choices>
-          </ui-select>
+  <div ng-show="$ctrl.isVisualization">
+    <div class="form-group">
+      <input type="text" placeholder="Search a query by name" class="form-control" autofocus="autofocus"
+        ng-if="!$ctrl.selectedQuery" ng-change="$ctrl.searchQueries($ctrl.searchTerm)"
+        ng-model="$ctrl.searchTerm" ng-model-options="{ debounce: 200 }">
+      <div ng-if="$ctrl.selectedQuery" class="p-relative">
+        <input type="text" class="form-control bg-white"
+          ng-value="$ctrl.selectedQuery.name" readonly="readonly">
+        <a href="javascript:void(0)" ng-click="$ctrl.selectQuery(null)"
+          class="d-flex align-items-center justify-content-center"
+          style="position: absolute; right: 1px; top: 1px; bottom: 1px; width: 30px; background: #fff; border-radius: 3px;"
+        ><i class="text-muted fa fa-times"></i></a>
       </div>
+    </div>
 
-      <div ng-show="$ctrl.selected_query">
-          <div class="form-group">
-              <label for="">Choose Visualization</label>
-              <select ng-model="$ctrl.selectedVis" ng-options="vis as vis.name group by vis.type for vis in $ctrl.selected_query.visualizations" class="form-control"></select>
-          </div>
+    <div ng-if="!$ctrl.selectedQuery && ($ctrl.searchTerm == '')" class="scrollbox" style="max-height: 50vh">
+      <div class="list-group" ng-if="$ctrl.recentQueries.length > 0">
+        <a href="javascript:void(0)" class="list-group-item"
+          ng-repeat="query in $ctrl.recentQueries" ng-click="$ctrl.selectQuery(query.id)"
+        >
+          <span>{{query.name}}</span>
+          <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
+        </a>
       </div>
+    </div>
+
+    <div ng-if="!$ctrl.selectedQuery && ($ctrl.searchTerm != '')" class="scrollbox" style="max-height: 50vh">
+      <div ng-if="$ctrl.searchedQueries.length == 0" class="text-muted">
+        No results matching search term.
+      </div>
+      <div class="list-group" ng-if="$ctrl.searchedQueries.length > 0">
+        <a href="javascript:void(0)" class="list-group-item"
+          ng-repeat="query in $ctrl.searchedQueries" ng-click="$ctrl.selectQuery(query.id)"
+        >
+          <span ng-bind-html="$ctrl.trustAsHtml(query.name | highlight: $ctrl.searchTerm)"></span>
+          <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
+        </a>
+      </div>
+    </div>
+
+    <div ng-show="$ctrl.selectedQuery">
+      <div class="form-group">
+        <label for="">Choose Visualization</label>
+        <select ng-model="$ctrl.selectedVis" class="form-control"
+          ng-options="vis as vis.name group by vis.type for vis in $ctrl.selectedQuery.visualizations"></select>
+      </div>
+    </div>
   </div>
 
-  <div class="form-group" ng-if="$ctrl.isTextBox()">
-      <label><input type="checkbox" ng-model="$ctrl.isHidden">&nbsp;Hidden</label>
+  <div class="form-group" ng-if="$ctrl.isTextBox">
+    <label><input type="checkbox" ng-model="$ctrl.isHidden">&nbsp;Hidden</label>
   </div>
 </div>
 
 <div class="modal-footer">
   <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.dismiss()">Close</button>
-  <button type="button" class="btn btn-primary" ng-disabled="$ctrl.saveInProgress || !($ctrl.selectedVis || $ctrl.isTextBox())" ng-click="$ctrl.saveWidget()">Add to Dashboard</button>
+  <button type="button" class="btn btn-primary" ng-disabled="$ctrl.saveInProgress || !($ctrl.selectedVis || $ctrl.isTextBox)" ng-click="$ctrl.saveWidget()">Add to Dashboard</button>
 </div>

--- a/client/app/components/dashboards/add-widget-dialog.js
+++ b/client/app/components/dashboards/add-widget-dialog.js
@@ -21,7 +21,13 @@ const AddWidgetDialog = {
     // Visualization
     this.selectedQuery = null;
     this.searchTerm = '';
-    this.recentQueries = Query.recent();
+    this.recentQueries = [];
+
+    // Don't show draft (unpublished) queries
+    Query.recent().$promise.then((items) => {
+      this.recentQueries = items.filter(item => !item.is_draft);
+    });
+
     this.searchedQueries = [];
     this.selectedVis = null;
 


### PR DESCRIPTION
Issue getredash/redash#2214

After opening modal, user see recent queries; when user starts typing in search input, search results are loaded and shown; when user clears search input - recent queries are shown. Everything related to text widgets left unchanged.

Screenshots:

![image](https://user-images.githubusercontent.com/12139186/36167742-9305c9d0-10ff-11e8-9ab0-d51aaa7e148e.png)
![image](https://user-images.githubusercontent.com/12139186/36167786-b9e5db62-10ff-11e8-90cf-1039b6fc6d4e.png)
![image](https://user-images.githubusercontent.com/12139186/36167811-d14c40a2-10ff-11e8-8635-a53e16841ca6.png)
