### PR TITLE
Dashboard stops rendering when adding widget with empty query

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -19,32 +19,6 @@ function collectParams(parts) {
   return parameters;
 }
 
-class QueryResultError {
-  constructor(errorMessage) {
-    this.errorMessage = errorMessage;
-  }
-
-  getError() {
-    return this.errorMessage;
-  }
-
-  static getStatus() {
-    return 'failed';
-  }
-
-  static getData() {
-    return null;
-  }
-
-  static getLog() {
-    return null;
-  }
-
-  static getChartData() {
-    return null;
-  }
-}
-
 class Parameter {
   constructor(parameter) {
     this.title = parameter.title;
@@ -170,6 +144,36 @@ class Parameters {
 }
 
 function QueryResource($resource, $http, $q, $location, currentUser, QueryResult) {
+  class QueryResultError {
+    constructor(errorMessage) {
+      this.errorMessage = errorMessage;
+    }
+
+    getError() {
+      return this.errorMessage;
+    }
+
+    toPromise() {
+      return $q.reject(this.getError());
+    }
+
+    static getStatus() {
+      return 'failed';
+    }
+
+    static getData() {
+      return null;
+    }
+
+    static getLog() {
+      return null;
+    }
+
+    static getChartData() {
+      return null;
+    }
+  }
+
   const Query = $resource(
     'api/queries/:id',
     { id: '@id' },

--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -1,6 +1,6 @@
 import {
   isArray, isNumber, isString, isUndefined, includes, min, max, has, find,
-each, values, sortBy, identity, filter, map, extend, reduce,
+  each, values, sortBy, identity, filter, map, extend, reduce,
 } from 'lodash';
 import moment from 'moment';
 import { createFormatter, formatSimpleTemplate } from '@/lib/value-format';


### PR DESCRIPTION
Issue getredash/redash#2534

When adding widget with empty query, dashboard tried to access query results. Empty query returns `QueryResultsError` instead of `QueryResults`, and the first one does not have some methods, for example `toPromise`. This PR fixes the issue by adding `QueryResultsError.toPromise` method which just returns rejected promise.