### PR TITLE
FIX: templating error was breaking dashboard and query editor

### DIFF
--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -1,14 +1,10 @@
 import * as _ from 'lodash';
-import debug from 'debug';
 import PromiseRejectionError from '@/lib/promise-rejection-error';
-import { QueryResultError } from '@/services/query';
 import { durationHumanize } from '@/filters';
 import { getTags } from '@/services/tags';
 import template from './dashboard.html';
 import shareDashboardTemplate from './share-dashboard.html';
 import './dashboard.less';
-
-const logger = debug('redash:pages:dashboards:dashboard');
 
 function isWidgetPositionChanged(oldPosition, newPosition) {
   const fields = ['col', 'row', 'sizeX', 'sizeY', 'autoHeight'];
@@ -132,14 +128,7 @@ function DashboardCtrl(
   };
 
   const collectFilters = (dashboard, forceRefresh) => {
-    const queryResultPromises = _.compact(this.dashboard.widgets.map(widget => widget.load(forceRefresh)))
-      .map((queryResult) => {
-        if (queryResult instanceof QueryResultError) {
-          logger('Found and error on query: %s', queryResult.getError());
-          return $q.reject(queryResult);
-        }
-        return queryResult.toPromise();
-      });
+    const queryResultPromises = _.compact(this.dashboard.widgets.map(widget => widget.load(forceRefresh)));
 
     $q.all(queryResultPromises).then((queryResults) => {
       const filters = {};

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -29,34 +29,6 @@ function collectParams(parts) {
   return parameters;
 }
 
-export class QueryResultError {
-  constructor(errorMessage) {
-    this.errorMessage = errorMessage;
-    this.status = 'failed';
-    this.data = this.log = this.chartData = null;
-  }
-
-  getError() {
-    return this.errorMessage;
-  }
-
-  getStatus() {
-    return this.status;
-  }
-
-  getData() {
-    return this.data;
-  }
-
-  getLog() {
-    return this.log;
-  }
-
-  getChartData() {
-    return this.chartData;
-  }
-}
-
 class Parameter {
   constructor(parameter) {
     this.title = parameter.title;
@@ -382,7 +354,7 @@ function QueryResource(
         this.id,
       );
     } else {
-      return new QueryResultError('Please select data source to run this query.');
+      this.queryResult = new QueryResultError('Please select data source to run this query.');
     }
 
     return this.queryResult;

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -29,6 +29,34 @@ function collectParams(parts) {
   return parameters;
 }
 
+export class QueryResultError {
+  constructor(errorMessage) {
+    this.errorMessage = errorMessage;
+    this.status = 'failed';
+    this.data = this.log = this.chartData = null;
+  }
+
+  getError() {
+    return this.errorMessage;
+  }
+
+  getStatus() {
+    return this.status;
+  }
+
+  getData() {
+    return this.data;
+  }
+
+  getLog() {
+    return this.log;
+  }
+
+  getChartData() {
+    return this.chartData;
+  }
+}
+
 class Parameter {
   constructor(parameter) {
     this.title = parameter.title;
@@ -325,7 +353,11 @@ function QueryResource(
     }
 
     if (parameters.isRequired()) {
-      queryText = Mustache.render(queryText, parameters.getValues());
+      try {
+        queryText = Mustache.render(queryText, parameters.getValues());
+      } catch (e) {
+        return new QueryResultError('Malformed query with parameters. Please edit the query to fix the error.');
+      }
 
       // Need to clear latest results, to make sure we don't use results for different params.
       this.latest_query_data = null;


### PR DESCRIPTION
I was demoing ReDash to my team and obviously it had to break 😃 

To reproduce:

  - Create a query with a parameter `{{{foo}}}`
  - Set a value for the parameter
  - Save, Publish and add to a dashboard
  - Edit the query and modify the parameter to `{{{foo}}` (**unbalanced braces**)
  - Now the dashboard is not rendered (error on console)
  - Now the query is not possible to edit (error on console)
