### PR TITLE
Introduce Policy object

### DIFF
--- a/client/app/components/dashboards/edit-dashboard-dialog.html
+++ b/client/app/components/dashboards/edit-dashboard-dialog.html
@@ -2,12 +2,16 @@
   <button type="button" class="close" ng-click="$ctrl.dismiss()" ng-disabled="$ctrl.saveInProgress" aria-hidden="true">&times;</button>
   <h4 class="modal-title">New Dashboard</h4>
 </div>
-<div class="modal-body">
+<div class="modal-body" ng-if="$ctrl.policy.isCreateDashboardEnabled()">
   <p>
     <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name" autofocus ng-keyup="$event.keyCode === 13 && $ctrl.saveDashboard()">
   </p>
 </div>
-<div class="modal-footer">
+<div class="modal-footer" ng-if="$ctrl.policy.isCreateDashboardEnabled()">
   <button type="button" class="btn btn-default" ng-disabled="$ctrl.saveInProgress" ng-click="$ctrl.dismiss()">Close</button>
   <button type="button" class="btn btn-primary" ng-disabled="$ctrl.saveInProgress || !$ctrl.isFormValid()" ng-click="$ctrl.saveDashboard()">Save</button>
+</div>
+
+<div class="modal-body" ng-if="!ctrl.policy.isCreateDashboardEnabled()">
+  <edit-dashboard-dialog-disabled></edit-dashboard-dialog-disabled>
 </div>

--- a/client/app/components/dashboards/edit-dashboard-dialog.html
+++ b/client/app/components/dashboards/edit-dashboard-dialog.html
@@ -1,10 +1,10 @@
 <div class="modal-header">
   <button type="button" class="close" ng-click="$ctrl.dismiss()" ng-disabled="$ctrl.saveInProgress" aria-hidden="true">&times;</button>
-  <h4 class="modal-title">Dashboard name: {{$ctrl.dashboard.name}}</h4>
+  <h4 class="modal-title">New Dashboard</h4>
 </div>
 <div class="modal-body">
   <p>
-    <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name" autofocus>
+    <input type="text" class="form-control" placeholder="Dashboard Name" ng-model="$ctrl.dashboard.name" autofocus ng-keyup="$event.keyCode === 13 && $ctrl.saveDashboard()">
   </p>
 </div>
 <div class="modal-footer">

--- a/client/app/components/dashboards/edit-dashboard-dialog.js
+++ b/client/app/components/dashboards/edit-dashboard-dialog.js
@@ -8,14 +8,19 @@ const EditDashboardDialog = {
     dismiss: '&',
   },
   template,
