### PR TITLE
UI Fixes for favorites and empty state

### DIFF
--- a/client/app/components/app-header/app-header.html
+++ b/client/app/components/app-header/app-header.html
@@ -26,7 +26,7 @@
                   <span class="btn-favourite">
                     <i class="fa fa-star" aria-hidden="true"></i>
                   </span>
-                  Dashboards will appear here
+                  Favorite Dashboards will appear here
                 </em>
               </a>
             </li>
@@ -49,7 +49,7 @@
                   <span class="btn-favourite">
                     <i class="fa fa-star" aria-hidden="true"></i>
                   </span>
-                  Queries will appear here
+                  Favorite Queries will appear here
                 </em>
               </a>
             </li>

--- a/client/app/pages/dashboards/dashboard-list.html
+++ b/client/app/pages/dashboards/dashboard-list.html
@@ -31,7 +31,7 @@
     </div>
 
     <div ng-if="$ctrl.loaded && $ctrl.showEmptyState" class="col-md-9 list-content">
-      <div ng-if="($ctrl.currentPage == 'all') && ($ctrl.searchText.length == 0)">
+      <div ng-if="($ctrl.currentPage == 'all') && ($ctrl.searchText.length == 0 || $ctrl.searchText === undefined)">
         <empty-state icon="zmdi zmdi-view-quilt" description="See the big picture" show-dashboard-step="true" illustration="dashboard"
           help-link="http://help.redash.io/category/22-dashboards"></empty-state>
       </div>

--- a/client/app/pages/home/home.html
+++ b/client/app/pages/home/home.html
@@ -9,9 +9,18 @@
       <div class="row">
         <div class="col-sm-6">
           <p class="f-500 m-b-20 c-black">Favorite Dashboards</p>
+
+          <p ng-if="$ctrl.noDashboards">
+            <span class="btn-favourite">
+              <i class="fa fa-star" aria-hidden="true"></i>
+            </span>
+            Favorite <a href="dashboards">Dashboards</a> will appear here
+          </p>
+
           <div class="list-group">
-            <a ng-href="dashboard/{{dashboard.slug}}" class="list-group-item" ng-repeat="dashboard in $ctrl.favoriteDashboards" ng-if="dashboard.is_favorite">
-              <favorites-control item="dashboard"></favorites-control>
+            <a ng-href="dashboard/{{dashboard.slug}}" class="list-group-item" ng-repeat="dashboard in $ctrl.favoriteDashboards"
+              ng-if="dashboard.is_favorite">
+              <i class="fa fa-star"></i>
               {{dashboard.name}}
               <span class="label label-default" ng-if="dashboard.is_draft">Unpublished</span>
             </a>
@@ -20,9 +29,15 @@
 
         <div class="col-sm-6">
           <p class="f-500 m-b-20 c-black">Favorite Queries</p>
+          <p ng-if="$ctrl.noQueries">
+            <span class="btn-favourite">
+              <i class="fa fa-star" aria-hidden="true"></i>
+            </span>
+            Favorite <a href="queries">Queries</a> will appear here
+          </p>
           <div class="list-group">
             <a ng-href="queries/{{query.id}}" class="list-group-item" ng-repeat="query in $ctrl.favoriteQueries" ng-if="query.is_favorite">
-              <favorites-control item="query"></favorites-control>
+              <i class="fa fa-star"></i>
               {{query.name}}
               <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
             </a>

--- a/client/app/pages/home/index.js
+++ b/client/app/pages/home/index.js
@@ -1,23 +1,20 @@
 import template from './home.html';
 
-function HomeCtrl($scope, $uibModal, currentUser, Events, Dashboard, Query) {
+function HomeCtrl(Events, Dashboard, Query) {
   Events.record('view', 'page', 'personal_homepage');
+
+  this.noDashboards = false;
+  this.noQueries = false;
+
 
   Dashboard.favorites().$promise.then((data) => {
     this.favoriteDashboards = data.results;
+    this.noDashboards = data.results.length === 0;
   });
   Query.favorites().$promise.then((data) => {
     this.favoriteQueries = data.results;
+    this.noQueries = data.results.length === 0;
   });
-
-  this.newDashboard = () => {
-    $uibModal.open({
-      component: 'editDashboardDialog',
-      resolve: {
-        dashboard: () => ({ name: null, layout: null }),
-      },
-    });
-  };
 }
 
 export default function init(ngModule) {


### PR DESCRIPTION
* Fixed an issue where the dashboards empty state won't show up for no dashboards available.
* Changed the empty state of queries/dashboards dropdown text to explicitly mention Favorites, as it's not entirely clear otherwise ("⭐️Dashboards will appear here" -> "⭐️Favorite Dashboards will appear here").
* Added an empty state on the homepage:

![image](https://user-images.githubusercontent.com/71468/45412639-d5de0800-b67f-11e8-957e-d9adda343a89.png)
