### PR TITLE
add environment vairable REDASH_CELERY_TIMEZONE

### DIFF
--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -34,6 +34,7 @@ SQLALCHEMY_ECHO = False
 CELERY_BROKER = os.environ.get("REDASH_CELERY_BROKER", REDIS_URL)
 CELERY_BACKEND = os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER)
 CELERY_TASK_RESULT_EXPIRES = int(os.environ.get('REDASH_CELERY_TASK_RESULT_EXPIRES', 3600 * 4))
+CELERY_TIMEZONE = os.environ.get("REDASH_CELERY_TIMEZONE", 'UTC')
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -46,7 +46,7 @@ if settings.QUERY_RESULTS_CLEANUP_ENABLED:
 
 celery.conf.update(CELERY_RESULT_BACKEND=settings.CELERY_BACKEND,
                    CELERYBEAT_SCHEDULE=celery_schedule,
-                   CELERY_TIMEZONE='UTC',
+                   CELERY_TIMEZONE=settings.CELERY_TIMEZONE,
                    CELERY_TASK_RESULT_EXPIRES=settings.CELERY_TASK_RESULT_EXPIRES,
                    CELERYD_LOG_FORMAT=settings.CELERYD_LOG_FORMAT,
                    CELERYD_TASK_LOG_FORMAT=settings.CELERYD_TASK_LOG_FORMAT)


### PR DESCRIPTION
I would like to add functionality to Celery 's TIMEZONE other than UTC, is it the way of this approach? Or is there a better way?

Or is it included in this PR https://github.com/getredash/redash/pull/1990?

Thanks.