### PR TITLE
use MongoClient for ReplicaSet

### DIFF
--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -158,7 +158,8 @@ class MongoDB(BaseQueryRunner):
 
     def _get_db(self):
         if self.is_replica_set:
-            db_connection = pymongo.MongoReplicaSetClient(self.configuration["connectionString"], replicaSet=self.configuration["replicaSetName"])
+            db_connection = pymongo.MongoClient(self.configuration["connectionString"],
+                                                replicaSet=self.configuration["replicaSetName"])
         else:
             db_connection = pymongo.MongoClient(self.configuration["connectionString"])
 


### PR DESCRIPTION
MongoReplicaSetClient is deprecated and will be removed in future.

See http://api.mongodb.com/python/current/api/pymongo/mongo_replica_set_client.html
```
MongoReplicaSetClient will be removed in a future version of PyMongo.

Changed in version 3.0: MongoClient is now the one and only client class for a standalone server, mongos, or replica set. It includes the functionality that had been split into MongoReplicaSetClient: it can connect to a replica set, discover all its members, and monitor the set for stepdowns, elections, and reconfigs.
```