### PR TITLE
Support elasticsearch-sql plugin for SQL query

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -430,8 +430,8 @@ class ElasticSearch(BaseElasticSearch):
                 if sql_query.lower().startswith("select"):
                     logger.debug("Query using SQL statement")
                     index_name = get_index_from_sql(sql_query)
-                    url = "{0}/_sql".format(self.server_url)
-                    params = {"sql": sql_query}
+                    url = "{0}/_sql?sql={1}".format(self.server_url, sql_query)
+                    params = {}
 
             mapping_url = "{0}/{1}/_mapping".format(self.server_url, index_name)
             mappings, error = self._get_query_mappings(mapping_url)

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -51,6 +51,7 @@ def get_index_from_sql(sql):
         return None
     return matches.groups()[0]
 
+
 class BaseElasticSearch(BaseQueryRunner):
     DEBUG_ENABLED = False
 

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -45,6 +45,12 @@ PYTHON_TYPES_MAPPING = {
 }
 
 
+def get_index_from_sql(sql):
+    matches = re.search(r"from ([\w\d]+)", sql, flags=re.IGNORECASE)
+    if not matches:
+        return None
+    return matches.groups()[0]
+
 class BaseElasticSearch(BaseQueryRunner):
     DEBUG_ENABLED = False
 
@@ -423,10 +429,7 @@ class ElasticSearch(BaseElasticSearch):
                 sql_query = query.strip() if isinstance(query, str) or isinstance(query, unicode) else ''
                 if sql_query.lower().startswith("select"):
                     logger.debug("Query using SQL statement")
-                    # matches index name from sql statement Ex. "select * from movies" index_name will be "movies"
-                    matches = re.search(r"from ([\w\d]+)", sql_query, flags=re.IGNORECASE)
-                    if matches:
-                        index_name = matches.groups()[0]
+                    index_name = get_index_from_sql(sql_query)
                     url = "{0}/_sql".format(self.server_url)
                     params = {"sql": sql_query}
 


### PR DESCRIPTION
ElasticSearch version 6.3 and later supported SQL statement for querying  the data but not for the earlier versions. To use the SQL statement, you have to install [elasticsearch-sql](https://github.com/NLPchina/elasticsearch-sql) plugin.

The PR is to support SQL statement if user use ElasticSearch as data source and the plugin is already installed.