### PR TITLE
Fix: Box plot hover

### DIFF
--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -266,6 +266,7 @@ function prepareChartData(seriesList, options) {
       };
     } else if (seriesOptions.type === 'box') {
       plotlySeries.boxpoints = 'outliers';
+      plotlySeries.hoverinfo = false;
       plotlySeries.marker = {
         color: seriesColor,
         size: 3,


### PR DESCRIPTION
Plotly box plot hover values were not so helpful with default setting `hoverinfo: 'x+text+name'`.
This PR changes hoverinfo to false when chart type is boxplot. 

Fixes #2388.

before
![image](https://user-images.githubusercontent.com/1698635/37863703-050ff4a0-2fa6-11e8-9cac-402ff7165f02.png)

after
![image](https://user-images.githubusercontent.com/1698635/37863704-0fa670b0-2fa6-11e8-8255-7fa81cc4a12b.png)
