### PR TITLE
Upgrade gspread to 2.1.1

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,5 +1,5 @@
 google-api-python-client==1.5.1
-gspread==0.6.2
+gspread==2.1.1
 impyla==0.10.0
 influxdb==2.7.1
 MySQL-python==1.2.5


### PR DESCRIPTION
Hi team,

Here is an improvement for Spreadsheets Query Runner.

FYI, latest version of gspread is 3.0.0, but 3.0.0 drops Sheets API v3 support.

For now, Redash's Spreadsheets Query Runner depends on old version of gspread(<=2.1.1).

I think we have to do more work for upgrade to 3.0.0.

Thanks,