### PR TITLE
Refactor list based controllers.

### DIFF
--- a/client/app/components/app-header/app-header.html
+++ b/client/app/components/app-header/app-header.html
@@ -128,7 +128,7 @@
       <!-- Search -->
       <form class="navbar-form navbar-right" role="search" ng-submit="$ctrl.searchQueries()">
         <div class="input-group menu-search">
-          <input type="text" ng-model="$ctrl.term" class="form-control navbar__search__input" placeholder="Search queries...">
+          <input type="text" ng-model="$ctrl.searchTerm" class="form-control navbar__search__input" placeholder="Search queries...">
           <span class="input-group-btn">
             <button type="submit" class="btn btn-default"><span class="zmdi zmdi-search"></span></button>
           </span>

--- a/client/app/components/app-header/index.js
+++ b/client/app/components/app-header/index.js
@@ -40,7 +40,7 @@ function controller($rootScope, $location, $route, $uibModal, Auth, currentUser,
   };
 
   this.searchQueries = () => {
-    $location.path('/queries').search({ q: this.term });
+    $location.path('/queries').search({ q: this.searchTerm });
     $route.reload();
   };
 

--- a/client/app/lib/list-ctrl.js
+++ b/client/app/lib/list-ctrl.js
@@ -1,0 +1,104 @@
+import { bind } from 'lodash';
+import { LivePaginator } from '@/lib/pagination';
+
+export default class ListCtrl {
+  constructor($scope, $location, currentUser, defaultOrder = '-created_at') {
+    this.searchTerm = $location.search().q || '';
+
+    this.page = parseInt($location.search().page || 1, 10);
+    this.pageSize = parseInt($location.search().page_size || 20, 10);
+    this.pageSizeOptions = [5, 10, 20, 50, 100];
+    this.pageSizeLabel = value => `${value} results`;
+
+    this.orderSeparator = '-';
+    this.defaultOrder = defaultOrder;
+    this.pageOrder = $location.search().order || this.defaultOrder;
+    this.pageOrderReverse = this.pageOrder.startsWith(this.orderSeparator);
+    if (this.pageOrderReverse) {
+      this.pageOrder = this.pageOrder.substr(1);
+    }
+
+    this.defaultOptions = {};
+
+    // use $parent because we're using a component as route target instead of controller;
+    // $parent refers to scope created for the page by router
+    this.resource = $scope.$parent.$resolve.resource;
+    this.currentPage = $scope.$parent.$resolve.currentPage;
+
+    this.currentUser = currentUser;
+
+    this.showEmptyState = false;
+    this.loaded = false;
+
+    this.selectedTags = new Set();
+    this.onTagsUpdate = (tags) => {
+      this.selectedTags = tags;
+      this.update();
+    };
+
+    this.isInSearchMode = () => this.searchTerm !== undefined && this.searchTerm !== null && this.searchTerm.length > 0;
+
+    const fetcher = (requestedPage, itemsPerPage, orderByField, orderByReverse) => {
+      $location.search('page', requestedPage);
+      $location.search('page_size', itemsPerPage);
+
+      if (orderByReverse && !orderByField.startsWith(this.orderSeparator)) {
+        orderByField = this.orderSeparator + orderByField;
+      }
+      if (orderByField) {
+        $location.search('order', orderByField);
+      } else {
+        $location.search('order', undefined);
+      }
+
+      const request = this.getRequest(requestedPage, itemsPerPage, orderByField);
+
+      if (this.searchTerm === '') {
+        this.searchTerm = null;
+      }
+      $location.search('q', this.searchTerm);
+
+      this.loaded = false;
+      const requestCallback = bind(this.processResponse, this);
+      return this.resource(request).$promise.then(requestCallback);
+    };
+
+    this.paginator = new LivePaginator(fetcher, {
+      page: this.page,
+      itemsPerPage: this.pageSize,
+      orderByField: this.pageOrder,
+      orderByReverse: this.pageOrderReverse,
+    });
+
+    this.navigateTo = ($event, url) => {
+      if ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey) {
+        // keep default browser behavior
+        return;
+      }
+      $event.preventDefault();
+      $location.url(url);
+    };
+
+    this.update = () => {
+      // `queriesFetcher` will be called by paginator
+      this.paginator.setPage(this.page, this.pageSize);
+    };
+  }
+
+  processResponse() {
+    this.loaded = true;
+  }
+
+  getRequest(requestedPage, itemsPerPage, orderByField) {
+    const request = Object.assign({}, this.defaultOptions, {
+      page: requestedPage,
+      page_size: itemsPerPage,
+      order: orderByField,
+      tags: [...this.selectedTags], // convert Set to Array
+    });
+    if (this.isInSearchMode()) {
+      request.q = this.searchTerm;
+    }
+    return request;
+  }
+}

