### PR TITLE
Explicitly set order of tabs on Settings page

### DIFF
--- a/client/app/pages/destinations/list.js
+++ b/client/app/pages/destinations/list.js
@@ -12,6 +12,7 @@ export default function init(ngModule) {
     permission: 'admin',
     title: 'Alert Destinations',
     path: 'destinations',
+    order: 4,
   });
 
   ngModule.controller('DestinationsCtrl', DestinationsCtrl);

--- a/client/app/pages/query-snippets/list.js
+++ b/client/app/pages/query-snippets/list.js
@@ -16,6 +16,7 @@ export default function init(ngModule) {
     permission: 'create_query',
     title: 'Query Snippets',
     path: 'query_snippets',
+    order: 5,
   });
 
   ngModule.component('snippetsListPage', {

--- a/client/app/pages/settings/organization.js
+++ b/client/app/pages/settings/organization.js
@@ -24,6 +24,7 @@ export default function init(ngModule) {
     permission: 'admin',
     title: 'Settings',
     path: 'settings/organization',
+    order: 6,
   });
 
   ngModule.component('organizationSettingsPage', {

--- a/client/app/pages/users/show.js
+++ b/client/app/pages/users/show.js
@@ -114,6 +114,7 @@ export default function init(ngModule) {
   settingsMenu.add({
     title: 'Account',
     path: 'users/me',
+    order: 7,
   });
 
   ngModule.controller('UserCtrl', UserCtrl);


### PR DESCRIPTION
Tabs with `order` property were sorted using it; other tabs were placed after them. This fix adds `order` property to all tabs - it makes tab order predictable (it will help when adding new tabs).