### PR TITLE
Allow easier method of extending GUNICORN's worker timeout for Docker images.

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -19,7 +19,7 @@ scheduler() {
 }
 
 server() {
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} -t${REDASH_WEB_WORKERS_TIMEOUT:-30} redash.wsgi:app
 }
 
 create_db() {


### PR DESCRIPTION
This is something that was an issue for my team since we use docker images to run ReDash and we deal with pretty large datasets at times.  After some research it turned out the timeout was the issue of why some of our larger queries where failing.  I set it to 30 seconds which is the normal default but for our needs I set it to 5 minutes via the environment variable.  Hopefully this will get posted to help those that need an easy way to increase the timeout for those large result sets (think 200k rows or more).

Let me know if any questions, thank you!