### PR TITLE
Fix export query results output file name

### DIFF
--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -476,7 +476,7 @@ function QueryResultService($resource, $timeout, $q) {
     }
 
     getName(queryName, fileType) {
-      return `${queryName.replace(' ', '_') + moment(this.getUpdatedAt()).format('_YYYY_MM_DD')}.${fileType}`;
+      return `${queryName.replace(/ /g, '_') + moment(this.getUpdatedAt()).format('_YYYY_MM_DD')}.${fileType}`;
     }
 
     static get(dataSourceId, query, maxAge, queryId) {


### PR DESCRIPTION
Hi guys, this is a small change on the output file name when you export a query result.

`queryName.replace(/ /g, '_')` will seek for all the occurrences of space in the file name. Not only the first one, as it was before.