### PR TITLE
Add references to Airbnb's style guides in contribution guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you would like to suggest an enhancement or ask for a new feature:
 - Please add [documentation](#documentation) for new features or changes in functionality along with the code.
 - Please follow existing code style:
   - Python: we use PEP8 for Python.
-  - Javascript: we use Airbnb's style guides for [JavaScript](https://github.com/airbnb/javascript#naming-conventions) and [React](https://github.com/airbnb/javascript/blob/master/react) (currently we don't follow Airbnb's convention for naming files, but we're gradually fixing this).
+  - Javascript: we use Airbnb's style guides for [JavaScript](https://github.com/airbnb/javascript#naming-conventions) and [React](https://github.com/airbnb/javascript/blob/master/react) (currently we don't follow Airbnb's convention for naming files, but we're gradually fixing this). To make it automatic and easy, we recommend using [Prettier](https://github.com/prettier/prettier).
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ If you would like to suggest an enhancement or ask for a new feature:
 - **Code contributions are welcomed**. For big changes or significant features, it's usually better to reach out first and discuss what you want to implement and how (we recommend reading: [Pull Request First](https://medium.com/practical-blend/pull-request-first-f6bb667a9b6#.ozlqxvj36)). This to make sure that what you want to implement is aligned with our goals for the project and that no one else is already working on it.
 - Include screenshots and animated GIFs in your pull request whenever possible.
 - Please add [documentation](#documentation) for new features or changes in functionality along with the code.
-- Please follow existing code style. We use PEP8 for Python and sensible style for JavaScript.
+- Please follow existing code style:
+  - Python: we use PEP8 for Python.
+  - Javascript: we use Airbnb's style guides for [JavaScript](https://github.com/airbnb/javascript#naming-conventions) and [React](https://github.com/airbnb/javascript/blob/master/react) (currently we don't follow Airbnb's convention for naming files, but we're gradually fixing this).
 
 ### Documentation
 


### PR DESCRIPTION
As we begin [a big refactor](https://discuss.redash.io/t/react-migration-an-experiment-with-less-di/2077) of our frontend codebase, I thought that it's good time to revisit our style and make sure we're consistent.

As we already use Airbnb's `eslint` rules and it seems widely adopted, I thought that we should follow their general guide as well, mainly including filename convention:

https://github.com/airbnb/javascript#naming-conventions
https://github.com/airbnb/javascript/tree/master/react#naming

It's different than what we did so far, but seems reasonable.

@getredash/maintainers what do you think?