### PR TITLE
Sometimes widgets are getting zero height value

### DIFF
--- a/client/app/components/dashboards/gridstack/index.js
+++ b/client/app/components/dashboards/gridstack/index.js
@@ -79,6 +79,24 @@ function gridstack($parse, dashboardGridOptions) {
 
       this.grid = () => (this.$el ? this.$el.data('gridstack') : null);
 
+      this._updateStyles = () => {
+        const grid = this.grid();
+        if (grid) {
+          // compute real grid height; `gridstack` sometimes uses only "dirty"
+          // items and computes wrong height
+          const gridHeight = _.chain(grid.grid.nodes)
+            .map(node => node.y + node.height)
+            .max()
+            .value();
+          // `_updateStyles` is internal, but grid sometimes "forgets"
+          // to rebuild stylesheet, so we need to force it
+          if (_.isObject(grid._styles)) {
+            grid._styles._max = 0; // reset size cache
+          }
+          grid._updateStyles(gridHeight + 10);
+        }
+      };
+
       this.addWidget = ($element, item, itemId) => {
         const grid = this.grid();
         if (grid) {
@@ -89,8 +107,7 @@ function gridstack($parse, dashboardGridOptions) {
             item.minSizeX, item.maxSizeX, item.minSizeY, item.maxSizeY,
             itemId,
           );
-          const gridHeight = grid.grid.getGridHeight() + 10;
-          grid._updateStyles(gridHeight);
+          this._updateStyles();
         }
       };
 
@@ -169,6 +186,7 @@ function gridstack($parse, dashboardGridOptions) {
         const grid = this.grid();
         if (grid) {
           grid.removeWidget($element, false);
+          this._updateStyles();
         }
       };
 
@@ -204,18 +222,14 @@ function gridstack($parse, dashboardGridOptions) {
       this.update = (callback) => {
         const grid = this.grid();
         if (grid) {
-          const gridHeight = grid.grid.getGridHeight() + 10;
           grid.batchUpdate();
           try {
             if (_.isFunction(callback)) {
               callback(grid);
             }
-            // `_updateStyles` is internal, but grid sometimes "forgets"
-            // to rebuild stylesheet, so we need to force it
-            grid._updateStyles(gridHeight);
           } finally {
             grid.commit();
-            grid._updateStyles(gridHeight);
+            this._updateStyles();
           }
         }
       };


### PR DESCRIPTION
Sometimes table widgets with auto-height were getting zero height value, so only widget header was visible. Probably bug is more generic and may affect other widgets (possibly only with auto-height enabled), but currently reproduced only with table widgets. 

Most likely bug was introduced in getredash/redash#2754