### PR TITLE
Add funnel visualization

### DIFF
--- a/client/app/visualizations/funnel/funnel-editor.html
+++ b/client/app/visualizations/funnel/funnel-editor.html
@@ -1,12 +1,7 @@
 <div class="form-horizontal">
-  <div>
-    This visualization constructs funnel chart. Please notice that:
-    <ul>
-      <li>Records would be sorted first</li>
-      <li>Value column only accept number for values</li>
-    </ul>
+  <div style="margin-bottom: 20px;">
+    This visualization constructs funnel chart. Please notice that value column only accept number for values.
   </div>
-
   <div class="form-group">
     <label class="col-lg-6">Step Column Name</label>
     <div class="col-lg-6">
@@ -29,6 +24,20 @@
     <label class="col-lg-6">Funnel Value Column Dispaly Name</label>
     <div class="col-lg-6">
       <input type="text" ng-model="visualization.options.valueCol.dispAs" class="form-control">
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Auto Sort Record By Value</label>
+    <div class="col-lg-6">
+      <input type="checkbox" ng-model="visualization.options.autoSort">
+    </div>
+  </div>
+  <div ng-show="!visualization.options.autoSort">
+    <div class="form-group">
+      <label class="col-lg-6">Funnel Value Columns Name</label>
+      <div class="col-lg-6">
+        <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.sortKeyCol.colName" class="form-control"></select>
+      </div>
     </div>
   </div>
 </div>

--- a/client/app/visualizations/funnel/funnel-editor.html
+++ b/client/app/visualizations/funnel/funnel-editor.html
@@ -1,9 +1,34 @@
 <div class="form-horizontal">
   <div>
-    This visualization expects the query result to be in the following formats:
+    This visualization constructs funnel chart. Please notice that:
     <ul>
-      <li><strong>steps</strong> - the name of the funnel steps</li>
-      <li><strong>values</strong> - value of the funnel steps</li>
+      <li>Records would be sorted first</li>
+      <li>Value column only accept number for values</li>
     </ul>
+  </div>
+
+  <div class="form-group">
+    <label class="col-lg-6">Step Column Name</label>
+    <div class="col-lg-6">
+      <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.stepCol.colName" class="form-control"></select>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Step Column Dispaly Name</label>
+    <div class="col-lg-6">
+      <input type="text" ng-model="visualization.options.stepCol.dispAs" class="form-control">
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Funnel Value Column Name</label>
+    <div class="col-lg-6">
+      <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.valueCol.colName" class="form-control"></select>
+    </div>
+  </div>
+  <div class="form-group">
+    <label class="col-lg-6">Funnel Value Column Dispaly Name</label>
+    <div class="col-lg-6">
+      <input type="text" ng-model="visualization.options.valueCol.dispAs" class="form-control">
+    </div>
   </div>
 </div>

--- a/client/app/visualizations/funnel/funnel-editor.html
+++ b/client/app/visualizations/funnel/funnel-editor.html
@@ -1,0 +1,9 @@
+<div class="form-horizontal">
+  <div>
+    This visualization expects the query result to be in the following formats:
+    <ul>
+      <li><strong>steps</strong> - the name of the funnel steps</li>
+      <li><strong>values</strong> - value of the funnel steps</li>
+    </ul>
+  </div>
+</div>

--- a/client/app/visualizations/funnel/funnel-editor.html
+++ b/client/app/visualizations/funnel/funnel-editor.html
@@ -11,7 +11,7 @@
   <div class="form-group">
     <label class="col-lg-6">Step Column Dispaly Name</label>
     <div class="col-lg-6">
-      <input type="text" ng-model="visualization.options.stepCol.dispAs" class="form-control">
+      <input type="text" ng-model="visualization.options.stepCol.displayAs" class="form-control">
     </div>
   </div>
   <div class="form-group">
@@ -23,7 +23,7 @@
   <div class="form-group">
     <label class="col-lg-6">Funnel Value Column Dispaly Name</label>
     <div class="col-lg-6">
-      <input type="text" ng-model="visualization.options.valueCol.dispAs" class="form-control">
+      <input type="text" ng-model="visualization.options.valueCol.displayAs" class="form-control">
     </div>
   </div>
   <div class="form-group">

