### PR TITLE
Add Selenium & Firefox based UI tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,37 @@
 FROM redash/base:latest
 
+ENV DEBIAN_FRONTEND=noninteractive \
+    MOZ_HEADLESS=1
+
+RUN dependencies=' \
+        bzip2 \
+        curl \
+        firefox \
+    ' \
+    && set -x \
+    && apt-get -qq update && apt-get -qq install --no-install-recommends -y $dependencies \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+ENV FIREFOX_VERSION=59.0
+RUN FIREFOX_DOWNLOAD_URL=https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+    && apt-get -y purge firefox \
+    && rm -rf /opt/firefox \
+    && curl -sSL $FIREFOX_DOWNLOAD_URL -o /tmp/firefox.tar.bz2 \
+    && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+    && rm /tmp/firefox.tar.bz2 \
+    && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
+    && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+
+ENV GECKODRIVER_VERSION=0.20.0
+RUN GECKODRIVER_DOWNLOAD_URL=https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
+    && rm -rf /opt/geckodriver \
+    && curl -sSL $GECKODRIVER_DOWNLOAD_URL -o /tmp/geckodriver.tar.gz \
+    && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
+    && rm /tmp/geckodriver.tar.gz \
+    && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION \
+    && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
+    && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
+
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.
 COPY requirements.txt requirements_dev.txt requirements_all_ds.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM redash/base:latest
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    MOZ_HEADLESS=1
+    MOZ_HEADLESS=1 \
+    FIREFOX_VERSION=59.0 \
+    GECKODRIVER_VERSION=0.20.0
 
+# Install requirements for UI tests
 RUN dependencies=' \
         bzip2 \
         curl \
@@ -10,27 +13,14 @@ RUN dependencies=' \
     ' \
     && set -x \
     && apt-get -qq update && apt-get -qq install --no-install-recommends -y $dependencies \
+    && apt-get -y purge firefox \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-ENV FIREFOX_VERSION=59.0
-RUN FIREFOX_DOWNLOAD_URL=https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
-    && apt-get -y purge firefox \
-    && rm -rf /opt/firefox \
-    && curl -sSL $FIREFOX_DOWNLOAD_URL -o /tmp/firefox.tar.bz2 \
-    && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-    && rm /tmp/firefox.tar.bz2 \
-    && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-    && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+COPY bin/install-firefox.sh /usr/local/bin/install-firefox
+COPY bin/install-geckodriver.sh /usr/local/bin/install-geckodriver
 
-ENV GECKODRIVER_VERSION=0.20.0
-RUN GECKODRIVER_DOWNLOAD_URL=https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
-    && rm -rf /opt/geckodriver \
-    && curl -sSL $GECKODRIVER_DOWNLOAD_URL -o /tmp/geckodriver.tar.gz \
-    && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
-    && rm /tmp/geckodriver.tar.gz \
-    && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION \
-    && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
-    && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
+RUN install-firefox
+RUN install-geckodriver
 
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.

--- a/bin/install-firefox.sh
+++ b/bin/install-firefox.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ -z "$FIREFOX_VERSION" ]; then
+    echo "Set FIREFOX_VERSION environment variable." >&2
+    exit 1
+fi
+
+# Remove existing Firefox files
+sudo rm -rf /opt/firefox
+
+FIREFOX_DOWNLOAD_URL=https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2
+curl -sSL $FIREFOX_DOWNLOAD_URL -o /tmp/firefox.tar.bz2
+
+# Extract tarball
+sudo tar -C /opt -xjf /tmp/firefox.tar.bz2
+
+# Remove bz2 archive
+rm /tmp/firefox.tar.bz2
+
+# Create symlink to Firefox bin
+sudo mv /opt/firefox /opt/firefox-$FIREFOX_VERSION
+sudo ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox

