### PR TITLE
YAML as parser for JSON queries

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import logging
 import json
+import yaml
 
 from collections import OrderedDict
 from redash import settings
@@ -83,6 +84,21 @@ class BaseQueryRunner(object):
 
         if error is not None:
             raise Exception(error)
+
+    def parse_query(self, query, syntax=None):
+        syntax = syntax if syntax else self.syntax
+        if syntax in ('json', 'yaml'):
+            try:
+                query = yaml.safe_load(query)
+            except yaml.YAMLError as e:
+                if hasattr(e, 'problem_mark'):
+                    mark = e.problem_mark
+                    error = "Syntax error at {}:{}: {}".format(mark.line+1, mark.column+1, e.problem)
+                else:
+                    error = "Syntax error: {}".format(e)
+                raise SyntaxError(error)
+
+        return query
 
     def run_query(self, query, user):
         raise NotImplementedError()

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -318,7 +318,7 @@ class Kibana(BaseElasticSearch):
             error = None
 
             logger.debug(query)
-            query_params = yaml.load(query)
+            query_params = yaml.safe_load(query)
 
             index_name = query_params["index"]
             query_data = query_params["query"]

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -4,7 +4,6 @@ import urllib
 
 import requests
 import simplejson as json
-import yaml
 from requests.auth import HTTPBasicAuth
 
 from redash.query_runner import *
@@ -318,7 +317,7 @@ class Kibana(BaseElasticSearch):
             error = None
 
             logger.debug(query)
-            query_params = yaml.safe_load(query)
+            query_params = self.parse_query(query)
 
             index_name = query_params["index"]
             query_data = query_params["query"]
@@ -376,13 +375,6 @@ class Kibana(BaseElasticSearch):
             logger.exception(e)
             error = "Connection refused"
             json_data = None
-        except yaml.YAMLError as e:
-            if hasattr(e, 'problem_mark'):
-                mark = e.problem_mark
-                error = "Syntax error at {}:{}: {}".format(mark.line+1, mark.column+1, e.problem)
-            else:
-                error = "Syntax error: {}".format(e)
-            json_data = None
         except Exception as e:
             logger.exception(e)
             raise sys.exc_info()[1], None, sys.exc_info()[2]
@@ -412,7 +404,7 @@ class ElasticSearch(BaseElasticSearch):
             error = None
 
             logger.debug(query)
-            query_dict = json.loads(query)
+            query_dict = self.parse_query(query)
 
             index_name = query_dict.pop("index", "")
             result_fields = query_dict.pop("result_fields", None)
@@ -454,13 +446,6 @@ class ElasticSearch(BaseElasticSearch):
         except requests.exceptions.RequestException as e:
             logger.exception(e)
             error = "Connection refused"
-            json_data = None
-        except yaml.YAMLError as e:
-            if hasattr(e, 'problem_mark'):
-                mark = e.problem_mark
-                error = "Syntax error at {}:{}: {}".format(mark.line+1, mark.column+1, e.problem)
-            else:
-                error = "Syntax error: {}".format(e)
             json_data = None
         except Exception as e:
             logger.exception(e)

--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -150,7 +150,7 @@ class GoogleAnalytics(BaseSQLQueryRunner):
         query = query.strip()
         if query.startswith('{') or query.startswith('---'):
             try:
-                params = yaml.load(query)
+                params = yaml.safe_load(query)
             except yaml.YAMLError as e:
                 if hasattr(e, 'problem_mark'):
                     mark = e.problem_mark

--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -6,8 +6,6 @@ from base64 import b64decode
 from datetime import datetime
 from urlparse import parse_qs, urlparse
 
-import yaml
-
 from redash.query_runner import *
 from redash.utils import JSONEncoder
 
@@ -149,15 +147,7 @@ class GoogleAnalytics(BaseSQLQueryRunner):
         logger.debug("Analytics is about to execute query: %s", query)
         query = query.strip()
         if query.startswith('{') or query.startswith('---'):
-            try:
-                params = yaml.safe_load(query)
-            except yaml.YAMLError as e:
-                if hasattr(e, 'problem_mark'):
-                    mark = e.problem_mark
-                    error = "Syntax error at {}:{}: {}".format(mark.line+1, mark.column+1, e.problem)
-                else:
-                    error = "Syntax error: {}".format(e)
-                return None, error
+            params = self.parse_query(query)
         else:
             params = parse_qs(urlparse(query).query, keep_blank_values=True)
             for key in params.keys():

--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -178,7 +178,7 @@ class JiraJQL(BaseQueryRunner):
         jql_url = '{}/rest/api/2/search'.format(self.configuration["url"])
 
         try:
-            query = yaml.load(query)
+            query = yaml.safe_load(query)
             query_type = query.pop('queryType', 'select')
             field_mapping = FieldMapping(query.pop('fieldMapping', {}))
 

