### PR TITLE
Add Zeit's now support to have preview builds for every PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,4 @@ RUN chown -R redash /app
 USER redash
 
 ENTRYPOINT ["/app/bin/docker-entrypoint"]
+CMD ["server"]

--- a/now.json
+++ b/now.json
@@ -1,0 +1,9 @@
+{
+  "name": "redash-dev-preview",
+  "type": "docker",
+  "env": {
+    "DATABASE_URL": "@redash-dev-postgres-url",
+    "REDIS_URL": "@redash-dev-redis-url",
+    "REDASH_WEB_WORKERS": "2"
+  }
+}


### PR DESCRIPTION
Using [Zeit's Now GitHub integration](https://zeit.co/blog/now-for-github) we will now have a unique deployment for each Pull Request. 👌

We're using Now only to serve the HTTP requests. Redash worker, database and Redis are shared. Meaning that this is useful mainly for reviewing frontend changes, but considering that there are quite a few pull requests that are waiting for visual review, I think this will provide value too.