### PR TITLE
Upgrade bootstrap script to Redash 4.0.1

### DIFF
--- a/setup/ubuntu/bootstrap.sh
+++ b/setup/ubuntu/bootstrap.sh
@@ -11,7 +11,7 @@ set -eu
 
 REDASH_BASE_PATH=/opt/redash
 REDASH_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
-REDASH_VERSION=${REDASH_VERSION-3.0.0.b3134} # Install latest version if not specified in REDASH_VERSION env var
+REDASH_VERSION=${REDASH_VERSION-4.0.1.b4038} # Install latest version if not specified in REDASH_VERSION env var
 LATEST_URL="https://s3.amazonaws.com/redash-releases/redash.${REDASH_VERSION}.tar.gz"
 VERSION_DIR="$REDASH_BASE_PATH/redash.${REDASH_VERSION}"
 REDASH_TARBALL=/tmp/redash.tar.gz


### PR DESCRIPTION
Hi, @arikfr 

I would like to suggest upgrade the script for Ubuntu in this PR,

I know you are working on [Docker based setup scripts](https://github.com/getredash/redash/pull/2463).

However, that PR seems to be sleeping for me.

I think we should maintain bootstrap script for new Redash users until Docker based script out.

Thank you,