### PR TITLE
Fix: don't send source_content_type

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -420,10 +420,9 @@ class ElasticSearch(BaseElasticSearch):
             if error:
                 return None, error
 
-            params = {"source": json.dumps(query_dict), "source_content_type": "application/json"}
             logger.debug("Using URL: %s", url)
-            logger.debug("Using params : %s", params)
-            r = requests.get(url, params=params, auth=self.auth)
+            logger.debug("Using query: %s", query_dict)
+            r = requests.get(url, json=query_dict, auth=self.auth)
             r.raise_for_status()
             logger.debug("Result: %s", r.json())
 


### PR DESCRIPTION
Instead we use GET body with a content type header, which seems like it was supported on all versions (tested with ES 6.3 and 5.2).

Closes #2689.