### PR TITLE
Custom CSS based on column type

### DIFF
--- a/client/app/components/dynamic-table/default-cell/template.html
+++ b/client/app/components/dynamic-table/default-cell/template.html
@@ -1,4 +1,4 @@
-<td ng-class="'content-align-' + column.alignContent">
+<td ng-class="'content-align-' + column.alignContent + ' display-as-' + column.displayAs">
   <div ng-if="allowHTML" ng-bind-html="value"></div>
   <div ng-if="!allowHTML" ng-bind="value"></div>
 </td>

--- a/client/app/components/dynamic-table/dynamic-table.html
+++ b/client/app/components/dynamic-table/dynamic-table.html
@@ -3,8 +3,7 @@
     <thead>
       <tr>
         <th ng-repeat="column in $ctrl.columns" ng-click="$ctrl.onColumnHeaderClick($event, column)"
-          class="sortable-column" ng-class="'content-align-' + column.alignContent"
-          width="{{ ['number', 'boolean', 'datetime', 'image'].indexOf(column.displayAs) >= 0 ? '1%' : undefined }}">
+          class="sortable-column" ng-class="'content-align-' + column.alignContent + ' display-as-' + column.displayAs">
           <span ng-if="($ctrl.orderBy.length > 1) && ($ctrl.orderByColumnsIndex[column.name] > 0)"
             class="sort-order-indicator">{{ $ctrl.orderByColumnsIndex[column.name] }}</span>
           <span>{{column.title}}</span>

--- a/client/app/components/dynamic-table/dynamic-table.less
+++ b/client/app/components/dynamic-table/dynamic-table.less
@@ -49,4 +49,12 @@
       }
     }
   }
+
+  .display-as-number,
+  .display-as-boolean,
+  .display-as-datetime,
+  .display-as-image {
+    width: 1%;
+    white-space: nowrap;
+  }
 }

--- a/client/app/components/dynamic-table/json-cell/template.html
+++ b/client/app/components/dynamic-table/json-cell/template.html
@@ -1,4 +1,4 @@
-<td>
+<td ng-class="'display-as-' + column.displayAs">
   <div ng-if="!isValid" class="json-cell-invalid">{{ value }}</div>
   <div ng-show="isValid" class="json-cell-valid"></div>
 </td>


### PR DESCRIPTION
Related to getredash/redash#2215

Allow to set styles for table cells based on column type (discussion here: getredash/redash/pull/2231). Currently sets minimal column width for `number`, `datetime`, `boolean` and `image` columns (was hard-coded in template), and disables word-wrapping on this columns (crucial for `numeric` and `datetime`).