### PR TITLE
Use server side sort order for tag list and show count of tagged items.

### DIFF
--- a/client/app/components/NoTaggedObjectsFound.jsx
+++ b/client/app/components/NoTaggedObjectsFound.jsx
@@ -8,8 +8,8 @@ function NoTaggedObjectsFound({ objectType, tags }) {
     <BigMessage icon="fa-tags">
       No {objectType} found tagged with
       {Array.from(tags).map(tag => (
-        <span className="label label-tag" key={tag}>
-          {tag}
+        <span className="label label-tag" key={tag.name}>
+          {tag.name}
         </span>
       ))}.
     </BigMessage>

--- a/client/app/components/tags-control/index.js
+++ b/client/app/components/tags-control/index.js
@@ -44,7 +44,7 @@ export default function init(ngModule) {
           promise = this.getAvailableTags();
         }
         promise.then((availableTags) => {
-          availableTags = map(isArray(availableTags) ? availableTags : [], trim);
+          availableTags = map(isArray(availableTags) ? availableTags : [], tag => trim(tag.name));
           $uibModal
             .open({
               component: 'tagsEditorModal',

--- a/client/app/components/tags-list/tags-list.html
+++ b/client/app/components/tags-list/tags-list.html
@@ -1,5 +1,5 @@
 <div class="list-group m-t-10 tags-list tiled" ng-if="$ctrl.allTags.length > 0">
     <a ng-repeat="tag in $ctrl.allTags" ng-class="{active: $ctrl.selectedTags.has(tag.name)}" class="list-group-item" ng-click="$ctrl.toggleTag($event, tag.name)">
-        {{ tag }}
+        {{ tag.name }} <span class="badge badge-light">{{ tag.count }}</span>
     </a>
 </div>

--- a/client/app/components/tags-list/tags-list.html
+++ b/client/app/components/tags-list/tags-list.html
@@ -1,5 +1,5 @@
 <div class="list-group m-t-10 tags-list tiled" ng-if="$ctrl.allTags.length > 0">
-    <a ng-repeat="tag in $ctrl.allTags" ng-class="{active: $ctrl.selectedTags.has(tag)}" class="list-group-item" ng-click="$ctrl.toggleTag($event, tag)">
+    <a ng-repeat="tag in $ctrl.allTags" ng-class="{active: $ctrl.selectedTags.has(tag.name)}" class="list-group-item" ng-click="$ctrl.toggleTag($event, tag.name)">
         {{ tag }}
     </a>
 </div>

--- a/client/app/components/tags-list/tags-list.js
+++ b/client/app/components/tags-list/tags-list.js
@@ -3,7 +3,9 @@ import template from './tags-list.html';
 
 class TagsList {
   constructor() {
+    // An array of objects that with the name and count of the tagged items
     this.allTags = [];
+    // A set of tag names
     this.selectedTags = new Set();
     getTags(this.tagsUrl).then((tags) => {
       this.allTags = tags;

--- a/client/app/services/tags.js
+++ b/client/app/services/tags.js
@@ -1,9 +1,7 @@
-import { map, sortBy } from 'lodash';
 import { $http } from '@/services/http';
 
-function processTags(tags) {
-  tags = tags || {};
-  return map(sortBy(map(tags, (count, tag) => ({ tag, count })), 'count'), item => item.tag);
+function processTags(data) {
+  return data.tags || [];
 }
 
 export function getTags(url) {

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -259,10 +259,20 @@ class DashboardShareResource(BaseResource):
             'object_type': 'dashboard',
         })
 
+
 class DashboardTagsResource(BaseResource):
     @require_permission('list_dashboards')
     def get(self):
         """
         Lists all accessible dashboards.
         """
-        return {t[0]: t[1] for t in models.Dashboard.all_tags(self.current_org, self.current_user)}
+        tags = models.Dashboard.all_tags(self.current_org, self.current_user)
+        return {
+            'tags': [
+                {
+                    'name': name,
+                    'count': count,
+                }
+                for name, count in tags
+            ]
+        }

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -350,4 +350,16 @@ class QueryRefreshResource(BaseResource):
 
 class QueryTagsResource(BaseResource):
     def get(self):
-        return {t[0]: t[1] for t in models.Query.all_tags(self.current_user, True)}
+        """
+        Returns all query tags including those for drafts.
+        """
+        tags = models.Query.all_tags(self.current_user, include_drafts=True)
+        return {
+            'tags': [
+                {
+                    'name': name,
+                    'count': count,
+                }
+                for name, count in tags
+            ]
+        }


### PR DESCRIPTION
Fix #2819

It turned out to be just a problem of the client side sorting
the list of tags again even though the server side provided the
tags already correctly sorted.