-  controller($rootScope, $location, $http, toastr, Events) {
+  controller($location, $http, Policy, Events) {
     'ngInject';
 
     this.dashboard = this.resolve.dashboard;
+    this.policy = Policy;
 
     this.isFormValid = () => !isEmpty(this.dashboard.name);
 
     this.saveDashboard = () => {
+      if (!this.isFormValid()) {
+        return;
+      }
+
       this.saveInProgress = true;
 
       $http

--- a/client/app/components/queries/schedule-dialog.js
+++ b/client/app/components/queries/schedule-dialog.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { map, range, partial } from 'underscore';
+import { map, range, partial, each, isArray } from 'underscore';
 import { durationHumanize } from '@/filters';
 
 import template from './schedule-dialog.html';
@@ -21,8 +21,10 @@ function queryTimePicker() {
       saveQuery: '=',
     },
     template: `
-      <select ng-disabled="refreshType != 'daily'" ng-model="hour" ng-change="updateSchedule()" ng-options="c as c for c in hourOptions"></select> :
-      <select ng-disabled="refreshType != 'daily'" ng-model="minute" ng-change="updateSchedule()" ng-options="c as c for c in minuteOptions"></select>
+      <select ng-disabled="refreshType != 'daily'" ng-model="hour" ng-change="updateSchedule()" 
+        ng-options="c as c for c in hourOptions"></select> :
+      <select ng-disabled="refreshType != 'daily'" ng-model="minute" ng-change="updateSchedule()" 
+        ng-options="c as c for c in minuteOptions"></select>
     `,
     link($scope) {
       $scope.hourOptions = map(range(0, 24), partial(padWithZeros, 2));
@@ -58,7 +60,7 @@ function queryTimePicker() {
   };
 }
 
-function queryRefreshSelect(clientConfig) {
+function queryRefreshSelect(clientConfig, Policy) {
   return {
     restrict: 'E',
     scope: {
@@ -70,12 +72,23 @@ function queryRefreshSelect(clientConfig) {
                 ng-disabled="refreshType != 'periodic'"
                 ng-model="query.schedule"
                 ng-change="saveQuery()"
-                ng-options="c.value as c.name for c in refreshOptions">
+                ng-options="c.value as c.name disable when !c.enabled for c in refreshOptions">
                 <option value="">No Refresh</option>
                 </select>`,
     link($scope) {
       $scope.refreshOptions =
-        clientConfig.queryRefreshIntervals.map(interval => ({ value: String(interval), name: `Every ${durationHumanize(interval)}` }));
+        clientConfig.queryRefreshIntervals.map(interval => ({
+          value: String(interval),
+          name: `Every ${durationHumanize(interval)}`,
+          enabled: true,
+        }));
+
+      const allowedIntervals = Policy.getQueryRefreshIntervals();
+      if (isArray(allowedIntervals)) {
+        each($scope.refreshOptions, (interval) => {
+          interval.enabled = allowedIntervals.indexOf(Number(interval.value)) >= 0;
+        });
+      }
 
       $scope.$watch('refreshType', () => {
         if ($scope.refreshType === 'periodic') {

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -40,8 +40,8 @@
               <span class="sr-only">Split button!</span>
             </button>
             <ul class="dropdown-menu pull-right" ng-model="$ctrl.refreshRate" uib-dropdown-menu role="menu" aria-labelledby="split-button">
-              <li role="menuitem" ng-repeat="refreshRate in $ctrl.refreshRates">
-                <a href="#" ng-click="$ctrl.setRefreshRate(refreshRate)">{{refreshRate.name}}</a>
+              <li role="menuitem" ng-repeat="refreshRate in $ctrl.refreshRates" ng-class="{disabled: !refreshRate.enabled}">
+                <a href="javascript:void(0)" ng-click="$ctrl.setRefreshRate(refreshRate)">{{refreshRate.name}}</a>
               </li>
               <li role="menuitem" ng-if="$ctrl.refreshRate !== null">
                 <a href="#" ng-click="$ctrl.setRefreshRate(null)">Stop auto refresh</a>

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -35,6 +35,7 @@ function DashboardCtrl(
   clientConfig,
   Events,
   toastr,
+  Policy,
 ) {
   this.saveInProgress = false;
 
@@ -77,7 +78,15 @@ function DashboardCtrl(
   this.refreshRates = clientConfig.dashboardRefreshIntervals.map(interval => ({
     name: durationHumanize(interval),
     rate: interval,
+    enabled: true,
   }));
+
+  const allowedIntervals = Policy.getDashboardRefreshIntervals();
+  if (_.isArray(allowedIntervals)) {
+    _.each(this.refreshRates, (rate) => {
+      rate.enabled = allowedIntervals.indexOf(rate.rate) >= 0;
+    });
+  }
 
   this.setRefreshRate = (rate, load = true) => {
     this.refreshRate = rate;

--- a/client/app/pages/data-sources/list.html
+++ b/client/app/pages/data-sources/list.html
@@ -2,10 +2,12 @@
   <div class="row">
     <div class="col-md-12">
       <p>
-        <a href="data_sources/new" class="btn btn-default"><i class="fa fa-plus"></i> New Data Source</a>
+        <a href="data_sources/new" class="btn btn-default" ng-class="{'disabled': !$ctrl.policy.isCreateDataSourceEnabled()}">
+          <i class="fa fa-plus"></i> New Data Source</a>
+        <datasources-list-extra></datasources-list-extra>
       </p>
       <div class="database-source">
-        <a class="visual-card" ng-href="data_sources/{{dataSource.id}}" ng-repeat="dataSource in dataSources" title="{{dataSource.name}}">
+        <a class="visual-card" ng-href="data_sources/{{dataSource.id}}" ng-repeat="dataSource in $ctrl.dataSources" title="{{dataSource.name}}">
           <img ng-src="/static/images/db-logos/{{dataSource.type}}.png" alt="{{dataSource.name}}">
           <h3>{{dataSource.name}}</h3>
         </a>

--- a/client/app/pages/data-sources/list.js
+++ b/client/app/pages/data-sources/list.js
@@ -1,10 +1,11 @@
 import settingsMenu from '@/lib/settings-menu';
 import template from './list.html';
 
-function DataSourcesCtrl($scope, $location, currentUser, Events, DataSource) {
+function DataSourcesCtrl(Policy, Events, DataSource) {
   Events.record('view', 'page', 'admin/data_sources');
 
-  $scope.dataSources = DataSource.query();
+  this.policy = Policy;
+  this.dataSources = DataSource.query();
 }
 
 export default function init(ngModule) {
@@ -15,12 +16,14 @@ export default function init(ngModule) {
     order: 1,
   });
 
-  ngModule.controller('DataSourcesCtrl', DataSourcesCtrl);
+  ngModule.component('dsListPage', {
+    controller: DataSourcesCtrl,
+    template,
+  });
 
   return {
     '/data_sources': {
-      template,
-      controller: 'DataSourcesCtrl',
+      template: '<ds-list-page></ds-list-page>',
       title: 'Data Sources',
     },
   };

--- a/client/app/pages/users/list.html
+++ b/client/app/pages/users/list.html
@@ -1,16 +1,14 @@
 <settings-screen>
   <div class="row">
     <div class="col-md-12">
-      <div class="clearfix m-b-10" ng-if="$ctrl.currentUser.hasPermission('admin')">
-        <a href="users/new" class="btn btn-default pull-left"><i class="fa fa-plus"></i> New User</a>
+      <div class="clearfix m-b-10" ng-if="$ctrl.policy.canCreateUser()">
+        <a href="users/new" class="btn btn-default" ng-class="{'disabled': !$ctrl.policy.isCreateUserEnabled()}">
+          <i class="fa fa-plus"></i> New User</a>
+        <users-list-extra></users-list-extra>
 
         <div class="btn-group pull-right">
-          <button class="btn btn-default" type="button"
-            ng-click="$ctrl.setUsersCategory('enabled')" ng-class="{ active: $ctrl.usersCategory == 'enabled' }"
-          >Enabled ({{ $ctrl.userCategories.enabled.length }})</button>
-          <button class="btn btn-default" type="button"
-            ng-click="$ctrl.setUsersCategory('disabled')" ng-class="{ active: $ctrl.usersCategory == 'disabled' }"
-          >Disabled ({{ $ctrl.userCategories.disabled.length }})</button>
+          <button class="btn btn-default" type="button" ng-click="$ctrl.setUsersCategory('enabled')" ng-class="{ active: $ctrl.usersCategory == 'enabled' }">Enabled ({{ $ctrl.userCategories.enabled.length }})</button>
+          <button class="btn btn-default" type="button" ng-click="$ctrl.setUsersCategory('disabled')" ng-class="{ active: $ctrl.usersCategory == 'disabled' }">Disabled ({{ $ctrl.userCategories.disabled.length }})</button>
         </div>
       </div>
 
@@ -25,7 +23,7 @@
         <tbody>
           <tr ng-repeat="user in $ctrl.users.getPageRows()">
             <td>
-              <img ng-src="{{ user.profile_image_url }}" height="32px" class="profile__image--settings"/>
+              <img ng-src="{{ user.profile_image_url }}" height="32px" class="profile__image--settings" />
               <a href="users/{{ user.id }}" ng-class="{'text-muted': user.is_disabled}">{{ user.name }}</a>
             </td>
             <td>
@@ -33,12 +31,8 @@
             </td>
             <td>
               <div ng-if="$ctrl.currentUser.hasPermission('admin') && (user.id != $ctrl.currentUser.id)">
-                <button type="button" class="btn btn-primary"
-                  ng-if="user.is_disabled" ng-click="$ctrl.enableUser(user)"
-                >Enable</button>
-                <button type="button" class="btn btn-default"
-                  ng-if="!user.is_disabled" ng-click="$ctrl.disableUser(user)"
-                >Disable</button>
+                <button type="button" class="btn btn-primary" ng-if="user.is_disabled" ng-click="$ctrl.enableUser(user)">Enable</button>
+                <button type="button" class="btn btn-default" ng-if="!user.is_disabled" ng-click="$ctrl.disableUser(user)">Disable</button>
               </div>
             </td>
           </tr>

--- a/client/app/pages/users/list.js
+++ b/client/app/pages/users/list.js
@@ -4,10 +4,10 @@ import settingsMenu from '@/lib/settings-menu';
 import { Paginator } from '@/lib/pagination';
 import template from './list.html';
 
-function UsersCtrl(currentUser, Events, User) {
+function UsersCtrl(Policy, Events, User) {
   Events.record('view', 'page', 'users');
 
-  this.currentUser = currentUser;
+  this.policy = Policy;
   this.users = new Paginator([], { itemsPerPage: 20 });
 
   this.userCategories = {
@@ -53,7 +53,6 @@ export default function init(ngModule) {
     isActive: $location => startsWith($location.path(), '/users') && $location.path() !== '/users/me',
     order: 2,
   });
-
 
   ngModule.component('usersListPage', {
     controller: UsersCtrl,

--- a/client/app/services/policy.js
+++ b/client/app/services/policy.js
@@ -1,0 +1,81 @@
+import { isFunction, isArray } from 'underscore';
+
+export class Policy {
+  constructor($injector) {
+    this.$injector = $injector;
+  }
+
+  get user() {
+    return this.$injector.get('currentUser');
+  }
+
+  get organizationStatus() {
+    return this.$injector.get('organizationStatus');
+  }
+
+  refresh() {
+    const $q = this.$injector.get('$q');
+    return $q.resolve(this);
+  }
+
+  canCreateDataSource() {
+    return this.user.hasPermission('admin');
+  }
+
+  isCreateDataSourceEnabled() {
+    return this.user.hasPermission('admin');
+  }
+
+  canCreateDashboard() {
+    return this.user.hasPermission('create_dashboard');
+  }
+
+  isCreateDashboardEnabled() {
+    return this.user.hasPermission('create_dashboard');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  canCreateAlert() {
+    return true;
+  }
+
+  canCreateUser() {
+    return this.user.hasPermission('admin');
+  }
+
+  isCreateUserEnabled() {
+    return this.user.hasPermission('admin');
+  }
+
+  getDashboardRefreshIntervals() {
+    const clientConfig = this.$injector.get('clientConfig');
+    const result = clientConfig.dashboardRefreshIntervals;
+    return isArray(result) ? result : null;
+  }
+
+  getQueryRefreshIntervals() {
+    const clientConfig = this.$injector.get('clientConfig');
+    const result = clientConfig.queryRefreshIntervals;
+    return isArray(result) ? result : null;
+  }
+}
+
+export default function init(ngModule) {
+  let appInjector = null;
+
+  ngModule.run(($injector) => {
+    'ngInject';
+
+    appInjector = $injector;
+  });
+
+  ngModule.provider('Policy', function policyProvider() {
+    let PolicyClass = Policy;
+
+    this.setPolicyClass = (policyClass) => {
+      PolicyClass = policyClass;
+    };
+
+    this.$get = () => (isFunction(PolicyClass) ? new PolicyClass(appInjector) : null);
+  });
+}


### PR DESCRIPTION
This pull request introduces the `Policy` object and a few extension points. The idea is to encapsulate the logic of whether a user can do a specific action (or whether it's enabled) in a single place. This has the following benefits --

* Easier to understand where things are controlled.
* Easier to extend and change in custom deployments of Redash.

Also added a few extension points in form of HTML tags of non existing components (like the `<users-list-extra>` or `<edit-dashboard-dialog-disabled>` tags). Normally they have no effect, but if your project has them defined, they will be rendered.

This is the first step, we still need to review all the additional places the `Policy` object should be used and actually use it...