### PR TITLE
add Helm Chart for Redash 

### DIFF
--- a/setup/helm/Chart.yaml
+++ b/setup/helm/Chart.yaml
@@ -1,0 +1,2 @@
+name: redash
+version: 4.0.0

--- a/setup/helm/README.md
+++ b/setup/helm/README.md
@@ -1,0 +1,22 @@
+## Redash's Helm chart
+
+
+To run the chart in a Kubernetes cluster with Helm installed : 
+
+```
+git clone https://github.com/getredash/redash.git
+cd redash/setup/helm
+# Edit values.yaml
+helm install -n redash.domain.tld --namespace my-redash  . 
+```
+
+```
+$- kubectl -n my-redash get pod
+
+NAME                                READY     STATUS    RESTARTS   AGE
+redash-77857b9745-5kk9l             1/1       Running   0          3h
+redash-db-5dcdf449b6-dfvs9          1/1       Running   0          5h
+redash-redis-794d777dd9-8pq62       1/1       Running   0          5h
+redash-scheduler-5f947996f7-mmgmc   1/1       Running   0          5h
+```
+

--- a/setup/helm/templates/configMap.yml
+++ b/setup/helm/templates/configMap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redash-start
+  labels:
+    name: redash-start 
+  namespace: {{ .Release.Namespace }}
+data:
+  config: |-
+    sleep 5 && /app/bin/docker-entrypoint create_db && /app/bin/docker-entrypoint server

--- a/setup/helm/templates/deployment.yaml
+++ b/setup/helm/templates/deployment.yaml
@@ -1,0 +1,182 @@
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ .Values.global.podName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ .Values.global.podName }}
+spec:
+  minReadySeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: {{ .Values.global.podName }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ .Values.global.podName }}
+        version: {{ .Values.global.tag }}
+    spec:
+      containers:
+      - image: {{ .Values.global.image }}:{{ .Values.global.tag }}
+        name: {{ .Values.global.podName }}
+        command: ["bash", "/tmp/start.sh"]
+        imagePullPolicy: Always
+        env:
+        - name: PYTHONUNBUFFERED
+          value: "0"
+        - name: REDASH_LOG_LEVEL
+          value: "INFO"
+        - name: REDASH_REDIS_URL
+          value: "redis://{{ .Values.global.redisUrl }}:6379/0"
+        - name: REDASH_DATABASE_URL
+          value: "postgresql://{{ .Values.global.postgresUser }}:{{ .Values.global.postgresDbPassword }}@{{ .Values.global.postgresUrl }}:{{ .Values.global.postgresPort }}/{{ .Values.global.postgresDbName }}"
+        - name: QUEUES
+          value: "queries,scheduled_queries,celery"
+        - name: REDASH_WEB_WORKERS
+          value: "{{ .Values.global.workers }}"
+        - name: REDASH_COOKIE_SECRET
+          value: "{{ .Values.global.redashCookie }}"
+        - name: REDASH_ADDITIONAL_QUERY_RUNNERS
+          value: "redash.query_runner.python"
+        - name: REDASH_ALLOW_PARAMETERS_IN_EMBEDS
+          value: "True"
+        - name: REDASH_GOOGLE_CLIENT_ID
+          value: "{{ .Values.global.googleClientID }}"
+        - name: REDASH_GOOGLE_CLIENT_SECRET
+          value: "{{ .Values.global.googleClientSecret }}"
+        - name: REDASH_MAIL_SERVER
+          value: "{{ .Values.global.mailServer }}"
+        - name: REDASH_MAIL_PORT
+          value: "{{ .Values.global.mailPort }}"
+        - name: REDASH_MAIL_USE_TLS
+          value: "{{ .Values.global.mailUseTls }}"
+        - name: REDASH_MAIL_USE_SSL
+          value: "false"
+        - name: REDASH_MAIL_USERNAME
+          value: "{{ .Values.global.mailUsername }}"
+        - name: REDASH_MAIL_PASSWORD
+          value: "{{ .Values.global.mailPassword }}"
+        - name: REDASH_MAIL_DEFAULT_SENDER
+          value: "{{ .Values.global.mailSender }}"
+        - name: REDASH_HOST
+          value: "{{ .Values.global.vhost }}"
+
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 150
+        volumeMounts:
+            - mountPath: /tmp/
+              name: redash-start
+      volumes:
+        - name: redash-start
+          configMap:
+             name: redash-start
+             items:
+              - key: config
+                path:  start.sh
+---
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ .Values.global.schedName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ .Values.global.schedName }}
+spec:
+  minReadySeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: {{ .Values.global.schedName }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ .Values.global.schedName }}
+        version: {{ .Values.global.tag }}
+    spec:
+      containers:
+      - image: {{ .Values.global.image }}:{{ .Values.global.tag }}
+        name: {{ .Values.global.schedName }}
+        command: ["/app/bin/docker-entrypoint", "scheduler"]
+        imagePullPolicy: Always
+        env:
+        - name: PYTHONUNBUFFERED
+          value: "0"
+        - name: REDASH_LOG_LEVEL
+          value: "INFO"
+        - name: REDASH_REDIS_URL
+          value: "redis://{{ .Values.global.redisUrl }}:6379/0"
+        - name: REDASH_DATABASE_URL
+          value: "postgresql://{{ .Values.global.postgresUser }}:{{ .Values.global.postgresDbPassword }}@{{ .Values.global.postgresUrl }}:{{ .Values.global.postgresPort }}/{{ .Values.global.postgresDbName }}"
+        - name: QUEUES
+          value: "queries,scheduled_queries,celery"
+        - name: REDASH_WEB_WORKERS
+          value: "{{ .Values.global.workers }}"
+        - name: REDASH_COOKIE_SECRET
+          value: "{{ .Values.global.redashCookie }}"
+        - name: REDASH_ADDITIONAL_QUERY_RUNNERS
+          value: "redash.query_runner.python"
+        - name: REDASH_ALLOW_PARAMETERS_IN_EMBEDS
+          value: "True"
+        - name: REDASH_GOOGLE_CLIENT_ID
+          value: "{{ .Values.global.googleClientID }}"
+        - name: REDASH_GOOGLE_CLIENT_SECRET
+          value: "{{ .Values.global.googleClientSecret }}"
+        - name: REDASH_MAIL_SERVER
+          value: "{{ .Values.global.mailServer }}"
+        - name: REDASH_MAIL_PORT
+          value: "{{ .Values.global.mailPort }}"
+        - name: REDASH_MAIL_USE_TLS
+          value: "{{ .Values.global.mailUseTls }}"
+        - name: REDASH_MAIL_USE_SSL
+          value: "false"
+        - name: REDASH_MAIL_USERNAME
+          value: "{{ .Values.global.mailUsername }}"
+        - name: REDASH_MAIL_PASSWORD
+          value: "{{ .Values.global.mailPassword }}"
+        - name: REDASH_MAIL_DEFAULT_SENDER
+          value: "{{ .Values.global.mailSender }}"
+        - name: REDASH_HOST
+          value: "{{ .Values.global.vhost }}"
+
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 150
+---
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ .Values.global.redisName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ .Values.global.redisName }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: {{ .Values.global.redisName }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ .Values.global.redisName }}
+    spec:
+      containers:
+      - image: {{ .Values.global.redisImage }}
+        name: {{ .Values.global.redisName }}
+        imagePullPolicy: Always

