### PR TITLE
Fix so that ALLOW_SCRIPTS applies to text widgets

### DIFF
--- a/client/app/filters/markdown.js
+++ b/client/app/filters/markdown.js
@@ -9,7 +9,7 @@ export default function init(ngModule) {
 
       let html = markdown.toHTML(String(text));
       if (clientConfig.allowScriptsInUserInput) {
-        html = $sce.trustAsHtml(html);
+        html = $sce.trustAsHtml(text);
       }
 
       return html;


### PR DESCRIPTION
When the env setting `REDASH_ALLOW_SCRIPTS_IN_USER_INPUT` or `ALLOW_SCRIPTS_IN_USER_INPUT` is set to True the text widgets take escaped HTML and "trust" it versus "trusting" the original text value.

This negates the actual purpose of the env setting of allowing the user to put <script> tags or other valid html tags in the text block