### PR TITLE
port autocomplete toggle

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -496,6 +496,10 @@ a.label-tag {
   }
 }
 
+.off {
+  background-color: #999999 !important;
+}
+
 // Left nav fixes for filling all the space
 nav .rg-bottom {
   visibility: hidden;

--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -496,10 +496,6 @@ a.label-tag {
   }
 }
 
-.off {
-  background-color: #999999 !important;
-}
-
 // Left nav fixes for filling all the space
 nav .rg-bottom {
   visibility: hidden;

--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -98,10 +98,11 @@ function queryEditor(QuerySnippet, $timeout) {
                 if (newSchema === undefined) {
                   return;
                 }
-                const tokensCount = newSchema.reduce((totalLength, table) => totalLength + table.columns.length, 0);
-                // If there are too many tokens we disable live autocomplete,
-                // as it makes typing slower.
-                if (tokensCount > 5000) {
+                const tokensCount =
+                  newSchema.reduce((totalLength, table) => totalLength + table.columns.length, 0);
+                // If there are too many tokens or if it's requested via the UI
+                // we disable live autocomplete, as it makes typing slower.
+                if (tokensCount > 5000 || !$scope.$parent.autoCompleteQuery) {
                   editor.setOption('enableLiveAutocompletion', false);
                 } else {
                   editor.setOption('enableLiveAutocompletion', true);
@@ -111,6 +112,10 @@ function queryEditor(QuerySnippet, $timeout) {
 
             $scope.$parent.$on('angular-resizable.resizing', () => {
               editor.resize();
+            });
+
+            $scope.$parent.$watch('autoCompleteQuery', () => {
+              editor.setOption('enableLiveAutocompletion', $scope.$parent.autoCompleteQuery);
             });
 
             editor.focus();

--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -26,6 +26,7 @@ function queryEditor(QuerySnippet, $timeout) {
       query: '=',
       schema: '=',
       syntax: '=',
+      autoCompleteQuery: '=',
     },
     template: '<div ui-ace="editorOptions" ng-model="query.query"></div>',
     link: {
@@ -114,8 +115,8 @@ function queryEditor(QuerySnippet, $timeout) {
               editor.resize();
             });
 
-            $scope.$parent.$watch('autoCompleteQuery', () => {
-              editor.setOption('enableLiveAutocompletion', $scope.$parent.autoCompleteQuery);
+            $scope.$watch('autoCompleteQuery', () => {
+              editor.setOption('enableLiveAutocompletion', $scope.autoCompleteQuery);
             });
 
             editor.focus();

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -143,7 +143,7 @@
 
               <div class="container p-15 m-b-10" style="height:100%;">
                 <p style="height:calc(100% - 40px); margin-bottom: 0px;" class="editor__container">
-                  <query-editor query="query" schema="schema" syntax="dataSource.syntax"></query-editor>
+                  <query-editor query="query" schema="schema" syntax="dataSource.syntax" auto-complete-query="autoCompleteQuery"></query-editor>
                 </p>
 
                 <div class="editor__control">
@@ -157,7 +157,7 @@
                       <span class="zmdi zmdi-format-indent-increase"></span>
                     </button>
 
-                    <button type="button" class="btn btn-default m-r-5" ng-click="toggleAutoComplete()" uib-tooltip="Toggle AutoComplete" ng-class="onOrOff">
+                    <button type="button" class="btn btn-default m-r-5" ng-click="toggleAutoComplete()" uib-tooltip="Toggle AutoComplete" ng-class="{active: autoCompleteQuery}">
                       <span class="fa fa-magic"></span>
                     </button>
 

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -153,8 +153,12 @@
                       <span ng-non-bindable>{{&nbsp;}}</span>
                     </button>
 
-                    <button type="button" class="btn btn-default" ng-click="formatQuery()" uib-tooltip="Format Query">
+                    <button type="button" class="btn btn-default m-r-5" ng-click="formatQuery()" uib-tooltip="Format Query">
                       <span class="zmdi zmdi-format-indent-increase"></span>
+                    </button>
+
+                    <button type="button" class="btn btn-default m-r-5" ng-click="toggleAutoComplete()" uib-tooltip="Toggle AutoComplete" ng-class="onOrOff">
+                      <span class="fa fa-magic"></span>
                     </button>
 
                     <select class="form-control datasource-small flex-fill w-100" ng-disabled="!isQueryOwner || !sourceMode" ng-model="query.data_source_id"

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -81,13 +81,13 @@ function QuerySourceCtrl(
   };
 
   $scope.autoCompleteQuery = true;
-  $scope.onOrOff = '';
+  $scope.onOrOff = 'active';
   $scope.toggleAutoComplete = () => {
     $scope.autoCompleteQuery = !$scope.autoCompleteQuery;
     if (!$scope.autoCompleteQuery) {
-      $scope.onOrOff = 'off';
-    } else {
       $scope.onOrOff = '';
+    } else {
+      $scope.onOrOff = 'active';
     }
   };
 

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -81,14 +81,8 @@ function QuerySourceCtrl(
   };
 
   $scope.autoCompleteQuery = true;
-  $scope.onOrOff = 'active';
   $scope.toggleAutoComplete = () => {
     $scope.autoCompleteQuery = !$scope.autoCompleteQuery;
-    if (!$scope.autoCompleteQuery) {
-      $scope.onOrOff = '';
-    } else {
-      $scope.onOrOff = 'active';
-    }
   };
 
   $scope.addNewParameter = () => {

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -80,6 +80,17 @@ function QuerySourceCtrl(
       .catch(error => toastr.error(error));
   };
 
+  $scope.autoCompleteQuery = true;
+  $scope.onOrOff = '';
+  $scope.toggleAutoComplete = () => {
+    $scope.autoCompleteQuery = !$scope.autoCompleteQuery;
+    if (!$scope.autoCompleteQuery) {
+      $scope.onOrOff = 'off';
+    } else {
+      $scope.onOrOff = '';
+    }
+  };
+
   $scope.addNewParameter = () => {
     $uibModal
       .open({


### PR DESCRIPTION
History of this change:
* Originally, a Mozilla redash user asked for a toggle to turn autocomplete off in https://github.com/mozilla/redash/issues/282 That was implemented in the Mozilla fork. 
* Madalin, the Mozilla QA person, then filed https://github.com/mozilla/redash/issues/344 to say that the autocomplete button should always be displayed, not just on hover over the query textarea. In the [PR to make that change](https://github.com/getredash/redash/pull/2588) discussion evolved to discuss the UI of this change. Now that https://github.com/getredash/redash/pull/2678 is merged, we can implement the solution.

This PR:
* Adds the autocomplete toggle as a button next to the Add a Parameter and the Format Query buttons.

Because this button has a state (on or off) I implemented it with a darker background color when off. This color change provides more information to the user and will communicate more in screenshots of bug reports.

When AutoComplete is on:
![screenshot 2018-09-02 16 17 52](https://user-images.githubusercontent.com/1840865/44960886-22318700-aecd-11e8-9eee-049a0c163a2f.png)

When AutoComplete is off:
![screenshot 2018-09-02 16 16 52](https://user-images.githubusercontent.com/1840865/44960889-31183980-aecd-11e8-96c1-e31e57765be2.png)
