### PR TITLE
keep query result pagination out of scroll

### DIFF
--- a/client/app/components/dynamic-table/dynamic-table.less
+++ b/client/app/components/dynamic-table/dynamic-table.less
@@ -1,4 +1,6 @@
 .dynamic-table-container {
+  overflow-x: scroll;
+
   th {
     white-space: nowrap;
     span {


### PR DESCRIPTION
fixes #2581 

The query result pagination was already in a separate div, I just had to force the scroll into the query results and out of the entire dynamic-table tag.