### PR TITLE
WIP: add API hook for schema browser display

### DIFF
--- a/client/app/components/queries/query-editor.js
+++ b/client/app/components/queries/query-editor.js
@@ -131,8 +131,18 @@ function queryEditor(QuerySnippet, $timeout) {
                 keywords[table.name] = 'Table';
 
                 table.columns.forEach((c) => {
-                  keywords[c] = 'Column';
-                  keywords[`${table.name}.${c}`] = 'Column';
+                  if (typeof c === 'string') {
+                    keywords[c] = 'Column';
+                    keywords[`${table.name}.${c}`] = 'Column';
+                  } else if (typeof c === 'object') {
+                    c.forEach((a, b) => {
+                      if (a === 'column_name') {
+                        const columnName = b;
+                        keywords[columnName] = 'Column';
+                        keywords[`${table.name}.${columnName}`] = 'Column';
+                      }
+                    });
+                  }
                 });
               });
 

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -8,23 +8,44 @@
     </button>
   </div>
 
-  <div class="schema-browser" vs-repeat vs-size="$ctrl.getSize(table)">
-    <div ng-repeat="table in $ctrl.schema | filter:$ctrl.schemaFilter track by table.name">
-      <div class="table-name" ng-click="$ctrl.showTable(table)">
-        <i class="fa fa-table"></i>
-        <strong>
-          <span title="{{table.name}}">{{table.name}}</span>
-          <span ng-if="table.size !== undefined"> ({{table.size}})</span>
-        </strong>
-        <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
-          ng-click="$ctrl.itemSelected($event, [table.name])"></i>
-      </div>
-      <div uib-collapse="table.collapsed">
-        <div ng-repeat="column in table.columns track by column" class="table-open">{{column}}
+  <div ng-if="$ctrl.schemabrowser == 'default'" class="schema-browser" vs-repeat vs-size="$ctrl.getSize(table)">
+      <div ng-repeat="table in $ctrl.schema | filter:$ctrl.schemaFilter track by table.name">
+        <div class="table-name" ng-click="$ctrl.showTable(table)">
+          <i class="fa fa-table"></i>
+          <strong>
+            <span title="{{table.name}}">{{table.name}}</span>
+            <span ng-if="table.size !== undefined"> ({{table.size}})</span>
+          </strong>
           <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
-            ng-click="$ctrl.itemSelected($event, [column])"></i>
+            ng-click="$ctrl.itemSelected($event, [table.name])"></i>
+        </div>
+        <div uib-collapse="table.collapsed">
+          <div ng-repeat="column in table.columns track by column" class="table-open">{{column}}
+            <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
+              ng-click="$ctrl.itemSelected($event, [column])"></i>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+
+  <div ng-if="$ctrl.schemabrowser == 'presto'" class="schema-browser" vs-repeat vs-size="$ctrl.getSize(table)">
+      <div ng-repeat="table in $ctrl.schema | filter:$ctrl.schemaFilter track by table.name">
+        <div class="table-name" ng-click="$ctrl.showTable(table)">
+          <i class="fa fa-table"></i>
+          <strong>
+            <span title="{{table.name}}">{{table.name}}</span>
+            <span ng-if="table.size !== undefined"> ({{table.size}})</span>
+          </strong>
+          <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
+            ng-click="$ctrl.itemSelected($event, [table.name])"></i>
+        </div>
+        <div uib-collapse="table.collapsed">
+          <div ng-repeat="column in table.columns track by column.column_name" class="table-open">
+            <span ng-if="column.extra_info == 'partition key'"><i class="fa fa-key" aria-hidden="true"></i></span> {{column.column_name}} <span ng-if="column.column_type"> ({{column.column_type}})</span>
+            <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
+              ng-click="$ctrl.itemSelected($event, [column.column_name])"></i>
+          </div>
+        </div>
+      </div>
+    </div>
 </div>

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -32,6 +32,7 @@ function SchemaBrowserCtrl($rootScope, $scope) {
 const SchemaBrowser = {
   bindings: {
     schema: '<',
+    schemabrowser: '<',
     onRefresh: '&',
   },
   controller: SchemaBrowserCtrl,

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -84,7 +84,7 @@
       </div>
 
       <div class="editor__left__schema" ng-if="sourceMode">
-        <schema-browser class="schema-container" schema="schema" on-refresh="refreshSchema()"></schema-browser>
+        <schema-browser class="schema-container" schemabrowser="schemabrowser" schema="schema" on-refresh="refreshSchema()"></schema-browser>
       </div>
       <div ng-if="!sourceMode" style="flex-grow: 1;">&nbsp;</div>
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -75,6 +75,9 @@ function QueryViewCtrl(
       } else {
         toastr.error('Schema refresh failed. Please try again later.');
       }
+      if (data.schemabrowser) {
+        $scope.schemabrowser = data.schemabrowser;
+      }
     });
   }
 

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -135,6 +135,7 @@ class DataSourceSchemaResource(BaseResource):
 
         try:
             response['schema'] = data_source.get_schema(refresh)
+            response['schemabrowser'] = data_source.get_schema_browser(refresh)
         except NotSupported:
             response['error'] = {
                 'code': 1,

--- a/redash/models.py
+++ b/redash/models.py
@@ -650,6 +650,11 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
         return schema
 
+    def get_schema_browser(self, refresh=False):
+        query_runner = self.query_runner
+        schema_browser = query_runner.get_schema_browser()
+        return schema_browser
+
     def _pause_key(self):
         return 'ds:{}:pause'.format(self.id)
 

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -121,6 +121,10 @@ class BaseQueryRunner(object):
             'configuration_schema': cls.configuration_schema()
         }
 
+    @classmethod
+    def get_schema_browser(cls):
+        return 'default'
+
 
 class BaseSQLQueryRunner(BaseQueryRunner):
 


### PR DESCRIPTION
Original issue: https://github.com/mozilla/redash/issues/185
Original PR: https://github.com/mozilla/redash/pull/201

Issue to post this upstream: https://github.com/mozilla/redash/issues/430
Previous PR code reviews trying to port this upstream: https://github.com/getredash/redash/pull/2655 https://github.com/getredash/redash/pull/2764

Problem: [This javascript forEach loop](https://github.com/getredash/redash/compare/master...StantonVentures:alison_2654v3?expand=1#diff-ffb12a3b09d99f048b796d1abeae6d17R138) breaks the autoComplete feature/typing in the query textarea. Additional/random keys appear in it when typing. If you comment out this forEach loop the problem disappears. I have tried writing the loop different ways and this is the only one that really passes the linter. I have no idea why this interaction is occurring and would love any help or pointers in the right direction.

This PR:
* Adds the key font awesome icon to partition keys in the schema browser for Presto and Athena data sources.
* Adds a hook and API response to tell the front-end javascript which schema browser to use.
* Supports partition keys in the Athena Glue catalog generated schema.