### PR TITLE
Dashboard shows a spinner when query failed to load

### DIFF
--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -133,6 +133,9 @@ function QueryResultService($resource, $timeout, $q) {
         this.deferred.resolve(this);
       } else if (this.job.status === 3) {
         this.status = 'processing';
+      } else if (this.job.status === 4) {
+        this.status = statuses[this.job.status];
+        this.deferred.reject(this.job.error);
       } else {
         this.status = undefined;
       }

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -147,6 +147,11 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
   class QueryResultError {
     constructor(errorMessage) {
       this.errorMessage = errorMessage;
+      this.updatedAt = moment.utc();
+    }
+
+    getUpdatedAt() {
+      return this.updatedAt;
     }
 
     getError() {
@@ -157,19 +162,23 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
       return $q.reject(this.getError());
     }
 
-    static getStatus() {
+    // eslint-disable-next-line class-methods-use-this
+    getStatus() {
       return 'failed';
     }
 
-    static getData() {
+    // eslint-disable-next-line class-methods-use-this
+    getData() {
       return null;
     }
 
-    static getLog() {
+    // eslint-disable-next-line class-methods-use-this
+    getLog() {
       return null;
     }
 
-    static getChartData() {
+    // eslint-disable-next-line class-methods-use-this
+    getChartData() {
       return null;
     }
   }

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -143,7 +143,7 @@ class Parameters {
   }
 }
 
-function QueryResource($resource, $http, $q, $location, currentUser, QueryResult) {
+function QueryResultErrorFactory($q) {
   class QueryResultError {
     constructor(errorMessage) {
       this.errorMessage = errorMessage;
@@ -159,7 +159,7 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
     }
 
     toPromise() {
-      return $q.reject(this.getError());
+      return $q.reject(this);
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -183,6 +183,18 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
     }
   }
 
+  return QueryResultError;
+}
+
+function QueryResource(
+  $resource,
+  $http,
+  $location,
+  $q,
+  currentUser,
+  QueryResultError,
+  QueryResult,
+) {
   const Query = $resource(
     'api/queries/:id',
     { id: '@id' },
@@ -397,5 +409,6 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
 }
 
 export default function init(ngModule) {
+  ngModule.factory('QueryResultError', QueryResultErrorFactory);
   ngModule.factory('Query', QueryResource);
 }

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -116,17 +116,23 @@ function WidgetFactory($http, Query, Visualization, dashboardGridOptions) {
       // while widget is refreshing, `this.data` !== `this.queryResult`
 
       if (force || (this.queryResult === undefined)) {
+        this.loading = true;
+        this.refreshStartedAt = moment();
+
         if (maxAge === undefined || force) {
           maxAge = force ? 0 : undefined;
         }
         this.queryResult = this.getQuery().getQueryResult(maxAge);
-        this.loading = true;
-        this.refreshStartedAt = moment();
 
-        this.queryResult.toPromise().finally(() => {
-          this.loading = false;
-          this.data = this.queryResult;
-        });
+        this.queryResult.toPromise()
+          .then((result) => {
+            this.loading = false;
+            this.data = result;
+          })
+          .catch((error) => {
+            this.loading = false;
+            this.data = error;
+          });
       }
 
       return this.queryResult.toPromise();


### PR DESCRIPTION
Issue getredash/redash#2602 

As I mentioned in comment to the issue, bug is more generic: widget didn't process all query results errors correctly.

Screenshot how it works with this fix:
![image](https://user-images.githubusercontent.com/12139186/42212783-d077689a-7ebf-11e8-830a-f13b020c09dc.png)