--- a/setup/helm/templates/postgres.yaml
+++ b/setup/helm/templates/postgres.yaml
@@ -1,0 +1,68 @@
+{{ if eq .Values.global.deployDB true }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.global.dbVolName }} 
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+     requests:
+       storage: {{ .Values.global.volumeSize }}
+---
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ .Values.global.dbName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ .Values.global.dbName }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: {{ .Values.global.dbName }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ .Values.global.dbName }}
+    spec:
+      imagePullSecrets:
+      - name: {{ .Values.global.pullSecret }}
+      containers:
+      - image: {{ .Values.global.dbImage }}
+        name: {{ .Values.global.dbName }}
+        imagePullPolicy: Always
+        env:
+        - name: POSTGRES_USER
+          value: {{ .Values.global.postgresUser }}
+        - name: POSTGRES_DB
+          value: {{ .Values.global.postgresDbName }}
+        - name: POSTGRES_PASSWORD
+          value: {{ .Values.global.postgresDbPassword }}
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        volumeMounts:
+        - name: db-folder
+          mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: db-folder
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.dbVolName }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.global.dbName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    name: db
+  selector:
+    k8s-app: {{ .Values.global.dbName }}
+{{ end }}

--- a/setup/helm/templates/service.yaml
+++ b/setup/helm/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.global.podName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5000
+    name: http
+  selector:
+    k8s-app: {{ .Values.global.podName }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.global.redisName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    name: redis
+  selector:
+    k8s-app: {{ .Values.global.redisName }}

--- a/setup/helm/values.yaml
+++ b/setup/helm/values.yaml
@@ -1,0 +1,36 @@
+global:
+  # Redash
+  podName: redash
+  schedName: redash-scheduler
+  dbName: redash-db 
+  redisName: redash-redis
+  image: redash/redash
+  tag: latest
+  redashCookie: averylongcookieforredashinstallation
+  workers: 4
+  # DB & Redis
+  deployDB: true
+  dbImage: postgres:latest
+  redisImage: redis:latest
+  redisUrl: redash-redis
+  dbVolName: redash-db
+  postgresUrl: redash-db
+  postgresUser: redash
+  postgresDbName: redash
+  postgresDbPassword: averylongpassword
+  postgresPort: 5432
+  volumeSize: 10Gi
+  # Ingress
+  vhost: redash.domain.tld
+  # Cluster
+  clusterDomain: cluster.local
+  # Google 
+  googleClientID: googleclientID
+  googleClientSecret: googlesecret
+  # Mail
+  mailServer: smtp.domain.tld
+  mailPort: 587
+  mailUseTls: true
+  mailUsername: user
+  mailPassword: averylongpassword
+  mailsSender: redash@domain.tld


### PR DESCRIPTION
Hi,

I wrote an Helm Chart (for Kubernetes) of Redash deployment,  

Would you see that merged in the repo and become a way to deploy redash containers ? 

https://helm.sh/