### PR TITLE
[Alternative] Change multi-filter behavior and fix dashboard multi-filter bug

### DIFF
--- a/client/app/components/filters.html
+++ b/client/app/components/filters.html
@@ -11,7 +11,7 @@
         </ui-select-choices>
       </ui-select>
 
-      <ui-select ng-model="filter.current" multiple ng-if="filter.multiple" on-select="$ctrl.filterChangeListener(filter, $model)"
+      <ui-select ng-model="filter.current" multiple ng-if="filter.multiple" on-select="$ctrl.multiFilterChangeListener(filter, $model)"
                  on-remove="$ctrl.filterChangeListener(filter, $model)" remove-selected="false">
         <ui-select-match placeholder="Select value for {{filter.friendlyName}}...">{{$item | filterValue:filter}}</ui-select-match>
         <ui-select-choices repeat="value in filter.values | filter: $select.search" group-by="$ctrl.itemGroup">

--- a/client/app/components/filters.js
+++ b/client/app/components/filters.js
@@ -1,3 +1,4 @@
+import { includes } from 'underscore';
 import template from './filters.html';
 
 const FiltersComponent = {
@@ -13,13 +14,17 @@ const FiltersComponent = {
       this.onChange({ filter, $modal: modal });
     };
 
-    this.itemGroup = (item) => {
-      if (item === '*' || item === '-') {
-        return '';
+    this.multiFilterChangeListener = (filter, modal) => {
+      if (modal === '-') {
+        filter.current = [];
+      } else if (modal === '*') {
+        filter.current = filter.values.slice(2);
       }
 
-      return 'Values';
+      this.onChange({ filter, $modal: modal });
     };
+
+    this.itemGroup = item => (includes(['*', '-'], item) ? '' : 'Values');
   },
 };
 

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import moment from 'moment';
-import { sortBy, uniq, contains, values, some, each, isArray, isNumber, isString, includes } from 'underscore';
+import { sortBy, uniq, contains, values, some, each, isArray, isNumber, isString } from 'underscore';
 
 const logger = debug('redash:services:QueryResult');
 const filterTypes = ['filter', 'multi-filter', 'multiFilter'];
@@ -210,16 +210,6 @@ function QueryResultService($resource, $timeout, $q) {
         this.filterFreeze = filterFreeze;
 
         if (filters) {
-          filters.forEach((filter) => {
-            if (filter.multiple && includes(filter.current, ALL_VALUES)) {
-              filter.current = filter.values.slice(2);
-            }
-
-            if (filter.multiple && includes(filter.current, NONE_VALUES)) {
-              filter.current = [];
-            }
-          });
-
           this.filteredData = this.query_result.data.rows.filter(row =>
             filters.reduce((memo, filter) => {
               if (!isArray(filter.current)) {

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -372,9 +372,10 @@ function QueryResultService($resource, $timeout, $q) {
       this.getRawData().forEach((row) => {
         filters.forEach((filter) => {
           filter.values.push(row[filter.name]);
+
           if (filter.values.length === 1) {
             if (filter.multiple) {
-              filter.current = [row[filter.name]];
+              filter.current = [];
             } else {
               filter.current = row[filter.name];
             }

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -216,6 +216,10 @@ function QueryResultService($resource, $timeout, $q) {
                 filter.current = [filter.current];
               }
 
+              if (filter.current.length === 0) {
+                return memo;
+              }
+
               return (memo && some(filter.current, (v) => {
                 const value = row[filter.name];
                 if (moment.isMoment(value)) {


### PR DESCRIPTION
Alternative to this: https://github.com/getredash/redash/pull/2262
I prefer this one better.
We could keep one and close the other.

Before
===
![](https://user-images.githubusercontent.com/16881036/35444321-8afbf730-02f1-11e8-86a2-ac9e64f84bc3.png)
* Dashboard level multi-filter acts weird

After
===
change Clear behavior (Thanks to darylerwin's idea)
---
![image](https://user-images.githubusercontent.com/16881036/36003894-3e846d10-0d73-11e8-976b-dedc12ede3ea.png)
* Multi-filter `Clear` removes all tag but shows all data
* Dashboard-level multi-filter and queryResult-level multi-filter synced
* Default value for multi-filter becomes NON_VALUE
