### PR TITLE
Separation of Scheduler and Worker

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -24,7 +24,7 @@ services:
     restart: always
   worker:
     image: redash/redash:latest
-    command: scheduler
+    command: worker
     environment:
       PYTHONUNBUFFERED: 0
       REDASH_LOG_LEVEL: "INFO"
@@ -32,6 +32,17 @@ services:
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
       QUEUES: "queries,scheduled_queries,celery"
       WORKERS_COUNT: 2
+    restart: always
+  schceduler:
+    image: redash/redash:latest
+    command: scheduler
+    environment:
+      PYTHONUNBUFFERED: 0
+      REDASH_LOG_LEVEL: "INFO"
+      REDASH_REDIS_URL: "redis://redis:6379/0"
+      REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
+      QUEUES: "queries,scheduled_queries,celery"
+      WORKERS_COUNT: 1
     restart: always
   redis:
     image: redis:3.0-alpine
@@ -49,4 +60,5 @@ services:
       - server
     links:
       - server:redash
+      - worker
     restart: always

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -33,7 +33,7 @@ services:
       QUEUES: "queries,scheduled_queries,celery"
       WORKERS_COUNT: 2
     restart: always
-  schceduler:
+  scheduler:
     image: redash/redash:latest
     command: scheduler
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
   worker:
     build: .
-    command: scheduler
+    command: worker
     volumes_from:
       - server
     depends_on:
@@ -31,6 +31,20 @@ services:
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
       QUEUES: "queries,scheduled_queries,celery"
       WORKERS_COUNT: 2
+  scheduler:
+    build: .
+    command: scheduler
+    volumes_from:
+      - server
+    depends_on:
+      - server
+    environment:
+      PYTHONUNBUFFERED: 0
+      REDASH_LOG_LEVEL: "INFO"
+      REDASH_REDIS_URL: "redis://redis:6379/0"
+      REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
+      QUEUES: "queries,scheduled_queries,celery"
+      WORKERS_COUNT: 1
   redis:
     image: redis:3.0-alpine
     restart: unless-stopped


### PR DESCRIPTION
This PR solves the following two problems.

When using `docker-compose`,

- https://github.com/getredash/redash/issues/1743
- Query schedule execution does not work

---

Background

When I used `docker-compose.production.yaml`, I faced a problem that no query was executed.

Apparently, the Worker seemed to have not worked well.

I simply used it as `./bin/docker-entrypoint worker` but now it is no longer scheduled to run, so I added a container for` scheduler`.

Are there other ideas to solve these problems?

thanks.