--- a/bin/install-geckodriver.sh
+++ b/bin/install-geckodriver.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ -z "$GECKODRIVER_VERSION" ]; then
+    echo "Set GECKODRIVER_VERSION environment variable." >&2
+    exit 1
+fi
+
+# Remove existing Geckodriver files
+sudo rm -rf /opt/geckodriver
+
+GECKODRIVER_DOWNLOAD_URL=https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz
+curl -sSL $GECKODRIVER_DOWNLOAD_URL -o /tmp/geckodriver.tar.gz
+
+# Extract tarball
+sudo tar -C /opt -zxf /tmp/geckodriver.tar.gz
+
+# Remove gz archive
+rm /tmp/geckodriver.tar.gz
+
+# Create symlink to Geckodriver bin
+sudo mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION
+sudo chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION
+sudo ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,10 @@ machine:
   node:
     version:
       6.9.1
+  environment:
+    FIREFOX_VERSION: "59.0"
+    GECKODRIVER_VERSION: "0.20.0"
+    MOZ_HEADLESS: 1
 dependencies:
   override:
     - pip install --upgrade setuptools
@@ -12,6 +16,11 @@ dependencies:
     - pip install -r requirements.txt
     - npm install
     - npm run build
+    - sudo apt-get -qq update
+    - sudo apt-get -qq install --no-install-recommends -y bzip2 curl firefox
+    - sudo apt-get -y purge firefox
+    - ./bin/install-firefox.sh
+    - ./bin/install-geckodriver.sh
   cache_directories:
     - node_modules/
 test:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = --cov-report xml --cov-report=term-missing --cov=redash --cov-config .coveragerc --driver Firefox
 norecursedirs = *.egg .eggs dist build docs .tox
+markers =
+    ui: mark the test as a UI test running Selenium against a live server.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov-report xml --cov-report=term-missing --cov=redash --cov-config .coveragerc
+addopts = --cov-report xml --cov-report=term-missing --cov=redash --cov-config .coveragerc --driver Firefox
 norecursedirs = *.egg .eggs dist build docs .tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,5 @@ mock==2.0.0
 pymongo==3.6.1
 
 # uitests
+PyPOM==1.3.0
 pytest-selenium==1.12.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,6 @@ mock==2.0.0
 
 # PyMongo is needed for one of the unit tests:
 pymongo==3.6.1