--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -4,8 +4,6 @@ import re
 
 from collections import OrderedDict
 
-import yaml
-
 from redash.query_runner import *
 
 
@@ -178,7 +176,7 @@ class JiraJQL(BaseQueryRunner):
         jql_url = '{}/rest/api/2/search'.format(self.configuration["url"])
 
         try:
-            query = yaml.safe_load(query)
+            query = self.parse_query(query)
             query_type = query.pop('queryType', 'select')
             field_mapping = FieldMapping(query.pop('fieldMapping', {}))
 
@@ -204,13 +202,6 @@ class JiraJQL(BaseQueryRunner):
                 results = parse_issues(data, field_mapping)
 
             return results.to_json(), None
-        except yaml.YAMLError as e:
-            if hasattr(e, 'problem_mark'):
-                mark = e.problem_mark
-                error = "Syntax error at {}:{}: {}".format(mark.line+1, mark.column+1, e.problem)
-            else:
-                error = "Syntax error: {}".format(e)
-            return None, error
         except KeyboardInterrupt:
             return None, "Query cancelled by user."
 

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -72,7 +72,7 @@ def datetime_parser(dct):
 
 
 def parse_query_yaml(query):
-    query_data = yaml.load(query)
+    query_data = yaml.safe_load(query)
     # HACK: round trip to JSON so we can handle object_hook easily
     query_data = json.loads(json.dumps(query_data), object_hook=datetime_parser)
     return query_data

--- a/redash/query_runner/yandex_metrika.py
+++ b/redash/query_runner/yandex_metrika.py
@@ -1,5 +1,4 @@
 import json
-import yaml
 import logging
 from redash.query_runner import *
 from redash.utils import JSONEncoder
@@ -124,13 +123,8 @@ class YandexMetrika(BaseSQLQueryRunner):
         if query == "":
             error = "Query is empty"
             return data, error
-        try:
-            params = yaml.safe_load(query)
-        except ValueError as e:
-            logging.exception(e)
-            error = unicode(e)
-            return data, error
 
+        params = self.parse_query(query)
         if isinstance(params, dict):
             if 'url' in params:
                 params = parse_qs(urlparse(params['url']).query, keep_blank_values=True)

--- a/redash/query_runner/yandex_metrika.py
+++ b/redash/query_runner/yandex_metrika.py
@@ -34,7 +34,7 @@ for type_, elements in COLUMN_TYPES.items():
 def parse_ym_response(response):
     columns = []
     dimensions_len = len(response['query']['dimensions'])
-   
+
     for h in response['query']['dimensions'] + response['query']['metrics']:
         friendly_name = h.split(':')[-1]
         if friendly_name in COLUMN_TYPES['date']:
@@ -125,7 +125,7 @@ class YandexMetrika(BaseSQLQueryRunner):
             error = "Query is empty"
             return data, error
         try:
-            params = yaml.load(query)
+            params = yaml.safe_load(query)
         except ValueError as e:
             logging.exception(e)
             error = unicode(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pystache==0.5.4
 parsedatetime==2.1
 cryptography==2.0.2
 simplejson==3.10.0
-ua-parser==0.7.3 
+ua-parser==0.7.3
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
 chromelogger==0.4.3

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -1,13 +1,12 @@
 import datetime
-import json
 from unittest import TestCase
 from pytz import utc
-from redash.query_runner.mongodb import parse_query_yaml, parse_results, _get_column_by_name
+from redash.query_runner.mongodb import parse_dates, parse_results, _get_column_by_name
 
 from redash.utils import parse_human_time
 
 
-class TestParseQueryJson(TestCase):
+class TestParseQueryDates(TestCase):
     def test_ignores_non_isodate_fields(self):
         query = {
             'test': 1,
@@ -18,7 +17,7 @@ class TestParseQueryJson(TestCase):
             }
         }
 
-        query_data = parse_query_yaml(json.dumps(query))
+        query_data = parse_dates(query)
         self.assertDictEqual(query_data, query)
 
     def test_parses_isodate_fields(self):
@@ -32,7 +31,7 @@ class TestParseQueryJson(TestCase):
             'testIsoDate': "ISODate(\"2014-10-03T00:00\")"
         }
 
-        query_data = parse_query_yaml(json.dumps(query))
+        query_data = parse_dates(query)
 
         self.assertEqual(query_data['testIsoDate'], datetime.datetime(2014, 10, 3, 0, 0))
 
@@ -49,7 +48,7 @@ class TestParseQueryJson(TestCase):
             'testIsoDate': "ISODate(\"2014-10-03T00:00\")"
         }
 
