### PR TITLE
Exporting query results as Google Spreadsheet

### DIFF
--- a/client/app/components/queries/query-results-link.js
+++ b/client/app/components/queries/query-results-link.js
@@ -22,6 +22,7 @@ function queryResultLink() {
             url = `api/query_results/${scope.queryResult.getId()}.${fileType}`;
           }
           element.attr('href', url);
+          if (fileType === 'spreadsheet') return;
           element.attr(
             'download',
             `${scope.query.name.replace(' ', '_') +

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -254,6 +254,11 @@
                   <span class="fa fa-file-excel-o"></span> Download as Excel File
                 </a>
               </li>
+              <li>
+                <a query-result-link file-type="spreadsheet" target="_blank">
+                  <span class="fa fa-file-o"></span> Export as Spreadsheet
+                </a>
+              </li>
             </ul>
           </div>
 

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -256,7 +256,7 @@
               </li>
               <li>
                 <a query-result-link file-type="spreadsheet" target="_blank">
-                  <span class="fa fa-file-o"></span> Export as Spreadsheet
+                  <span class="fa fa-file-o"></span> Export as Google Spreadsheet
                 </a>
               </li>
             </ul>

--- a/client/app/pages/settings/organization.html
+++ b/client/app/pages/settings/organization.html
@@ -1,4 +1,5 @@
 <settings-screen>
+    <p class="alert alert-danger" ng-if="!$ctrl.settings.google_spreadsheet_json_key_file">It looks like your JSON key file of Google Spreadsheet isn't submitted. Make sure to submit it for the JSON key file of Google Spreadsheet to work.</p>
     <div class="row">
         <div class="col-md-offset-4 col-md-4">
             <h3 class="m-t-0">General</h3>

--- a/client/app/pages/settings/organization.html
+++ b/client/app/pages/settings/organization.html
@@ -13,6 +13,16 @@
                 </select>
             </p>
             <hr>
+            <h3>Export</h3>
+            <h4>Spreadsheet</h4>
+            <form name="form" type="type" actions="actions">
+            <p>
+                <label>JSON Key File</label>
+                <input type="file" file-model ng-model="$ctrl.settings.google_spreadsheet_json_key_file" base-sixty-four-input class="form-control" accesskey="tab">
+                <button ng-click="$ctrl.submitJsonKeyFile()" class="btn btn-primary m-t-10">submit</button>
+            </p>
+            </form>
+            <hr>
             <h3>Authentication</h3>
             <p>
                 <label>

--- a/client/app/pages/settings/organization.html
+++ b/client/app/pages/settings/organization.html
@@ -14,7 +14,7 @@
             </p>
             <hr>
             <h3>Export</h3>
-            <h4>Spreadsheet</h4>
+            <h4>Google Spreadsheet</h4>
             <form name="form" type="type" actions="actions">
             <p>
                 <label>JSON Key File</label>

--- a/client/app/pages/settings/organization.js
+++ b/client/app/pages/settings/organization.js
@@ -27,6 +27,11 @@ function OrganizationSettingsCtrl($http, toastr, clientConfig, Events) {
 
   this.disablePasswordLoginToggle = () =>
     (clientConfig.googleLoginEnabled || this.settings.auth_saml_enabled) === false;
+
+  this.submitJsonKeyFile = () => {
+    this.settings.google_spreadsheet_json_key_file = this.settings.google_spreadsheet_json_key_file.base64;
+    this.update('google_spreadsheet_json_key_file');
+  };
 }
 
 export default function init(ngModule) {

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -261,7 +261,16 @@ class QueryResultResource(BaseResource):
 
     @staticmethod
     def make_spreadsheet_response(query_result, query_name, email, org):
-        url = query_result.make_spreadsheet(query_name, email, org)
+        url = ''
+        try:
+            url = query_result.make_spreadsheet(query_name, email, org)
+        except ValueError:
+            url = '/settings/organization'
+            logging.error("JSON key file of Google Spreadsheet doesn't exist or wrong.")
+        except Exception, e:
+            logging.error("Something wrong error. " + str(e))
+            abort(500, message='Something wrong error.')
+
         return redirect(url)
 
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -3,7 +3,7 @@ import json
 import time
 
 import pystache
-from flask import make_response, request
+from flask import make_response, request, redirect
 from flask_login import current_user
 from flask_restful import abort
 from redash import models, settings, utils
@@ -227,6 +227,9 @@ class QueryResultResource(BaseResource):
                 response = self.make_json_response(query_result)
             elif filetype == 'xlsx':
                 response = self.make_excel_response(query_result)
+            elif filetype == 'spreadsheet':
+                response = self.make_spreadsheet_response(query_result, query.name,
+                                                          current_user.email, self.current_org)
             else:
                 response = self.make_csv_response(query_result)
 
@@ -255,6 +258,11 @@ class QueryResultResource(BaseResource):
     def make_excel_response(query_result):
         headers = {'Content-Type': "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}
         return make_response(query_result.make_excel_content(), 200, headers)
+
+    @staticmethod
+    def make_spreadsheet_response(query_result, query_name, email, org):
+        url = query_result.make_spreadsheet(query_name, email, org)
+        return redirect(url)
 
 
 class JobResource(BaseResource):

--- a/redash/models.py
+++ b/redash/models.py
@@ -791,11 +791,11 @@ class QueryResult(db.Model, BelongsToOrgMixin):
         key_file = org.get_setting('google_spreadsheet_json_key_file')
         key = json.loads(b64decode(key_file))
         creds = ServiceAccountCredentials.from_json_keyfile_dict(key, scope)
-        gc = gspread.authorize(creds)
 
-        sh = gc.create(query_name)
+        sh = gspread.authorize(creds).create(query_name)
         sh.share(email, perm_type='user', role='owner')
         worksheet = sh.get_worksheet(0)
+
         data = json.loads(self.data)
         columns = data['columns']
         rows = data['rows']

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -23,5 +23,6 @@ settings = {
     "auth_saml_entity_id": SAML_ENTITY_ID,
     "auth_saml_metadata_url": SAML_METADATA_URL,
     "auth_saml_nameid_format": SAML_NAMEID_FORMAT,
-    "date_format": DATE_FORMAT
+    "date_format": DATE_FORMAT,
+    "google_spreadsheet_json_key_file": ""
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,8 @@ simplejson==3.10.0
 ua-parser==0.7.3 
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
+gspread==0.6.2
+oauth2client==3.0.0
 # Uncomment the requirement for ldap3 if using ldap.
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,9 +1,7 @@
 google-api-python-client==1.5.1
-gspread==0.6.2
 impyla==0.10.0
 influxdb==2.7.1
 MySQL-python==1.2.5
-oauth2client==3.0.0
 pyhive==0.3.0
 pymongo==3.2.1
 vertica-python==0.5.1


### PR DESCRIPTION
In order to export query results to Google Spreadsheet, calling [IMPORTDATA](https://support.google.com/docs/answer/3093335?hl=en) with CSV format URL from Spreadsheet is the easiest way. However, the way is needed to make access public to allow access from Google.

This feature is export query results by using Google Spreadsheet API and add you as the owner. Also, after you export results, then open the sheet page.

## Steps to use

1. Submit **JSON Key File** which has `https://spreadsheets.google.com/feeds` and `https://www.googleapis.com/auth/drive` scope of Google Spreadsheet  at settings page
1. Run a query and get the result
1. Click **Export button** on query page

## Screenshot

**Export button on query page**

"Download" label may not be an appropriate name.

| Before | After |
| ------- | ------ |
| <img width="200" alt="download_before" src="https://user-images.githubusercontent.com/3317191/36642283-a79d2c6e-1a80-11e8-8535-8e1ff0c462d5.png"> | <img width="208" alt="download_after" src="https://user-images.githubusercontent.com/3317191/36642284-b1b690dc-1a80-11e8-9a7d-48120b16a63f.png"> |

**JSON key file input on settings page**

| Before | After |
| ------- | ------ |
| <img width="300" alt="settings_before" src="https://user-images.githubusercontent.com/3317191/36642336-76d1d340-1a81-11e8-815a-bfa16ff35e9f.png">  | <img width="300" alt="settings_after" src="https://user-images.githubusercontent.com/3317191/36642314-22d8147a-1a81-11e8-9fcc-9be4e48a60ba.png"> |