+
+# uitests
+pytest-selenium==1.12.0

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+
+"""Plugin for running UI tests."""
+
+import multiprocessing
+import time
+import socket
+
+import pytest
+
+from redash import (
+    create_app,
+    redis_connection,
+)
+from redash.models import db
+from tests.factories import Factory
+
+
+class LiveServer(object):
+    """LiveServer context manager to run the Flask app."""
+
+    def __init__(self, app, host='localhost', port=5000, timeout=5):
+        """Initialize the LiveServer."""
+        self.app = app
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+        self._proc = None
+
+    def __enter__(self):
+        """Run the Flask app in a separate process."""
+        self._proc = multiprocessing.Process(
+            target=self.app.run,
+            kwargs={
+                'port': self.port,
+                'use_reloader': False,
+                'threaded': True,
+            },
+        )
+
+        self._proc.daemon = True
+        self._proc.start()
+
+        start_time = time.time()
+
+        while True:
+            elapsed_time = time.time() - start_time
+
+            if elapsed_time > self.timeout:
+                msg = 'Failed to start LiveServer at {server.url}'
+                raise RuntimeError(msg.format(server=self))
+
+            if self.ping():
+                break
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Terminate the process running the Flask app."""
+        self._proc.terminate()
+        self._proc.join()
+
+        # Make sure to propagate exceptions
+        return False
+
+    def ping(self):
+        """Open a socket and try to connect to the server."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        try:
+            s.connect((self.host, self.port))
+        except socket.error as e:
+            success = False
+        else:
+            success = True
+        finally:
+            s.close()
+
+        return success
+
+    @property
+    def url(self):
+        """Return the URL to the LiveServer."""
+        return 'http://{host}:{port}'.format(
+            host=self.host,
+            port=self.port,
+        )
+
+    def __str__(self):
+        """Return the URL to the LiveServer."""
+        return self.url
+
+    def __add__(self, other):
+        """Implement addition for LiveServer."""
+        if not isinstance(other, str):
+            msg = 'Require str to concatenate with LiveServer; got {}'
+            raise TypeError(msg.format(type(other).__name__))
+
+        return str(self) + other
+
+
+@pytest.fixture(name='host')
+def fixture_host():
+    """Return a host name as str."""
+    return 'localhost'
+
+
+@pytest.fixture(name='port')
+def fixture_port():
+    """Return a free port as int."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture(name='app')
+def fixture_app(host, port):
+    """Run setup and teardown code for the Flask app."""
+    app = create_app('testing')
+
+    app.config['TESTING'] = True
+    app.config['SERVER_NAME'] = '{host}:{port}'.format(host=host, port=port)
+
+    app_ctx = app.app_context()
+    app_ctx.push()
+
+    db.session.close()
+    db.drop_all()
+    db.create_all()
+
+    yield app
+
+    db.session.remove()
+    db.get_engine(app).dispose()
+
+    app_ctx.pop()
+
+    redis_connection.flushdb()
+
+
+@pytest.fixture(name='live_server')
+def fixture_live_server(request, app, host, port):
+    """Return the LiveServer instance running the Flask app."""
+    config = {
+        'host': host,
+        'port': port,
+        'timeout': request.config.getoption('live_server_timeout'),
+    }
+
+    with LiveServer(app, **config) as live_server:
+        yield live_server
+
+
+@pytest.fixture(name='factory')
+def fixture_factory(app):
+    """Return a Factory instance."""
+    return Factory()
+
+
+def pytest_addoption(parser):
+    """Add custom options to pytest."""
+    group = parser.getgroup('flask')
+
+    group.addoption(
+        '--live-server-timeout',
+        action='store',
+        dest='live_server_timeout',
+        default=5,
+        type=float,
+        help="timeout in seconds to wait for the live_server to start up.",
+    )

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -121,7 +121,7 @@ def fixture_user(create_user, user_name, user_email, user_password):
 
 def pytest_addoption(parser):
     """Add custom options to pytest."""
-    group = parser.getgroup('flask')
+    group = parser.getgroup('ui')
 
     group.addoption(
         '--live-server-timeout',

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -160,6 +160,50 @@ def fixture_factory(app):
     return Factory()
 
 
+@pytest.fixture(name='create_user')
+def fixture_create_user(factory):
+    """Return a function to create a user with password."""
+    def create(password=None, **kwargs):
+        """Create a user with password."""
+        user = factory.create_user(**kwargs)
+
+        if password is not None:
+            user.hash_password(password)
+            db.session.commit()
+
+        return user
+
+    return create
+
+
+@pytest.fixture(name='user_password')
+def fixture_user_password():
+    """Return a password str."""
+    return 'a#12B%@c3D'
+
+
+@pytest.fixture(name='user_name')
+def fixture_user_name():
+    """Return a name str."""
+    return 'Ashley McTest'
+
+
+@pytest.fixture(name='user_email')
+def fixture_user_email():
+    """Return an email address str."""
+    return 'ashley@example.com'
+
+
+@pytest.fixture(name='user')
+def fixture_user(create_user, user_name, user_email, user_password):
+    """Return a user with a password."""
+    return create_user(
+        name=user_name,
+        email=user_email,
+        password=user_password,
+    )
+
+
 def pytest_addoption(parser):
     """Add custom options to pytest."""
     group = parser.getgroup('flask')

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -2,8 +2,6 @@
 
 """Plugin for running UI tests."""
 
-import multiprocessing
-import time
 import socket
 
 import pytest
@@ -14,90 +12,7 @@ from redash import (
 )
 from redash.models import db
 from tests.factories import Factory
-
-
-class LiveServer(object):
-    """LiveServer context manager to run the Flask app."""
-
-    def __init__(self, app, host='localhost', port=5000, timeout=5):
-        """Initialize the LiveServer."""
-        self.app = app
-        self.host = host
-        self.port = port
-        self.timeout = timeout
-
-        self._proc = None
-
-    def __enter__(self):
-        """Run the Flask app in a separate process."""
-        self._proc = multiprocessing.Process(
-            target=self.app.run,
-            kwargs={
-                'port': self.port,
-                'use_reloader': False,
-                'threaded': True,
-            },
-        )
-
-        self._proc.daemon = True
-        self._proc.start()
-
-        start_time = time.time()
-
-        while True:
-            elapsed_time = time.time() - start_time
-
-            if elapsed_time > self.timeout:
-                msg = 'Failed to start LiveServer at {server.url}'
-                raise RuntimeError(msg.format(server=self))
-
-            if self.ping():
-                break
-
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Terminate the process running the Flask app."""
-        self._proc.terminate()
-        self._proc.join()
-
-        # Make sure to propagate exceptions
-        return False
-
-    def ping(self):
-        """Open a socket and try to connect to the server."""
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        try:
-            s.connect((self.host, self.port))
-        except socket.error as e:
-            success = False
-        else:
-            success = True
-        finally:
-            s.close()
-
-        return success
-
-    @property
-    def url(self):
-        """Return the URL to the LiveServer."""
-        return 'http://{host}:{port}'.format(
-            host=self.host,
-            port=self.port,
-        )
-
-    def __str__(self):
-        """Return the URL to the LiveServer."""
-        return self.url
-
-    def __add__(self, other):
-        """Implement addition for LiveServer."""
-        if not isinstance(other, str):
-            msg = 'Require str to concatenate with LiveServer; got {}'
-            raise TypeError(msg.format(type(other).__name__))
-
-        return str(self) + other
+from tests.ui.live_server import LiveServer
 
 
 @pytest.fixture(name='host')

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -119,6 +119,17 @@ def fixture_user(create_user, user_name, user_email, user_password):
     )
 
 
