### PR TITLE
Add location property to BigQuery data source settings

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -68,12 +68,15 @@ def _load_key(filename):
         f.close()
 
 
-def _get_query_results(jobs, project_id, job_id, start_index):
-    query_reply = jobs.getQueryResults(projectId=project_id, jobId=job_id, startIndex=start_index).execute()
+def _get_query_results(jobs, project_id, location, job_id, start_index):
+    query_reply = jobs.getQueryResults(projectId=project_id,
+                                       location=location,
+                                       jobId=job_id,
+                                       startIndex=start_index).execute()
     logging.debug('query_reply %s', query_reply)
     if not query_reply['jobComplete']:
         time.sleep(10)
-        return _get_query_results(jobs, project_id, job_id, start_index)
+        return _get_query_results(jobs, project_id, location, job_id, start_index)
 
     return query_reply
 
@@ -110,6 +113,10 @@ class BigQuery(BaseQueryRunner):
                     "type": "boolean",
                     'title': "Use Standard SQL (Beta)",
                 },
+                'location': {
+                    "type": "string",
+                    'title': 'Processing Location (default: US)',
+                },
                 'loadSchema': {
                     "type": "boolean",
                     "title": "Load Schema"
@@ -120,7 +127,7 @@ class BigQuery(BaseQueryRunner):
                 }
             },
             'required': ['jsonKeyFile', 'projectId'],
-            "order": ['projectId', 'jsonKeyFile', 'loadSchema', 'useStandardSql', 'totalMBytesProcessedLimit', 'maximumBillingTier', 'userDefinedFunctionResourceUri'],
+            "order": ['projectId', 'jsonKeyFile', 'loadSchema', 'useStandardSql', 'location', 'totalMBytesProcessedLimit', 'maximumBillingTier', 'userDefinedFunctionResourceUri'],
             'secret': ['jsonKeyFile']
         }
 
@@ -148,10 +155,15 @@ class BigQuery(BaseQueryRunner):
     def _get_project_id(self):
         return self.configuration["projectId"]
 
+    def _get_location(self):
+        location = self.configuration.get("location", "")
+        return "US" if location == "" else location
+
     def _get_total_bytes_processed(self, jobs, query):
         job_data = {
             "query": query,
             "dryRun": True,
+            'location': self._get_location()
         }
 
         if self.configuration.get('useStandardSql', False):
@@ -169,6 +181,9 @@ class BigQuery(BaseQueryRunner):
                 }
             }
         }
+        job_data['jobReference'] = {
+                'location': self._get_location()
+        }
 
         if self.configuration.get('useStandardSql', False):
             job_data['configuration']['query']['useLegacySql'] = False
@@ -183,7 +198,7 @@ class BigQuery(BaseQueryRunner):
 
         insert_response = jobs.insert(projectId=project_id, body=job_data).execute()
         current_row = 0
-        query_reply = _get_query_results(jobs, project_id=project_id,
+        query_reply = _get_query_results(jobs, project_id=project_id, location=self._get_location(),
                                          job_id=insert_response['jobReference']['jobId'], start_index=current_row)
 
         logger.debug("bigquery replied: %s", query_reply)
@@ -195,7 +210,9 @@ class BigQuery(BaseQueryRunner):
                 rows.append(transform_row(row, query_reply["schema"]["fields"]))
 
             current_row += len(query_reply['rows'])
-            query_reply = jobs.getQueryResults(projectId=project_id, jobId=query_reply['jobReference']['jobId'],
+            query_reply = jobs.getQueryResults(projectId=project_id,
+                                               location=self._get_location(),
+                                               jobId=query_reply['jobReference']['jobId'],
                                                startIndex=current_row).execute()
 
         columns = [{'name': f["name"],
@@ -298,6 +315,10 @@ class BigQueryGCE(BigQuery):
                 'useStandardSql': {
                     "type": "boolean",
                     'title': "Use Standard SQL (Beta)",
+                },
+                'location': {
+                    "type": "string",
+                    'title': 'Processing Location (default: US)',
                 },
                 'loadSchema': {
                     "type": "boolean",

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -115,7 +115,8 @@ class BigQuery(BaseQueryRunner):
                 },
                 'location': {
                     "type": "string",
-                    'title': 'Processing Location (default: US)',
+                    "title": "Processing Location",
+                    "default": "US",
                 },
                 'loadSchema': {
                     "type": "boolean",
@@ -156,8 +157,7 @@ class BigQuery(BaseQueryRunner):
         return self.configuration["projectId"]
 
     def _get_location(self):
-        location = self.configuration.get("location", "")
-        return "US" if location == "" else location
+        return self.configuration.get("location", "US")
 
     def _get_total_bytes_processed(self, jobs, query):
         job_data = {
@@ -318,7 +318,8 @@ class BigQueryGCE(BigQuery):
                 },
                 'location': {
                     "type": "string",
-                    'title': 'Processing Location (default: US)',
+                    "title": "Processing Location",
+                    "default": "US",
                 },
                 'loadSchema': {
                     "type": "boolean",


### PR DESCRIPTION
# Feature

BigQuery began to support Tokyo region from April this year.

- [Google Cloud Platform Blog: BigQuery arrives in the Tokyo region](https://cloudplatform.googleblog.com/2018/04/BigQuery-arrives-in-the-Tokyo-region.html)
- [Dataset Locations  \|  BigQuery  \|  Google Cloud](https://cloud.google.com/bigquery/docs/dataset-locations)

This PR adds a location property to BigQuery data source settings. And calls job query with it.

If it is not specified, the value is `US` (which is default BigQuery location).

# Screenshot

![bq_location](https://user-images.githubusercontent.com/3317191/39615113-4ab9ad56-4faf-11e8-8800-2115bd0d912c.png)
