### PR TITLE
requirements: added pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ blinker==1.3
 psycopg2==2.7.3.2
 python-dateutil==2.4.2
 pytz==2016.7
+PyYAML==3.12
 redis==2.10.5
 requests==2.11.1
 six==1.10.0


### PR DESCRIPTION
New Metrika/Appmetrika datasources requires PyYAML lib. I forgot to add it to requirements.