### PR TITLE
LDAP Authentication. Create two envars REDASH_LDAP_USE_SSL and REDASH_LDAP_AUTH_BIND

### DIFF
--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -7,7 +7,7 @@ from flask import flash, redirect, render_template, request, url_for, Blueprint
 from flask_login import current_user, login_required, login_user, logout_user
 
 try:
-    from ldap3 import Server, Connection, SIMPLE
+    from ldap3 import Server, Connection, SIMPLE, ANONYMOUS
 except ImportError:
     if settings.LDAP_LOGIN_ENABLED:
         logger.error("The ldap3 library was not found. This is required to use LDAP authentication (see requirements.txt).")

--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -58,7 +58,7 @@ def login(org_slug=None):
 
 
 def auth_ldap_user(username, password):
-    server = Server(settings.LDAP_HOST_URL, settings.LDAP_SSL)
+    server = Server(settings.LDAP_HOST_URL, use_ssl=settings.LDAP_SSL)
     conn = Connection(server, settings.LDAP_BIND_DN, password=settings.LDAP_BIND_DN_PASSWORD, authentication=settings.LDAP_AUTH_BIND, auto_bind=True)
 
     conn.search(settings.LDAP_SEARCH_DN, settings.LDAP_SEARCH_TEMPLATE % {"username": username}, attributes=[settings.LDAP_DISPLAY_NAME_KEY, settings.LDAP_EMAIL_KEY])

--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -58,8 +58,8 @@ def login(org_slug=None):
 
 
 def auth_ldap_user(username, password):
-    server = Server(settings.LDAP_HOST_URL)
-    conn = Connection(server, settings.LDAP_BIND_DN, password=settings.LDAP_BIND_DN_PASSWORD, authentication=SIMPLE, auto_bind=True)
+    server = Server(settings.LDAP_HOST_URL, settings.LDAP_SSL)
+    conn = Connection(server, settings.LDAP_BIND_DN, password=settings.LDAP_BIND_DN_PASSWORD, authentication=settings.LDAP_AUTH_BIND, auto_bind=True)
 
     conn.search(settings.LDAP_SEARCH_DN, settings.LDAP_SEARCH_TEMPLATE % {"username": username}, attributes=[settings.LDAP_DISPLAY_NAME_KEY, settings.LDAP_EMAIL_KEY])
 

--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -59,7 +59,7 @@ def login(org_slug=None):
 
 def auth_ldap_user(username, password):
     server = Server(settings.LDAP_HOST_URL, use_ssl=settings.LDAP_SSL)
-    conn = Connection(server, settings.LDAP_BIND_DN, password=settings.LDAP_BIND_DN_PASSWORD, authentication=settings.LDAP_AUTH_BIND, auto_bind=True)
+    conn = Connection(server, settings.LDAP_BIND_DN, password=settings.LDAP_BIND_DN_PASSWORD, authentication=settings.LDAP_AUTH_METHOD, auto_bind=True)
 
     conn.search(settings.LDAP_SEARCH_DN, settings.LDAP_SEARCH_TEMPLATE % {"username": username}, attributes=[settings.LDAP_DISPLAY_NAME_KEY, settings.LDAP_EMAIL_KEY])
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -82,9 +82,9 @@ REMOTE_USER_HEADER = os.environ.get("REDASH_REMOTE_USER_HEADER", "X-Forwarded-Re
 # able to login through Redash instead of the LDAP server
 LDAP_LOGIN_ENABLED = parse_boolean(os.environ.get('REDASH_LDAP_LOGIN_ENABLED', 'false'))
 # Bind LDAP using SSL. Default is False
-LDAP_SSL = os.environ.get('REDASH_LDAP_USE_SSL', 'false')
+LDAP_SSL = parse_boolean(os.environ.get('REDASH_LDAP_USE_SSL', 'false'))
 #Choose authentication method(SIMPLE or ANONYMOUS). Default is SIMPLE
-LDAP_AUTH_BIND = os.environ.get('REDASH_LDAP_AUTH_BIND', 'SIMPLE')
+LDAP_AUTH_METHOD = os.environ.get('REDASH_LDAP_AUTH_METHOD', 'SIMPLE')
 # The LDAP directory address (ex. ldap://10.0.10.1:389)
 LDAP_HOST_URL = os.environ.get('REDASH_LDAP_URL', None)
 # The DN & password used to connect to LDAP to determine the identity of the user being authenticated.

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -81,6 +81,10 @@ REMOTE_USER_HEADER = os.environ.get("REDASH_REMOTE_USER_HEADER", "X-Forwarded-Re
 # If the organization setting auth_password_login_enabled is not false, then users will still be
 # able to login through Redash instead of the LDAP server
 LDAP_LOGIN_ENABLED = parse_boolean(os.environ.get('REDASH_LDAP_LOGIN_ENABLED', 'false'))
+# Bind LDAP using SSL. Default is False
+LDAP_SSL = os.environ.get('REDASH_LDAP_USE_SSL', 'false')
+#Choose authentication method(SIMPLE or ANONYMOUS). Default is SIMPLE
+LDAP_AUTH_BIND = os.environ.get('REDASH_LDAP_AUTH_BIND', 'SIMPLE')
 # The LDAP directory address (ex. ldap://10.0.10.1:389)
 LDAP_HOST_URL = os.environ.get('REDASH_LDAP_URL', None)
 # The DN & password used to connect to LDAP to determine the identity of the user being authenticated.

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -83,7 +83,7 @@ REMOTE_USER_HEADER = os.environ.get("REDASH_REMOTE_USER_HEADER", "X-Forwarded-Re
 LDAP_LOGIN_ENABLED = parse_boolean(os.environ.get('REDASH_LDAP_LOGIN_ENABLED', 'false'))
 # Bind LDAP using SSL. Default is False
 LDAP_SSL = parse_boolean(os.environ.get('REDASH_LDAP_USE_SSL', 'false'))
-#Choose authentication method(SIMPLE or ANONYMOUS). Default is SIMPLE
+# Choose authentication method(SIMPLE or ANONYMOUS). Default is SIMPLE
 LDAP_AUTH_METHOD = os.environ.get('REDASH_LDAP_AUTH_METHOD', 'SIMPLE')
 # The LDAP directory address (ex. ldap://10.0.10.1:389)
 LDAP_HOST_URL = os.environ.get('REDASH_LDAP_URL', None)


### PR DESCRIPTION
Hello,
I have created 2 new envars. 

- REDASH_LDAP_USE_SSL : This envar determines the use of SSL or not, giving value to use_ssl parameter. Default is false

- REDASH_LDAP_AUTH_METHOD:  This envar determines the authentication method(**SIMPLE** or **ANONYMOUS**). Default is SIMPLE