+def pytest_collection_modifyitems(items):
+    """Add a 'ui' marker to all test items under 'ui/'.
+
+    If you wish to only run UI tests add the '-m ui' CLI option. If you wish
+    to exclude UI tests from your test run add the '-m not ui' CLI option.
+    """
+    for item in items:
+        if item.fspath is not None and 'ui/' in str(item.fspath):
+            item.add_marker(pytest.mark.ui)
+
+
 def pytest_addoption(parser):
     """Add custom options to pytest."""
     group = parser.getgroup('ui')

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -27,6 +27,10 @@ def fixture_port():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(('', 0))
     port = s.getsockname()[1]
+
+    # Avoid 'address already in use' errors
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
     s.close()
     return port
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -26,14 +26,14 @@ def fixture_host():
 @pytest.fixture(name='port')
 def fixture_port():
     """Return a free port as int."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(('', 0))
-    port = s.getsockname()[1]
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('', 0))
+    port = sock.getsockname()[1]
 
     # Avoid 'address already in use' errors
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-    s.close()
+    sock.close()
     return port
 
 
@@ -128,8 +128,8 @@ def fixture_user(create_user, user_name, user_email, user_password):
 @pytest.fixture(name='login_page')
 def fixture_login_page(selenium, live_server, factory):
     """Return a page object model for login."""
-    p = LoginPage(selenium, live_server.url, org=factory.org.slug)
-    return p.open()
+    login_page = LoginPage(selenium, live_server.url, org=factory.org.slug)
+    return login_page.open()
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -27,12 +27,12 @@ def fixture_host():
 def fixture_port():
     """Return a free port as int."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(('', 0))
-    port = sock.getsockname()[1]
 
     # Avoid 'address already in use' errors
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
+    sock.bind(('', 0))
+    port = sock.getsockname()[1]
     sock.close()
     return port
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -11,8 +11,10 @@ from redash import (
     redis_connection,
 )
 from redash.models import db
+
 from tests.factories import Factory
 from tests.ui.live_server import LiveServer
+from tests.ui.pages.login import LoginPage
 
 
 @pytest.fixture(name='host')
@@ -121,6 +123,13 @@ def fixture_user(create_user, user_name, user_email, user_password):
         email=user_email,
         password=user_password,
     )
