### PR TITLE
add last_active_at to users page

### DIFF
--- a/client/app/pages/users/list.html
+++ b/client/app/pages/users/list.html
@@ -46,6 +46,10 @@
               Joined
               <sort-icon column="'created_at'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
             </th>
+            <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('last_active_at')">
+              Last Active At
+              <sort-icon column="'last_active_at'" sort-column="$ctrl.paginator.orderByField" reverse="$ctrl.paginator.orderByReverse"></sort-icon>
+            </th>
             <th width="1%"></th>
           </tr>
         </thead>
@@ -61,6 +65,9 @@
             </td>
             <td>
               <span am-time-ago="user.created_at"></span>
+            </td>
+            <td>
+              <span am-time-ago="user.last_active_at[0]" uib-tooltop="user.last_active_at[0]"></span>
             </td>
             <td>
               <div ng-if="$ctrl.currentUser.hasPermission('admin') && (user.id != $ctrl.currentUser.id)">

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -23,6 +23,8 @@ order_map = {
     '-created_at': '-created_at',
     'groups': 'group_ids',
     '-groups': '-group_ids',
+    'last_active_at': 'last_active_at',
+    '-last_active_at': '-last_active_at',
 }
 
 order_results = rpartial(_order_results, '-created_at', order_map)

--- a/redash/models.py
+++ b/redash/models.py
@@ -473,6 +473,8 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
         if with_api_key:
             d['api_key'] = self.api_key
 
+        d['last_active_at'] = Event.query.filter(Event.user_id == self.id).with_entities(Event.created_at).order_by(Event.created_at.desc()).first()
+
         return d
 
     def is_api_user(self):


### PR DESCRIPTION
This feature request was originally made in #789. It was implemented in the Mozilla fork in [issue 155](https://github.com/mozilla/redash/issues/155) with [PR 191](https://github.com/mozilla/redash/pull/191). This ports the feature to getredash/redash. It works with the revised pagination and table sort.