### PR TITLE
Show data only mode: allow to add and delete visualizations

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -16,6 +16,17 @@ body.fixed-layout {
   }
 }
 
+.tab-nav .tab-new-vis {
+  margin: 0 5px;
+
+  > a {
+    color: @headings-color;
+    padding: 7px;
+    margin: 8px 0;
+    font-weight: 400;
+  }
+}
+
 .bottom-controller {
   padding: 10px 15px;
   background: #fff;

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -223,9 +223,9 @@
                   <ul class="tab-nav">
                     <rd-tab ng-if="!query.visualizations.length" tab-id="table" name="Table" base-path="query.getUrl(sourceMode)"></rd-tab>
                     <rd-tab tab-id="{{vis.id}}" name="{{vis.name}}" base-path="query.getUrl(sourceMode)" ng-repeat="vis in query.visualizations | orderBy:'id'">
-                      <span class="remove" ng-click="deleteVisualization($event, vis)" ng-if="canEdit && !($first && (vis.type === 'TABLE'))"> &times;</span>
+                      <span class="remove" ng-click="deleteVisualization($event, vis)" ng-if="canEdit && !($first && (vis.type === 'TABLE'))"> <i class="zmdi zmdi-close"></i></span>
                     </rd-tab>
-                    <li class="rd-tab"><a ng-click="openVisualizationEditor()" ng-if="canEdit">&plus; New Visualization</a></li>
+                    <li class="rd-tab tab-new-vis"><a ng-click="openVisualizationEditor()" class="btn btn-default" ng-if="canEdit"><i class="zmdi zmdi-plus"></i> New Visualization</a></li>
                   </ul>
                   <div ng-if="!query.visualizations.length" class="query__vis m-t-15 p-b-15 scrollbox">
                     <filters filters="filters"></filters>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -225,7 +225,7 @@
                     <rd-tab tab-id="{{vis.id}}" name="{{vis.name}}" base-path="query.getUrl(sourceMode)" ng-repeat="vis in query.visualizations | orderBy:'id'">
                       <span class="remove" ng-click="deleteVisualization($event, vis)" ng-if="canEdit && !($first && (vis.type === 'TABLE'))"> &times;</span>
                     </rd-tab>
-                    <li class="rd-tab"><a ng-click="openVisualizationEditor()" ng-if="sourceMode && canEdit">&plus; New Visualization</a></li>
+                    <li class="rd-tab"><a ng-click="openVisualizationEditor()" ng-if="canEdit">&plus; New Visualization</a></li>
                   </ul>
                   <div ng-if="!query.visualizations.length" class="query__vis m-t-15 p-b-15 scrollbox">
                     <filters filters="filters"></filters>

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -6,10 +6,6 @@ function QuerySourceCtrl(
 ) {
   // extends QueryViewCtrl
   $controller('QueryViewCtrl', { $scope });
-  // TODO:
-  // This doesn't get inherited. Setting it on this didn't work either (which is weird).
-  // Obviously it shouldn't be repeated, but we got bigger fish to fry.
-  const DEFAULT_TAB = 'table';
 
   Events.record('view_source', 'query', $scope.query.id);
 
@@ -20,8 +16,6 @@ function QuerySourceCtrl(
   $scope.sourceMode = true;
   $scope.isDirty = false;
   $scope.base_url = `${$location.protocol()}://${$location.host()}:${$location.port()}`;
-
-  $scope.newVisualization = undefined;
 
   // @override
   Object.defineProperty($scope, 'showDataset', {
@@ -69,28 +63,6 @@ function QuerySourceCtrl(
     Query.format($scope.dataSource.syntax, $scope.query.query)
       .then((query) => { $scope.query.query = query; })
       .catch(error => toastr.error(error));
-  };
-
-  $scope.deleteVisualization = ($e, vis) => {
-    $e.preventDefault();
-
-    const title = undefined;
-    const message = `Are you sure you want to delete ${vis.name} ?`;
-    const confirm = { class: 'btn-danger', title: 'Delete' };
-
-    AlertDialog.open(title, message, confirm).then(() => {
-      Events.record('delete', 'visualization', vis.id);
-
-      Visualization.delete({ id: vis.id }, () => {
-        if ($scope.selectedTab === String(vis.id)) {
-          $scope.selectedTab = DEFAULT_TAB;
-          $location.hash($scope.selectedTab);
-        }
-        $scope.query.visualizations = $scope.query.visualizations.filter(v => vis.id !== v.id);
-      }, () => {
-        toastr.error("Error deleting visualization. Maybe it's used in a dashboard?");
-      });
-    });
   };
 
   $scope.$watch('query.query', (newQueryText) => {


### PR DESCRIPTION
Requested by @kocsmy 

On query page in data-only mode:
1. allow to delete visualizations (currently button is visible but does not work);
2. allow to add new visualizations (currently user should go to editing mode to add viz).