### PR TITLE
Sort columns with undefined values

### DIFF
--- a/client/app/components/dynamic-table/index.js
+++ b/client/app/components/dynamic-table/index.js
@@ -34,11 +34,11 @@ function sortRows(rows, orderBy) {
     for (let i = 0; i < orderBy.length; i += 1) {
       va = a[orderBy[i].name];
       vb = b[orderBy[i].name];
-      if (!va || (va < vb)) {
+      if (va == undefined || (va < vb)) {
         // if a < b - we should return -1, but take in account direction
         return orderBy[i].direction * -1;
       }
-      if ((va > vb) || !vb) {
+      if ((va > vb) || vb == undefined) {
         // if a > b - we should return 1, but take in account direction
         return orderBy[i].direction * 1;
       }

--- a/client/app/components/dynamic-table/index.js
+++ b/client/app/components/dynamic-table/index.js
@@ -34,11 +34,11 @@ function sortRows(rows, orderBy) {
     for (let i = 0; i < orderBy.length; i += 1) {
       va = a[orderBy[i].name];
       vb = b[orderBy[i].name];
-      if (va < vb) {
+      if (!va || (va < vb)) {
         // if a < b - we should return -1, but take in account direction
         return orderBy[i].direction * -1;
       }
-      if (va > vb) {
+      if ((va > vb) || !vb) {
         // if a > b - we should return 1, but take in account direction
         return orderBy[i].direction * 1;
       }


### PR DESCRIPTION
Issue #2744 

When a query has column with undefined value, the column sorting result in a random order.
This fix place the undefined values in the first or last place depends on the sort direction.