### PR TITLE
To avoid "cannot import name main" error

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -71,7 +71,7 @@ extract_redash_sources() {
 }
 
 install_python_packages() {
-    pip install --upgrade pip
+    pip install --upgrade pip==9.0.3
     # TODO: venv?
     pip install setproctitle # setproctitle is used by Celery for "pretty" process titles
     pip install -r $REDASH_BASE_PATH/current/requirements.txt


### PR DESCRIPTION
Hi, 

I got below error when I ran bootstrap script for Ubuntu.

```
...snip...

Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError:
cannot import name main

...snip...
```

I guess this is related to https://github.com/pypa/pip/issues/5240 .

I think we should use pip 9.0.x for now.

Thank you,