### PR TITLE
Date/time params not working as global param

### DIFF
--- a/client/app/components/parameters.js
+++ b/client/app/components/parameters.js
@@ -136,7 +136,7 @@ function ParametersDirective($location, $uibModal) {
           if (scope.changed) {
             scope.changed({});
           }
-          const params = {};
+          const params = extend({}, $location.search());
           scope.parameters.forEach((param) => {
             extend(params, param.toUrlParams());
           });

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -109,7 +109,7 @@ function DashboardCtrl(
           .filter(p => p.global)
           .forEach((param) => {
             const defaults = {};
-            defaults[param.name] = _.create(Object.getPrototypeOf(param), param);
+            defaults[param.name] = param.clone();
             defaults[param.name].locals = [];
             globalParams = _.defaults(globalParams, defaults);
             globalParams[param.name].locals.push(param);

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -57,10 +57,10 @@ class Parameter {
 
     // validate value and init internal state
     this.setValue(parameter.value);
+  }
 
-    // explicitly bind it to `this` to allow passing it as callback to Ant's
-    // DatePicker component
-    this.setValue = this.setValue.bind(this);
+  clone() {
+    return new Parameter(this);
   }
 
   get isEmpty() {


### PR DESCRIPTION
Issue getredash/redash#2730

Two issues fixed:

1. bug when updating URL query parameters: if there were multiple parameters sections, there were race condition;
2. `_.create` does not call class constructor, therefore global parameters were not updated.