### PR TITLE
Improve a query failure message for Treasure Data Runner

### DIFF
--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import tdclient
+    from tdclient import errors
     enabled = True
 
 except ImportError:
@@ -102,22 +103,24 @@ class TreasureData(BaseQueryRunner):
                 db=self.configuration.get('db'))
 
         cursor = connection.cursor()
+        try:
+            cursor.execute(query)
+            columns_data = [(row[0], cursor.show_job()['hive_result_schema'][i][1]) for i,row in enumerate(cursor.description)]
 
-        cursor.execute(query)
-        columns_data = [(row[0], cursor.show_job()['hive_result_schema'][i][1]) for i,row in enumerate(cursor.description)]
+            columns = [{'name': col[0],
+                'friendly_name': col[0],
+                'type': TD_TYPES_MAPPING.get(col[1], None)} for col in columns_data]
 
-        columns = [{'name': col[0],
-            'friendly_name': col[0],
-            'type': TD_TYPES_MAPPING.get(col[1], None)} for col in columns_data]
-
-        if cursor.rowcount == 0:
-            rows = []
-        else:
-            rows = [dict(zip(([c[0] for c in columns_data]), r)) for i, r in enumerate(cursor.fetchall())]
-        data = {'columns': columns, 'rows': rows}
-        json_data = json.dumps(data, cls=JSONEncoder)
-        error = None
-
+            if cursor.rowcount == 0:
+                rows = []
+            else:
+                rows = [dict(zip(([c[0] for c in columns_data]), r)) for i, r in enumerate(cursor.fetchall())]
+            data = {'columns': columns, 'rows': rows}
+            json_data = json.dumps(data, cls=JSONEncoder)
+            error = None
+        except errors.InternalError as e:
+            json_data = None
+            error = "%s: %s" % (e.message, cursor.show_job()['debug']['stderr'])
         return json_data, error
 
 register(TreasureData)

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -120,7 +120,7 @@ class TreasureData(BaseQueryRunner):
             error = None
         except errors.InternalError as e:
             json_data = None
-            error = "%s: %s" % (e.message, cursor.show_job()['debug']['stderr'])
+            error = "%s: %s" % (e.message, cursor.show_job().get('debug', {}).get('stderr', 'No stderr message in the response')
         return json_data, error
 
 register(TreasureData)


### PR DESCRIPTION
The current Treasure Data Query Runner doesn't show an error message if the query failed due to any errors (e.g. syntax error, etc...)

This PR improves a message to include the actual error message on the query editor by overriding [errors.InternalError](https://github.com/treasure-data/td-client-python/blob/bf8b8b550fd9e11afa88969f69c462b6f8739a5b/tdclient/cursor.py#L72)

- Current

![](https://t.gyazo.com/teams/treasure-data/2685ac9e8f7d745db58efa8be1ee5869.png)

- New

![](https://t.gyazo.com/teams/treasure-data/ed9d5ad186389b447887f9d676d86458.png)