### PR TITLE
PubNub integration for faster query results

### DIFF
--- a/client/app/services/pubnub.js
+++ b/client/app/services/pubnub.js
@@ -1,0 +1,48 @@
+import debug from 'debug';
+import PubNub from 'pubnub';
+
+const logger = debug('redash:services:PubNubSubscriber');
+
+function PubNubFactory() {
+  class PubNubSubscriber {
+    constructor(key, channel) {
+      this.callbacks = [];
+      this.channel = channel;
+
+      const pubnub = new PubNub({ subscribeKey: key });
+
+      pubnub.addListener({
+        status: (event) => {
+          logger('[' + channel + ']', event);
+        },
+        message: (envelope) => {
+          logger(envelope);
+          this.callbacks.forEach(fn => fn(envelope));
+        },
+      });
+
+      pubnub.subscribe({ channels: [channel] });
+    }
+
+    on(id, fn) {
+      if (typeof fn === 'undefined') {
+        this.callbacks.push(fn);
+        return fn;
+      }
+
+      const cb = x => x.userMetadata.id === id && fn(x.message);
+      this.callbacks.push(cb);
+      return cb;
+    }
+
+    off(ref) {
+      this.callbacks = this.callbacks.filter(x => x !== ref);
+    }
+  }
+
+  return PubNubSubscriber;
+}
+
+export default function init(ngModule) {
+  ngModule.factory('PubNubSubscriber', PubNubFactory);
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "pace-progress": "git+https://github.com/getredash/pace.git",
     "pivottable": "^2.15.0",
     "plotly.js": "1.30.1",
+    "pubnub": "^4.20.2",
     "ui-select": "^0.19.8",
     "underscore": "^1.8.3",
     "underscore.string": "^3.3.4"

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -158,7 +158,9 @@ def client_config():
     if not current_user.is_api_user() and current_user.is_authenticated:
         client_config = {
             'newVersionAvailable': get_latest_version(),
-            'version': __version__
+            'version': __version__,
+            'pubnubSubscribeKey': settings.PUBNUB_SUBSCRIBE_KEY,
+            'pubnubQueryChannel': settings.PUBNUB_QUERY_CHANNEL
         }
     else:
         client_config = {}

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -221,3 +221,9 @@ SCHEMA_RUN_TABLE_SIZE_CALCULATIONS = parse_boolean(os.environ.get("REDASH_SCHEMA
 # Allow Parameters in Embeds
 # WARNING: With this option enabled, Redash reads query parameters from the request URL (risk of SQL injection!)
 ALLOW_PARAMETERS_IN_EMBEDS = parse_boolean(os.environ.get("REDASH_ALLOW_PARAMETERS_IN_EMBEDS", "false"))
+
+# PubNub
+PUBNUB_SSL = parse_boolean(os.environ.get("PUBNUB_SSL", "true"))
+PUBNUB_PUBLISH_KEY = os.environ.get("PUBNUB_PUBLISH_KEY")
+PUBNUB_SUBSCRIBE_KEY = os.environ.get("PUBNUB_SUBSCRIBE_KEY")
+PUBNUB_QUERY_CHANNEL = os.environ.get("PUBNUB_QUERY_CHANNEL", 'redash-query')

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,9 +45,12 @@ pystache==0.5.4
 parsedatetime==2.1
 cryptography==2.0.2
 simplejson==3.10.0
-ua-parser==0.7.3 
+ua-parser==0.7.3
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
 # Uncomment the requirement for ldap3 if using ldap.
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
+
+# Uncomment for PubNub support
+#pubnub>=4.0.13


### PR DESCRIPTION
Ideally the client should have a websocket connection against the server to receive realtime updates about the tasks. However this is a bit hard to implement given the current server technology.

These changes take an alternative approach, relying on the third party,[PubNub](https://www.pubnub.com/) which has a very interesting free tier offering which should cover most use cases.

> FREE FOREVER up to 100 devices and 1M messages a month to get your app up and running. Basic support included.

⚠️ Since the *subscriber key* is passed on to the browser (under logged in sessions), it could be stolen and the thief could inspect all the task IDs that are being executed. I can't think of a way to directly exploit this but anyone using it should be aware of that potential information leak.

To enable the feature we need to install the `pubnub` Python package (uncomment on `requirements.txt`) and define the following environment variables:

      PUBNUB_SSL=true
      PUBNUB_PUBLISH_KEY=pub-c-xyz
      PUBNUB_SUBSCRIBE_KEY=sub-c-xyz

The current polling mechanism checks for completion every 3 seconds, so the user experience is greatly improved, specially for fast queries.