### PR TITLE
Authentication fixes (SAML and login page)

### DIFF
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -20,7 +20,7 @@ def get_saml_client(org):
     """
     metadata_url = org.get_setting("auth_saml_metadata_url")
     entity_id = org.get_setting("auth_saml_entity_id")
-    acs_url = url_for("saml_auth.idp_initiated", _external=True)
+    acs_url = url_for("saml_auth.idp_initiated", org_slug=org.slug, _external=True)
 
     saml_settings = {
         'metadata': {
@@ -61,10 +61,10 @@ def get_saml_client(org):
 
 
 @blueprint.route(org_scoped_rule('/saml/callback'), methods=['POST'])
-def idp_initiated():
+def idp_initiated(org_slug=None):
     if not current_org.get_setting("auth_saml_enabled"):
         logger.error("SAML Login is not enabled")
-        return redirect(url_for('redash.index'))
+        return redirect(url_for('redash.index', org_slug=org_slug))
 
     saml_client = get_saml_client(current_org)
     authn_response = saml_client.parse_authn_request_response(
@@ -84,16 +84,16 @@ def idp_initiated():
         group_names = authn_response.ava.get('RedashGroups')
         user.update_group_assignments(group_names)
 
-    url = url_for('redash.index')
+    url = url_for('redash.index', org_slug=org_slug)
 
     return redirect(url)
 
 
 @blueprint.route(org_scoped_rule("/saml/login"))
-def sp_initiated():
+def sp_initiated(org_slug=None):
     if not current_org.get_setting("auth_saml_enabled"):
         logger.error("SAML Login is not enabled")
-        return redirect(url_for('redash.index'))
+        return redirect(url_for('redash.index', org_slug=org_slug))
 
     saml_client = get_saml_client(current_org)
     nameid_format = current_org.get_setting('auth_saml_nameid_format')

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -111,16 +111,6 @@ def login(org_slug=None):
     if current_user.is_authenticated:
         return redirect(next_path)
 
-    if not current_org.get_setting('auth_password_login_enabled'):
-        if settings.REMOTE_USER_LOGIN_ENABLED:
-            return redirect(url_for("remote_user_auth.login", next=next_path))
-        elif current_org.get_setting('auth_saml_enabled'):  # settings.SAML_LOGIN_ENABLED:
-            return redirect(url_for("saml_auth.sp_initiated", next=next_path))
-        elif settings.LDAP_LOGIN_ENABLED:
-            return redirect(url_for("ldap_auth.login", next=next_path))
-        else:
-            return redirect(get_google_auth_url(next_path))
-
     if request.method == 'POST':
         try:
             org = current_org._get_current_object()
@@ -142,6 +132,7 @@ def login(org_slug=None):
                            email=request.form.get('email', ''),
                            show_google_openid=settings.GOOGLE_OAUTH_ENABLED,
                            google_auth_url=google_auth_url,
+                           show_password_login=current_org.get_setting('auth_password_login_enabled'),
                            show_saml_login=current_org.get_setting('auth_saml_enabled'),
                            show_remote_user_login=settings.REMOTE_USER_LOGIN_ENABLED,
                            show_ldap_login=settings.LDAP_LOGIN_ENABLED)

--- a/redash/handlers/organization.py
+++ b/redash/handlers/organization.py
@@ -9,7 +9,6 @@ from redash.permissions import require_admin
 
 
 @routes.route(org_scoped_rule('/api/organization/status'), methods=['GET'])
-@require_admin
 @login_required
 def organization_status(org_slug=None):
     counters = {

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -32,6 +32,7 @@
       <a href="{{ url_for('ldap_auth.login', next=next) }}" class="login-button btn btn-default btn-block">LDAP/SSO Login</a>
     {% endif %}
 
+    {% if show_password_login %}
     {% if show_google_openid or show_saml_login or show_remote_user_login or show_ldap_login %}
       <hr>
     {% endif %}
@@ -49,11 +50,11 @@
 
       <button type="submit" class="btn btn-primary btn-block m-t-25">Log In</button>
     </form>
-
     {% if not hide_forgot_password %}
       <div class="m-t-25">
         <a href="{{ url_for("redash.forgot_password", org_slug=org_slug) }}">I forgot my password</a>
       </div>
+    {% endif %}
     {% endif %}
   </div>
 </div>

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -21,15 +21,15 @@
     {% endif %}
 
     {% if show_saml_login %}
-      <a href="/saml/login" class="login-button btn btn-default btn-block">SAML Login</a>
+      <a href="{{ url_for('saml_auth.sp_initiated', org_slug=org_slug, next=next) }}" class="login-button btn btn-default btn-block">SAML Login</a>
     {% endif %}
 
     {% if show_remote_user_login %}
-      <a href="/remote_user/login" class="login-button btn btn-default btn-block">Remote User Login</a>
+      <a href="{{ url_for('remote_user_auth.login', next=next) }}" class="login-button btn btn-default btn-block">Remote User Login</a>
     {% endif %}
 
     {% if show_ldap_login %}
-      <a href="/ldap_auth/login" class="login-button btn btn-default btn-block">LDAP/SSO Login</a>
+      <a href="{{ url_for('ldap_auth.login', next=next) }}" class="login-button btn btn-default btn-block">LDAP/SSO Login</a>
     {% endif %}
 
     {% if show_google_openid or show_saml_login or show_remote_user_login or show_ldap_login %}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -83,14 +83,6 @@ class TestLogin(BaseTestCase):
     def tearDownClass(cls):
         settings.ORG_RESOLVING = "multi_org"
 
-    def test_redirects_to_google_login_if_password_disabled(self):
-        self.factory.org.set_setting('auth_password_login_enabled', False)
-        with self.app.test_request_context('/default/login'):
-            rv = self.client.get('/default/login')
-            self.assertEquals(rv.status_code, 302)
-            self.assertTrue(rv.location.endswith(url_for('google_oauth.authorize', next='/default/')))
-        self.factory.org.set_setting('auth_password_login_enabled', True)
-
     def test_get_login_form(self):
         rv = self.client.get('/default/login')
         self.assertEquals(rv.status_code, 200)


### PR DESCRIPTION
* Always show login page, even if password based login disabled.
* Make SAML work in MULTI_ORG mode.
* Generate URLs with `url_for` (should fix #2235).