### PR TITLE
allow view_only permission to run query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ node_modules
 .tmp
 .sass-cache
 npm-debug.log
+.history
+postgresql-data

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -116,7 +116,7 @@ class QueryResultListResource(BaseResource):
 
         data_source = models.DataSource.get_by_id_and_org(params.get('data_source_id'), self.current_org)
 
-        if not has_access(data_source.groups, self.current_user, not_view_only):
+        if not has_access(data_source.groups, self.current_user, view_only):
             return {'job': {'status': 4, 'error': 'You do not have permission to run queries with this data source.'}}, 403
 
         self.record_event({


### PR DESCRIPTION
I believe this is more appropriate for general use cases - running queries should equal to view_only rights, otherwise I don't really understand what is view only stands for.