### PR TITLE
Add other aggregation and target value setting to counter

### DIFF
--- a/client/app/visualizations/counter/counter-editor.html
+++ b/client/app/visualizations/counter/counter-editor.html
@@ -24,8 +24,14 @@
       <label class="col-lg-6">Target Value Column Name</label>
       <div class="col-lg-6">
         <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.targetColName" class="form-control">
-          <option value="">No target value</option>
+          <option value="">Use no column</option>
         </select>
+      </div>
+    </div>
+    <div class="form-group" ng-if="!visualization.options.targetColName">
+      <label class="col-lg-6">Specify target Value</label>
+      <div class="col-lg-6">
+        <input type="number" ng-model="visualization.options.targetValue" class="form-control">
       </div>
     </div>
     <div class="form-group" ng-if="visualization.options.targetColName">

--- a/client/app/visualizations/counter/counter-editor.html
+++ b/client/app/visualizations/counter/counter-editor.html
@@ -11,7 +11,7 @@
     <div class="form-group">
       <label class="col-lg-6">Counter Value Column Name</label>
       <div class="col-lg-6">
-        <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.counterColName" class="form-control" ng-disabled="visualization.options.countRow"></select>
+        <select ng-options="name for name in queryResult.getColumnNames()" ng-model="visualization.options.counterColName" class="form-control"></select>
       </div>
     </div>
     <div class="form-group">
@@ -42,8 +42,15 @@
     </div>
     <div class="form-group">
       <div class="col-lg-6">
-        <input type="checkbox" ng-model="visualization.options.countRow">
-        <i class="input-helper"></i> Count Rows
+        <input type="checkbox" ng-model="visualization.options.aggregateRow">
+        <i class="input-helper"></i> Aggregate Rows
+      </div>
+    </div>
+    <div class="form-group" ng-if="visualization.options.aggregateRow">
+      <label class="col-lg-6">Aggregation method</label>
+      <div class="col-lg-6">
+        <select ng-options="method for method in availableAggregations" ng-model="visualization.options.aggregationMethod" class="form-control">
+        </select>
       </div>
     </div>
   </div>

--- a/client/app/visualizations/counter/index.js
+++ b/client/app/visualizations/counter/index.js
@@ -72,7 +72,7 @@ function CounterRenderer($timeout) {
               $scope.trendPositive = $scope.delta >= 0;
             }
           } else {
-            $scope.targetValue = null;
+            $scope.targetValue = $scope.visualization.options.targetValue;
           }
 
           $scope.isNumber = _.isNumber($scope.counterValue);
@@ -151,6 +151,7 @@ export default function init(ngModule) {
     const defaultOptions = {
       counterColName: 'counter',
       rowNumber: 1,
+      targetValue: null,
       targetRowNumber: 1,
       stringDecimal: 0,
       stringDecChar: '.',


### PR DESCRIPTION
Before
===

![image](https://user-images.githubusercontent.com/16881036/37238060-4d733cde-2461-11e8-9080-07be470724ee.png)

After
===
![image](https://user-images.githubusercontent.com/16881036/37238071-923d85cc-2461-11e8-932d-f9e5ec52032c.png)

Diff
===
- Allow specifying target value directly in couonter viz edit
  - Activated when selected `Use no column`, (used to be `No target Value`)
  - Target value disabled when specifying null
- Change count rows to aggregate rows and add support for sum and average
  - Backward support rowCounter

I'm not sure what's the best plan here to handle the rowCounter setting. I chose the current plan because
- I think the parameter name should be changed to make it easier to understand.
- I also want to have a smooth migrate from the former `rowCounter` that users don't have to do any new setup