### PR TITLE
Implement server side pagination and sorting for queries lists

### DIFF
--- a/client/app/filters/index.js
+++ b/client/app/filters/index.js
@@ -4,7 +4,7 @@ import { capitalize as _capitalize, isEmpty } from 'lodash';
 export function durationHumanize(duration) {
   let humanized = '';
 
-  if (duration === undefined) {
+  if (duration === undefined || duration === null) {
     humanized = '-';
   } else if (duration < 60) {
     const seconds = Math.round(duration);
@@ -31,7 +31,8 @@ export function scheduleHumanize(schedule) {
     return 'Never';
   } else if (schedule.match(/\d\d:\d\d/) !== null) {
     const parts = schedule.split(':');
-    const localTime = moment.utc()
+    const localTime = moment
+      .utc()
       .hour(parts[0])
       .minute(parts[1])
       .local()
@@ -44,8 +45,7 @@ export function scheduleHumanize(schedule) {
 }
 
 export function toHuman(text) {
-  return text.replace(/_/g, ' ').replace(/(?:^|\s)\S/g, a =>
-    a.toUpperCase());
+  return text.replace(/_/g, ' ').replace(/(?:^|\s)\S/g, a => a.toUpperCase());
 }
 
 export function colWidth(widgetWidth) {
@@ -103,14 +103,7 @@ export function showError(field) {
   return field.$touched && field.$invalid;
 }
 
-const units = [
-  'bytes',
-  'KB',
-  'MB',
-  'GB',
-  'TB',
-  'PB',
-];
+const units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
 
 export function prettySize(bytes) {
   if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) {

--- a/client/app/lib/pagination/live-paginator.js
+++ b/client/app/lib/pagination/live-paginator.js
@@ -1,14 +1,34 @@
 export default class LivePaginator {
-  constructor(rowsFetcher, { page = 1, itemsPerPage = 20 } = {}) {
+  constructor(rowsFetcher, {
+    page = 1,
+    itemsPerPage = 20,
+    orderByField,
+    orderByReverse = false,
+  } = {}) {
     this.page = page;
     this.itemsPerPage = itemsPerPage;
+    this.orderByField = orderByField;
+    this.orderByReverse = orderByReverse;
     this.rowsFetcher = rowsFetcher;
-    this.rowsFetcher(this.page, this.itemsPerPage, this);
+    this.fetchPage(page);
   }
 
-  setPage(page) {
+  fetchPage(page) {
+    this.rowsFetcher(
+      page,
+      this.itemsPerPage,
+      this.orderByField,
+      this.orderByReverse,
+      this,
+    );
+  }
+
+  setPage(page, pageSize) {
+    if (pageSize) {
+      this.itemsPerPage = pageSize;
+    }
     this.page = page;
-    this.rowsFetcher(page, this.itemsPerPage, this);
+    this.fetchPage(page);
   }
 
   getPageRows() {
@@ -23,5 +43,17 @@ export default class LivePaginator {
       this.totalCount = 0;
     }
   }
-}
 
+  orderBy(column) {
+    if (column === this.orderByField) {
+      this.orderByReverse = !this.orderByReverse;
+    } else {
+      this.orderByField = column;
+      this.orderByReverse = false;
+    }
+
+    if (this.orderByField) {
+      this.fetchPage(this.page);
+    }
+  }
+}

--- a/client/app/pages/queries-list/queries-list.css
+++ b/client/app/pages/queries-list/queries-list.css
@@ -1,0 +1,4 @@
+.search input[type="text"],
+.search button {
+  height: 35px;
+}

--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -29,6 +29,12 @@
           <tags-list tags-url="api/queries/tags" on-tags-update="$ctrl.onTagsUpdate"></tags-list>
         </div>
       </div>
+
+      <div class="m-b-10">
+        <select ng-change="$ctrl.update()" ng-model="$ctrl.pageSize" class="form-control"
+          ng-options="value as $ctrl.pageSizeLabel(value) for value in $ctrl.pageSizeOptions"></select>
+      </div>
+
     </div>
 
     <div ng-if="!$ctrl.loaded" class="col-md-9 list-content text-center">
@@ -60,12 +66,27 @@
           <thead>
             <tr>
               <th></th>
-              <th>Name</th>
+              <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('name')">
+                Name
+                <sort-icon column="'name'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
+              </th>
               <th></th>
-              <th>Created At</th>
-              <th>Runtime</th>
-              <th>Last Executed At</th>
-              <th>Update Schedule</th>
+              <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('created_at')">
+                Created At
+                <sort-icon column="'created_at'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
+              </th>
+              <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('runtime')">
+                Runtime
+                <sort-icon column="'runtime'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
+              </th>
+              <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('executed_at')">
+                Last Executed At
+                <sort-icon column="'executed_at'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
+              </th>
+              <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('schedule')">
+                Update Schedule
+                <sort-icon column="'schedule'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -94,9 +115,14 @@
     </div>
 
     <div class="col-md-3 list-control-r-b">
-      <div class="m-b-5" ng-if="$ctrl.currentPage != 'my'">
+      <div class="m-b-5 input-group search">
         <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.term" ng-model-options="{ allowInvalid: true, debounce: 200 }"
           ng-change="$ctrl.update()">
+        <span class="input-group-btn">
+          <button class="btn btn-secondary" type="button" title="Clear search" ng-click="$ctrl.clearSearch()">
+            <span class="zmdi zmdi-close"></span>
+          </button>
+        </span>
       </div>
       <div class='list-group m-b-10 tags-list tiled'>
         <a href="queries" class="list-group-item" ng-class="{active: $ctrl.currentPage == 'all'}">
@@ -113,8 +139,12 @@
           /> My Queries
         </a>
       </div>
-      <div ng-if="$ctrl.currentPage != 'my'">
+      <div ng-if="$ctrl.currentPage != 'my'" class="m-b-10">
         <tags-list tags-url="api/queries/tags" on-tags-update="$ctrl.onTagsUpdate"></tags-list>
+      </div>
+      <div class="m-b-5">
+        <select ng-change="$ctrl.update()" ng-model="$ctrl.pageSize" class="form-control"
+          ng-options="value as $ctrl.pageSizeLabel(value) for value in $ctrl.pageSizeOptions"></select>
       </div>
     </div>
   </div>

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -22,6 +22,10 @@ from redash.serializers import QuerySerializer
 order_map = {
     'name': 'lowercase_name',
     '-name': '-lowercase_name',
+    'created_at': 'created_at',
+    '-created_at': '-created_at',
+    'schedule': 'schedule',
+    '-schedule': '-schedule',
     'runtime': 'query_results-runtime',
     '-runtime': '-query_results-runtime',
     'executed_at': 'query_results-retrieved_at',

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -1,15 +1,14 @@
-from itertools import chain
-
 import sqlparse
-from flask import jsonify, request
+from flask import jsonify, request, url_for
 from flask_login import login_required
 from flask_restful import abort
-from funcy import distinct, take
 from sqlalchemy.orm.exc import StaleDataError
+from sqlalchemy_utils import sort_query
 
-from redash import models, settings
-from redash.handlers.base import (BaseResource, get_object_or_404,
-                                  org_scoped_rule, paginate, routes, filter_by_tags)
+from redash import models
+from redash.authentication.org_resolving import current_org
+from redash.handlers.base import (BaseResource, filter_by_tags, get_object_or_404,
+                                  org_scoped_rule, paginate, routes)
 from redash.handlers.query_results import run_query
 from redash.permissions import (can_modify, not_view_only, require_access,
                                 require_admin_or_owner,
@@ -17,6 +16,34 @@ from redash.permissions import (can_modify, not_view_only, require_access,
                                 require_permission, view_only)
 from redash.utils import collect_parameters_from_request
 from redash.serializers import QuerySerializer
+
+
+# Ordering map for relationships
+order_map = {
+    'name': 'lowercase_name',
+    '-name': '-lowercase_name',
+    'runtime': 'query_results-runtime',
+    '-runtime': '-query_results-runtime',
+    'executed_at': 'query_results-retrieved_at',
+    '-executed_at': '-query_results-retrieved_at',
+    'created_by': 'users-name',
+    '-created_by': '-users-name',
+}
+
+
+def order_results(results, default_order='-created_at'):
+    """
+    Orders the given results with the sort order as requested in the
+    "order" request query parameter or the given default order.
+    """
+    # See if a particular order has been requested
+    order = request.args.get('order', '').strip() or default_order
+    # and if it matches a long-form for related fields, falling
+    # back to the default order
+    selected_order = order_map.get(order, default_order)
+    # The query may already have an ORDER BY statement attached
+    # so we clear it here and apply the selected order
+    return sort_query(results.order_by(None), selected_order)
 
 
 @routes.route(org_scoped_rule('/api/queries/format'), methods=['POST'])
@@ -41,6 +68,7 @@ class QuerySearchResource(BaseResource):
         Search query text, names, and descriptions.
 
         :qparam string q: Search term
+        :qparam number include_drafts: Whether to include draft in results
 
         Responds with a list of :ref:`query <query-response-label>` objects.
         """
@@ -50,10 +78,14 @@ class QuerySearchResource(BaseResource):
 
         include_drafts = request.args.get('include_drafts') is not None
 
-        queries = models.Query.search(term, self.current_user.group_ids, include_drafts=include_drafts, limit=None)
-        queries = filter_by_tags(queries, models.Query.tags)
-
-        return QuerySerializer(queries, with_last_modified_by=False).serialize()
+        # this redirects to the new query list API that is aware of search
+        new_location = url_for(
+            'queries',
+            q=term,
+            org_slug=current_org.slug,
+            drafts='true' if include_drafts else 'false',
+        )
+        return {}, 301, {'Location': new_location}
 
 
 class QueryRecentResource(BaseResource):
@@ -133,24 +165,47 @@ class QueryListResource(BaseResource):
         """
         Retrieve a list of queries.
 
-        :qparam number page_size: Number of queries to return
+        :qparam number page_size: Number of queries to return per page
         :qparam number page: Page number to retrieve
+        :qparam number order: Name of column to order by
+        :qparam number q: Full text search term
 
         Responds with an array of :ref:`query <query-response-label>` objects.
         """
-
-        search_term = request.args.get('q')
+        # See if we want to do full-text search or just regular queries
+        search_term = request.args.get('q', '')
 
         if search_term:
-            results = models.Query.search(search_term, self.current_user.group_ids, include_drafts=True, limit=None)
+            results = models.Query.search(
+                search_term,
+                self.current_user.group_ids,
+                self.current_user.id,
+                include_drafts=True,
+            )
         else:
-            results = models.Query.all_queries(self.current_user.group_ids, self.current_user.id)
+            results = models.Query.all_queries(
+                self.current_user.group_ids,
+                self.current_user.id,
+                drafts=True,
+            )
 
         results = filter_by_tags(results, models.Query.tags)
 
+        # order results according to passed order parameter
+        ordered_results = order_results(results)
+
         page = request.args.get('page', 1, type=int)
         page_size = request.args.get('page_size', 25, type=int)
-        response = paginate(results, page, page_size, QuerySerializer, with_stats=True, with_last_modified_by=False)
+
+        response = paginate(
+            ordered_results,
+            page=page,
+            page_size=page_size,
+            serializer=QuerySerializer,
+            with_stats=True,
+            with_last_modified_by=False
+        )
+
         return response
 
 
@@ -160,16 +215,34 @@ class MyQueriesResource(BaseResource):
         """
         Retrieve a list of queries created by the current user.
 
-        :qparam number page_size: Number of queries to return
+        :qparam number page_size: Number of queries to return per page
         :qparam number page: Page number to retrieve
+        :qparam number order: Name of column to order by
+        :qparam number search: Full text search term
 
         Responds with an array of :ref:`query <query-response-label>` objects.
         """
-        drafts = request.args.get('drafts') is not None
-        results = models.Query.by_user(self.current_user)
+        search_term = request.args.get('q', '')
+        if search_term:
+            results = models.Query.search_by_user(search_term, self.current_user)
+        else:
+            results = models.Query.by_user(self.current_user)
+
+        results = filter_by_tags(results, models.Query.tags)
+
+        # order results according to passed order parameter
+        ordered_results = order_results(results)
+
         page = request.args.get('page', 1, type=int)
         page_size = request.args.get('page_size', 25, type=int)
-        return paginate(results, page, page_size, QuerySerializer, with_stats=True, with_last_modified_by=False)
+        return paginate(
+            ordered_results,
+            page,
+            page_size,
+            QuerySerializer,
+            with_stats=True,
+            with_last_modified_by=False,
+        )
 
 
 class QueryResource(BaseResource):
@@ -282,6 +355,7 @@ class QueryRefreshResource(BaseResource):
         parameter_values = collect_parameters_from_request(request.args)
 
         return run_query(query.data_source, parameter_values, query.query_text, query.id)
+
 
 class QueryTagsResource(BaseResource):
     def get(self):

--- a/redash/models.py
+++ b/redash/models.py
@@ -1008,24 +1008,14 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         return outdated_queries.values()
 
     @classmethod
-    def search(cls, term, group_ids, include_drafts=False, limit=20):
-        where = cls.is_archived == False
+    def search(cls, term, group_ids, user_id=None, include_drafts=False, limit=None):
+        all_queries = cls.all_queries(group_ids, user_id=user_id, drafts=include_drafts)
+        # sort the result using the weight as defined in the search vector column
+        return all_queries.search(term, sort=True).limit(limit)
 
-        if not include_drafts:
-            where &= cls.is_draft == False
-
-        where &= DataSourceGroup.group_id.in_(group_ids)
-
-        return cls.query.join(
-            DataSourceGroup,
-            cls.data_source_id == DataSourceGroup.data_source_id
-        ).options(
-            joinedload(cls.user)
-        ).filter(where).search(
-            term,
-            # sort the result using the weight as defined in the search vector column
-            sort=True
-        ).distinct().limit(limit)
+    @classmethod
+    def search_by_user(cls, term, user, limit=None):
+        return cls.by_user(user).search(term, sort=True).limit(limit)
 
     @classmethod
     def recent(cls, group_ids, user_id=None, limit=20):

--- a/redash/models.py
+++ b/redash/models.py
@@ -932,27 +932,49 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def all_queries(cls, group_ids, user_id=None, drafts=False):
-        query_ids = (db.session.query(distinct(cls.id))
-                               .join(DataSourceGroup, Query.data_source_id == DataSourceGroup.data_source_id)
-                               .filter(Query.is_archived == False)
-                               .filter(DataSourceGroup.group_id.in_(group_ids)))
-
-        q = (cls.query
-                .options(joinedload(Query.user),
-                         joinedload(Query.latest_query_data).load_only('runtime', 'retrieved_at'))
-                .filter(cls.id.in_(query_ids))
-                # Adding outer joins to be able to order by relationship
-                .outerjoin(User, User.id == Query.user_id)
-                .outerjoin(QueryResult, QueryResult.id == Query.latest_query_data_id)
-                .options(
-                    contains_eager(Query.user),
-                    contains_eager(Query.latest_query_data),
+        query_ids = (
+            db.session
+            .query(distinct(cls.id))
+            .join(
+                DataSourceGroup,
+                Query.data_source_id == DataSourceGroup.data_source_id
+            )
+            .filter(Query.is_archived == False)
+            .filter(DataSourceGroup.group_id.in_(group_ids))
+        )
+        q = (
+            cls
+            .query
+            .options(
+                joinedload(Query.user),
+                joinedload(
+                    Query.latest_query_data
+                ).load_only(
+                    'runtime',
+                    'retrieved_at',
                 )
-                .order_by(Query.created_at.desc()))
+            )
+            .filter(cls.id.in_(query_ids))
+            # Adding outer joins to be able to order by relationship
+            .outerjoin(User, User.id == Query.user_id)
+            .outerjoin(
+                QueryResult,
+                QueryResult.id == Query.latest_query_data_id
+            )
+            .options(
+                contains_eager(Query.user),
+                contains_eager(Query.latest_query_data),
+            )
+            .order_by(Query.created_at.desc())
+        )
 
         if not drafts:
-            q = q.filter(or_(Query.is_draft == False, Query.user_id == user_id))
-
+            q = q.filter(
+                or_(
+                    Query.is_draft == False,
+                    Query.user_id == user_id
+                )
+            )
         return q
 
     @classmethod

--- a/redash/models.py
+++ b/redash/models.py
@@ -28,6 +28,7 @@ from redash.settings.organization import settings as org_settings
 from sqlalchemy import distinct, or_, and_, UniqueConstraint
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.event import listens_for
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import backref, contains_eager, joinedload, object_session
@@ -1084,6 +1085,16 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
             return {}
 
         return self.data_source.groups
+
+    @hybrid_property
+    def lowercase_name(self):
+        "Optional property useful for sorting purposes."
+        return self.name.lower()
+
+    @lowercase_name.expression
+    def lowercase_name(cls):
+        "The SQLAlchemy expression for the property above."
+        return func.lower(cls.name)
 
     def __unicode__(self):
         return unicode(self.id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyYAML==3.12
 redis==2.10.5
 requests==2.11.1
 six==1.10.0
-SQLAlchemy==1.1.4
+SQLAlchemy==1.2.7
 SQLAlchemy-Searchable==0.10.6
 SQLAlchemy-Utils>=0.29.0
 sqlparse==0.2.4
@@ -46,7 +46,7 @@ pystache==0.5.4
 parsedatetime==2.1
 cryptography==2.0.2
 simplejson==3.10.0
-ua-parser==0.7.3 
+ua-parser==0.7.3
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
 chromelogger==0.4.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,6 +45,7 @@ class BaseTestCase(TestCase):
         self.app = create_app()
         self.db = db
         self.app.config['TESTING'] = True
+        self.app.config['SERVER_NAME'] = 'localhost'
         self.app_ctx = self.app.app_context()
         self.app_ctx.push()
         db.session.close()
@@ -60,7 +61,7 @@ class BaseTestCase(TestCase):
         redis_connection.flushdb()
 
     def make_request(self, method, path, org=None, user=None, data=None,
-                     is_json=True):
+                     is_json=True, follow_redirects=False):
         if user is None:
             user = self.factory.user
 
@@ -84,7 +85,13 @@ class BaseTestCase(TestCase):
         else:
             content_type = None
 
-        response = method_fn(path, data=data, headers=headers, content_type=content_type)
+        response = method_fn(
+            path,
+            data=data,
+            headers=headers,
+            content_type=content_type,
+            follow_redirects=follow_redirects,
+        )
 
         if response.data and is_json:
             response.json = json.loads(response.data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -356,6 +356,20 @@ class TestQueryAll(BaseTestCase):
         q = self.factory.create_query(is_draft=True)
         self.assertIn(q, models.Query.all_queries([self.factory.default_group.id], user_id=q.user_id))
 
+    def test_order_by_relationship(self):
+        u1 = self.factory.create_user(name='alice')
+        u2 = self.factory.create_user(name='bob')
+        self.factory.create_query(user=u1)
+        self.factory.create_query(user=u2)
+        db.session.commit()
+        # have to reset the order here with None since all_queries orders by
+        # created_at by default
+        base = models.Query.all_queries([self.factory.default_group.id]).order_by(None)
+        qs1 = base.order_by(models.User.name)
+        self.assertEqual(['alice', 'bob'], [q.user.name for q in qs1])
+        qs2 = base.order_by(models.User.name.desc())
+        self.assertEqual(['bob', 'alice'], [q.user.name for q in qs2])
+
 
 class TestGroup(BaseTestCase):
     def test_returns_groups_with_specified_names(self):


### PR DESCRIPTION
This was initially reported in #78 but also applies to the queries search where the list of results can become quite large depending on the number of queries and search term used.

This was originally reported in mozilla#384 and mozilla#385.

## Notes:

- The sorting criteria are hardcoded and only allow specified columns (and related columns) to be used.

- It adds a page size dropdown to the query-list page (and the appropriate backend handling) and allows clearing the search input to reset the query list to the non search result status.

- It deprecates the standalone backend query search handler and redirects requests for it.

- I believe the live paginator should also be used in more list views and the non-live paginator deprecated or outright removed.

- I'm not sure how Redash is handling API backward compatibility, so I erred on the side of caution and followed a deprecation policy (that could mean removing old APIs after the next version for example).

## Screenshot:

<img width="1110" alt="screen-shot-2018-07-18-22-31-32" src="https://user-images.githubusercontent.com/1610/42908115-4c45d9a8-8ae0-11e8-9807-38476e228165.png">

## TODOs:

- [ ] Check code if uses of old search API works with handler redirect 