### PR TITLE
Fix: widget is not removed from dashboard, only after page refresh

### DIFF
--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -71,7 +71,8 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
     Events.record('delete', 'widget', this.widget.id);
 
     this.widget.$delete((response) => {
-      this.dashboard.widgets = this.dashboard.widgets.filter(widget => widget.id !== undefined);
+      this.dashboard.widgets = this.dashboard.widgets
+        .filter(widget => (widget.id !== undefined) && (widget.id !== this.widget.id));
       this.dashboard.version = response.version;
       if (this.deleted) {
         this.deleted({});

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -317,7 +317,11 @@ function DashboardCtrl(
   this.removeWidget = () => {
     this.extractGlobalParameters();
     if (!this.layoutEditing) {
-      saveDashboardLayout();
+      // We need to wait a bit for `angular-gridster` before it updates widgets,
+      // and only then save new layout
+      $timeout(() => {
+        saveDashboardLayout();
+      }, 50);
     }
   };
 


### PR DESCRIPTION
Issue: when trying to remove widget from dashboard, it was removed on server, but not removed on client. All next attempts to update dashboard layout will fail because frontend will try to save non-existing widget and will get an error. This PR fixes it.