### PR TITLE
Add a Mattermost option for alert destinations

### DIFF
--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -1,0 +1,40 @@
+import logging
+import requests
+
+from redash.destinations import *
+from redash.utils import json_dumps
+
+
+class Mattermost(BaseDestination):
+    @classmethod
+    def configuration_schema(cls):
+        return {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                }
+            },
+            "required": ["url"]
+        }
+
+    @classmethod
+    def icon(cls):
+        return 'fa-bolt'
+
+    def notify(self, alert, query, user, new_state, app, host, options):
+        try:
+            data = {
+                'text': alert.name + " just triggered",
+                'url_base': host 
+            }
+            headers = {'Content-Type': 'application/json'}
+            auth = None
+            resp = requests.post(options.get('url'), data=json_dumps(data), auth=auth, headers=headers)
+            if resp.status_code != 200:
+                logging.error("Mattermost webhook send ERROR. status_code => {status}".format(status=resp.status_code))
+        except Exception:
+            logging.exception("Mattermost webhook send ERROR.")
+
+
+register(Mattermost)

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -185,6 +185,7 @@ default_destinations = [
     'redash.destinations.slack',
     'redash.destinations.webhook',
     'redash.destinations.hipchat',
+    'redash.destinations.mattermost',
 ]
 
 enabled_destinations = array_from_string(os.environ.get("REDASH_ENABLED_DESTINATIONS", ",".join(default_destinations)))


### PR DESCRIPTION
Mattermost is an open source alternative to Slack. Webhooks are supported, using a specific format for the payload.

This PR adds the compatibilty with Mattermost for setting up alert destinations and adds and entry in the list of available options, as shown below:

![capture du 2018-03-16 15-34-27](https://user-images.githubusercontent.com/884520/37526408-8beb0aa0-292f-11e8-8d19-11bcff548121.png)
