### PR TITLE
Fix syntax error

### DIFF
--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -120,7 +120,7 @@ class TreasureData(BaseQueryRunner):
             error = None
         except errors.InternalError as e:
             json_data = None
-            error = "%s: %s" % (e.message, cursor.show_job().get('debug', {}).get('stderr', 'No stderr message in the response')
+            error = "%s: %s" % (e.message, cursor.show_job().get('debug', {}).get('stderr', 'No stderr message in the response'))
         return json_data, error
 
 register(TreasureData)


### PR DESCRIPTION
For example, when I started worker(celery) service without Redis, the following error raised.

```
  File "/Users/katsuhiko.yoshida/.pyenv/versions/2.7.14/lib/python2.7/site-packages/kombu/utils/__init__.py", line 96, in symbol_by_name
    module = imp(module_name, package=package, **kwargs)
  File "/Users/katsuhiko.yoshida/.pyenv/versions/2.7.14/lib/python2.7/site-packages/celery/utils/imports.py", line 101, in import_from_cwd
    return imp(module, package=package)
  File "/Users/katsuhiko.yoshida/.pyenv/versions/2.7.14/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/Users/katsuhiko.yoshida/work/redash/redash/__init__.py", line 72, in <module>
    import_query_runners(settings.QUERY_RUNNERS)
  File "/Users/katsuhiko.yoshida/work/redash/redash/query_runner/__init__.py", line 179, in import_query_runners
    __import__(runner_import)
  File "/Users/katsuhiko.yoshida/work/redash/redash/query_runner/treasuredata.py", line 124
    return json_data, error
         ^
SyntaxError: invalid syntax
```