### PR TITLE
Fix max_age behavior on embed graphs

### DIFF
--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -1,69 +1,14 @@
 from __future__ import absolute_import
-import logging
-import time
 
-import pystache
 from flask import request
 
 from .authentication import current_org
 from flask_login import current_user, login_required
-from flask_restful import abort
-from redash import models, utils
+from redash import models
 from redash.handlers import routes
 from redash.handlers.base import (get_object_or_404, org_scoped_rule,
                                   record_event)
-from redash.handlers.query_results import collect_query_parameters
 from redash.handlers.static import render_index
-from redash.utils import gen_query_hash
-
-
-#
-# Run a parameterized query synchronously and return the result
-# DISCLAIMER: Temporary solution to support parameters in queries. Should be
-#             removed once we refactor the query results API endpoints and handling
-#             on the client side. Please don't reuse in other API handlers.
-#
-def run_query_sync(data_source, parameter_values, query_text, max_age=0):
-    query_parameters = set(collect_query_parameters(query_text))
-    missing_params = set(query_parameters) - set(parameter_values.keys())
-    if missing_params:
-        raise Exception('Missing parameter value for: {}'.format(", ".join(missing_params)))
-
-    if query_parameters:
-        query_text = pystache.render(query_text, parameter_values)
-
-    if max_age <= 0:
-        query_result = None
-    else:
-        query_result = models.QueryResult.get_latest(data_source, query_text, max_age)
-
-    query_hash = gen_query_hash(query_text)
-
-    if query_result:
-        logging.info("Returning cached result for query %s" % query_hash)
-        return query_result.data
-
-    try:
-        started_at = time.time()
-        data, error = data_source.query_runner.run_query(query_text, current_user)
-
-        if error:
-            return None
-        # update cache
-        if max_age > 0:
-            run_time = time.time() - started_at
-            query_result, updated_query_ids = models.QueryResult.store_result(data_source.org_id, data_source.id,
-                                                                              query_hash, query_text, data,
-                                                                              run_time, utils.utcnow())
-
-            models.db.session.commit()
-        return data
-    except Exception:
-        if max_age > 0:
-            abort(404, message="Unable to get result from the database, and no cached query result found.")
-        else:
-            abort(503, message="Unable to get result from the database.")
-        return None
 
 
 @routes.route(org_scoped_rule('/embed/query/<query_id>/visualization/<visualization_id>'), methods=['GET'])

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -104,7 +104,7 @@ class QueryResultListResource(BaseResource):
 
         :qparam string query: The query text to execute
         :qparam number query_id: The query object to update with the result (optional)
-        :qparam number max_age: If query results less than `max_age` seconds old are available, return them, otherwise execute the query; if omitted, always execute
+        :qparam number max_age: If query results less than `max_age` seconds old are available, return them, otherwise execute the query; set to -1 return latest indepenent of max_age; if omitted, -1
         :qparam number data_source_id: ID of data source to query
         """
         params = request.get_json(force=True)

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -33,7 +33,7 @@ def run_query_sync(data_source, parameter_values, query_text, max_age=0):
     if query_parameters:
         query_text = pystache.render(query_text, parameter_values)
 
-    if max_age <= 0:
+    if max_age == 0:
         query_result = None
     else:
         query_result = models.QueryResult.get_latest(data_source, query_text, max_age)
@@ -179,7 +179,7 @@ class QueryResultResource(BaseResource):
         should_cache = query_result_id is not None
 
         parameter_values = collect_parameters_from_request(request.args)
-        max_age = int(request.args.get('maxAge', 0))
+        max_age = int(request.args.get('max_age', -1))
 
         query_result = None
 


### PR DESCRIPTION
The behavior for the `max_age` parameter when doing a `POST` or `GET` with parameters on QueryResults was different. This PR makes it so that max_age of
- -1: Always return the last query result independent of age.
- 0: Execute the query.
- \> 0: Try to get latest query not older than max_age, else execute query.

I'd love some pointers on how to add tests for this.