--- a/client/app/visualizations/funnel/funnel.less
+++ b/client/app/visualizations/funnel/funnel.less
@@ -1,6 +1,3 @@
-@lightgrey: rgb(211, 211, 211);
-@lightblue: rgb(135, 206, 250);
-
 .funnel-visualization-container {
   table {
     max-width: 800px;
@@ -11,11 +8,9 @@
   }
   div.bar {
     height: 30px;
-    background-color: @lightgrey;
   }
   div.bar.centered {
     margin: auto;
-    background-color: @lightblue;
   }
   .value {
     position: absolute;

--- a/client/app/visualizations/funnel/funnel.less
+++ b/client/app/visualizations/funnel/funnel.less
@@ -12,6 +12,23 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+  .step .step-name {
+    visibility: hidden;
+    width: inherit;
+    padding: 3px 5px;
+    background-color: white;
+    border: 1px solid;
+    border-radius: 3px;
+    position: absolute;
+    z-index: 1;
+    white-space: initial;
+    word-wrap: break-word;
+  }
+
+  .step:hover .step-name {
+    visibility: visible;
+  }
+
   div.bar {
     height: 30px;
   }

--- a/client/app/visualizations/funnel/funnel.less
+++ b/client/app/visualizations/funnel/funnel.less
@@ -1,0 +1,31 @@
+@lightgrey: rgb(211, 211, 211);
+@lightblue: rgb(135, 206, 250);
+
+.funnel-visualization-container {
+  table {
+    max-width: 800px;
+  }
+  .table-borderless td, .table-borderless th {
+    border: 0;
+    vertical-align: middle;
+  }
+  div.bar {
+    height: 30px;
+    background-color: @lightgrey;
+  }
+  div.bar.centered {
+    margin: auto;
+    background-color: @lightblue;
+  }
+  .value {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+  .container {
+    position: relative;
+    padding: 0;
+    text-align: center;
+  }
+}

--- a/client/app/visualizations/funnel/funnel.less
+++ b/client/app/visualizations/funnel/funnel.less
@@ -1,10 +1,16 @@
 .funnel-visualization-container {
   table {
-    max-width: 800px;
+    min-width: 450px;
   }
   .table-borderless td, .table-borderless th {
     border: 0;
     vertical-align: middle;
+  }
+  .step {
+    max-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   div.bar {
     height: 30px;

--- a/client/app/visualizations/funnel/index.js
+++ b/client/app/visualizations/funnel/index.js
@@ -97,13 +97,18 @@ function Funnel(scope, element) {
       value: Number(row[options.valueCol.colName]),
       sortVal: options.autoSort ? '' : row[options.sortKeyCol.colName],
     }), []);
-    const maxVal = d3.max(data, d => d.value);
-    const sortedData = sortBy(data, options.autoSort ? 'value' : 'sortVal').reverse();
+    let sortedData;
+    if (options.autoSort) {
+      sortedData = sortBy(data, 'value').reverse();
+    } else {
+      sortedData = sortBy(data, 'sortVal');
+    }
 
     // Column validity
     if (sortedData[0].value === 0 || !every(sortedData, d => isNoneNaNNum(d.value))) {
       return;
     }
+    const maxVal = d3.max(data, d => d.value);
     sortedData.forEach((d, i) => {
       d.pctMax = d.value / maxVal * 100.0;
       d.pctPrevious = i === 0 ? 100.0 : d.value / sortedData[i - 1].value * 100.0;

--- a/client/app/visualizations/funnel/index.js
+++ b/client/app/visualizations/funnel/index.js
@@ -47,14 +47,14 @@ function Funnel(scope, element) {
 
     // Steps row
     trs.append('td')
-      .attr('class', 'col-md-3')
+      .attr('class', 'col-xs-3 step')
       .text(d => d.step);
 
     // Funnel bars
     const valContainers = trs.append('td')
+      .attr('class', 'col-xs-5')
       .append('div')
-      .attr('class', 'container')
-      .style('min-width', '200px');
+      .attr('class', 'container');
     valContainers.append('div')
       .attr('class', 'bar centered')
       .style('background-color', ColorPalette.Cyan)
@@ -65,12 +65,12 @@ function Funnel(scope, element) {
 
     // pctMax
     trs.append('td')
-      .attr('class', 'col-md-2 text-center')
+      .attr('class', 'col-xs-2 text-center')
       .text(d => normalizePercentage(d.pctMax));
 
     // pctPrevious
     const pctContainers = trs.append('td')
-      .attr('class', 'col-md-2')
+      .attr('class', 'col-xs-2')
       .append('div')
       .attr('class', 'container');
     pctContainers.append('div')
@@ -113,7 +113,7 @@ function Funnel(scope, element) {
       d.pctMax = d.value / maxVal * 100.0;
       d.pctPrevious = i === 0 ? 100.0 : d.value / sortedData[i - 1].value * 100.0;
     });
-    return sortedData;
+    return sortedData.slice(0, 100);
   }
 
   function invalidColNames() {

--- a/client/app/visualizations/funnel/index.js
+++ b/client/app/visualizations/funnel/index.js
@@ -1,0 +1,169 @@
+import { debounce, sortBy } from 'underscore';
+import d3 from 'd3';
+import angular from 'angular';
+
+import editorTemplate from './funnel-editor.html';
+import './funnel.less';
+
+function Funnel(scope, element) {
+  this.element = element;
+  this.watches = [];
+  const vis = d3.select(element);
+
+  function normalizePercentage(num) {
+    return num < 0.01 ? '<0.01%' : num.toFixed(2) + '%';
+  }
+
+  function drawFunnel(data) {
+    // Table
+    const table = vis.append('table')
+      .attr('class', 'table table-condensed table-hover table-borderless');
+
+    // Header
+    const header = table.append('thead').append('tr');
+    header.append('th').text('Step');
+    header.append('th');
+    header.append('th').attr('class', 'text-center').text('% Total');
+    header.append('th').attr('class', 'text-center').text('% Previous');
+
+    // Body
+    const trs = table.append('tbody')
+      .selectAll('tr')
+      .data(data)
+      .enter()
+      .append('tr');
+
+    // Steps row
+    trs.append('td')
+      .attr('class', 'col-md-3')
+      .text(d => d.step);
+
+    // Funnel bars
+    const valContainers = trs.append('td')
+      .attr('class', 'col-md-5')
+      .append('div')
+      .attr('class', 'container')
+      .style('min-width', '200px');
+    valContainers.append('div')
+      .attr('class', 'bar centered')
+      .style('width', d => d.pctTotal + '%');
+    valContainers.append('div')
+      .attr('class', 'value')
+      .text(d => d.value.toLocaleString());
+
+    // pctTotal
+    trs.append('td')
+      .attr('class', 'col-md-2 text-center')
+      .text(d => normalizePercentage(d.pctTotal));
+
+    // pctPrevious
+    const pctContainers = trs.append('td')
+      .attr('class', 'col-md-2')
+      .append('div')
+      .attr('class', 'container');
+    pctContainers.append('div')
+      .attr('class', 'bar')
+      .style('width', d => d.pctPrevious.toFixed(2) + '%');
+    pctContainers.append('div')
+      .attr('class', 'value')
+      .text(d => normalizePercentage(d.pctPrevious));
+  }
+
+  // visualize funnel data
+  function createVisualization(data) {
+    drawFunnel(data); // draw funnel
+  }
+
+  function removeVisualization() {
+    vis.selectAll('table').remove();
+  }
+
+  function prepareData(queryData, stepCol, valCol) {
+    // Column validity
+    const sortedData = sortBy(queryData, valCol).reverse();
+    return sortedData.map((row, i) => ({
+      step: row[stepCol],
+      value: row[valCol],
+      pctTotal: row[valCol] / sortedData[0][valCol] * 100.0,
+      pctPrevious: i === 0 ? 100.0 : row[valCol] / sortedData[i - 1][valCol] * 100.0,
+    }), []);
+  }
+
+  function render(queryData) {
+    const data = prepareData(queryData, 'steps', 'values'); // build funnel data
+    removeVisualization(); // remove existing visualization if any
+    createVisualization(data); // visualize funnel data
+  }
+
+  function refreshData() {
+    const queryData = scope.queryResult.getData();
+    if (queryData) {
+      render(queryData);
+    }
+  }
+
+  refreshData();
+  this.watches.push(scope.$watch('visualization.options', refreshData, true));
+  this.watches.push(scope.$watch('queryResult && queryResult.getData()', refreshData));
+}
+
+Funnel.prototype.remove = function remove() {
+  this.watches.forEach((unregister) => {
+    unregister();
+  });
+  angular.element(this.element).empty('.vis-container');
+};
+
+function funnelRenderer() {
+  return {
+    restrict: 'E',
+    template: '<div class="funnel-visualization-container resize-event="handleResize()"></div>',
+    link(scope, element) {
+      const container = element[0].querySelector('.funnel-visualization-container');
+      let funnel = new Funnel(scope, container);
+
+      function resize() {
+        funnel.remove();
+        funnel = new Funnel(scope, container);
+      }
+
+      scope.handleResize = debounce(resize, 50);
+
+      scope.$watch('visualization.options.height', (oldValue, newValue) => {
+        if (oldValue !== newValue) {
+          resize();
+        }
+      });
+    },
+  };
+}
+
+function funnelEditor() {
+  return {
+    restrict: 'E',
+    template: editorTemplate,
+  };
+}
+
+export default function init(ngModule) {
+  ngModule.directive('funnelRenderer', funnelRenderer);
+  ngModule.directive('funnelEditor', funnelEditor);
+
+  ngModule.config((VisualizationProvider) => {
+    const renderTemplate =
+      '<funnel-renderer options="visualization.options" query-result="queryResult"></funnel-renderer>';
+
+    const editTemplate = '<funnel-editor></funnel-editor>';
+    const defaultOptions = {
+      defaultrs: 7,
+    };
+
+    VisualizationProvider.registerVisualization({
+      type: 'FUNNEL',
+      name: 'Funnel',
+      renderTemplate,
+      editorTemplate: editTemplate,
+      defaultOptions,
+    });
+  });
+}

--- a/client/app/visualizations/funnel/index.js
+++ b/client/app/visualizations/funnel/index.js
@@ -2,6 +2,7 @@ import { debounce, sortBy } from 'underscore';
 import d3 from 'd3';
 import angular from 'angular';
 
+import { ColorPalette } from '@/visualizations/chart/plotly/utils';
 import editorTemplate from './funnel-editor.html';
 import './funnel.less';
 
@@ -46,6 +47,7 @@ function Funnel(scope, element) {
       .style('min-width', '200px');
     valContainers.append('div')
       .attr('class', 'bar centered')
+      .style('background-color', ColorPalette.Cyan)
       .style('width', d => d.pctTotal + '%');
     valContainers.append('div')
       .attr('class', 'value')
@@ -63,6 +65,8 @@ function Funnel(scope, element) {
       .attr('class', 'container');
     pctContainers.append('div')
       .attr('class', 'bar')
+      .style('background-color', ColorPalette.Gray)
+      .style('opacity', '0.2')
       .style('width', d => d.pctPrevious.toFixed(2) + '%');
     pctContainers.append('div')
       .attr('class', 'value')

--- a/client/app/visualizations/funnel/index.js
+++ b/client/app/visualizations/funnel/index.js
@@ -33,8 +33,8 @@ function Funnel(scope, element) {
 
     // Header
     const header = table.append('thead').append('tr');
-    header.append('th').text(options.stepCol.dispAs);
-    header.append('th').attr('class', 'text-center').text(options.valueCol.dispAs);
+    header.append('th').text(options.stepCol.displayAs);
+    header.append('th').attr('class', 'text-center').text(options.valueCol.displayAs);
     header.append('th').attr('class', 'text-center').text('% Max');
     header.append('th').attr('class', 'text-center').text('% Previous');
 
@@ -193,8 +193,8 @@ export default function init(ngModule) {
 
     const editTemplate = '<funnel-editor></funnel-editor>';
     const defaultOptions = {
-      stepCol: { colName: '', dispAs: 'Steps' },
-      valueCol: { colName: '', dispAs: 'Value' },
+      stepCol: { colName: '', displayAs: 'Steps' },
+      valueCol: { colName: '', displayAs: 'Value' },
       sortKeyCol: { colName: '' },
       autoSort: true,
       defaultRows: 10,

--- a/client/app/visualizations/funnel/index.js
+++ b/client/app/visualizations/funnel/index.js
@@ -48,6 +48,9 @@ function Funnel(scope, element) {
     // Steps row
     trs.append('td')
       .attr('class', 'col-xs-3 step')
+      .text(d => d.step)
+      .append('div')
+      .attr('class', 'step-name')
       .text(d => d.step);
 
     // Funnel bars


### PR DESCRIPTION
Issue
---
https://github.com/getredash/redash/issues/2139

Implementation
---
- Table + Containers
- D3 for DOM manipulation 
- Bootstrap for formatting mostly
- Code structure based on sunburst

Possible alternatives: [svg with d3](https://codepen.io/tonyjiangh/pen/xYWbya)

Task lists
---
- [x] Add basic funnel visualization
- [x] Fix color styles
- [x] Optimize edit page
- [x] Test some corner cases
   - [x] Long list of steps
   - [x] Long step names
   - [x] Big values
   - [x] Small ratio for the last step
   - [x] Extreme resizing
- [x] Maybe some hover handling if necessary (for long step names?)
- ~~Documentation~~
  - Different repository

Screenshot
---
**Auto sorted setting**
![image](https://user-images.githubusercontent.com/16881036/36734151-012c6ace-1c16-11e8-812f-12b95707e2f9.png)


**Order specified setting**
![image](https://user-images.githubusercontent.com/16881036/36571747-b67fdb48-187b-11e8-9bde-2aff75ffe3f8.png)

Updates
----
- Initial commit
  - Add basic funnel visualization
  - QueryResult has to have `steps` and `values` column
  - Auto sort records using value column in decreasing order
  - Auto calculate % of max and % of previous
- Added @ 2018/2/23(JP)
  - Allow choosing column to use for step names and for value
  - Allow setting display name for the funnel chart(table) header for the step columna and the value column
  - Allow choosing column to use for ordering
  - Use chart color `Cyan`
  - Normalize date column for steps display
  - Stop rendering when 1. value column is NaN or not number, 2. selected column name is invalid
- Added @ 2018/2/26~27
  - Silece top 100 rows for display
  - Handled long step name with ellipsis text-overflow and hovered full step name.
  - Some styling adjustment