### PR TITLE
Add support for TLS connections to redis

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import urlparse
 import urllib
-import redis
+from redis import StrictRedis
 from flask import Flask, safe_join
 from flask_sslify import SSLify
 from werkzeug.contrib.fixers import ProxyFix
@@ -39,26 +39,7 @@ def setup_logging():
 
 def create_redis_connection():
     logging.debug("Creating Redis connection (%s)", settings.REDIS_URL)
-    redis_url = urlparse.urlparse(settings.REDIS_URL)
-
-    if redis_url.scheme == 'redis+socket':
-        qs = urlparse.parse_qs(redis_url.query)
-        if 'virtual_host' in qs:
-            db = qs['virtual_host'][0]
-        else:
-            db = 0
-
-        r = redis.StrictRedis(unix_socket_path=redis_url.path, db=db)
-    else:
-        if redis_url.path:
-            redis_db = redis_url.path[1]
-        else:
-            redis_db = 0
-        # Redis passwords might be quoted with special characters
-        redis_password = redis_url.password and urllib.unquote(redis_url.password)
-        r = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_password)
-
-    return r
+    return StrictRedis.from_url(settings.REDIS_URL)
 
 
 setup_logging()


### PR DESCRIPTION
The current method does not allow secure redis `rediss://`

```
redash@1dfd88a3e15e:/app$ bin/docker-entrypoint shell                                                                                                
[2018-03-01 18:20:54,568][PID:160][INFO][root] Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt                                                                                                                     
[2018-03-01 18:20:54,593][PID:160][INFO][root] Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt                                                                                                                   Traceback (most recent call last):                                                                                                                                                                                                              File "/app/manage.py", line 6, in <module>                                                                                                                                                                                                      from redash.cli import manager                                                                                                                                                                                                              File "/app/redash/__init__.py", line 74, in <module>                                                                                                                                                                                            reset_new_version_status()                                                                                                                                                                                                               
  File "/app/redash/version_check.py", line 34, in reset_new_version_status
    latest_version = get_latest_version()                                                                  
  File "/app/redash/version_check.py", line 40, in get_latest_version                                                                                                                                                                    
    return redis_connection.get(REDIS_KEY)                                                                                                                                                                                               
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 880, in get
    return self.execute_command('GET', name)                                                                                                                                                                                                 
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 578, in execute_command
    connection.send_command(*args)                             
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 563, in send_command
    self.send_packed_command(self.pack_command(*args))                     
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 538, in send_packed_command
    self.connect()                                              
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 446, in connect                                                                                                                                                         self.on_connect()                                                                                                                                                                                                                        
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 514, in on_connect                                                                                                                                                      if nativestr(self.read_response()) != 'OK':                                                                             
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 577, in read_response                                                                                                                                              
    response = self._parser.read_response()                                  
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 238, in read_response                            
    response = self._buffer.readline()                                                                                                                                                                                                          File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 168, in readline
    self._read_from_socket()    
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 143, in _read_from_socket
    (e.args,))                     
redis.exceptions.ConnectionError: Error while reading from socket: (104, 'Connection reset by peer')
```

After this change:

```
redash@a29e20353e5d:/app$ bin/docker-entrypoint shell
[GCC 5.4.0 20160609] on linux2
App: redash
Instance: /app/instance
```