### PR TITLE
support JSON5 for mongodb queries

### DIFF
--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -1,5 +1,5 @@
 import datetime
-import json
+import json5
 import logging
 import re
 
@@ -70,7 +70,7 @@ def datetime_parser(dct):
 
 
 def parse_query_json(query):
-    query_data = json.loads(query, object_hook=datetime_parser)
+    query_data = json5.loads(query, object_hook=datetime_parser)
     return query_data
 
 
@@ -150,7 +150,7 @@ class MongoDB(BaseQueryRunner):
     def __init__(self, configuration):
         super(MongoDB, self).__init__(configuration)
 
-        self.syntax = 'json'
+        self.syntax = 'json5'
 
         self.db_name = self.configuration["dbName"]
 
@@ -312,7 +312,7 @@ class MongoDB(BaseQueryRunner):
             "rows": rows
         }
         error = None
-        json_data = json.dumps(data, cls=MongoDBJSONEncoder)
+        json_data = json5.dumps(data, cls=MongoDBJSONEncoder)
 
         return json_data, error
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ statsd==2.1.2
 gunicorn==19.7.1
 celery==3.1.25
 jsonschema==2.4.0
+json5==0.6.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0
 pycrypto==2.6.1

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -104,6 +104,29 @@ class TestParseQueryJson(TestCase):
         query_data = parse_query_json(json.dumps(query))
         self.assertEqual(query_data['ts'], one_hour_ago)
 
+    def test_json5_syntax(self):
+        json = """
+        {
+            "column1": 1,
+            "nested": {
+                "inside": 2
+            }
+        }
+        """
+
+        json5 = """
+        // comment
+        {
+            column1: 1,
+            nested: {
+                inside: 2,
+            },
+        }
+        """
+
+        query_json = parse_query_json(json)
+        query_json5 = parse_query_json(json5)
+        self.assertDictEqual(query_json, query_json5)
 
 class TestMongoResults(TestCase):
     def test_parses_regular_results(self):


### PR DESCRIPTION
Add [JSON5](https://github.com/json5/json5) support for mongo queries.
I think JSON is too strict to write queries for most people.
I'm not familiar with angular, so I did't address `json5` syntax highlight yet.

Maybe this can be applied to GoogleAnalytics queries too.

| image |
|---|
| <img width="590" alt="2018-05-09 23 55 57" src="https://user-images.githubusercontent.com/856469/39822468-98b776c0-53e5-11e8-96e4-541cec02b9d8.png"> |

checklist
- [x] write test codes
- [x] work with object_hook `$humanTime`
- [x] work with object_hook `$oid`
- [x] work with `aggregate` queries
- [x] work with normal JSON queries

todo?
- support JSON5 syntax highlight
- change docs