### PR TITLE
Add a Redash extension system based on Python entrypoints.

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -91,7 +91,7 @@ class SlugConverter(BaseConverter):
 
 
 def create_app(load_admin=True):
-    from redash import handlers
+    from redash import extensions, handlers
     from redash.handlers.webpack import configure_webpack
     from redash.admin import init_admin
     from redash.models import db
@@ -137,5 +137,5 @@ def create_app(load_admin=True):
     limiter.init_app(app)
     handlers.init_app(app)
     configure_webpack(app)
-
+    extensions.init_extensions(app)
     return app

--- a/redash/extensions.py
+++ b/redash/extensions.py
@@ -1,0 +1,14 @@
+from pkg_resources import iter_entry_points
+
+
+def init_extensions(app):
+    """
+    Load the Redash extensions for the given Redash Flask app.
+    """
+    if not hasattr(app, 'redash_extensions'):
+        app.redash_extensions = {}
+
+    for entry_point in iter_entry_points('redash.extensions'):
+        app.logger.info('Loading Redash extension %s.', entry_point.name)
+        extension = entry_point.load()
+        app.redash_extensions[entry_point.name] = extension(app)


### PR DESCRIPTION
This is along the lines of what Flask does for CLI plugins:

  http://flask.pocoo.org/docs/0.12/cli/#cli-plugins

The API allows specifying Python callbacks that receive the
Redash Flask app as the only argument and allow extending
the Redash process with the usual Flask API as needed. This
does not cover front-end specific extensions (yet).

This is a backport from https://github.com/mozilla/redash/pull/348
that should make our lives at Mozilla easier and maybe lead to
a more extensible Redash code base.

A suggested path forward would be investigating additional
extension points for adding front-end components/pages and
query runners (e.g. the Cassandra query runner which slows
build time down a lot).