+
+
+@pytest.fixture(name='login_page')
+def fixture_login_page(selenium, live_server, factory):
+    """Return a page object model for login."""
+    p = LoginPage(selenium, live_server.url, org=factory.org.slug)
+    return p.open()
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/ui/live_server.py
+++ b/tests/ui/live_server.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+"""Live Server implementation for UI tests."""
+
+import multiprocessing
+import socket
+import time
+
+
+class LiveServer(object):
+    """LiveServer context manager to run the Flask app."""
+
+    def __init__(self, app, host='localhost', port=5000, timeout=5):
+        """Initialize the LiveServer."""
+        self.app = app
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+        self._proc = None
+
+    def __enter__(self):
+        """Run the Flask app in a separate process."""
+        self._proc = multiprocessing.Process(
+            target=self.app.run,
+            kwargs={
+                'port': self.port,
+                'use_reloader': False,
+                'threaded': True,
+            },
+        )
+
+        self._proc.daemon = True
+        self._proc.start()
+
+        start_time = time.time()
+
+        while True:
+            elapsed_time = time.time() - start_time
+
+            if elapsed_time > self.timeout:
+                msg = 'Failed to start LiveServer at {server.url}'
+                raise RuntimeError(msg.format(server=self))
+
+            if self.ping():
+                break
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Terminate the process running the Flask app."""
+        self._proc.terminate()
+        self._proc.join()
+
+        # Make sure to propagate exceptions
+        return False
+
+    def ping(self):
+        """Open a socket and try to connect to the server."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        try:
+            s.connect((self.host, self.port))
+        except socket.error as e:
+            success = False
+        else:
+            success = True
+        finally:
+            s.close()
+
+        return success
+
+    @property
+    def url(self):
+        """Return the URL to the LiveServer."""
+        return 'http://{host}:{port}'.format(
+            host=self.host,
+            port=self.port,
+        )
+
+    def __str__(self):
+        """Return the URL to the LiveServer."""
+        return self.url
+
+    def __add__(self, other):
+        """Implement addition for LiveServer."""
+        if not isinstance(other, str):
+            msg = 'Require str to concatenate with LiveServer; got {}'
+            raise TypeError(msg.format(type(other).__name__))
+
+        return str(self) + other

--- a/tests/ui/live_server.py
+++ b/tests/ui/live_server.py
@@ -61,7 +61,7 @@ class LiveServer(object):
 
         try:
             s.connect((self.host, self.port))
-        except socket.error as e:
+        except socket.error:
             success = False
         else:
             success = True

