### PR TITLE
feat: add support for expanding dashboard visualizations

### DIFF
--- a/client/app/components/dashboards/widget-dialog.html
+++ b/client/app/components/dashboards/widget-dialog.html
@@ -1,12 +1,11 @@
 <div class="modal-header">
   <button type="button" class="close" aria-hidden="true" ng-click="$ctrl.dismiss()">&times;</button>
   <div class="visualization-title">
-    <visualization-name visualization="$ctrl.widget.visualization"/>
-    <span>{{$ctrl.widget.getQuery().name}}</span>
+    <query-link query="$ctrl.widget.getQuery()" visualization="$ctrl.widget.visualization" readonly="true"></query-link>
   </div>
 </div>
 <div class="modal-body">
-    <visualization-renderer visualization="$ctrl.widget.visualization" query-result="$ctrl.widget.getQueryResult()" class="t-body"></visualization-renderer>
+  <visualization-renderer visualization="$ctrl.widget.visualization" query-result="$ctrl.widget.getQueryResult()" class="t-body"></visualization-renderer>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-default" ng-click="$ctrl.dismiss()">Close</button>

--- a/client/app/components/dashboards/widget-dialog.html
+++ b/client/app/components/dashboards/widget-dialog.html
@@ -1,0 +1,13 @@
+<div class="modal-header">
+  <button type="button" class="close" aria-hidden="true" ng-click="$ctrl.dismiss()">&times;</button>
+  <div class="visualization-title">
+    <visualization-name visualization="$ctrl.widget.visualization"/>
+    <span>{{$ctrl.widget.getQuery().name}}</span>
+  </div>
+</div>
+<div class="modal-body">
+    <visualization-renderer visualization="$ctrl.widget.visualization" query-result="$ctrl.widget.getQueryResult()" class="t-body"></visualization-renderer>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-default" ng-click="$ctrl.dismiss()">Close</button>
+</div>

--- a/client/app/components/dashboards/widget-dialog.less
+++ b/client/app/components/dashboards/widget-dialog.less
@@ -1,0 +1,4 @@
+.visualization-title {
+    font-weight: 500;
+    font-size: 15px;
+}

--- a/client/app/components/dashboards/widget-dialog.less
+++ b/client/app/components/dashboards/widget-dialog.less
@@ -2,3 +2,7 @@
     font-weight: 500;
     font-size: 15px;
 }
+
+body.modal-open .dropdown.open {
+    z-index: 10000;
+}

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -59,6 +59,7 @@
       </span>
 
       <button class="btn btn-sm btn-default pull-right hidden-print btn-transparent btn__refresh" ng-click="$ctrl.refresh()" ng-if="!$ctrl.public"><i class="zmdi zmdi-refresh"></i></button>
+      <button class="btn btn-sm btn-default pull-right hidden-print btn-transparent btn__refresh" ng-click="$ctrl.expandVisualization()"><i class="zmdi zmdi-fullscreen"></i></button>
     </div>
   </div>
 

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -1,7 +1,21 @@
 import template from './widget.html';
 import editTextBoxTemplate from './edit-text-box.html';
+import widgetDialogTemplate from './widget-dialog.html';
 import './widget.less';
+import './widget-dialog.less';
 import './add-widget-dialog.less';
+
+const WidgetDialog = {
+  template: widgetDialogTemplate,
+  bindings: {
+    resolve: '<',
+    close: '&',
+    dismiss: '&',
+  },
+  controller() {
+    this.widget = this.resolve.widget;
+  },
+};
 
 const EditTextBoxComponent = {
   template: editTextBoxTemplate,
@@ -48,6 +62,16 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
       resolve: {
         widget: this.widget,
       },
+    });
+  };
+
+  this.expandVisualization = () => {
+    $uibModal.open({
+      component: 'widgetDialog',
+      resolve: {
+        widget: this.widget,
+      },
+      size: 'lg',
     });
   };
 
@@ -99,6 +123,7 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
 
 export default function init(ngModule) {
   ngModule.component('editTextBox', EditTextBoxComponent);
+  ngModule.component('widgetDialog', WidgetDialog);
   ngModule.component('dashboardWidget', {
     template,
     controller: DashboardWidgetCtrl,


### PR DESCRIPTION
These changes implement support for expanding a dashboard visualization
into a larger modal dialog.

This is useful if you have a dashboard with lots of small widgets and
want to inspect one of the widgets more closely. In the past, this
would've required you to navigate to the query page to see a larger
version of the visualization. With these changes, visualizations can
be expanded right from the dashboard.

The implementation is simple as it just renders the visualization into
a modal dialog. Other parts of the widget (e.g. parameters) are not
included in this dialog.

--

![Example Screenshot](https://user-images.githubusercontent.com/10127907/45583290-b6392080-b8c7-11e8-9b61-2baed9718f21.png)
