### PR TITLE
upgrade to Celery 4.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
       QUEUES: "queries,scheduled_queries,celery"
       WORKERS_COUNT: 2
+      # REDASH_WORKER_MAX_MEMORY_PER_CHILD: 10000
   redis:
     image: redis:3.0-alpine
     restart: unless-stopped

--- a/redash/metrics/celery.py
+++ b/redash/metrics/celery.py
@@ -12,7 +12,7 @@ tasks_start_time = {}
 
 
 @task_prerun.connect
-def task_prerun_handler(signal, sender, task_id, task, args, kwargs):
+def task_prerun_handler(signal, sender, task_id, task, args, kwargs, **kw):
     try:
         tasks_start_time[task_id] = time.time()
     except Exception:
@@ -30,7 +30,7 @@ def metric_name(name, tags):
 
 
 @task_postrun.connect
-def task_postrun_handler(signal, sender, task_id, task, args, kwargs, retval, state):
+def task_postrun_handler(signal, sender, task_id, task, args, kwargs, retval, state, **kw):
     try:
         run_time = 1000 * (time.time() - tasks_start_time.pop(task_id))
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -38,6 +38,7 @@ CELERY_RESULT_BACKEND = os.environ.get(
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))
+CELERY_WORKER_MAX_MEMORY_PER_CHILD = int_or_none(os.environ.get("REDASH_WORKER_MAX_MEMORY_PER_CHILD"))
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -32,8 +32,12 @@ SQLALCHEMY_ECHO = False
 
 # Celery related settings
 CELERY_BROKER = os.environ.get("REDASH_CELERY_BROKER", REDIS_URL)
-CELERY_BACKEND = os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER)
-CELERY_TASK_RESULT_EXPIRES = int(os.environ.get('REDASH_CELERY_TASK_RESULT_EXPIRES', 3600 * 4))
+CELERY_RESULT_BACKEND = os.environ.get(
+    "REDASH_CELERY_RESULT_BACKEND",
+    os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER))
+CELERY_RESULT_EXPIRES = int(os.environ.get(
+    "REDASH_CELERY_RESULT_EXPIRES",
+    os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))
@@ -107,8 +111,15 @@ LOG_LEVEL = os.environ.get("REDASH_LOG_LEVEL", "INFO")
 LOG_STDOUT = parse_boolean(os.environ.get('REDASH_LOG_STDOUT', 'false'))
 LOG_PREFIX = os.environ.get('REDASH_LOG_PREFIX', '')
 LOG_FORMAT = os.environ.get('REDASH_LOG_FORMAT', LOG_PREFIX + '[%(asctime)s][PID:%(process)d][%(levelname)s][%(name)s] %(message)s')
-CELERYD_LOG_FORMAT = os.environ.get('REDASH_CELERYD_LOG_FORMAT', LOG_PREFIX + '[%(asctime)s][PID:%(process)d][%(levelname)s][%(processName)s] %(message)s')
-CELERYD_TASK_LOG_FORMAT = os.environ.get('REDASH_CELERYD_TASK_LOG_FORMAT', LOG_PREFIX + '[%(asctime)s][PID:%(process)d][%(levelname)s][%(processName)s] task_name=%(task_name)s taks_id=%(task_id)s %(message)s')
+CELERYD_WORKER_LOG_FORMAT = os.environ.get(
+    "REDASH_CELERYD_WORKER_LOG_FORMAT",
+    os.environ.get('REDASH_CELERYD_LOG_FORMAT',
+                   '[%(asctime)s][PID:%(process)d][%(levelname)s][%(processName)s] %(message)s'))
+CELERYD_WORKER_TASK_LOG_FORMAT = os.environ.get(
+    "REDASH_CELERYD_WORKER_TASK_LOG_FORMAT",
+    os.environ.get('REDASH_CELERYD_TASK_LOG_FORMAT',
+                   '[%(asctime)s][PID:%(process)d][%(levelname)s][%(processName)s] task_name=%(task_name)s '
+                   'task_id=%(task_id)s %(message)s'))
 
 # Mail settings:
 MAIL_SERVER = os.environ.get('REDASH_MAIL_SERVER', 'localhost')

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -44,12 +44,12 @@ if settings.QUERY_RESULTS_CLEANUP_ENABLED:
         'schedule': timedelta(minutes=5)
     }
 
-celery.conf.update(CELERY_RESULT_BACKEND=settings.CELERY_BACKEND,
-                   CELERYBEAT_SCHEDULE=celery_schedule,
-                   CELERY_TIMEZONE='UTC',
-                   CELERY_TASK_RESULT_EXPIRES=settings.CELERY_TASK_RESULT_EXPIRES,
-                   CELERYD_LOG_FORMAT=settings.CELERYD_LOG_FORMAT,
-                   CELERYD_TASK_LOG_FORMAT=settings.CELERYD_TASK_LOG_FORMAT)
+celery.conf.update(result_backend=settings.CELERY_RESULT_BACKEND,
+                   beat_schedule=celery_schedule,
+                   timezone='UTC',
+                   result_expires=settings.CELERY_RESULT_EXPIRES,
+                   worker_log_format=settings.CELERYD_WORKER_LOG_FORMAT,
+                   worker_task_log_format=settings.CELERYD_WORKER_TASK_LOG_FORMAT)
 
 if settings.SENTRY_DSN:
     from raven import Client

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -49,7 +49,8 @@ celery.conf.update(result_backend=settings.CELERY_RESULT_BACKEND,
                    timezone='UTC',
                    result_expires=settings.CELERY_RESULT_EXPIRES,
                    worker_log_format=settings.CELERYD_WORKER_LOG_FORMAT,
-                   worker_task_log_format=settings.CELERYD_WORKER_TASK_LOG_FORMAT)
+                   worker_task_log_format=settings.CELERYD_WORKER_TASK_LOG_FORMAT,
+                   worker_max_memory_per_child=settings.CELERY_WORKER_MAX_MEMORY_PER_CHILD)
 
 if settings.SENTRY_DSN:
     from raven import Client

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ wsgiref==0.1.2
 honcho==0.5.0
 statsd==2.1.2
 gunicorn==19.7.1
-celery==3.1.25
+celery==4.1.0
 jsonschema==2.4.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0
@@ -45,7 +45,7 @@ pystache==0.5.4
 parsedatetime==2.1
 cryptography==2.0.2
 simplejson==3.10.0
-ua-parser==0.7.3 
+ua-parser==0.7.3
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
 # Uncomment the requirement for ldap3 if using ldap.


### PR DESCRIPTION
This refers to #2517 

I have reviewed Mozilla's both upgrade to [Celery 3.1.25](https://github.com/getredash/redash/pull/2270) and [Celery 4.1.0](https://github.com/mozilla/redash/pull/297).

I feel like I should give you guys a heads up regarding [this](https://github.com/celery/celery/issues/4356).
