### PR TITLE
search by data_source in Search Page

### DIFF
--- a/client/app/pages/queries/queries-search-results-page.html
+++ b/client/app/pages/queries/queries-search-results-page.html
@@ -21,6 +21,7 @@
             <th class="sortable-column" ng-click="$ctrl.paginator.orderBy($ctrl.createdBySort)">Created By <sort-icon column="$ctrl.createdBySort" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
             <th class="sortable-column" ng-click="$ctrl.paginator.orderBy($ctrl.createdAtSort)">Created At <sort-icon column="$ctrl.createdAtSort" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
             <th class="sortable-column" ng-click="$ctrl.paginator.orderBy($ctrl.scheduleSort)">Update Schedule <sort-icon column="$ctrl.scheduleSort" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
+            <th class="sortable-column" ng-click="$ctrl.paginator.orderBy($ctrl.dataSourceSort)">Data Source <sort-icon column="$ctrl.dataSourceSort" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon></th>
           </tr>
         </thead>
         <tbody>
@@ -31,6 +32,7 @@
               {{query.user.name}}</td>
             <td>{{query.created_at | dateTime}}</td>
             <td>{{query.schedule | scheduleHumanize}}</td>
+            <td>{{query.data_source.name}}</td>
           </tr>
           <tr ng-if="$ctrl.paginator.rows.length == 0">
             <td>No results found.</td>


### PR DESCRIPTION
Hello!

We usually use redash for analyze our product and this is great tool.
We create many queries with various types of datasources, but we would like to display the datasources type from hard to find queries by datasources.

Then:
I add follow feature: show datasources name in Search Page

・screenshot here
<img width="669" alt="2018-05-12 23 54 43" src="https://user-images.githubusercontent.com/771218/39958690-3f08a37a-5641-11e8-88e9-9c41663a4b71.png">

Thanks.