### PR TITLE
Update mssql_odbc.py

### DIFF
--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -118,10 +118,10 @@ class SQLServerODBC(BaseSQLQueryRunner):
             charset = self.configuration.get('charset', 'UTF-8')
             driver = self.configuration.get('driver', '{ODBC Driver 13 for SQL Server}')
 
-            connection_string_fmt = 'DRIVER={};PORT={};SERVER={};DATABASE={};UID={};PWD={}'
+            connection_string_fmt = 'DRIVER={};SERVER={},{};DATABASE={};UID={};PWD={}'
             connection_string = connection_string_fmt.format(driver,
-                                                             port,
                                                              server,
+                                                             port,
                                                              db,
                                                              user,
                                                              password)


### PR DESCRIPTION
In case of Microsoft ODBC Driver for SQL Server on Linux, it need to be set like below,
Server = [protocol:]server[,port]  
https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/connection-string-keywords-and-data-source-names-dsns