### PR TITLE
commit query result to db before evaluating alerts

### DIFF
--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -475,6 +475,7 @@ class QueryExecutor(object):
                 self.data_source.org_id, self.data_source,
                 self.query_hash, self.query, data,
                 run_time, utils.utcnow())
+            models.db.session.commit()  # make sure that alert sees the latest query result
             self._log_progress('checking_alerts')
             for query_id in updated_query_ids:
                 check_alerts_for_query.delay(query_id)


### PR DESCRIPTION
We have run into a problem where alert is triggering incorrectly because it is using stale query result. The race condition happens when the query result is relatively big and when the `check_alerts_for_query` task runs the result is not yet committed to the database.

Committing the db session before firing the celery tasks solves the problem for us.