### PR TITLE
 Keyboard shortcut to collapse query editor/schema browser

### DIFF
--- a/client/app/directives/resizable-toggle.js
+++ b/client/app/directives/resizable-toggle.js
@@ -11,7 +11,7 @@ const flexBasis = find(
 
 const threshold = 5;
 
-function resizableToggle() {
+function resizableToggle(KeyboardShortcuts) {
   return {
     link($scope, $element, $attrs) {
       if ($attrs.resizable === 'false') return;
@@ -25,6 +25,22 @@ function resizableToggle() {
       let lastHeight = $element.height();
 
       const isFlex = $scope.$eval($attrs.rFlex);
+
+      const shortcuts = {
+        [$attrs.toggleShortcut]: () => {
+          // It's a bit jQuery-way to handle this, but I really don't want
+          // to add any custom code that will detect resizer direction (keep
+          // in mind that this component is a hook to another 3dr-party one).
+          // So let's just find any available handle and "click" it, and let
+          // `angular-resizable` does it's job
+          $element.find('.rg-left, .rg-right, .rg-top, .rg-bottom').click();
+        },
+      };
+
+      KeyboardShortcuts.bind(shortcuts);
+      $scope.$on('$destroy', () => {
+        KeyboardShortcuts.unbind(shortcuts);
+      });
 
       $scope.$on('angular-resizable.resizeStart', ($event, info) => {
         if (!ignoreResizeEvents) {

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -71,7 +71,7 @@
     </div>
   </div>
   <main class="query-fullscreen">
-    <nav resizable r-directions="['right']" r-flex="true" resizable-toggle>
+    <nav resizable r-directions="['right']" r-flex="true" resizable-toggle toggle-shortcut="Alt+Shift+D, Alt+D">
       <div class="editor__left__data-source">
         <ui-select ng-model="query.data_source_id" remove-selected="false" ng-disabled="!isQueryOwner || !sourceMode" on-select="updateDataSource()">
           <ui-select-match placeholder="Select Data Source...">{{$select.selected.name}}</ui-select-match>
@@ -123,7 +123,8 @@
     <div class="content">
       <div class="flex-fill p-relative">
         <div class="p-absolute d-flex flex-column p-l-15 p-r-15" style="left: 0; top: 0; right: 0; bottom: 0;">
-          <div class="row editor" resizable r-directions="['bottom']" r-flex="true" resizable-toggle
+          <div class="row editor" resizable r-directions="['bottom']" r-flex="true"
+            resizable-toggle toggle-shortcut="Alt+D"
             style="min-height: 11px; max-height: 70vh;" ng-if="sourceMode">
             <section>
 

--- a/client/app/services/keyboard-shortcuts.js
+++ b/client/app/services/keyboard-shortcuts.js
@@ -1,21 +1,36 @@
-import { each } from 'lodash';
+import { each, trim, without } from 'lodash';
 import Mousetrap from 'mousetrap';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
 
+const handlers = {};
+
+function onShortcut(event, shortcut) {
+  event.preventDefault();
+  event.retunValue = false;
+  each(handlers[shortcut], fn => fn());
+}
 
 function KeyboardShortcuts() {
   this.bind = function bind(keymap) {
     each(keymap, (fn, key) => {
-      Mousetrap.bindGlobal(key, (e) => {
-        e.preventDefault();
-        fn();
+      const keys = key.toLowerCase().split(',').map(trim);
+      each(keys, (k) => {
+        handlers[k] = [...without(handlers[k], fn), fn];
+        Mousetrap.bindGlobal(k, onShortcut);
       });
     });
   };
 
   this.unbind = function unbind(keymap) {
     each(keymap, (fn, key) => {
-      Mousetrap.unbind(key);
+      const keys = key.toLowerCase().split(',').map(trim);
+      each(keys, (k) => {
+        handlers[k] = without(handlers[k], fn);
+        if (handlers[k].length === 0) {
+          handlers[k] = undefined;
+          Mousetrap.unbind(k);
+        }
+      });
     });
   };
 }


### PR DESCRIPTION
Issue getredash/redash#2402

Combinations assigned as described in issue. `KeyboardShortcuts` updated to allow using multiple handlers for the same shortcut (needed to toggle both editor and schema browser). Changes are backward-compatible (all existing shortcuts work).