### PR TITLE
BigQuery: Replace project id with dataset in table list format

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -231,7 +231,10 @@ class BigQuery(BaseQueryRunner):
                             columns.append(u"{}.{}".format(column['name'], field['name']))
                     else:
                         columns.append(column['name'])
-                schema.append({'name': table_data['id'], 'columns': columns})
+
+                table_reference = table_data['tableReference']
+                table_name = "{}.{}".format(table_reference['datasetId'], table_reference['tableId'])
+                schema.append({'name': table_name, 'columns': columns})
 
         return schema
 


### PR DESCRIPTION
# Issue

Using BigQuery data source, a name format of the table is `"Project ID"."Table Name"` in table list.

It is not strictly a table name in the BigQuery. So, if paste it to query as table name by clicking an arrow link on table list, then fail to run the query.

Like this.

![schema1](https://user-images.githubusercontent.com/3317191/39596153-7bc94798-4f4c-11e8-9ce0-0773d5675075.png)

# Changes

Change format to `"Dataset"."Table Name"`.

![schema2](https://user-images.githubusercontent.com/3317191/39596154-7bf25304-4f4c-11e8-8782-7d63234b7cd8.png)
