### PR TITLE
Remove X at the end of the input on Queries list page

### DIFF
--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -3,7 +3,7 @@
 
   <div class="row">
     <div class="col-md-3 list-control-t">
-      <div class="m-b-5">
+      <div class="m-b-10">
         <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.term" ng-model-options="{ allowInvalid: true, debounce: 200 }"
           ng-change="$ctrl.update()">
       </div>
@@ -115,14 +115,9 @@
     </div>
 
     <div class="col-md-3 list-control-r-b">
-      <div class="m-b-5 input-group search">
+      <div class="m-b-10">
         <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.term" ng-model-options="{ allowInvalid: true, debounce: 200 }"
           ng-change="$ctrl.update()">
-        <span class="input-group-btn">
-          <button class="btn btn-secondary" type="button" title="Clear search" ng-click="$ctrl.clearSearch()">
-            <span class="zmdi zmdi-close"></span>
-          </button>
-        </span>
       </div>
       <div class='list-group m-b-10 tags-list tiled'>
         <a href="queries" class="list-group-item" ng-class="{active: $ctrl.currentPage == 'all'}">


### PR DESCRIPTION
Before:
<img width="382" alt="screenshot 2018-08-10 17 06 12" src="https://user-images.githubusercontent.com/2378022/43965827-95eefcd2-9cc0-11e8-9617-03b68ac1a776.png">

After:
<img width="412" alt="screenshot 2018-08-10 17 12 25" src="https://user-images.githubusercontent.com/2378022/43965846-a2729e14-9cc0-11e8-802c-bd7bf5270482.png">

I don't think this extra clean option adds anything to the interface other than unnecessary complexity.
