### PR TITLE
Reduce restart to unless-stopped for Redis and Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,11 +33,11 @@ services:
       WORKERS_COUNT: 2
   redis:
     image: redis:3.0-alpine
-    restart: always
+    restart: unless-stopped
   postgres:
     image: postgres:9.5.6-alpine
     # The following turns the DB into less durable, but gains significant performance improvements for the tests run (x3
     # improvement on my personal machine). We should consider moving this into a dedicated Docker Compose configuration for
     # tests.
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
-    restart: always
+    restart: unless-stopped


### PR DESCRIPTION
`restart: always` will cause containers to restart when the machine is rebooted or the docker process restarts. Setting this to `unless-stopped` will mean the container will restart only if the docker process/computer was rebooted without stopping the container first. Otherwise, running `docker-compose stop` and rebooting will cause the docker containers all to start again (and goodbye laptop battery!)

We might also consider `restart: on-failures` which would mean that rebooting would _not_ cause containers to start again unless requested via `docker-compose up`.