--- a/tests/ui/pages/__init__.py
+++ b/tests/ui/pages/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Page object models for Redash."""

--- a/tests/ui/pages/login.py
+++ b/tests/ui/pages/login.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+"""Page object model for login."""
+
+from pypom import Page
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+
+class LoginPage(Page):
+    """Page object model for the login."""
+
+    URL_TEMPLATE = '/{org}/login/'
+
+    @property
+    def title(self):
+        """Return the page title."""
+        self.wait.until(lambda s: self.selenium.title)
+        return self.selenium.title
+
+    @property
+    def alert(self):
+        """Return the alert element."""
+        return self.wait.until(expected.visibility_of_element_located((
+            By.CSS_SELECTOR,
+            ".alert-danger",
+        )))
+
+    @property
+    def profile_dropdown(self):
+        """Return the profile dropdown element."""
+        return self.wait.until(expected.visibility_of_element_located((
+            By.CSS_SELECTOR,
+            ".dropdown--profile__username",
+        )))
+
+    def enter_email(self, email):
+        """Enter the given user email."""
+        input_email = self.find_element(By.ID, 'inputEmail')
+        input_email.send_keys(email)
+
+    def enter_password(self, password):
+        """Enter the given user password."""
+        input_password = self.find_element(By.ID, 'inputPassword')
+        input_password.send_keys(password)
+
+    def click_login(self):
+        """Click the login button."""
+        btn = self.find_element(By.CSS_SELECTOR, "button[type='submit']")
+        btn.click()
+
+    def login(self, email='', password=''):
+        """Log in the user with the given credentials."""
+        self.enter_email(email)
+        self.enter_password(password)
+        self.click_login()

--- a/tests/ui/pages/login.py
+++ b/tests/ui/pages/login.py
@@ -16,24 +16,25 @@ class LoginPage(Page):
     @property
     def title(self):
         """Return the page title."""
-        self.wait.until(lambda s: self.selenium.title)
-        return self.selenium.title
+        return self.wait.until(lambda s: self.selenium.title)
 
     @property
     def alert(self):
         """Return the alert element."""
-        return self.wait.until(expected.visibility_of_element_located((
+        element = self.wait.until(expected.visibility_of_element_located((
             By.CSS_SELECTOR,
             ".alert-danger",
         )))
+        return element.text
 
     @property
     def profile_dropdown(self):
         """Return the profile dropdown element."""
-        return self.wait.until(expected.visibility_of_element_located((
+        element = self.wait.until(expected.visibility_of_element_located((
             By.CSS_SELECTOR,
             ".dropdown--profile__username",
         )))
+        return element.text
 
     def enter_email(self, email):
         """Enter the given user email."""

--- a/tests/ui/test_login.py
+++ b/tests/ui/test_login.py
@@ -4,6 +4,10 @@
 
 import pytest
 
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
 
 @pytest.fixture
 def login_url(live_server, factory):
@@ -14,8 +18,53 @@ def login_url(live_server, factory):
     )
 
 
-def test_login_title(selenium, login_url):
-    """Test the title of the login page."""
+def test_login_wrong_user_credentials(selenium, login_url):
+    """Test for a failed login attempt."""
     selenium.get(login_url)
 
     assert selenium.title == 'Login to Redash'
+
+    email = selenium.find_element_by_id('inputEmail')
+    email.send_keys('wrong@example.com')
+
+    password = selenium.find_element_by_id('inputPassword')
+    password.send_keys('wrong')
+
+    btn = selenium.find_element_by_css_selector("button[type='submit']")
+    btn.click()
+
+    alert = WebDriverWait(selenium, 10).until(
+        EC.visibility_of_element_located((
+            By.CSS_SELECTOR,
+            ".alert-danger",
+        ))
+    )
+    assert alert.text == 'Wrong email or password.'
+
+    assert selenium.title == 'Login to Redash'
+
+
+def test_login(selenium, login_url, user, user_password):
+    """Test for a successful login attempt."""
+    selenium.get(login_url)
+
+    assert selenium.title == 'Login to Redash'
+
+    email = selenium.find_element_by_id('inputEmail')
+    email.send_keys(user.email)
+
+    password = selenium.find_element_by_id('inputPassword')
+    password.send_keys(user_password)
+
+    btn = selenium.find_element_by_css_selector("button[type='submit']")
+    btn.click()
+
+    dropdown = WebDriverWait(selenium, 10).until(
+        EC.visibility_of_element_located((
+            By.CSS_SELECTOR,
+            ".dropdown--profile__username",
+        ))
+    )
+    assert dropdown.text == user.name
+
+    assert selenium.title == 'Redash'

--- a/tests/ui/test_login.py
+++ b/tests/ui/test_login.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""UI tests for the login page."""
+
+import pytest
+
+
+@pytest.fixture
+def login_url(live_server, factory):
+    """Return the URL for the login page of the org."""
+    return '{live_server.url}/{org.slug}/login'.format(
+        live_server=live_server,
+        org=factory.org,
+    )
+
+
+def test_login_title(selenium, login_url):
+    """Test the title of the login page."""
+    selenium.get(login_url)
+
+    assert selenium.title == 'Login to Redash'

--- a/tests/ui/test_login.py
+++ b/tests/ui/test_login.py
@@ -2,69 +2,22 @@
 
 """UI tests for the login page."""
 
-import pytest
 
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-
-
-@pytest.fixture
-def login_url(live_server, factory):
-    """Return the URL for the login page of the org."""
-    return '{live_server.url}/{org.slug}/login'.format(
-        live_server=live_server,
-        org=factory.org,
-    )
-
-
-def test_login_wrong_user_credentials(selenium, login_url):
+def test_login_wrong_user_credentials(login_page):
     """Test for a failed login attempt."""
-    selenium.get(login_url)
+    assert login_page.title == 'Login to Redash'
 
