### PR TITLE
Chart: formats for values, labels and tooltips

### DIFF
--- a/client/app/lib/value-format.js
+++ b/client/app/lib/value-format.js
@@ -2,6 +2,8 @@ import moment from 'moment/moment';
 import numeral from 'numeral';
 import _ from 'underscore';
 
+numeral.options.scalePercentBy100 = false;
+
 // eslint-disable-next-line
 const urlPattern = /(^|[\s\n]|<br\/?>)((?:https?|ftp):\/\/[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi;
 
@@ -65,7 +67,7 @@ export function formatSimpleTemplate(str, data) {
   if (!_.isString(str)) {
     return '';
   }
-  return str.replace(/{{\s*([^\s]+)\s*}}/g, (match, prop) => {
+  return str.replace(/{{\s*([^\s]+?)\s*}}/g, (match, prop) => {
     if (hasOwnProperty.call(data, prop) && !_.isUndefined(data[prop])) {
       return data[prop];
     }

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -252,7 +252,7 @@ function QueryResultService($resource, $timeout, $q) {
       const series = {};
 
       this.getData().forEach((row) => {
-        let point = {};
+        let point = { $raw: row };
         let seriesName;
         let xValue = 0;
         const yValues = {};
@@ -302,7 +302,7 @@ function QueryResultService($resource, $timeout, $q) {
 
         if (seriesName === undefined) {
           each(yValues, (yValue, ySeriesName) => {
-            point = { x: xValue, y: yValue };
+            point = { x: xValue, y: yValue, $raw: point.$raw };
             if (eValue !== null) {
               point.yError = eValue;
             }

--- a/client/app/visualizations/chart/chart-editor.html
+++ b/client/app/visualizations/chart/chart-editor.html
@@ -12,6 +12,9 @@
     <li ng-class="{active: currentTab == 'series'}" ng-if="options.globalSeriesType != 'custom'">
       <a ng-click="changeTab('series')">Series</a>
     </li>
+    <li ng-class="{active: currentTab == 'appearance'}" ng-if="options.globalSeriesType != 'custom'">
+      <a ng-click="changeTab('appearance')">Appearance</a>
+    </li>
   </ul>
   <div ng-if="currentTab == 'general'" class="m-t-10 m-b-10">
     <div class="form-group">
@@ -30,10 +33,6 @@
           </ui-select-choices>
         </ui-select>
       </div>
-    </div>
-
-    <div ng-if="['line', 'area', 'column', 'scatter'].indexOf(options.globalSeriesType) >= 0" class="checkbox">
-      <label><input type="checkbox" ng-model="options.showDataLabels"> Show data labels</label>
     </div>
 
     <div class="form-group" ng-class="{'has-error': chartEditor.xAxisColumn.$invalid}">
@@ -135,24 +134,26 @@
     </div>
   </div>
 
-  <div class="form-group" ng-if="options.globalSeriesType == 'custom'">
-    <label class="control-label">Custom code</label>
-    <textarea ng-model="options.customCode" class="form-control v-resizable" rows="10">
-    </textarea>
-  </div>
+  <div ng-if="options.globalSeriesType == 'custom'">
+    <div class="form-group">
+      <label class="control-label">Custom code</label>
+      <textarea ng-model="options.customCode" class="form-control v-resizable" rows="10">
+      </textarea>
+    </div>
 
-  <div class="checkbox" ng-if="options.globalSeriesType == 'custom'">
-    <label>
-      <input type="checkbox" ng-model="options.enableConsoleLogs">
-      <i class="input-helper"></i> Show errors in the console
-    </label>
-  </div>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" ng-model="options.enableConsoleLogs">
+        <i class="input-helper"></i> Show errors in the console
+      </label>
+    </div>
 
-  <div class="checkbox" ng-if="options.globalSeriesType == 'custom'">
-    <label>
-      <input type="checkbox" ng-model="options.autoRedraw">
-      <i class="input-helper"></i> Auto update graph
-    </label>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" ng-model="options.autoRedraw">
+        <i class="input-helper"></i> Auto update graph
+      </label>
+    </div>
   </div>
 
   <div ng-if="currentTab == 'xAxis'" class="m-t-10 m-b-10">
@@ -266,5 +267,56 @@
       </tr>
       </tbody>
     </table>
+  </div>
+
+  <div ng-if="currentTab == 'appearance'" class="m-t-10 m-b-10">
+    <div ng-if="['line', 'area', 'column', 'scatter', 'pie'].indexOf(options.globalSeriesType) >= 0" class="checkbox">
+      <label><input type="checkbox" ng-model="options.showDataLabels"> Show data labels</label>
+    </div>
+
+    <div class="form-group">
+      <label for="chart-editor-number-format">
+        Number format
+        <span class="m-l-5"
+          uib-popover-html="'Format <a href=&quot;http://numeraljs.com/&quot; target=&quot;_blank&quot;>specs.</a>'"
+          popover-trigger="'click outsideClick'"><i class="fa fa-question-circle"></i></span>
+      </label>
+      <input class="form-control" ng-model="options.numberFormat" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+        id="chart-editor-number-format">
+    </div>
+
+    <div class="form-group">
+      <label for="chart-editor-percent-format">
+        Percent format
+        <span class="m-l-5"
+          uib-popover-html="'Format <a href=&quot;http://numeraljs.com/&quot; target=&quot;_blank&quot;>specs.</a>'"
+          popover-trigger="'click outsideClick'"><i class="fa fa-question-circle"></i></span>
+      </label>
+      <input class="form-control" ng-model="options.percentFormat" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+        id="chart-editor-percent-format">
+    </div>
+
+    <div class="form-group">
+      <label for="chart-editor-datetime-format">
+        Date/Time format
+        <span class="m-l-5"
+          uib-popover-html="'Format <a href=&quot;http://momentjs.com/docs/#/displaying/format/&quot; target=&quot;_blank&quot;>specs.</a>'"
+          popover-trigger="'click outsideClick'"><i class="fa fa-question-circle"></i></span>
+      </label>
+      <input class="form-control" ng-model="options.dateTimeFormat" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+        id="chart-editor-datetime-format">
+    </div>
+
+    <div class="form-group">
+      <label for="chart-editor-text">
+        Data labels
+        <i class="fa fa-question-circle m-l-5"
+          uib-popover-html="templateHint"
+          popover-trigger="'click outsideClick'"
+          popover-placement="top-left"></i>
+      </label>
+      <input class="form-control" ng-model="options.textFormat" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+        id="chart-editor-text" placeholder="(auto)">
+    </div>
   </div>
 </div>

--- a/client/app/visualizations/chart/index.js
+++ b/client/app/visualizations/chart/index.js
@@ -16,9 +16,10 @@ const DEFAULT_OPTIONS = {
   seriesOptions: {},
   columnMapping: {},
 
+  // showDataLabels: false, // depends on chart type
   numberFormat: '0,0[.]00000',
   percentFormat: '0[.]00%',
-  dateTimeFormat: 'DD/MM/YYYY HH:mm',
+  // dateTimeFormat: 'DD/MM/YYYY HH:mm', // will be set from clientConfig
   textFormat: '', // default: combination of {{ @@yPercent }} ({{ @@y }} ± {{ @@yError }})
 
   defaultColumns: 3,
@@ -36,7 +37,7 @@ function ChartRenderer() {
     },
     template,
     replace: false,
-    controller($scope) {
+    controller($scope, clientConfig) {
       $scope.chartSeries = [];
 
       function zIndexCompare(series) {
@@ -57,6 +58,7 @@ function ChartRenderer() {
         reloadData();
         $scope.plotlyOptions = extend({
           showDataLabels: $scope.options.globalSeriesType === 'pie',
+          dateTimeFormat: clientConfig.dateTimeFormat,
         }, DEFAULT_OPTIONS, $scope.options);
       }
 
@@ -268,9 +270,10 @@ function ChartEditor(ColorPalette, clientConfig) {
       scope.$watch('options', () => {
         if (scope.options) {
           // For existing visualization - set default options
-          defaults(scope.options, DEFAULT_OPTIONS, {
+          defaults(scope.options, extend({}, DEFAULT_OPTIONS, {
             showDataLabels: scope.options.globalSeriesType === 'pie',
-          });
+            dateTimeFormat: clientConfig.dateTimeFormat,
+          }));
         }
       });
 

--- a/client/app/visualizations/chart/index.js
+++ b/client/app/visualizations/chart/index.js
@@ -20,7 +20,6 @@ const DEFAULT_OPTIONS = {
   percentFormat: '0[.]00%',
   dateTimeFormat: 'DD/MM/YYYY HH:mm',
   textFormat: '', // default: combination of {{ @@yPercent }} ({{ @@y }} ± {{ @@yError }})
-  tooltipLine: '{{ @@label }}',
 
   defaultColumns: 3,
   defaultRows: 8,

--- a/client/app/visualizations/chart/index.js
+++ b/client/app/visualizations/chart/index.js
@@ -281,6 +281,7 @@ function ChartEditor(ColorPalette, clientConfig) {
         <div><code>{{ @@y }}</code> y-value;</div>
         <div><code>{{ @@yPercent }}</code> relative y-value;</div>
         <div><code>{{ @@yError }}</code> y deviation;</div>       
+        <div><code>{{ @@size }}</code> bubble size;</div>       
         <div class="p-t-5">Also, all query result columns can be referenced using 
           <code class="text-nowrap">{{ column_name }}</code> syntax.</div>       
       `;

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -55,8 +55,8 @@ function getDefaultColumnsOptions(columns) {
 
 function getDefaultFormatOptions(column, clientConfig) {
   const dateTimeFormat = {
-    date: clientConfig.dateFormat || 'DD/MM/YY',
-    datetime: clientConfig.dateTimeFormat || 'DD/MM/YY HH:mm',
+    date: clientConfig.dateFormat || 'DD/MM/YYYY',
+    datetime: clientConfig.dateTimeFormat || 'DD/MM/YYYY HH:mm',
   };
   const numberFormat = {
     integer: clientConfig.integerFormat || '0,0',


### PR DESCRIPTION
Issue: getredash/redash#728

This PR is a replacement of getredash/redash#2468 and is based on discussion there.

Added tab with new settings: formats for numbers, date/time and tooltips. Tooltips now may include other fields from query records.

Screenshots:

![image](https://user-images.githubusercontent.com/12139186/40049149-997bb8f4-583c-11e8-8ff0-2bd318b2ecb7.png)

![image](https://user-images.githubusercontent.com/12139186/40049229-d3fbca14-583c-11e8-8a3a-5a276f8fb7f9.png)
