### PR TITLE
Show custom date format on settings page

### DIFF
--- a/client/app/pages/settings/organization.html
+++ b/client/app/pages/settings/organization.html
@@ -7,9 +7,7 @@
                     Date Format
                 </label>
                 <select class="form-control" ng-model="$ctrl.settings.date_format" ng-change="$ctrl.update('date_format')">
-                    <option value="DD/MM/YY">DD/MM/YY</option>
-                    <option value="MM/DD/YY">MM/DD/YY</option>
-                    <option value="YYYY-MM-DD">YYYY-MM-DD</option>
+                    <option ng-repeat="date_format in $ctrl.dateFormatList" value="{{date_format}}">{{date_format}}</option>
                 </select>
             </p>
             <hr>

--- a/client/app/pages/settings/organization.js
+++ b/client/app/pages/settings/organization.js
@@ -23,6 +23,7 @@ function OrganizationSettingsCtrl($http, toastr, clientConfig, Events) {
     });
   };
 
+  this.dateFormatList = clientConfig.dateFormatList;
   this.googleLoginEnabled = clientConfig.googleLoginEnabled;
 
   this.disablePasswordLoginToggle = () =>

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -164,6 +164,7 @@ def client_config():
         client_config = {}
 
     date_format = current_org.get_setting('date_format')
+    date_format_list = set(["DD/MM/YY", "MM/DD/YY", "YYYY-MM-DD", settings.DATE_FORMAT])
 
     defaults = {
         'allowScriptsInUserInput': settings.ALLOW_SCRIPTS_IN_USER_INPUT,
@@ -171,6 +172,7 @@ def client_config():
         'allowCustomJSVisualizations': settings.FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS,
         'autoPublishNamedQueries': settings.FEATURE_AUTO_PUBLISH_NAMED_QUERIES,
         'dateFormat': date_format,
+        'dateFormatList': list(date_format_list),
         'dateTimeFormat': "{0} HH:mm".format(date_format),
         'mailSettingsMissing': settings.MAIL_DEFAULT_SENDER is None,
         'dashboardRefreshIntervals': settings.DASHBOARD_REFRESH_INTERVALS,

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -154,6 +154,16 @@ def base_href():
     return base_href
 
 
+def date_format_config():
+    date_format = current_org.get_setting('date_format')
+    date_format_list = set(["DD/MM/YY", "MM/DD/YY", "YYYY-MM-DD", settings.DATE_FORMAT])
+    return {
+        'dateFormat': date_format,
+        'dateFormatList': list(date_format_list),
+        'dateTimeFormat': "{0} HH:mm".format(date_format),
+    }
+
+
 def client_config():
     if not current_user.is_api_user() and current_user.is_authenticated:
         client_config = {
@@ -163,17 +173,11 @@ def client_config():
     else:
         client_config = {}
 
-    date_format = current_org.get_setting('date_format')
-    date_format_list = set(["DD/MM/YY", "MM/DD/YY", "YYYY-MM-DD", settings.DATE_FORMAT])
-
     defaults = {
         'allowScriptsInUserInput': settings.ALLOW_SCRIPTS_IN_USER_INPUT,
         'showPermissionsControl': settings.FEATURE_SHOW_PERMISSIONS_CONTROL,
         'allowCustomJSVisualizations': settings.FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS,
         'autoPublishNamedQueries': settings.FEATURE_AUTO_PUBLISH_NAMED_QUERIES,
-        'dateFormat': date_format,
-        'dateFormatList': list(date_format_list),
-        'dateTimeFormat': "{0} HH:mm".format(date_format),
         'mailSettingsMissing': settings.MAIL_DEFAULT_SENDER is None,
         'dashboardRefreshIntervals': settings.DASHBOARD_REFRESH_INTERVALS,
         'queryRefreshIntervals': settings.QUERY_REFRESH_INTERVALS,
@@ -184,6 +188,7 @@ def client_config():
     client_config.update({
         'basePath': base_href()
     })
+    client_config.update(date_format_config())
 
     return client_config
 


### PR DESCRIPTION
# Issue

When I set custom date format like `YYYY/MM/DD` as `REDASH_DATE_FORMAT`, then it is not shown on settings page.

<img width="316" alt="dateformat1" src="https://user-images.githubusercontent.com/3317191/39553921-f3fe82c0-4eaa-11e8-8f1a-b349c5f643b9.png">

And if I selected another format, then never select `YYYY/MM/DD`.

<img width="305" alt="dateformat3" src="https://user-images.githubusercontent.com/3317191/39554270-d8deaf2c-4eac-11e8-94a1-04d9fb7329ea.png">


# Changes

Add custom date format into format candidates.

<img width="326" alt="dateformat2" src="https://user-images.githubusercontent.com/3317191/39554164-3dfa453e-4eac-11e8-8d56-d296166e16ea.png">