-    assert selenium.title == 'Login to Redash'
+    login_page.login(email='wrong@example.com', password='wrong')
 
-    email = selenium.find_element_by_id('inputEmail')
-    email.send_keys('wrong@example.com')
-
-    password = selenium.find_element_by_id('inputPassword')
-    password.send_keys('wrong')
-
-    btn = selenium.find_element_by_css_selector("button[type='submit']")
-    btn.click()
-
-    alert = WebDriverWait(selenium, 10).until(
-        EC.visibility_of_element_located((
-            By.CSS_SELECTOR,
-            ".alert-danger",
-        ))
-    )
-    assert alert.text == 'Wrong email or password.'
-
-    assert selenium.title == 'Login to Redash'
+    assert login_page.alert.text == 'Wrong email or password.'
+    assert login_page.title == 'Login to Redash'
 
 
-def test_login(selenium, login_url, user, user_password):
+def test_login(login_page, user, user_password):
     """Test for a successful login attempt."""
-    selenium.get(login_url)
+    assert login_page.title == 'Login to Redash'
 
-    assert selenium.title == 'Login to Redash'
+    login_page.login(email=user.email, password=user_password)
 
-    email = selenium.find_element_by_id('inputEmail')
-    email.send_keys(user.email)
-
-    password = selenium.find_element_by_id('inputPassword')
-    password.send_keys(user_password)
-
-    btn = selenium.find_element_by_css_selector("button[type='submit']")
-    btn.click()
-
-    dropdown = WebDriverWait(selenium, 10).until(
-        EC.visibility_of_element_located((
-            By.CSS_SELECTOR,
-            ".dropdown--profile__username",
-        ))
-    )
-    assert dropdown.text == user.name
-
-    assert selenium.title == 'Redash'
+    assert login_page.profile_dropdown.text == user.name
+    assert login_page.title == 'Redash'

--- a/tests/ui/test_login.py
+++ b/tests/ui/test_login.py
@@ -9,7 +9,7 @@ def test_login_wrong_user_credentials(login_page):
 
     login_page.login(email='wrong@example.com', password='wrong')
 
-    assert login_page.alert.text == 'Wrong email or password.'
+    assert login_page.alert == 'Wrong email or password.'
     assert login_page.title == 'Login to Redash'
 
 
@@ -19,5 +19,5 @@ def test_login(login_page, user, user_password):
 
     login_page.login(email=user.email, password=user_password)
 
-    assert login_page.profile_dropdown.text == user.name
+    assert login_page.profile_dropdown == user.name
     assert login_page.title == 'Redash'


### PR DESCRIPTION
Hi there! 👋 

Thank you for making Redash! 📊

My team would love to have test coverage for screens that are most important to our users, so this PR aims at adding the foundation for developing automated UI tests to Redash. I checked the [trello board](https://trello.com/b/b2LUHU7A/redash-roadmap) and the GitHub issues for related proposals, but couldn't find any. Please feel free to point me to any previous conversations!

This PR adds a proof-of-concept implementation, that will hopefully provide a good basis for discussion. Here's a gist of what it does...

* install Firefox and Geckodriver into the development server image and add [pytest-selenium](https://github.com/pytest-dev/pytest-selenium) to the Python dependencies
* define a pytest fixture to create a Redash app, which handles setup and teardown code, such as app config and database clean up
* add a live server implementation using multiprocessing to run the Redash app, which is required to open pages with Selenium
* automatically add a [pytest marker](https://docs.pytest.org/en/latest/example/markers.html#marking-test-functions-and-selecting-them-for-a-run) to every test in the ``ui/`` subdirectory to easily select and deselect UI tests
* add two UI tests for the login page: one for a successful attempt and one for a failed attempt

I'd also suggest to integrate a library for working with page objects, such as [PyPOM](https://github.com/mozilla/PyPOM), to make it more convenient to interact with pages in tests. For the sake of only adding external dependencies which are strictly required, I did not PyPOM as part of this PR.

For context: I work on test automation on @jezdez's team and plan to gradually add more tests in the future, but would like to hear your thoughts on this first. Looking forward to your feedback! 🙇 