### PR TITLE
Multiple V4 regression fixes

### DIFF
--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -1,5 +1,5 @@
 <div class="widget-wrapper">
-  <div class="tile body-container" ng-if="$ctrl.type=='visualization'" ng-class="$ctrl.type"
+  <div class="tile body-container widget-visualization" ng-if="$ctrl.type=='visualization'" ng-class="$ctrl.type"
     ng-switch="$ctrl.queryResult.getStatus()">
     <div class="body-row">
       <div class="t-header widget clearfix">
@@ -41,7 +41,7 @@
     <div ng-switch-when="failed" class="body-row-auto scrollbox">
       <div class="alert alert-danger m-5" ng-show="$ctrl.queryResult.getError()">Error running query: <strong>{{$ctrl.queryResult.getError()}}</strong></div>
     </div>
-    <div ng-switch-when="done" class="body-row-auto scrollbox" ng-style="$ctrl.getWidgetStyles()">
+    <div ng-switch-when="done" class="body-row-auto scrollbox">
       <visualization-renderer visualization="$ctrl.widget.visualization" query-result="$ctrl.queryResult" class="t-body"></visualization-renderer>
     </div>
     <div ng-switch-default class="body-row-auto spinner-container">
@@ -65,7 +65,7 @@
     </div>
   </div>
 
-  <div class="tile body-container" ng-if="$ctrl.type=='restricted'" ng-class="$ctrl.type">
+  <div class="tile body-container widget-restricted" ng-if="$ctrl.type=='restricted'" ng-class="$ctrl.type">
     <div class="t-body body-row-auto scrollbox">
       <div class="text-center">
         <h1><span class="zmdi zmdi-lock"></span></h1>
@@ -76,7 +76,7 @@
     </div>
   </div>
 
-  <div class="tile body-container" ng-hide="$ctrl.widget.width === 0" ng-if="$ctrl.type=='textbox'" ng-class="$ctrl.type">
+  <div class="tile body-container widget-text" ng-hide="$ctrl.widget.width === 0" ng-if="$ctrl.type=='textbox'" ng-class="$ctrl.type">
     <div class="body-row clearfix t-body">
       <div class="dropdown pull-right widget-menu-remove" ng-if="!$ctrl.public && $ctrl.dashboard.canEdit()">
         <div class="dropdown-header">

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -1,4 +1,3 @@
-import * as _ from 'underscore';
 import template from './widget.html';
 import editTextBoxTemplate from './edit-text-box.html';
 import './widget.less';
@@ -45,15 +44,6 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
         widget: this.widget,
       },
     });
-  };
-
-  this.getWidgetStyles = () => {
-    if (_.isObject(this.widget) && _.isObject(this.widget.visualization)) {
-      const visualization = this.widget.visualization;
-      if (visualization.type === 'PIVOT') {
-        return { overflow: 'visible' };
-      }
-    }
   };
 
   this.localParametersDefs = () => {

--- a/client/app/components/dashboards/widget.less
+++ b/client/app/components/dashboards/widget.less
@@ -39,12 +39,26 @@
 
   .t-header.widget {
     .dropdown {
-      margin-top: -5px;
-      margin-right: -5px;
+      margin-top: -15px;
+      margin-right: -15px;
 
       .actions {
         position: static;
       }
+    }
+  }
+
+  .scrollbox:empty {
+    padding: 0 !important;
+    font-size: 1px !important;
+  }
+
+  .widget-text {
+    :first-child {
+      margin-top: 0;
+    }
+    :last-child {
+      margin-bottom: 0;
     }
   }
 }

--- a/client/app/components/dynamic-form.html
+++ b/client/app/components/dynamic-form.html
@@ -6,14 +6,14 @@
     </div>
     <hr>
     <div class="form-group" ng-class='{"has-error": (inner.input | showError), "required": field.property.required}' ng-form="inner" ng-repeat="field in fields">
