### PR TITLE
Include a route to provide a health endpoint for Kubernetes based installs

### DIFF
--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -1,4 +1,5 @@
 import os
+from flask import jsonify
 
 from flask import current_app, render_template, safe_join, send_file
 from werkzeug.exceptions import NotFound
@@ -25,3 +26,8 @@ def render_index():
 @login_required
 def index(**kwargs):
     return render_index()
+
+
+@routes.route('/health')
+def health_check():
+    return jsonify({}), 204


### PR DESCRIPTION
This PR proposes, exposing an unauthenticated endpoint `/health` that returns a `200` and is not rate-limited to be used as a health check in Kubernetes based installs. Without it, it is more difficult to deploy redash into Kubernetes.

### Rationale

Kubernetes on Google Kubernetes Engine (GKE) requires that an endpoint path on the container provides a health endpoint if you are using an Ingress to loadbalance your requests. These are required for `liveness` and `readiness` probes. 

By default it expects `200` on `/`. Redash, of course, redirects `/` to `/login` for unauthenticated users so this can't be used. The health check can be configured to use `/login` as the health endpoint unfortunately, if you are not careful, GKE hits `/login` too frequently and trips the rate limiter (Flask-Limiter) which begins returning `429`. The Ingress then concludes that the pod isn't ready and issues a `502` to inbound requests — blocking the client from accessing the app.

This is the same behaviour you get if you did this on Amazon EKS and Azure Kubernetes Service.