### PR TITLE
Fix: download dataset dropup is being cut off

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -243,7 +243,7 @@
               uib-dropdown-toggle aria-expanded="false">
               Download <span class="hidden-xs">Dataset </span><span class="caret"></span>
             </button>
-            <ul class="dropdown-menu pull-right" uib-dropdown-menu>
+            <ul class="dropdown-menu" ng-class="{'pull-right': !query.isNew()}" uib-dropdown-menu>
               <li>
                 <a query-result-link target="_self">
                   <span class="fa fa-file-o"></span> Download as CSV File


### PR DESCRIPTION
New query page: `Download dataset` drop-up is being cut off by nearby div 

![screenshot](https://photos-5.dropbox.com/t/2/AACdYVQbUBvMrpl-FqdjcZpfWnlNdiLGOhvCmCbitpfsRQ/12/2186704/png/32x32/3/1519754400/0/2/screenshot_2018-02-26_09-48-53.png/EKGX3QEY26mZKiAHKAc/TlTGPVafNBmhWPNdyyiafjutwiJXfMnqRS1Ip_MKJdI?dl=0&preserve_transparency=1&size=2048x1536&size_mode=3)

Fix: do not add `pull-right` class while query is not saved (see screenshots):

![image](https://user-images.githubusercontent.com/12139186/36731245-d608f044-1bd2-11e8-9b1e-85cac4fa465f.png)

![image](https://user-images.githubusercontent.com/12139186/36731198-af6ac75a-1bd2-11e8-8844-bec1688828e1.png)
