### PR TITLE
Create TEMPLATE_PATH variable which gets value from new REDASH_TEMPLA…

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -100,7 +100,7 @@ def create_app(load_admin=True):
     from redash.metrics.request import provision_app
 
     app = Flask(__name__,
-                template_folder=settings.STATIC_ASSETS_PATH,
+                template_folder=settings.TEMPLATES_PATH,
                 static_folder=settings.STATIC_ASSETS_PATH,
                 static_path='/static')
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -99,7 +99,7 @@ LDAP_SEARCH_DN = os.environ.get('REDASH_LDAP_SEARCH_DN', os.environ.get('REDASH_
 
 STATIC_ASSETS_PATH = fix_assets_path(os.environ.get("REDASH_STATIC_ASSETS_PATH", "../client/dist/"))
 
-TEMPLATES_PATH = fix_assets_path(os.environ.get("REDASH_TEMPLATES_PATH", "../client/dist/"))
+TEMPLATES_PATH = fix_assets_path(os.environ.get("REDASH_TEMPLATES_PATH", STATIC_ASSETS_PATH))
 
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 12))
 COOKIE_SECRET = os.environ.get("REDASH_COOKIE_SECRET", "c292a0a3aa32397cdb050e233733900f")

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -99,6 +99,8 @@ LDAP_SEARCH_DN = os.environ.get('REDASH_LDAP_SEARCH_DN', os.environ.get('REDASH_
 
 STATIC_ASSETS_PATH = fix_assets_path(os.environ.get("REDASH_STATIC_ASSETS_PATH", "../client/dist/"))
 
+TEMPLATES_PATH = fix_assets_path(os.environ.get("REDASH_TEMPLATES_PATH", "../client/dist/"))
+
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 12))
 COOKIE_SECRET = os.environ.get("REDASH_COOKIE_SECRET", "c292a0a3aa32397cdb050e233733900f")
 SESSION_COOKIE_SECURE = parse_boolean(os.environ.get("REDASH_SESSION_COOKIE_SECURE") or str(ENFORCE_HTTPS))


### PR DESCRIPTION
Hello,
I have setup redash in **python virtual environment** with **uwsgi** instead of gunicorn.
Doing many setup deployments i got an error.
Templates directory could not be found.
So i was searching about this problem in source code. I was checking the REDASH_STATIC_ASSETS envar changing the path consecutively .
 
So i had two choices:

  In handlers/base.py

1. **routes = Blueprint('redash', __name__, template_folder=settings.fix_assets_path('templates'))**
     to
    **routes = Blueprint('redash', __name__, template_folder=settings.fix_assets_path('/opt/redash/dist/redash/templates'))** (bad hardcoded choice)

2. Create variable TEMPLATES_PATH in settings/__init__.py
  **TEMPLATE_PATH = fix_assets_path(os.environ.get("REDASH_TEMPLATE_PATH", "../client/dist"))** which  does not affect the deployment from bash script, because if is defined as envar, will get the same value with STATIC_ASSETS_PATH

If you want we could discuss about it and find a solution.

Thank you