### PR TITLE
Webpack: ignore vim swap files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,6 +153,9 @@ const config = {
     modules: false,
     chunkModules: false,
   },
+  watchOptions: {
+    ignored: /\.sw.$/,
+  },
   devServer: {
     inline: true,
     index: '/static/index.html',


### PR DESCRIPTION
Change webpack-dev-server behavior to ignore vim swap files.