### PR TITLE
Store Athena query id with result metadata

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -189,7 +189,7 @@ class Athena(BaseQueryRunner):
                 athena_query_id = cursor.query_id
             except AttributeError as e:
                 logger.debug("Athena Upstream can't get query_id: %s", e)
-            data = {  
+            data = {
                 'columns': columns,
                 'rows': rows,
                 'metadata': {

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -189,12 +189,12 @@ class Athena(BaseQueryRunner):
                 athena_query_id = cursor.query_id
             except AttributeError as e:
                 logger.debug("Athena Upstream can't get query_id: %s", e)
-            data =  {  
-                'columns':columns,
-                'rows':rows,
-                'metadata':{  
-                    'data_scanned':qbytes,
-                    'athena_query_id':athena_query_id
+            data = {  
+                'columns': columns,
+                'rows': rows,
+                'metadata': {
+                    'data_scanned': qbytes,
+                    'athena_query_id': athena_query_id
                 }
             }
             json_data = json.dumps(data, cls=JSONEncoder)

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -186,10 +186,17 @@ class Athena(BaseQueryRunner):
             except AttributeError as e:
                 logger.debug("Athena Upstream can't get data_scanned_in_bytes: %s", e)
             try:
-                athena_query_id= cursor.query_id
+                athena_query_id = cursor.query_id
             except AttributeError as e:
                 logger.debug("Athena Upstream can't get query_id: %s", e)
-            data = {'columns': columns, 'rows': rows, 'metadata': {'data_scanned': qbytes, 'athena_query_id': athena_query_id}}
+            data =  {  
+                'columns':columns,
+                'rows':rows,
+                'metadata':{  
+                    'data_scanned':qbytes,
+                    'athena_query_id':athena_query_id
+                }
+            }
             json_data = json.dumps(data, cls=JSONEncoder)
             error = None
         except KeyboardInterrupt:

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -180,11 +180,16 @@ class Athena(BaseQueryRunner):
             columns = self.fetch_columns(column_tuples)
             rows = [dict(zip(([c['name'] for c in columns]), r)) for i, r in enumerate(cursor.fetchall())]
             qbytes = None
+            athena_query_id = None
             try:
                 qbytes = cursor.data_scanned_in_bytes
             except AttributeError as e:
                 logger.debug("Athena Upstream can't get data_scanned_in_bytes: %s", e)
-            data = {'columns': columns, 'rows': rows, 'metadata': {'data_scanned': qbytes}}
+            try:
+                athena_query_id= cursor.query_id
+            except AttributeError as e:
+                logger.debug("Athena Upstream can't get query_id: %s", e)
+            data = {'columns': columns, 'rows': rows, 'metadata': {'data_scanned': qbytes, 'athena_query_id': athena_query_id}}
             json_data = json.dumps(data, cls=JSONEncoder)
             error = None
         except KeyboardInterrupt:


### PR DESCRIPTION
Here's a simple change that stores the Athena query id in the result metadata.

Here at Atlassian we are keen to be able to cross-reference Athena usage data with the internal Redash data, and this additional piece of metadata will help us achieve this.