### PR TITLE
add test for using saved parameters in scheduled queries

### DIFF
--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -45,3 +45,23 @@ class TestRefreshQuery(BaseTestCase):
                 add_job_mock.assert_called_with(
                     query.query_text, query.data_source, query.user_id,
                     scheduled_query=query, metadata=ANY)
+
+    def test_enqueues_parameterized_queries(self):
+        """
+        Scheduled queries with parameters use saved values.
+        """
+        query = self.factory.create_query(
+            query_text="select {{n}}",
+            options={"parameters": [{
+                "global": False,
+                "type": "text",
+                "name": "n",
+                "value": "42",
+                "title": "n"}]})
+        oq = staticmethod(lambda: [query])
+        with patch('redash.tasks.queries.enqueue_query') as add_job_mock, \
+                patch.object(Query, 'outdated_queries', oq):
+            refresh_queries()
+            add_job_mock.assert_called_with(
+                "select 42", query.data_source, query.user_id,
+                scheduled_query=query, metadata=ANY)


### PR DESCRIPTION
Original request in https://github.com/mozilla/redash/issues/43
Mozilla issue to port this upstream: https://github.com/mozilla/redash/issues/461

This test passes in upstream master from ~10 days ago, so here's a PR to add it so the functionality doesn't break without forewarning in the future.