--- a/client/app/lib/pagination/live-paginator.js
+++ b/client/app/lib/pagination/live-paginator.js
@@ -11,7 +11,7 @@ export default class LivePaginator {
   }
 
   fetchPage(page) {
-    this.rowsFetcher(page, this.itemsPerPage, this.orderByField, this.orderByReverse, this);
+    this.rowsFetcher(page, this.itemsPerPage, this.orderByField, this.orderByReverse);
   }
 
   setPage(page, pageSize) {

--- a/client/app/pages/dashboards/dashboard-list.html
+++ b/client/app/pages/dashboards/dashboard-list.html
@@ -1,10 +1,11 @@
-<div class='container'>
+<div class="container">
+
   <page-header title="Dashboards"></page-header>
 
   <div class="row">
     <div class="col-md-3 list-control-t">
-      <div class="m-b-5">
-        <input type='text' class='form-control' placeholder="Search Dashboards..." ng-change="$ctrl.update()" ng-model="$ctrl.searchText" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+      <div class="m-b-10">
+        <input type="text" class="form-control" placeholder="Search Dashboards..." ng-change="$ctrl.update()" ng-model="$ctrl.searchTerm" ng-model-options="{ allowInvalid: true, debounce: 200 }"
           autofocus/>
       </div>
 
@@ -24,6 +25,12 @@
       <div class="m-b-10">
         <tags-list tags-url="api/dashboards/tags" on-tags-update="$ctrl.onTagsUpdate"></tags-list>
       </div>
+
+      <div class="m-b-10">
+        <select ng-change="$ctrl.update()" ng-model="$ctrl.pageSize" class="form-control"
+          ng-options="value as $ctrl.pageSizeLabel(value) for value in $ctrl.pageSizeOptions"></select>
+      </div>
+
     </div>
 
     <div ng-if="!$ctrl.loaded" class="col-md-9 list-content text-center">
@@ -36,10 +43,10 @@
           help-link="http://help.redash.io/category/22-dashboards"></empty-state>
       </div>
 
-      <big-message ng-if="($ctrl.currentPage == 'favorites') && ($ctrl.searchText === undefined || $ctrl.searchText.length == 0) && $ctrl.selectedTags.size === 0"
+      <big-message ng-if="($ctrl.currentPage == 'favorites') && ($ctrl.searchTerm === undefined || $ctrl.searchTerm.length == 0) && $ctrl.selectedTags.size === 0"
         message="'Mark dashboards as Favorite to list them here.'" icon="'fa-star'" />
 
-      <big-message message="'Sorry, we couldn\'t find anything.'" icon="'fa-search'" ng-if="$ctrl.searchText.length > 0"></big-message>
+      <big-message message="'Sorry, we couldn\'t find anything.'" icon="'fa-search'" ng-if="$ctrl.searchTerm.length > 0"></big-message>
 
       <no-tagged-objects-found object-type="'dashboards'" tags="$ctrl.selectedTags" ng-if="$ctrl.selectedTags.size > 0" />
     </div>
@@ -87,9 +94,9 @@
     </div>
 
     <div class="col-md-3 list-control-r-b">
-      <div class="m-b-5">
-        <input type='text' class='form-control' placeholder="Search Dashboards..." ng-change="$ctrl.update()" ng-model="$ctrl.searchText" ng-model-options="{ allowInvalid: true, debounce: 200 }"
-          autofocus/>
+      <div class="m-b-10">
+        <input type="text" class="form-control" placeholder="Search Dashboards..." ng-change="$ctrl.update()" ng-model="$ctrl.searchTerm" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+          autofocus />
       </div>
 
       <div class="list-group m-b-10 tags-list tiled">
@@ -105,7 +112,13 @@
         </a>
       </div>
 
-      <tags-list tags-url="api/dashboards/tags" on-tags-update="$ctrl.onTagsUpdate"></tags-list>
+      <div class="m-b-10">
+          <tags-list tags-url="api/dashboards/tags" on-tags-update="$ctrl.onTagsUpdate"></tags-list>
+      </div>
+      <div class="m-b-5">
+        <select ng-change="$ctrl.update()" ng-model="$ctrl.pageSize" class="form-control"
+          ng-options="value as $ctrl.pageSizeLabel(value) for value in $ctrl.pageSizeOptions"></select>
+      </div>
     </div>
   </div>
 </div>

--- a/client/app/pages/dashboards/dashboard-list.js
+++ b/client/app/pages/dashboards/dashboard-list.js
@@ -1,96 +1,20 @@
-import { isString, extend } from 'lodash';
+import { extend } from 'lodash';
 
-import { LivePaginator } from '@/lib/pagination';
+import ListCtrl from '@/lib/list-ctrl';
 import template from './dashboard-list.html';
 import './dashboard-list.css';
 
-class DashboardListCtrl {
-  constructor($scope, currentUser, $location, Dashboard) {
-    const page = parseInt($location.search().page || 1, 10);
+class DashboardListCtrl extends ListCtrl {
+  constructor($scope, $location, currentUser, Dashboard) {
+    super($scope, $location, currentUser);
+    this.Type = Dashboard;
+  }
 
-    const orderSeparator = '-';
-    this.pageOrder = $location.search().order || '-created_at';
-    this.pageOrderReverse = this.pageOrder.startsWith(orderSeparator);
-    if (this.pageOrderReverse) {
-      this.pageOrder = this.pageOrder.substr(1);
-    }
-
-    // use $parent because we're using a component as route target instead of controller;
-    // $parent refers to scope created for the page by router
-    this.resource = $scope.$parent.$resolve.resource;
-    this.currentPage = $scope.$parent.$resolve.currentPage;
-
-    this.defaultOptions = {};
-
-    this.searchText = $location.search().q;
-
-    this.currentUser = currentUser;
-
-    this.selectedTags = new Set();
-    this.onTagsUpdate = (tags) => {
-      this.selectedTags = tags;
-      this.update();
-    };
-
-    this.showEmptyState = false;
-    this.loaded = false;
-
-    const setSearchOrClear = (name, value) => {
-      if (value) {
-        $location.search(name, value);
-      } else {
-        $location.search(name, undefined);
-      }
-    };
-
-    const fetcher = (requestedPage, itemsPerPage, orderByField, orderByReverse, paginator) => {
-      $location.search('page', requestedPage);
-
-      if (orderByReverse && !orderByField.startsWith(orderSeparator)) {
-        orderByField = orderSeparator + orderByField;
-      }
-      setSearchOrClear('order', orderByField);
-
-      const request = Object.assign({}, this.defaultOptions, {
-        page: requestedPage,
-        page_size: itemsPerPage,
-        tags: [...this.selectedTags], // convert Set to Array
-        order: orderByField,
-      });
-
-      if (isString(this.searchText) && this.searchText !== '') {
-        request.q = this.searchText;
-      }
-
-      this.loaded = false;
-      return this.resource(request).$promise.then((data) => {
-        this.loaded = true;
-        const rows = data.results.map(d => new Dashboard(d));
-        paginator.updateRows(rows, data.count);
-        this.showEmptyState = data.count === 0;
-      });
-    };
-
-    this.paginator = new LivePaginator(fetcher, {
-      page,
-      itemsPerPage: this.pageSize,
-      orderByField: this.pageOrder,
-      orderByReverse: this.pageOrderReverse,
-    });
-
-    this.navigateTo = ($event, url) => {
-      if ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey) {
-        // keep default browser behavior
-        return;
-      }
-      $event.preventDefault();
-      $location.url(url);
-    };
-
-    this.update = () => {
-      // trigger paginator refresh
-      this.paginator.setPage(page);
-    };
+  processResponse(data) {
+    super.processResponse(data);
+    const rows = data.results.map(d => new this.Type(d));
+    this.paginator.updateRows(rows, data.count);
+    this.showEmptyState = data.count === 0;
   }
 }
 

--- a/client/app/pages/queries-list/index.js
+++ b/client/app/pages/queries-list/index.js
@@ -1,141 +1,42 @@
 import moment from 'moment';
-import { extend, isString } from 'lodash';
+import { extend } from 'lodash';
 
-import { LivePaginator } from '@/lib/pagination';
+import ListCtrl from '@/lib/list-ctrl';
 import template from './queries-list.html';
 import './queries-list.css';
 
-class QueriesListCtrl {
-  constructor($scope, $location, Query, currentUser) {
-    const page = parseInt($location.search().page || 1, 10);
 
-    const orderSeparator = '-';
-    this.pageOrder = $location.search().order || '-created_at';
-    this.pageOrderReverse = this.pageOrder.startsWith(orderSeparator);
-    if (this.pageOrderReverse) {
-      this.pageOrder = this.pageOrder.substr(1);
-    }
-
-    this.term = $location.search().q;
-    this.pageSize = parseInt($location.search().page_size || 20, 10);
-    this.pageSizeOptions = [5, 10, 20, 50, 100];
-
-    if (!(isString(this.term) && this.term !== '')) {
-      this.term = '';
-    }
-
-    this.defaultOptions = {};
-
-    // use $parent because we're using a component as route target instead of controller;
-    // $parent refers to scope created for the page by router
-    this.resource = $scope.$parent.$resolve.resource;
-    this.currentPage = $scope.$parent.$resolve.currentPage;
-
-    this.currentUser = currentUser;
+class QueriesListCtrl extends ListCtrl {
+  constructor($scope, $location, currentUser, Query) {
+    super($scope, $location, currentUser);
+    this.Type = Query;
     this.showMyQueries = currentUser.hasPermission('create_query');
+  }
 
-    this.showEmptyState = false;
-    this.loaded = false;
-
-    this.selectedTags = new Set();
-    this.onTagsUpdate = (tags) => {
-      this.selectedTags = tags;
-      this.update();
-    };
-
-    const setSearchOrClear = (name, value) => {
-      if (value) {
-        $location.search(name, value);
-      } else {
-        $location.search(name, undefined);
-      }
-    };
-
-    this.isInSearchMode = () => this.term !== undefined && this.term !== null && this.term.length > 0;
-
-    const queriesFetcher = (requestedPage, itemsPerPage, orderByField, orderByReverse, paginator) => {
-      $location.search('page', requestedPage);
-      $location.search('page_size', itemsPerPage);
-
-      if (orderByReverse && !orderByField.startsWith(orderSeparator)) {
-        orderByField = orderSeparator + orderByField;
-      }
-      setSearchOrClear('order', orderByField);
-
-      const request = Object.assign({}, this.defaultOptions, {
-        page: requestedPage,
-        page_size: itemsPerPage,
-        tags: [...this.selectedTags], // convert Set to Array
-        order: orderByField,
-      });
-
-      if (isString(this.term) && this.term !== '') {
-        request.q = this.term;
-      }
-
-      if (this.term === '') {
-        this.term = null;
-      } else {
-        this.currentPage = 'search';
-      }
-      $location.search('q', this.term);
-
-      this.loaded = false;
-
-      return this.resource(request).$promise.then((data) => {
-        this.loaded = true;
-        const rows = data.results.map((query) => {
-          query.created_at = moment(query.created_at);
-          query.retrieved_at = moment(query.retrieved_at);
-          return new Query(query);
-        });
-
-        paginator.updateRows(rows, data.count);
-
-        if (data.count === 0) {
-          if (this.isInSearchMode()) {
-            this.emptyType = 'search';
-          } else if (this.selectedTags.size > 0) {
-            this.emptyType = 'tags';
-          } else if (this.currentPage === 'favorites') {
-            this.emptyType = 'favorites';
-          } else if (this.currentPage === 'my') {
-            this.emptyType = 'my';
-          } else {
-            this.emptyType = 'default';
-          }
-        }
-        this.showEmptyState = data.count === 0;
-      });
-    };
-
-    this.navigateTo = ($event, url) => {
-      if ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey) {
-        // keep default browser behavior
-        return;
-      }
-      $event.preventDefault();
-      $location.url(url);
-    };
-
-    this.paginator = new LivePaginator(queriesFetcher, {
-      page,
-      itemsPerPage: this.pageSize,
-      orderByField: this.pageOrder,
-      orderByReverse: this.pageOrderReverse,
+  processResponse(data) {
+    super.processResponse(data);
+    const rows = data.results.map((query) => {
+      query.created_at = moment(query.created_at);
+      query.retrieved_at = moment(query.retrieved_at);
+      return new this.Type(query);
     });
 
-    this.pageSizeLabel = value => `${value} results`;
+    this.paginator.updateRows(rows, data.count);
 
-    this.clearSearch = () => {
-      this.term = '';
-      this.update();
-    };
-
-    this.update = () => {
-      // `queriesFetcher` will be called by paginator
-      this.paginator.setPage(page, this.pageSize);
-    };
+    if (data.count === 0) {
+      if (this.isInSearchMode()) {
+        this.emptyType = 'search';
+      } else if (this.selectedTags.size > 0) {
+        this.emptyType = 'tags';
+      } else if (this.currentPage === 'favorites') {
+        this.emptyType = 'favorites';
+      } else if (this.currentPage === 'my') {
+        this.emptyType = 'my';
+      } else {
+        this.emptyType = 'default';
+      }
+    }
+    this.showEmptyState = data.count === 0;
   }
 }
 

--- a/client/app/pages/queries-list/queries-list.html
+++ b/client/app/pages/queries-list/queries-list.html
@@ -4,11 +4,10 @@
   <div class="row">
     <div class="col-md-3 list-control-t">
       <div class="m-b-10">
-        <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.term" ng-model-options="{ allowInvalid: true, debounce: 200 }"
-          ng-change="$ctrl.update()">
+        <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.searchTerm" ng-model-options="{ allowInvalid: true, debounce: 200 }" ng-change="$ctrl.update()">
       </div>
 
-      <div class='list-group m-b-10 tags-list tiled'>
+      <div class="list-group m-b-10 tags-list tiled">
         <a href="queries" class="list-group-item" ng-class="{active: $ctrl.currentPage == 'all'}">
           All Queries
         </a>
@@ -116,13 +115,14 @@
 
     <div class="col-md-3 list-control-r-b">
       <div class="m-b-10">
-        <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.term" ng-model-options="{ allowInvalid: true, debounce: 200 }"
-          ng-change="$ctrl.update()">
+        <input type="text" class="form-control" placeholder="Search Queries..." autofocus ng-model="$ctrl.searchTerm" ng-model-options="{ allowInvalid: true, debounce: 200 }" ng-change="$ctrl.update()" />
       </div>
-      <div class='list-group m-b-10 tags-list tiled'>
+
+      <div class="list-group m-b-10 tags-list tiled">
         <a href="queries" class="list-group-item" ng-class="{active: $ctrl.currentPage == 'all'}">
           All Queries
         </a>
+
         <a href="queries/favorites" class="list-group-item" ng-class="{active: $ctrl.currentPage == 'favorites'}">
           <span class="btn-favourite">
             <i class="fa fa-star" aria-hidden="true"></i>
@@ -134,9 +134,11 @@
           /> My Queries
         </a>
       </div>
+
       <div ng-if="$ctrl.currentPage != 'my'" class="m-b-10">
         <tags-list tags-url="api/queries/tags" on-tags-update="$ctrl.onTagsUpdate"></tags-list>
       </div>
+
       <div class="m-b-5">
         <select ng-change="$ctrl.update()" ng-model="$ctrl.pageSize" class="form-control"
           ng-options="value as $ctrl.pageSizeLabel(value) for value in $ctrl.pageSizeOptions"></select>

--- a/client/app/pages/users/list.html
+++ b/client/app/pages/users/list.html
@@ -7,17 +7,17 @@
         <users-list-extra></users-list-extra>
 
         <div class="pull-right">
-          <input type="text" class="form-control" placeholder="Search..." autofocus ng-model="$ctrl.term" ng-model-options="{ allowInvalid: true, debounce: 200 }"
-            ng-change="$ctrl.search()" />
+          <input type="text" class="form-control" placeholder="Search..." autofocus ng-model="$ctrl.searchTerm" ng-model-options="{ allowInvalid: true, debounce: 200 }"
+            ng-change="$ctrl.update()" />
         </div>
       </div>
 
       <div ng-if="$ctrl.currentUser.isAdmin">
         <ul class="tab-nav">
-          <li ng-class="{'active': $ctrl.currentPage === 'users'}">
+          <li ng-class="{'active': $ctrl.currentPage === 'all'}">
             <a href="users">Active Users</a>
           </li>
-          <li ng-class="{'active': $ctrl.currentPage === 'disabled_users' }">
+          <li ng-class="{'active': $ctrl.currentPage === 'disabled' }">
             <a href="users/disabled">Disabled Users</a>
           </li>
         </ul>
@@ -27,11 +27,11 @@
         <big-message icon="'fa-spinner fa-2x fa-pulse'" message="'Loading...'"></big-message>
       </div>
 
-      <div ng-if="$ctrl.notFound" class="list-content text-center">
+      <div ng-if="$ctrl.loaded && $ctrl.showEmptyState" class="list-content text-center">
         <big-message message="'Sorry, we couldn\'t find anything.'" icon="'fa-search'"></big-message>
       </div>
 
-      <table class="table table-hover table-border" ng-if="$ctrl.loaded && !$ctrl.notFound">
+      <table class="table table-hover table-border" ng-if="$ctrl.loaded && !$ctrl.showEmptyState">
         <thead>
           <tr>
             <th class="sortable-column" ng-click="$ctrl.paginator.orderBy('name')">

--- a/client/app/pages/users/list.js
+++ b/client/app/pages/users/list.js
@@ -1,88 +1,30 @@
-import { isString } from 'lodash';
+import { extend } from 'lodash';
+import ListCtrl from '@/lib/list-ctrl';
 import settingsMenu from '@/lib/settings-menu';
-import { LivePaginator } from '@/lib/pagination';
 import template from './list.html';
 
-function UsersCtrl($location, currentUser, Policy, User) {
-  this.currentUser = currentUser;
-  if ($location.path() === '/users/disabled') {
-    this.currentPage = 'disabled_users';
-  } else {
-    this.currentPage = 'users';
+class UsersListCtrl extends ListCtrl {
+  constructor($scope, $location, currentUser, Policy, User) {
+    super($scope, $location, currentUser);
+    this.policy = Policy;
+    this.enableUser = user => User.enableUser(user).then(this.update);
+    this.disableUser = user => User.disableUser(user).then(this.update);
   }
-  this.policy = Policy;
-  this.term = $location.search().q;
 
-  const fetcher = (requestedPage, itemsPerPage, orderByField, orderByReverse, paginator) => {
-    $location.search('page', requestedPage);
-
-    const setSearchOrClear = (name, value) => {
-      if (value) {
-        $location.search(name, value);
-      } else {
-        $location.search(name, undefined);
-      }
-    };
-
-    if (orderByReverse && !orderByField.startsWith('-')) {
-      orderByField = '-' + orderByField;
-    }
-    setSearchOrClear('order', orderByField);
-
-    const request = Object.assign({}, this.defaultOptions, {
-      page: requestedPage,
-      page_size: itemsPerPage,
-      order: orderByField,
-    });
-
-    if (isString(this.term) && this.term !== '') {
-      request.q = this.term;
-    }
-
-    if (this.term === '') {
-      this.term = null;
-    }
-
-    if (this.currentPage === 'disabled_users') {
+  getRequest(requestedPage, itemsPerPage, orderByField) {
+    const request = super.getRequest(requestedPage, itemsPerPage, orderByField);
+    if (this.currentPage === 'disabled') {
       request.disabled = true;
     }
+    return request;
+  }
 
-    $location.search('q', this.term);
-
-    this.loaded = false;
-    this.notFound = false;
-
-    return User.query(request).$promise.then((data) => {
-      this.loaded = true;
-      const rows = data.results;
-
-      if (this.term !== null && data.count === 0) {
-        this.notFound = true;
-      }
-
-      paginator.updateRows(rows, data.count);
-    });
-  };
-
-  const page = parseInt($location.search().page || 1, 10);
-  this.paginator = new LivePaginator(fetcher, { page });
-
-  this.update = () => {
-    this.paginator.setPage(page);
-  };
-
-  this.search = () => {
-    $location.search('page', 1);
-    this.paginator.setPage(1);
-  };
-
-  this.enableUser = (user) => {
-    User.enableUser(user).then(this.update);
-  };
-
-  this.disableUser = (user) => {
-    User.disableUser(user).then(this.update);
-  };
+  processResponse(data) {
+    super.processResponse(data);
+    const rows = data.results;
+    this.paginator.updateRows(rows, data.count);
+    this.showEmptyState = data.count === 0;
+  }
 }
 
 export default function init(ngModule) {
@@ -95,20 +37,43 @@ export default function init(ngModule) {
   });
 
   ngModule.component('usersListPage', {
-    controller: UsersCtrl,
+    controller: UsersListCtrl,
     template,
   });
 
+  const route = {
+    template: '<users-list-page></users-list-page>',
+    reloadOnSearch: false,
+  };
+
   return {
-    '/users': {
-      template: '<users-list-page></users-list-page>',
-      title: 'Users',
-      reloadOnSearch: false,
-    },
-    '/users/disabled': {
-      template: '<users-list-page></users-list-page>',
-      title: 'Users',
-      reloadOnSearch: false,
-    },
+    '/users': extend(
+      {
+        title: 'Users',
+        resolve: {
+          currentPage: () => 'all',
+          resource(User) {
+            'ngInject';
+
+            return User.query.bind(User);
+          },
+        },
+      },
+      route,
+    ),
+    '/users/disabled': extend(
+      {
+        resolve: {
+          currentPage: () => 'disabled',
+          resource(User) {
+            'ngInject';
+
+            return User.query.bind(User);
+          },
+        },
+        title: 'Disabled Users',
+      },
+      route,
+    ),
   };
 }

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -69,6 +69,18 @@ class DashboardListResource(BaseResource):
             serializer=serialize_dashboard,
         )
 
+        if search_term:
+            self.record_event({
+                'action': 'search',
+                'object_type': 'dashboard',
+                'term': search_term,
+            })
+        else:
+            self.record_event({
+                'action': 'list',
+                'object_type': 'dashboard',
+            })
+
         return response
 
     @require_permission('create_dashboard')

--- a/redash/handlers/favorites.py
+++ b/redash/handlers/favorites.py
@@ -2,6 +2,7 @@ from flask import request
 from redash import models
 from redash.permissions import require_access, view_only
 from redash.handlers.base import BaseResource, get_object_or_404, filter_by_tags, paginate
+from redash.handlers.queries import order_results
 from redash.serializers import QuerySerializer, serialize_dashboard
 
 from sqlalchemy.exc import IntegrityError
@@ -19,9 +20,19 @@ class QueryFavoriteListResource(BaseResource):
 
         favorites = filter_by_tags(favorites, models.Query.tags)
 
+        # order results according to passed order parameter
+        ordered_favorites = order_results(favorites)
+
         page = request.args.get('page', 1, type=int)
         page_size = request.args.get('page_size', 25, type=int)
-        response = paginate(favorites, page, page_size, QuerySerializer, with_stats=True, with_last_modified_by=False)
+        response = paginate(
+            ordered_favorites,
+            page,
+            page_size,
+            QuerySerializer,
+            with_stats=True,
+            with_last_modified_by=False,
+        )
 
         self.record_event({
             'action': 'load_favorites',

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -203,6 +203,18 @@ class QueryListResource(BaseResource):
             with_last_modified_by=False
         )
 
+        if search_term:
+            self.record_event({
+                'action': 'search',
+                'object_type': 'query',
+                'term': search_term,
+            })
+        else:
+            self.record_event({
+                'action': 'list',
+                'object_type': 'query',
+            })
+
         return response
 
 

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -27,6 +27,7 @@ order_map = {
 
 order_results = rpartial(_order_results, '-created_at', order_map)
 
+
 def invite_user(org, inviter, user):
     invite_url = invite_link_for_user(user)
     send_invite_email(inviter, user, invite_url, org)
@@ -49,13 +50,13 @@ class UserListResource(BaseResource):
 
                 if group:
                     user_groups.append({'id': group.id, 'name': group.name})
-            
+
             d['groups'] = user_groups
 
             return d
 
         search_term = request.args.get('q', '')
-        
+
         if request.args.get('disabled', None) is not None:
             users = models.User.all_disabled(self.current_org)
         else:
@@ -64,7 +65,7 @@ class UserListResource(BaseResource):
         if search_term:
             users = models.User.search(users, search_term)
             self.record_event({
-                'action': 'list',
+                'action': 'search',
                 'object_type': 'user',
                 'term': search_term,
             })
@@ -73,7 +74,7 @@ class UserListResource(BaseResource):
                 'action': 'list',
                 'object_type': 'user',
             })
-        
+
         users = order_results(users)
 
         return paginate(users, page, page_size, serialize_user)


### PR DESCRIPTION
This reduces the code duplication between the dashboard, user and queries list pages and normalizes many of the APIs between them.

This also:
- allows sorting query favorites
- adds a pagination size select to the dashboard list
- fixes a bunch of UI inconsistencies between the queries and dashboards list (e.g. margins)

The new ListCtrl class is subclassed in the various specific page controllers and extended as needed. New list pages can make use of the same pattern in the future.