### PR TITLE
Add option to allow empty parameter value

### DIFF
--- a/client/app/components/parameter-settings.html
+++ b/client/app/components/parameter-settings.html
@@ -20,11 +20,19 @@
           <option value="datetime-with-seconds">Date and Time (with seconds)</option>
         </select>
       </div>
-      <div class="form-group">
-        <label>
-          <input type="checkbox" class="form-inline" ng-model="$ctrl.parameter.global">
-          Global
-        </label>
+      <div class="row">
+        <div class="col-xs-3 form-group">
+          <label>
+            <input type="checkbox" class="form-inline" ng-model="$ctrl.parameter.global">
+            Global
+          </label>
+        </div>
+        <div class="col-xs-3 form-group">
+          <label>
+            <input type="checkbox" class="form-inline" ng-model="$ctrl.parameter.allowEmpty">
+            Allow empty
+          </label>
+        </div>
       </div>
       <div class="form-group" ng-if="$ctrl.parameter.type === 'enum'">
         <label>Dropdown List Values (newline delimited)</label>

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -52,6 +52,7 @@ class Parameter {
     this.type = parameter.type;
     this.value = parameter.value;
     this.global = parameter.global;
+    this.allowEmpty = parameter.allowEmpty;
     this.enumOptions = parameter.enumOptions;
     this.queryId = parameter.queryId;
   }
@@ -156,7 +157,7 @@ class Parameters {
   }
 
   getMissing() {
-    return pluck(filter(this.get(), p => p.value === null || p.value === ''), 'title');
+    return pluck(filter(this.get(), p => (p.value === null || p.value === '') && !p.allowEmpty), 'title');
   }
 
   isRequired() {


### PR DESCRIPTION
## The problem to tackle
The default value of parameter.
We have [this page about default value](https://help.redash.io/article/139-default) in knowledge base.
But since we currently don't allow null value, there has to be some value filled in first as an indicator of using default value.

I think using null for that is just more intuitive.

## The fix here
Add an 'Allow empty' option to parameter setting
<img src='https://user-images.githubusercontent.com/16881036/38062066-fbbf7fc6-332c-11e8-8295-85059a293b22.png'
 width=400>

## Functionality
Query like this
```sql
select case when '{{val}}' = '' then current_date else '{{val}}' end as value
```
Could work without preset value for parameter now

<img src='https://user-images.githubusercontent.com/16881036/38061942-7bdc3b1e-332c-11e8-84fc-a7f29a78197f.png' width=300>

## New challenge
Empty value handling might be difficult and generate a lot of syntax error. We might want a better error message to help editor get the query right.
Also, if this is merged, I'll try to update the website for new example of usage.