### PR TITLE
Add auth via JWT providers

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -208,7 +208,7 @@ def logout_and_redirect_to_index():
 
 
 def setup_authentication(app):
-    from redash.authentication import google_oauth, saml_auth, remote_user_auth, ldap_auth, jwt_auth
+    from redash.authentication import google_oauth, saml_auth, remote_user_auth, ldap_auth
 
     login_manager.init_app(app)
     login_manager.anonymous_user = models.AnonymousUser
@@ -218,7 +218,6 @@ def setup_authentication(app):
     app.register_blueprint(saml_auth.blueprint)
     app.register_blueprint(remote_user_auth.blueprint)
     app.register_blueprint(ldap_auth.blueprint)
-    app.register_blueprint(jwt_auth.blueprint)
 
     user_logged_in.connect(log_user_logged_in)
     login_manager.request_loader(request_loader)

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -138,13 +138,19 @@ def jwt_token_load_user_from_request(request):
     org = current_org._get_current_object()
 
     payload = None
-    cookie_name = org_settings['auth_jwt_auth_cookie_name']
 
-    jwt_token = request.cookies.get(cookie_name, None)
+    if org_settings['auth_jwt_auth_cookie_name']:
+        jwt_token = request.cookies.get(org_settings['auth_jwt_auth_cookie_name'], None)
+    elif org_settings['auth_jwt_auth_header_name']:
+        jwt_token = request.headers.get(org_settings['auth_jwt_auth_header_name'], None)
+    else:
+        return None
+
     if jwt_token:
         payload, token_is_valid = jwt_auth.verify_jwt_token(
             jwt_token,
-            audience=org_settings['auth_jwt_auth_audience'],
+            expected_issuer=org_settings['auth_jwt_auth_issuer'],
+            expected_audience=org_settings['auth_jwt_auth_audience'],
             algorithms=org_settings['auth_jwt_auth_algorithms'],
             public_certs_url=org_settings['auth_jwt_auth_public_certs_url'],
         )

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -1,0 +1,51 @@
+import json
+import jwt
+import requests
+
+from flask import Blueprint
+
+blueprint = Blueprint('jwt_auth', __name__)
+
+
+def get_public_keys(url):
+    """
+    Returns:
+        List of RSA public keys usable by PyJWT.
+    """
+    if not hasattr(blueprint, 'jwt_auth_public_keys'):
+        blueprint.jwt_auth_public_keys = dict()
+
+    if url in blueprint.jwt_auth_public_keys:
+        return blueprint.jwt_auth_public_keys[url]
+    else:
+        r = requests.get(url)
+        public_keys = []
+        jwk_set = r.json()
+        for key_dict in jwk_set['keys']:
+            public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key_dict))
+            public_keys.append(public_key)
+        blueprint.jwt_auth_public_keys[url] = public_keys
+        return public_keys
+
+
+def verify_jwt_token(token, audience, algorithms, public_certs_url):
+    # https://cloud.google.com/iap/docs/signed-headers-howto
+    # https://developers.cloudflare.com/access/setting-up-access/validate-jwt-tokens/
+    # Loop through the keys since we can't pass the key set to the decoder
+    keys = get_public_keys(public_certs_url)
+    valid_token = False
+    payload = None
+    for key in keys:
+        try:
+            # decode returns the claims which has the email if you need it
+            payload = jwt.decode(
+                token,
+                key=key,
+                audience=audience,
+                algorithms=algorithms
+            )
+            valid_token = True
+            break
+        except:
+            pass
+    return payload, valid_token

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -1,9 +1,9 @@
 import logging
-logger = logging.getLogger('jwt_auth')
-
 import json
 import jwt
 import requests
+
+logger = logging.getLogger('jwt_auth')
 
 
 def get_public_keys(url):

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -4,9 +4,6 @@ logger = logging.getLogger('jwt_auth')
 import json
 import jwt
 import requests
-from flask import Blueprint, request, jsonify
-
-blueprint = Blueprint('jwt_auth', __name__)
 
 
 def get_public_keys(url):
@@ -66,34 +63,3 @@ def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms, 
         except Exception as e:
             logging.exception(e)
     return payload, valid_token