-        query_data = parse_query_yaml(json.dumps(query))
+        query_data = parse_dates(query)
 
         self.assertEqual(query_data['testIsoDate'], datetime.datetime(2014, 10, 3, 0, 0))
         self.assertEqual(query_data['test_dict']['b']['date'], datetime.datetime(2014, 10, 4, 0, 0))
@@ -71,7 +70,7 @@ class TestParseQueryJson(TestCase):
             ]
         }
 
-        query_data = parse_query_yaml(json.dumps(query))
+        query_data = parse_dates(query)
 
         self.assertDictEqual(query, query_data)
 
@@ -91,7 +90,7 @@ class TestParseQueryJson(TestCase):
                 '$undefined': None
             }
         }
-        query_data = parse_query_yaml(json.dumps(query))
+        query_data = parse_dates(query)
         self.assertEqual(query_data['test$undefined'], None)
         self.assertEqual(query_data['test$date'], datetime.datetime(2014, 10, 3, 0, 0).replace(tzinfo=utc))
 
@@ -101,7 +100,7 @@ class TestParseQueryJson(TestCase):
         }
 
         one_hour_ago = parse_human_time("1 hour ago")
-        query_data = parse_query_yaml(json.dumps(query))
+        query_data = parse_dates(query)
         self.assertEqual(query_data['ts'], one_hour_ago)
 
 

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from unittest import TestCase
 from pytz import utc
-from redash.query_runner.mongodb import parse_query_json, parse_results, _get_column_by_name
+from redash.query_runner.mongodb import parse_query_yaml, parse_results, _get_column_by_name
 
 from redash.utils import parse_human_time
 
@@ -18,7 +18,7 @@ class TestParseQueryJson(TestCase):
             }
         }
 
-        query_data = parse_query_json(json.dumps(query))
+        query_data = parse_query_yaml(json.dumps(query))
         self.assertDictEqual(query_data, query)
 
     def test_parses_isodate_fields(self):
@@ -32,7 +32,7 @@ class TestParseQueryJson(TestCase):
             'testIsoDate': "ISODate(\"2014-10-03T00:00\")"
         }
 
-        query_data = parse_query_json(json.dumps(query))
+        query_data = parse_query_yaml(json.dumps(query))
 
         self.assertEqual(query_data['testIsoDate'], datetime.datetime(2014, 10, 3, 0, 0))
 
@@ -49,7 +49,7 @@ class TestParseQueryJson(TestCase):
             'testIsoDate': "ISODate(\"2014-10-03T00:00\")"
         }
 
-        query_data = parse_query_json(json.dumps(query))
+        query_data = parse_query_yaml(json.dumps(query))
 
         self.assertEqual(query_data['testIsoDate'], datetime.datetime(2014, 10, 3, 0, 0))
         self.assertEqual(query_data['test_dict']['b']['date'], datetime.datetime(2014, 10, 4, 0, 0))
@@ -71,7 +71,7 @@ class TestParseQueryJson(TestCase):
             ]
         }
 
-        query_data = parse_query_json(json.dumps(query))
+        query_data = parse_query_yaml(json.dumps(query))
 
         self.assertDictEqual(query, query_data)
 
@@ -91,7 +91,7 @@ class TestParseQueryJson(TestCase):
                 '$undefined': None
             }
         }
-        query_data = parse_query_json(json.dumps(query))
+        query_data = parse_query_yaml(json.dumps(query))
         self.assertEqual(query_data['test$undefined'], None)
         self.assertEqual(query_data['test$date'], datetime.datetime(2014, 10, 3, 0, 0).replace(tzinfo=utc))
 
@@ -101,7 +101,7 @@ class TestParseQueryJson(TestCase):
         }
 
         one_hour_ago = parse_human_time("1 hour ago")
-        query_data = parse_query_json(json.dumps(query))
+        query_data = parse_query_yaml(json.dumps(query))
         self.assertEqual(query_data['ts'], one_hour_ago)
 
 
@@ -119,7 +119,7 @@ class TestMongoResults(TestCase):
         self.assertIsNotNone(_get_column_by_name(columns, 'column'))
         self.assertIsNotNone(_get_column_by_name(columns, 'column2'))
         self.assertIsNotNone(_get_column_by_name(columns, 'column3'))
-    
+
     def test_parses_nested_results(self):
         raw_results = [
             {'column': 1, 'column2': 'test', 'nested': {


### PR DESCRIPTION
JSON is a great wire format but it's not well suited for typing it:

 - too noisy due to the required quotation and punctuation
 - does not allow comments

YAML is a superset of JSON and as such any JSON document is a valid YAML document. By switching the parser to YAML we ensure 100% backwards compatibility with existing queries while allowing to make use of the more liberal syntax of YAML for new ones.

I've updated all the query runners that had a `syntax=json` but only performed real testing against Elastic Search.