### PR TITLE
Issue 2534 Fix wrong behavior with empty query

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -263,7 +263,11 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
 
   Query.prototype.getQueryResult = function getQueryResult(maxAge) {
     if (!this.query) {
-      return new QueryResultError("Can't execute empty query.");
+      return new QueryResult({
+        job: {
+          status: 4,
+        },
+      });
     }
     let queryText = this.query;
 


### PR DESCRIPTION
This will fix #2534 
It seems empty QueryResult will blocks rendering.
I changed the function to return QueryResult with status 4 "failure".
Please let me know if you have any concern! Thanks.