### PR TITLE
Apply query format options from settings

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -30,7 +30,7 @@ def format_sql_query(org_slug=None):
     arguments = request.get_json(force=True)
     query = arguments.get("query", "")
 
-    return jsonify({'query': sqlparse.format(query, reindent=True, keyword_case='upper')})
+    return jsonify({'query': sqlparse.format(query, **settings.SQLPARSE_FORMAT_OPTIONS)})
 
 
 class QuerySearchResource(BaseResource):

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -223,6 +223,6 @@ ALLOW_PARAMETERS_IN_EMBEDS = parse_boolean(os.environ.get("REDASH_ALLOW_PARAMETE
 
 # sqlparse
 SQLPARSE_FORMAT_OPTIONS = {
-    'reindent': True,
-    'keyword_case': 'upper',
+    'reindent': parse_boolean(os.environ.get('SQLPARSE_FORMAT_REINDENT', 'true')),
+    'keyword_case': os.environ.get('SQLPARSE_FORMAT_KEYWORD_CASE', 'upper'),
 }

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -220,3 +220,9 @@ SCHEMA_RUN_TABLE_SIZE_CALCULATIONS = parse_boolean(os.environ.get("REDASH_SCHEMA
 # Allow Parameters in Embeds
 # WARNING: With this option enabled, Redash reads query parameters from the request URL (risk of SQL injection!)
 ALLOW_PARAMETERS_IN_EMBEDS = parse_boolean(os.environ.get("REDASH_ALLOW_PARAMETERS_IN_EMBEDS", "false"))
+
+# sqlparse
+SQLPARSE_FORMAT_OPTIONS = {
+    'reindent': True,
+    'keyword_case': 'upper',
+}


### PR DESCRIPTION
Hi, 

sqlparse has some [format options](http://sqlparse.readthedocs.io/en/latest/api/#formatting-of-sql-statements).

Query formatting rules are depends on team or some other reasons.
I think it is useful if these format options can be changed by settings.

Thank you
Takuya