### PR TITLE
Fix docker-entrypoint broke for other name than "postgres"

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -23,7 +23,16 @@ server() {
 }
 
 create_db() {
-  while ! bash -c "echo > /dev/tcp/postgres/5432" &> /dev/null ; do
+  DATABASE_FULLURL=$(echo $REDASH_DATABASE_URL |cut -d '@' -f2 |sed 's,/.*,,g')
+
+  if [[ $DATABASE_FULLURL = *":"* ]]; then
+    DATABASE_URL=$(echo $DATABASE_FULLURL |cut -d ':' -f1)
+    DATABASE_PORT=$(echo $DATABASE_FULLURL |cut -d ':' -f2)
+  else 
+    DATABASE_URL=$(echo $DATABASE_FULLURL)
+    DATABASE_PORT="5432"
+  fi 
+  while ! bash -c "echo > /dev/tcp/$DATABASE_URL/$DATABASE_PORT" &> /dev/null ; do
     echo "Waiting for PostgreSQL container to become available."
     sleep 5
   done
@@ -97,3 +106,4 @@ case "$1" in
     exec "$@"
     ;;
 esac
+

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -23,19 +23,6 @@ server() {
 }
 
 create_db() {
-  DATABASE_FULLURL=$(echo $REDASH_DATABASE_URL |cut -d '@' -f2 |sed 's,/.*,,g')
-
-  if [[ $DATABASE_FULLURL = *":"* ]]; then
-    DATABASE_URL=$(echo $DATABASE_FULLURL |cut -d ':' -f1)
-    DATABASE_PORT=$(echo $DATABASE_FULLURL |cut -d ':' -f2)
-  else 
-    DATABASE_URL=$(echo $DATABASE_FULLURL)
-    DATABASE_PORT="5432"
-  fi 
-  while ! bash -c "echo > /dev/tcp/$DATABASE_URL/$DATABASE_PORT" &> /dev/null ; do
-    echo "Waiting for PostgreSQL container to become available."
-    sleep 5
-  done
   exec /app/manage.py database create_tables
 }
 


### PR DESCRIPTION
This commit broke our Redash installation because we use other name than "Postgres" : 

https://github.com/getredash/redash/commit/aa06e44ff8330bd4e79ef7fcd7b1390016d80a34#diff-c1111bd512b29e821b120b86446026b8

I think using the REDASH_DATABASE_URL env variable to make this check is better ? 

What do you think ? 