### PR TITLE
Send a Retry-After header for running jobs with an estimate

### DIFF
--- a/client/app/components/rd-timer.js
+++ b/client/app/components/rd-timer.js
@@ -8,12 +8,21 @@ function rdTimer() {
     controller($scope) {
       $scope.currentTime = '00:00:00';
 
+      const compute = () => {
+        $scope.currentTime = moment(moment() - moment($scope.timestamp)).utc().format('HH:mm:ss');
+      };
+
       // We're using setInterval directly instead of $timeout, to avoid using $apply, to
       // prevent the digest loop being run every second.
       let currentTimer = setInterval(() => {
-        $scope.currentTime = moment(moment() - moment($scope.timestamp)).utc().format('HH:mm:ss');
+        compute();
         $scope.$digest();
       }, 1000);
+
+      // When the timestamp changes we need to recompute the time
+      $scope.$watch('timestamp', () => {
+        compute();
+      });
 
       $scope.$on('$destroy', () => {
         if (currentTimer) {

--- a/redash/models.py
+++ b/redash/models.py
@@ -781,6 +781,14 @@ class QueryResult(db.Model, BelongsToOrgMixin):
         return q.first()
 
     @classmethod
+    def get_estimated_runtime(cls, query_hash):
+        q = db.session.query(db.func.avg(QueryResult.runtime)).filter(
+                QueryResult.query_hash == query_hash
+            )
+
+        return q.scalar()
+
+    @classmethod
     def store_result(cls, org, data_source, query_hash, query, data, run_time, retrieved_at):
         query_result = cls(org_id=org,
                            query_hash=query_hash,

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -157,8 +157,9 @@ class QueryTask(object):
         return self._async_result.id
 
     def to_dict(self):
-        task_info = self._async_result._get_task_meta()
-        result, task_status = task_info['result'], task_info['status']
+        task_status = self._async_result.state
+        result = self._async_result.result
+
         if task_status == 'STARTED':
             updated_at = result.get('start_time', 0)
         else:


### PR DESCRIPTION
As commented on https://github.com/getredash/redash/pull/2427, the current polling algorithm is too simple and there is room of improvement there.

This changeset introduces a new header [Retry-After](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37) (part of HTTP/1.1 standard although we twist it a bit). When a client performs the polling operation asking for a job, if the job is still running:

 - Calculate the average duration of that query if it was run previously
 - Check how far off it currently is from that estimation
 - Apply an easing function so that it spans the intervals accordingly
 - Return a number of seconds to wait on the `Retry-After` header
