### PR TITLE
Query Result Datasource: Allow special characters in column names

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -85,7 +85,7 @@ def create_table(connection, table_name, query_results):
                for column in query_results['columns']]
     safe_columns = [fix_column_name(column) for column in columns]
 
-    column_list = ", ".join(safe_columns)
+    column_list = ', '.join('"{0}"'.format(c) for c in safe_columns)
     create_table = u"CREATE TABLE {table_name} ({column_list})".format(
         table_name=table_name, column_list=column_list)
     logger.debug("CREATE TABLE query: %s", create_table)


### PR DESCRIPTION
Currently for Query Result Datasource, if any of the source column has special character such as '(' in column name, CREATE_TABLE of the intermediate SQLite table will fail with syntax error.

This PR tries to fix that by quoting all column names with double quotes when executing CREATE_TABLE.