### PR TITLE
Widgets crumble when trying to move / resize a widget

### DIFF
--- a/client/app/components/dashboards/gridstack/index.js
+++ b/client/app/components/dashboards/gridstack/index.js
@@ -89,7 +89,8 @@ function gridstack($parse, dashboardGridOptions) {
             item.minSizeX, item.maxSizeX, item.minSizeY, item.maxSizeY,
             itemId,
           );
-          grid._updateStyles(grid.grid.getGridHeight());
+          const gridHeight = grid.grid.getGridHeight() + 10;
+          grid._updateStyles(gridHeight);
         }
       };
 
@@ -203,6 +204,7 @@ function gridstack($parse, dashboardGridOptions) {
       this.update = (callback) => {
         const grid = this.grid();
         if (grid) {
+          const gridHeight = grid.grid.getGridHeight() + 10;
           grid.batchUpdate();
           try {
             if (_.isFunction(callback)) {
@@ -210,9 +212,10 @@ function gridstack($parse, dashboardGridOptions) {
             }
             // `_updateStyles` is internal, but grid sometimes "forgets"
             // to rebuild stylesheet, so we need to force it
-            grid._updateStyles(grid.grid.getGridHeight());
+            grid._updateStyles(gridHeight);
           } finally {
             grid.commit();
+            grid._updateStyles(gridHeight);
           }
         }
       };

--- a/client/app/visualizations/choropleth/utils.js
+++ b/client/app/visualizations/choropleth/utils.js
@@ -133,8 +133,8 @@ export function inferCountryCodeType(data, countryCodeField) {
       iso_a3: 0,
       iso_n3: 0,
     })
-    .pairs()
-    .max(item => item[1])
+    .toPairs()
+    .reduce((memo, item) => (item[1] > memo[1] ? item : memo))
     .value();
 
   return (result[1] / data.length) >= 0.9 ? result[0] : null;


### PR DESCRIPTION
Issue getredash/redash#2494

Also fixed bug in choropleth viz (introduced when replaced `underscore` with `lodash` - `lodash.max()` works differently from `underscore.max()`; also `underscore.pairs()` has another name in `lodash`)