### PR TITLE
Fix: (BigQuery) UDF URI was used even if empty

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -173,8 +173,7 @@ class BigQuery(BaseQueryRunner):
         if self.configuration.get('useStandardSql', False):
             job_data['configuration']['query']['useLegacySql'] = False
 
-
-        if "userDefinedFunctionResourceUri" in self.configuration:
+        if self.configuration.get('userDefinedFunctionResourceUri'):
             resource_uris = self.configuration["userDefinedFunctionResourceUri"].split(',')
             job_data["configuration"]["query"]["userDefinedFunctionResources"] = map(
                 lambda resource_uri: {"resourceUri": resource_uri}, resource_uris)


### PR DESCRIPTION
This was causing the BigQuery connection to fail even if the field was empty (like if you "touched" it once and then removed the value).