-        <label ng-if="field.property.type !== 'checkbox'" class="control-label">{{field.property.title || field.name | capitalize}}</label>
+        <label ng-if="field.property.type !== 'checkbox'" class="control-label">{{field.property.title || field.name | toHuman}}</label>
         <input name="input" type="{{field.property.type}}" class="form-control" ng-model="target.options[field.name]" ng-required="field.property.required"
                ng-if="field.property.type !== 'file' && field.property.type !== 'checkbox'" accesskey="tab" placeholder="{{field.property.default}}">
 
         <label ng-if="field.property.type=='checkbox'">
             <input name="input" type="{{field.property.type}}" ng-model="target.options[field.name]" ng-required="field.property.required"
                    ng-if="field.property.type !== 'file'" accesskey="tab" placeholder="{{field.property.default}}">
-            {{field.property.title || field.name | capitalize}}
+            {{field.property.title || field.name | toHuman}}
         </label>
 
         <input name="input" type="file" class="form-control" ng-model="files[field.name]" ng-required="field.property.required && !target.options[field.name]"

--- a/client/app/config/dashboard-grid-options.js
+++ b/client/app/config/dashboard-grid-options.js
@@ -19,7 +19,7 @@ const dashboardGridOptions = {
   defaultSizeY: 3,
   minSizeX: 1,
   maxSizeX: null,
-  minSizeY: 4,
+  minSizeY: 1,
   maxSizeY: null,
   resizable: {
     enabled: false,

--- a/client/app/directives/gridster-auto-height.js
+++ b/client/app/directives/gridster-auto-height.js
@@ -1,76 +1,99 @@
 import * as _ from 'underscore';
-import { requestAnimationFrame } from './utils';
 
-function gridsterAutoHeight($timeout, $parse) {
+function toggleAutoHeightClass($element, isEnabled) {
+  const className = 'gridster-auto-height-enabled';
+  if (isEnabled) {
+    $element.addClass(className);
+  } else {
+    $element.removeClass(className);
+  }
+}
+
+function isInUserResize($element) {
+  return $element.hasClass('gridster-item-resizing');
+}
+
+function computeAutoHeight($element, controller) {
+  const wrapper = $element[0];
+  const element = wrapper.querySelector('.scrollbox, .spinner-container');
+  if (element) {
+    const childrenBounds = _.chain(element.children)
+      .map((child) => {
+        const bounds = child.getBoundingClientRect();
+        const style = window.getComputedStyle(child);
+        return {
+          top: bounds.top - parseFloat(style.marginTop),
+          bottom: bounds.bottom + parseFloat(style.marginBottom),
+        };
+      })
+      .reduce((result, bounds) => ({
+        top: Math.min(result.top, bounds.top),
+        bottom: Math.max(result.bottom, bounds.bottom),
+      }))
+      .value() || { top: 0, bottom: 0 };
+
+    // Height of controls outside visualization area
+    const bodyWrapper = wrapper.querySelector('.body-container');
+    if (bodyWrapper) {
+      const elementStyle = window.getComputedStyle(element);
+      const controlsHeight = _.chain(bodyWrapper.children)
+        .filter(node => node !== element)
+        .reduce((result, node) => result + node.offsetHeight, 0)
+        .value();
+
+      const additionalHeight = _.last(controller.gridster.margins) +
+        // include container paddings too
+        parseFloat(elementStyle.paddingTop) + parseFloat(elementStyle.paddingBottom) +
+        // add few pixels for scrollbar (if visible)
+        (element.scrollWidth > element.offsetWidth ? 16 : 0);
+
+      const contentsHeight = childrenBounds.bottom - childrenBounds.top;
+
+      return Math.ceil((controlsHeight + contentsHeight + additionalHeight) /
+        controller.gridster.curRowHeight);
+    }
+  }
+  return controller.sizeY;
+}
+
+function gridsterAutoHeight($timeout) {
   return {
     restrict: 'A',
     require: 'gridsterItem',
     link($scope, $element, attr, controller) {
-      let autoSized = true;
+      let userResizeFlag = false;
+      let sizeYBeforeResize = null;
 
-      const itemGetter = $parse(attr.gridsterItem);
-
-      $scope.$watch(attr.gridsterItem, (newValue, oldValue) => {
-        const item = _.extend({}, itemGetter($scope));
-        if (_.isObject(newValue) && _.isObject(oldValue)) {
-          if ((newValue.sizeY !== oldValue.sizeY) && !autoSized) {
-            item.autoHeight = false;
-            if (_.isFunction(itemGetter.assign)) {
-              itemGetter.assign($scope, item);
-            }
-          }
+      // use event instead of watcher
+      $scope.$on('gridster-item-resized', () => {
+        if (userResizeFlag && (sizeYBeforeResize !== controller.sizeY)) {
+          const item = $scope.$eval(attr.gridsterItem);
+          item.autoHeight = false;
+          toggleAutoHeightClass($element, item.autoHeight);
+          $scope.$applyAsync();
         }
-        if (item.autoHeight) {
-          $element.addClass('gridster-auto-height-enabled');
-        } else {
-          $element.removeClass('gridster-auto-height-enabled');
-        }
-        autoSized = false;
-      }, true);
+        userResizeFlag = false;
+        sizeYBeforeResize = null;
+      });
 
-      function updateHeight() {
-        const item = _.extend({}, itemGetter($scope));
+      function update() {
+        const item = $scope.$eval(attr.gridsterItem);
 
         if (controller.gridster && item.autoHeight) {
-          const wrapper = $element[0];
-          // Query element, but keep selector order
-          const element = _.chain(attr.gridsterAutoHeight.split(','))
-            .map(selector => wrapper.querySelector(selector))
-            .filter(_.isObject)
-            .first()
-            .value();
-          if (element) {
-            const childrenBounds = _.chain(element.children)
-              .map(child => child.getBoundingClientRect())
-              .reduce((result, bounds) => ({
-                left: Math.min(result.left, bounds.left),
-                top: Math.min(result.top, bounds.top),
-                right: Math.min(result.right, bounds.right),
-                bottom: Math.min(result.bottom, bounds.bottom),
-              }))
-              .value();
-
-            // Height of controls outside visualization area
-            const additionalHeight = $element[0].offsetHeight - element.offsetHeight
-              + _.last(controller.gridster.margins);
-            const contentsHeight = childrenBounds.bottom - childrenBounds.top;
-            $timeout(() => {
-              const sizeY = Math.ceil((contentsHeight + additionalHeight) /
-                controller.gridster.curRowHeight);
-              if (controller.sizeY !== sizeY) {
-                autoSized = true;
-                controller.sizeY = sizeY;
-              } else {
-                autoSized = false;
-              }
-            });
+          if (isInUserResize($element)) {
+            userResizeFlag = true;
+            sizeYBeforeResize = controller.sizeY;
+          } else {
+            controller.sizeY = computeAutoHeight($element, controller);
+            $scope.$applyAsync();
           }
-
-          requestAnimationFrame(updateHeight);
         }
+
+        toggleAutoHeightClass($element, item.autoHeight);
+        $timeout(update, 50);
       }
 
-      updateHeight();
+      update();
     },
   };
 }

--- a/client/app/directives/resize-event.js
+++ b/client/app/directives/resize-event.js
@@ -1,5 +1,4 @@
 import * as _ from 'underscore';
-import { requestAnimationFrame } from './utils';
 
 const items = new Map();
 
@@ -18,7 +17,7 @@ function checkItems() {
     }
   });
 
-  requestAnimationFrame(checkItems);
+  setTimeout(checkItems, 50);
 }
 
 checkItems(); // ensure it was called only once!

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -84,11 +84,10 @@
     <filters filters="$ctrl.filters" on-change="$ctrl.filtersOnChange(filter, $modal)"></filters>
   </div>
 
-  <div style="overflow: hidden; padding-bottom: 5px;" ng-if="$ctrl.dashboard.widgets.length > 0">
+  <div style="padding-bottom: 5px;" ng-if="$ctrl.dashboard.widgets.length > 0">
     <div gridster="$ctrl.dashboardGridOptions" class="dashboard-wrapper"
       ng-class="{'preview-mode': !$ctrl.layoutEditing, 'editing-mode': $ctrl.layoutEditing}">
-      <div ng-repeat="widget in $ctrl.dashboard.widgets" gridster-item="widget.options.position"
-        gridster-auto-height=".scrollbox, .spinner-container">
+      <div ng-repeat="widget in $ctrl.dashboard.widgets" gridster-item="widget.options.position" gridster-auto-height>
         <dashboard-widget widget="widget" dashboard="$ctrl.dashboard" on-delete="$ctrl.removeWidget()"></dashboard-widget>
       </div>
     </div>

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -110,7 +110,7 @@ function DashboardCtrl(
     this.refreshRate = rate;
     if (rate !== null) {
       if (load) {
-      this.loadDashboard(true);
+        this.loadDashboard(true);
       }
       this.autoRefresh();
     }
@@ -272,10 +272,7 @@ function DashboardCtrl(
         }
       } else {
         if (applyChanges) {
-          const changedWidgets = getWidgetsWithChangedPositions(
-            this.dashboard.widgets,
-            savedWidgetPositions,
-          );
+          const changedWidgets = getWidgetsWithChangedPositions(this.dashboard.widgets, savedWidgetPositions);
           saveDashboardLayout(changedWidgets).finally(() => {
             savedWidgetPositions = collectWidgetPositions(this.dashboard.widgets);
           });
@@ -350,10 +347,7 @@ function DashboardCtrl(
       // We need to wait a bit for `angular-gridster` before it updates widgets,
       // and only then save new layout
       $timeout(() => {
-        const changedWidgets = getWidgetsWithChangedPositions(
-          this.dashboard.widgets,
-          savedWidgetPositions,
-        );
+        const changedWidgets = getWidgetsWithChangedPositions(this.dashboard.widgets, savedWidgetPositions);
         saveDashboardLayout(changedWidgets).finally(() => {
           savedWidgetPositions = collectWidgetPositions(this.dashboard.widgets);
         });

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -192,9 +192,10 @@ function DashboardCtrl(
   };
 
   this.loadDashboard = _.throttle((force) => {
-    this.dashboard = Dashboard.get(
+    Dashboard.get(
       { slug: $routeParams.dashboardSlug },
       (dashboard) => {
+        this.dashboard = dashboard;
         Events.record('view', 'dashboard', dashboard.id);
         renderDashboard(dashboard, force);
 

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -96,29 +96,22 @@ function DashboardCtrl(
   this.isGridDisabled = false;
   this.showPermissionsControl = clientConfig.showPermissionsControl;
   this.globalParameters = [];
-  this.refreshRates = [
-    { name: '10 seconds', rate: 10 },
-    { name: '30 seconds', rate: 30 },
-    { name: '1 minute', rate: 60 },
-    { name: '5 minutes', rate: 60 * 5 },
-    { name: '10 minutes', rate: 60 * 10 },
-    { name: '30 minutes', rate: 60 * 30 },
-    { name: '1 hour', rate: 60 * 60 },
-    { name: '12 hour', rate: 12 * 60 * 60 },
-    { name: '24 hour', rate: 24 * 60 * 60 },
-  ];
 
-  this.refreshRates =
-    clientConfig.dashboardRefreshIntervals.map(interval => ({ name: durationHumanize(interval), rate: interval }));
+  this.refreshRates = clientConfig.dashboardRefreshIntervals.map(interval => ({
+    name: durationHumanize(interval),
+    rate: interval,
+  }));
 
   $rootScope.$on('gridster-mobile-changed', ($event, gridster) => {
     this.isGridDisabled = gridster.isMobile;
   });
 
-  this.setRefreshRate = (rate) => {
+  this.setRefreshRate = (rate, load = true) => {
     this.refreshRate = rate;
     if (rate !== null) {
+      if (load) {
       this.loadDashboard(true);
+      }
       this.autoRefresh();
     }
   };
@@ -208,6 +201,17 @@ function DashboardCtrl(
         if ($location.search().edit === true) {
           $location.search('edit', null);
           this.editLayout(true);
+        }
+
+        if ($location.search().refresh !== undefined) {
+          if (this.refreshRate === null) {
+            const refreshRate = Math.max(30, parseFloat($location.search().refresh));
+
+            this.setRefreshRate({
+              name: durationHumanize(refreshRate),
+              rate: refreshRate,
+            }, false);
+          }
         }
 
         savedWidgetPositions = collectWidgetPositions(dashboard.widgets);

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -50,7 +50,6 @@
       bottom: 0;
       width: auto;
       height: auto;
-      overflow: hidden;
       margin: 0;
       padding: 0;
     }

--- a/client/app/pages/dashboards/public-dashboard-page.html
+++ b/client/app/pages/dashboards/public-dashboard-page.html
@@ -6,10 +6,9 @@
     <filters ng-if="$ctrl.dashboard.dashboard_filters_enabled"></filters>
   </div>
 
-  <div style="overflow: hidden; padding-bottom: 5px">
+  <div style="padding-bottom: 5px">
     <div gridster="$ctrl.dashboardGridOptions" class="dashboard-wrapper">
-      <div ng-repeat="widget in $ctrl.dashboard.widgets" gridster-item="widget.options.position"
-        gridster-auto-height=".scrollbox, .spinner-container">
+      <div ng-repeat="widget in $ctrl.dashboard.widgets" gridster-item="widget.options.position" gridster-auto-height>
         <dashboard-widget widget="widget" dashboard="$ctrl.dashboard" public="true"></dashboard-widget>
       </div>
     </div>

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -71,14 +71,6 @@ function QuerySourceCtrl(
       .catch(error => toastr.error(error));
   };
 
-  $scope.duplicateQuery = () => {
-    Events.record('fork', 'query', $scope.query.id);
-
-    Query.fork({ id: $scope.query.id }, (newQuery) => {
-      $location.url(newQuery.getSourceLink()).replace();
-    });
-  };
-
   $scope.deleteVisualization = ($e, vis) => {
     $e.preventDefault();
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -172,6 +172,14 @@ function QueryViewCtrl(
     });
   };
 
+  $scope.duplicateQuery = () => {
+    Events.record('fork', 'query', $scope.query.id);
+
+    Query.fork({ id: $scope.query.id }, (newQuery) => {
+      $location.url(newQuery.getSourceLink()).replace();
+    });
+  };
+
   $scope.saveQuery = (customOptions, data) => {
     let request = data;
 

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -1,9 +1,9 @@
 import { truncate } from 'underscore.string';
-import { pick, omit, flatten, extend, isObject } from 'underscore';
+import { pick, flatten, extend, isObject } from 'underscore';
 
 function Widget($resource, $http, Query, Visualization, dashboardGridOptions) {
   function prepareForSave(data) {
-    return omit(data, 'query');
+    return pick(data, 'options', 'text', 'id', 'width', 'dashboard_id', 'visualization_id');
   }
 
   const WidgetResource = $resource('api/widgets/:id', { id: '@id' }, {

--- a/client/app/visualizations/chart/index.js
+++ b/client/app/visualizations/chart/index.js
@@ -85,7 +85,6 @@ function ChartEditor(ColorPalette, clientConfig) {
           scope.options.seriesOptions[key].type = scope.options.globalSeriesType;
         });
       };
-      scope.chartTypeChanged();
 
       scope.showSizeColumnPicker = () => some(scope.options.seriesOptions, options => options.type === 'bubble');
 

--- a/client/app/visualizations/chart/plotly/index.js
+++ b/client/app/visualizations/chart/plotly/index.js
@@ -78,7 +78,7 @@ const PlotlyChart = () => ({
       }
     }, true);
 
-    scope.handleResize = debounce(updateChartDimensions, 100);
+    scope.handleResize = debounce(updateChartDimensions, 50);
   },
 });
 

--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -33,7 +33,7 @@ export const ColorPalette = Object.assign({}, BaseColors, {
   'Pink 2': '#C63FA9',
 });
 
-const formatNumber = createFormatter({ displayAs: 'number', numberFormat: '0,0[.]00' });
+const formatNumber = createFormatter({ displayAs: 'number', numberFormat: '0,0[.]00000' });
 const formatPercent = createFormatter({ displayAs: 'number', numberFormat: '0[.]00' });
 
 const ColorPaletteArray = values(BaseColors);

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -47,7 +47,7 @@ function getDefaultColumnsOptions(columns) {
     allowSearch: false,
     alignContent: getColumnContentAlignment(col.type),
     // `string` cell options
-    allowHTML: false,
+    allowHTML: true,
     highlightLinks: false,
   }));
 }

--- a/redash/models.py
+++ b/redash/models.py
@@ -298,6 +298,8 @@ class Organization(TimestampMixin, db.Model):
     slug = Column(db.String(255), unique=True)
     settings = Column(MutableDict.as_mutable(PseudoJSON))
     groups = db.relationship("Group", lazy="dynamic")
+    events = db.relationship("Event", lazy="dynamic", order_by="desc(Event.created_at)",)
+
 
     __tablename__ = 'organizations'
 
@@ -1479,7 +1481,7 @@ class Widget(TimestampMixin, db.Model):
 class Event(db.Model):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey("organizations.id"))
-    org = db.relationship(Organization, backref="events")
+    org = db.relationship(Organization, back_populates="events")
     user_id = Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     user = db.relationship(User, backref="events")
     action = Column(db.String(255))

--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -30,5 +30,10 @@ def get_status():
             'data_sources': ', '.join(sources),
             'size': redis_connection.llen(queue)
         }
+    
+    status['manager']['queues']['celery'] = {
+        'size': redis_connection.llen('celery'),
+        'data_sources': ''
+    }
 
     return status

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -105,7 +105,11 @@ class DynamoDBSQL(BaseSQLQueryRunner):
             # When running a count query it returns the value as a string, in which case
             # we transform it into a dictionary to be the same as regular queries.
             if isinstance(result, basestring):
-                result = [{"value": result}]
+                # when count < scanned_count, dql returns a string with number of rows scanned
+                value = result.split(" (")[0]
+                if value:
+                    value = int(value)
+                result = [{"value": value}]
 
             for item in result:
                 if not columns:

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -17,7 +17,7 @@ except ImportError:
 # from _mssql.pyx ## DB-API type definitions & http://www.freetds.org/tds.html#types ##
 types_map = {
     1: TYPE_STRING,
-    2: TYPE_BOOLEAN,
+    2: TYPE_STRING,
     # Type #3 supposed to be an integer, but in some cases decimals are returned
     # with this type. To be on safe side, marking it as float.
     3: TYPE_FLOAT,

--- a/redash/tasks/alerts.py
+++ b/redash/tasks/alerts.py
@@ -33,7 +33,7 @@ def should_notify(alert, new_state):
     return new_state != alert.state or (alert.state == models.Alert.TRIGGERED_STATE and passed_rearm_threshold)
 
 
-@celery.task(name="redash.tasks.check_alerts_for_query")
+@celery.task(name="redash.tasks.check_alerts_for_query", time_limit=300, soft_time_limit=240)
 def check_alerts_for_query(query_id):
     logger.debug("Checking query %d for alerts", query_id)
 

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -462,8 +462,8 @@ class QueryExecutor(object):
         if error:
             self.tracker.update(state='failed')
             result = QueryExecutionError(error)
-            self.scheduled_query = models.db.session.merge(self.scheduled_query, load=False)
-            if self.scheduled_query:
+            if self.scheduled_query is not None:
+                self.scheduled_query = models.db.session.merge(self.scheduled_query, load=False)
                 self.scheduled_query.schedule_failures += 1
                 models.db.session.add(self.scheduled_query)
         else:


### PR DESCRIPTION
Multiple V4 regression fixes and improvements by me & @kravets-levko:

* Change: show friendly names in dynamic forms labels.
* Fix: Fork button was shown in data only view, but wasn't working.
* Fix: saving widget was sending too much data to the server, sometimes making dashboard save fail.
* Render safe HTML by default in tables to remain backward compatible.
* Add events property to Organization model.
* Report Celery queue size.
* DynamoDB fix: always return counter as a number rather than string.
* MSSQL Fix: UUID fields were detected as booleans.
* Change: apply time limit to alert status checking task.
* Fix: only try merging query object if it exists.
* Plotly: increase Y value accuracy.
* Load dashboard refresh rate from URL.
* Fix: dashboard was reloading when clicking on refresh.
* Fix: line chart with category x-axis: when some values missing, wrong hints displayed on hover
* Fix: second Y-axis not displayed when stacking enabled
* Set of dashboard improvements and bug fixes
    - set minimal height of widgets to 1 (was 4)
    - bug: for some widgets auto-height wasn't calculated properly (sometimess too small, sometimes too large)
    - bug: for small widgets, top-right menu was cut to widgets bounds
    - bug: with opened top-right menu widgets with auto-height started "dancing"
    - bug: at some point auto-height feature was disabling by itself (in fact - it depends on `angular-grindter`s internal processes)
    - fix: widget with empty contents had extra 40px of white space (paddings of container)
* Add scrollbars to pivot table widgets
* Fix: 100% CPU loading caused page lags