### PR TITLE
Firefox: widget height continuously increases

### DIFF
--- a/client/app/components/dashboards/gridstack/index.js
+++ b/client/app/components/dashboards/gridstack/index.js
@@ -39,7 +39,10 @@ function computeAutoHeight($element, grid, node, minHeight, maxHeight) {
       const elementStyle = window.getComputedStyle(element);
       const controlsHeight = _.chain(bodyWrapper.children)
         .filter(n => n !== element)
-        .reduce((result, n) => result + n.offsetHeight, 0)
+        .reduce((result, n) => {
+          const b = n.getBoundingClientRect();
+          return result + (b.bottom - b.top);
+        }, 0)
         .value();
 
       const additionalHeight = grid.opts.verticalMargin +
@@ -51,7 +54,7 @@ function computeAutoHeight($element, grid, node, minHeight, maxHeight) {
       const contentsHeight = childrenBounds.bottom - childrenBounds.top;
 
       const cellHeight = grid.cellHeight() + grid.opts.verticalMargin;
-      resultHeight = Math.ceil((controlsHeight + contentsHeight + additionalHeight) / cellHeight);
+      resultHeight = Math.ceil(Math.round(controlsHeight + contentsHeight + additionalHeight) / cellHeight);
     }
   }
 


### PR DESCRIPTION
Firefox, dashboard, auto-height feature: in some cases (loader shown and widget has params, but possibly other cases) widget starts continuously growing. Why: Firefox uses different rounding strategy for element's dimensions (`offsetHeight` is always integer (rounded up), `getBoundingClientRect` returns dimensions with a "garbage", i.e. if element has height `100.45px`, it will return something like `100.45006791123px`, but in fact will use only few fraction digits). Fix: explicitly round values before computing widget height.