### PR TITLE
Add support for the Chrome Logger extension

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -93,6 +93,7 @@ class SlugConverter(BaseConverter):
 def create_app(load_admin=True):
     from redash import extensions, handlers
     from redash.handlers.webpack import configure_webpack
+    from redash.handlers import chrome_logger
     from redash.admin import init_admin
     from redash.models import db
     from redash.authentication import setup_authentication
@@ -138,4 +139,6 @@ def create_app(load_admin=True):
     handlers.init_app(app)
     configure_webpack(app)
     extensions.init_extensions(app)
+    chrome_logger.init_app(app)
+
     return app

--- a/redash/handlers/chrome_logger.py
+++ b/redash/handlers/chrome_logger.py
@@ -1,0 +1,54 @@
+import time
+import chromelogger
+from flask import g, request
+from flask_sqlalchemy import get_debug_queries
+
+
+def log_queries():
+    total_duration = 0.0
+    queries_count = 0
+
+    chromelogger.group("SQL Queries")
+
+    for q in get_debug_queries():
+        total_duration += q.duration
+        queries_count += 1
+        chromelogger.info(q.statement % q.parameters)
+        chromelogger.info("Runtime: {:.2f}ms".format(1000 * q.duration))
+
+    chromelogger.info("{} queries executed in {:.2f}ms.".format(queries_count, total_duration*1000))
+
+    chromelogger.group_end("SQL Queries")
+
+
+def chrome_log(response):
+    request_duration = (time.time() - g.start_time) * 1000
+    queries_duration = g.get('queries_duration', 0.0)
+    queries_count = g.get('queries_count', 0.0)
+
+    group_name = '{} {} ({}, {:.2f}ms runtime, {} queries in {:.2f}ms)'.format(
+        request.method, request.path, response.status_code, request_duration, queries_count, queries_duration)
+
+    chromelogger.group_collapsed(group_name)
+    
+    endpoint = (request.endpoint or 'unknown').replace('.', '_')
+    chromelogger.info('Endpoint: {}'.format(endpoint))
+    chromelogger.info('Content Type: {}'.format(response.content_type))
+    chromelogger.info('Content Length: {}'.format(response.content_length or -1))
+
+    log_queries()
+
+    chromelogger.group_end(group_name)
+
+    header = chromelogger.get_header()
+    if header is not None:
+        response.headers.add(*header)
+
+    return response
+
+
+def init_app(app):
+    if not app.debug:
+        return 
+
+    app.after_request(chrome_log)

--- a/redash/handlers/chrome_logger.py
+++ b/redash/handlers/chrome_logger.py
@@ -24,7 +24,7 @@ def log_queries():
 def chrome_log(response):
     request_duration = (time.time() - g.start_time) * 1000
     queries_duration = g.get('queries_duration', 0.0)
-    queries_count = g.get('queries_count', 0.0)
+    queries_count = g.get('queries_count', 0)
 
     group_name = '{} {} ({}, {:.2f}ms runtime, {} queries in {:.2f}ms)'.format(
         request.method, request.path, response.status_code, request_duration, queries_count, queries_duration)

--- a/redash/metrics/request.py
+++ b/redash/metrics/request.py
@@ -32,7 +32,7 @@ def calculate_metrics(response):
                         request_duration,
                         queries_count,
                         queries_duration)
-
+    
     statsd_client.timing('requests.{}.{}'.format(endpoint, request.method.lower()), request_duration)
 
     return response

--- a/redash/metrics/request.py
+++ b/redash/metrics/request.py
@@ -32,7 +32,7 @@ def calculate_metrics(response):
                         request_duration,
                         queries_count,
                         queries_duration)
-    
+
     statsd_client.timing('requests.{}.{}'.format(endpoint, request.method.lower()), request_duration)
 
     return response

--- a/redash/models.py
+++ b/redash/models.py
@@ -972,7 +972,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         return db.session.query(tag_column, usage_count).join(
             DataSourceGroup,
             cls.data_source_id == DataSourceGroup.data_source_id
-        ).filter(where).distinct().group_by(tag_column).order_by(usage_count.desc())# .limit(limit)
+        ).filter(where).distinct().group_by(tag_column).order_by(usage_count.desc())  # .limit(limit)
 
     @classmethod
     def by_user(cls, user):
@@ -1122,7 +1122,7 @@ class Favorite(TimestampMixin, db.Model):
 
     @classmethod
     def is_favorite(cls, user, object):
-        return cls.query.filter(cls.object==object, cls.user_id==user).count() > 0
+        return cls.query.filter(cls.object == object, cls.user_id == user).count() > 0
     
     @classmethod
     def are_favorites(cls, user, objects):
@@ -1131,7 +1131,7 @@ class Favorite(TimestampMixin, db.Model):
             return []
         
         object_type = six.text_type(objects[0].__class__.__name__)
-        return map(lambda fav: fav.object_id, cls.query.filter(cls.object_id.in_(map(lambda o: o.id, objects)), cls.object_type==object_type, cls.user_id==user))
+        return map(lambda fav: fav.object_id, cls.query.filter(cls.object_id.in_(map(lambda o: o.id, objects)), cls.object_type == object_type, cls.user_id == user))
 
 
 class AccessPermission(GFKBase, db.Model):

--- a/redash/serializers.py
+++ b/redash/serializers.py
@@ -77,7 +77,7 @@ class QuerySerializer(Serializer):
                 favorite_ids = models.Favorite.are_favorites(current_user.id, self.object_or_list)
                 for query in result:
                     query['is_favorite'] = query['id'] in favorite_ids
-        
+  
         return result
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ simplejson==3.10.0
 ua-parser==0.7.3 
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
+chromelogger==0.4.3
 # Uncomment the requirement for ldap3 if using ldap.
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4


### PR DESCRIPTION
This adds support for logging to Chrome's console using the [Chrome Logger](https://craig.is/writing/chrome-logger) extension. 

This makes it easier to see server side information about the requests we're making (like what SQL queries it generates).

![](https://cl.ly/3U3s0e0j2k3R/Screen%20Recording%202018-07-12%20at%2011.41%20AM.gif)

It's only enabled in debug mode.