-
-
-@blueprint.route('/headers')
-def show_headers():
-    from redash.settings.organization import settings as org_settings
-    from flask import session as flask_session
-
-    if org_settings['auth_jwt_auth_cookie_name']:
-        jwt_token = request.cookies.get(org_settings['auth_jwt_auth_cookie_name'], None)
-    elif org_settings['auth_jwt_auth_header_name']:
-        jwt_token = request.headers.get(org_settings['auth_jwt_auth_header_name'], None)
-    else:
-        return None
-
-    jwt_payload = None
-
-    if jwt_token:
-        try:
-            jwt_payload = jwt.decode(
-                jwt_token,
-                verify=False,
-                algorithms=['HS256', 'RS256', 'ES256']
-            )
-        except Exception as e:
-            jwt_payload = repr(e)
-
-    return jsonify({
-        'jwt_payload': jwt_payload,
-        'headers': dict(request.headers),
-        'session': dict(flask_session)
-    })

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -1,8 +1,10 @@
+import logging
+logger = logging.getLogger('jwt_auth')
+
 import json
 import jwt
 import requests
-
-from flask import Blueprint
+from flask import Blueprint, request, jsonify
 
 blueprint = Blueprint('jwt_auth', __name__)
 
@@ -12,40 +14,86 @@ def get_public_keys(url):
     Returns:
         List of RSA public keys usable by PyJWT.
     """
-    if not hasattr(blueprint, 'jwt_auth_public_keys'):
-        blueprint.jwt_auth_public_keys = dict()
-
-    if url in blueprint.jwt_auth_public_keys:
-        return blueprint.jwt_auth_public_keys[url]
+    key_cache = get_public_keys.key_cache
+    if url in key_cache:
+        return key_cache[url]
     else:
         r = requests.get(url)
-        public_keys = []
-        jwk_set = r.json()
-        for key_dict in jwk_set['keys']:
-            public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key_dict))
-            public_keys.append(public_key)
-        blueprint.jwt_auth_public_keys[url] = public_keys
-        return public_keys
+        r.raise_for_status()
+        data = r.json()
+        if 'keys' in data:
+            public_keys = []
+            for key_dict in data['keys']:
+                public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key_dict))
+                public_keys.append(public_key)
+
+            get_public_keys.key_cache[url] = public_keys
+            return public_keys
+        else:
+            get_public_keys.key_cache[url] = data
+            return data
 
 
-def verify_jwt_token(token, audience, algorithms, public_certs_url):
-    # https://cloud.google.com/iap/docs/signed-headers-howto
+get_public_keys.key_cache = {}
+
+
+def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms, public_certs_url):
     # https://developers.cloudflare.com/access/setting-up-access/validate-jwt-tokens/
+    # https://cloud.google.com/iap/docs/signed-headers-howto
     # Loop through the keys since we can't pass the key set to the decoder
     keys = get_public_keys(public_certs_url)
+
+    key_id = jwt.get_unverified_header(jwt_token).get('kid', '')
+    if key_id and isinstance(keys, dict):
+        keys = [keys.get(key_id)]
+
     valid_token = False
     payload = None
     for key in keys:
         try:
             # decode returns the claims which has the email if you need it
             payload = jwt.decode(
-                token,
+                jwt_token,
                 key=key,
-                audience=audience,
+                audience=expected_audience,
                 algorithms=algorithms
             )
+            issuer = payload['iss']
+            if issuer != expected_issuer:
+                raise Exception('Wrong issuer: {}'.format(issuer))
             valid_token = True
             break
-        except:
-            pass
+        except Exception as e:
+            logging.exception(e)
     return payload, valid_token
+
+
+@blueprint.route('/headers')
+def show_headers():
+    from redash.settings.organization import settings as org_settings
+    from flask import session as flask_session
+
+    if org_settings['auth_jwt_auth_cookie_name']:
+        jwt_token = request.cookies.get(org_settings['auth_jwt_auth_cookie_name'], None)
+    elif org_settings['auth_jwt_auth_header_name']:
+        jwt_token = request.headers.get(org_settings['auth_jwt_auth_header_name'], None)
+    else:
+        return None
+
+    jwt_payload = None
+
+    if jwt_token:
+        try:
+            jwt_payload = jwt.decode(
+                jwt_token,
+                verify=False,
+                algorithms=['HS256', 'RS256', 'ES256']
+            )
+        except Exception as e:
+            jwt_payload = repr(e)
+
+    return jsonify({
+        'jwt_payload': jwt_payload,
+        'headers': dict(request.headers),
+        'session': dict(flask_session)
+    })

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -21,8 +21,9 @@ JWT_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_JWT_LOGIN_ENABLED", "fa
 JWT_AUTH_ISSUER = os.environ.get("REDASH_JWT_AUTH_ISSUER", "")
 JWT_AUTH_PUBLIC_CERTS_URL = os.environ.get("REDASH_JWT_AUTH_PUBLIC_CERTS_URL", "")
 JWT_AUTH_AUDIENCE = os.environ.get("REDASH_JWT_AUTH_AUDIENCE", "")
-JWT_AUTH_ALGORITHMS = os.environ.get("REDASH_JWT_AUTH_ALGORITHMS", "HS256,RS256").split(',')
+JWT_AUTH_ALGORITHMS = os.environ.get("REDASH_JWT_AUTH_ALGORITHMS", "HS256,RS256,ES256").split(',')
 JWT_AUTH_COOKIE_NAME = os.environ.get("REDASH_JWT_AUTH_COOKIE_NAME", "")
+JWT_AUTH_HEADER_NAME = os.environ.get("REDASH_JWT_AUTH_HEADER_NAME", "")
 
 settings = {
     "auth_password_login_enabled": PASSWORD_LOGIN_ENABLED,
@@ -37,4 +38,5 @@ settings = {
     "auth_jwt_auth_audience": JWT_AUTH_AUDIENCE,
     "auth_jwt_auth_algorithms": JWT_AUTH_ALGORITHMS,
     "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
+    "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,
 }

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -17,11 +17,24 @@ SAML_LOGIN_ENABLED = SAML_METADATA_URL != ""
 
 DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
 
+JWT_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_JWT_LOGIN_ENABLED", "false"))
+JWT_AUTH_ISSUER = os.environ.get("REDASH_JWT_AUTH_ISSUER", "")
+JWT_AUTH_PUBLIC_CERTS_URL = os.environ.get("REDASH_JWT_AUTH_PUBLIC_CERTS_URL", "")
+JWT_AUTH_AUDIENCE = os.environ.get("REDASH_JWT_AUTH_AUDIENCE", "")
+JWT_AUTH_ALGORITHMS = os.environ.get("REDASH_JWT_AUTH_ALGORITHMS", "HS256,RS256").split(',')
+JWT_AUTH_COOKIE_NAME = os.environ.get("REDASH_JWT_AUTH_COOKIE_NAME", "")
+
 settings = {
     "auth_password_login_enabled": PASSWORD_LOGIN_ENABLED,
     "auth_saml_enabled": SAML_LOGIN_ENABLED,
     "auth_saml_entity_id": SAML_ENTITY_ID,
     "auth_saml_metadata_url": SAML_METADATA_URL,
     "auth_saml_nameid_format": SAML_NAMEID_FORMAT,
-    "date_format": DATE_FORMAT
+    "date_format": DATE_FORMAT,
+    "auth_jwt_login_enabled": JWT_LOGIN_ENABLED,
+    "auth_jwt_auth_issuer": JWT_AUTH_ISSUER,
+    "auth_jwt_auth_public_certs_url": JWT_AUTH_PUBLIC_CERTS_URL,
+    "auth_jwt_auth_audience": JWT_AUTH_AUDIENCE,
+    "auth_jwt_auth_algorithms": JWT_AUTH_ALGORITHMS,
+    "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ semver==2.2.1
 xlsxwriter==0.9.3
 pystache==0.5.4
 parsedatetime==2.1
+PyJWT==1.6.4
 cryptography==2.0.2
 simplejson==3.10.0
 ua-parser==0.7.3


### PR DESCRIPTION
This add one more authentication method via JWT providers like Cloudflare Access or Google IAP.
Example config:

```python
REDASH_JWT_LOGIN_ENABLED=true
REDASH_JWT_AUTH_ALGORITHMS=HS256,RS256,ES256

# For CF Access
REDASH_JWT_AUTH_ISSUER=<your auth domain>
REDASH_JWT_AUTH_PUBLIC_CERTS_URL=<your auth domain>/cdn-cgi/access/certs
REDASH_JWT_AUTH_AUDIENCE=e71a4e5efa1dc461bcc44050ef65cf25ba124b8364ccd5db472f3845a72c34f9
REDASH_JWT_AUTH_COOKIE_NAME=CF_Authorization

# For Google IAP
REDASH_JWT_AUTH_PUBLIC_CERTS_URL=https://www.gstatic.com/iap/verify/public_key
REDASH_JWT_AUTH_AUDIENCE=/projects/PROJECT_NUMBER/apps/PROJECT_ID
REDASH_JWT_AUTH_ISSUER=https://cloud.google.com/iap
REDASH_JWT_AUTH_HEADER_NAME=X-Goog-IAP-JWT-Assertion

```

When we get user from JWT payload, it's match user by email in database and log in. If we don't have user with this email in database, then it will be created.