### PR TITLE
fix broken query selection in alert page

### DIFF
--- a/client/app/pages/alert/index.js
+++ b/client/app/pages/alert/index.js
@@ -13,8 +13,8 @@ function AlertCtrl($routeParams, $location, $sce, toastr, currentUser, Query, Ev
   this.trustAsHtml = html => $sce.trustAsHtml(html);
 
   this.onQuerySelected = (item) => {
-    this.selectedQuery = item;
-    item.getQueryResultPromise().then((result) => {
+    this.selectedQuery = new Query(item);
+    this.selectedQuery.getQueryResultPromise().then((result) => {
       this.queryResult = result;
       this.alert.options.column = this.alert.options.column || result.getColumnNames()[0];
     });
@@ -25,7 +25,7 @@ function AlertCtrl($routeParams, $location, $sce, toastr, currentUser, Query, Ev
     this.canEdit = true;
   } else {
     this.alert = Alert.get({ id: this.alertId }, (alert) => {
-      this.onQuerySelected(new Query(alert.query));
+      this.onQuerySelected(alert.query);
       this.canEdit = currentUser.canEdit(this.alert);
     });
   }


### PR DESCRIPTION
The following error occurs when a query is selected in the
alert page:

> TypeError: "item.getQueryResultPromise is not a function"

This is because .onQueryHandler() is given a plain object instead of a
Query when a query is selected from the dropdown.

These changes fix the issue by wrapping the plain object into a Query
object before calling .getQueryResultPromise() on it.