### PR TITLE
data source sort case insensitive

### DIFF
--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -83,7 +83,7 @@ class DataSourceListResource(BaseResource):
             except AttributeError:
                 logging.exception("Error with DataSource#to_dict (data source id: %d)", ds.id)
 
-        return sorted(response.values(), key=lambda d: d['name'])
+        return sorted(response.values(), key=lambda d: d['name'].lower())
 
     @require_admin
     def post(self):


### PR DESCRIPTION
#2567 
In QA on the Mozilla side Madalin noticed that the sort wasn't case insensitive. This fixes that.