### PR TITLE
Fix for DPI-1054 error on Oracle driver

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -66,10 +66,7 @@ class Oracle(BaseSQLQueryRunner):
                     "type": "string",
                     "title": "DSN Service Name"
                 },
-                "tns": {
-                    "type": "string",
-                    "title": "TNS Connect String (Override properties above)"
-                }
+                "tns": {"type": "string", "title": "TNS Connect String"}
             },
             "order": ["host", "port", "user", "password", "servicename"],
             "required": ["servicename", "user", "password", "host", "port"],

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -7,8 +7,6 @@ from redash.utils import JSONEncoder
 
 try:
     import cx_Oracle
-    os.environ["NLS_LANG"] = "BRAZILIAN PORTUGUESE_BRAZIL.WE8MSWIN1252"
-    os.environ["NLS_NUMERIC_CHARACTERS"] = ".,"
 
     TYPES_MAP = {
         cx_Oracle.DATETIME: TYPE_DATETIME,

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -1,4 +1,4 @@
 # Requires installation of, or similar versions of:
 #    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
 #    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm
-cx_Oracle==5.3
+cx_Oracle==6.1


### PR DESCRIPTION
I was unable to use redash with Oracle, using cx_Oracle 5.3. I kept getting this error:
DPI-1054: connection cannot be closed when open statements or LOBs exist

To fix the issue I installed cx_Oracle version 6.1 and changed I few lines of code on the oracle query runner to delete the data after it has been used and close the cursor.