### PR TITLE
Fix invalid reference to alert.to_dict() in webhook

### DIFF
--- a/redash/destinations/webhook.py
+++ b/redash/destinations/webhook.py
@@ -4,6 +4,7 @@ from requests.auth import HTTPBasicAuth
 
 from redash.destinations import *
 from redash.utils import json_dumps
+from redash.serializers import serialize_alert
 
 
 class Webhook(BaseDestination):
@@ -34,7 +35,7 @@ class Webhook(BaseDestination):
         try:
             data = {
                 'event': 'alert_state_change',
-                'alert': alert.to_dict(full=False),
+                'alert': serialize_alert(alert, full=False),
                 'url_base': host 
             }
             headers = {'Content-Type': 'application/json'}


### PR DESCRIPTION
It appears that alert.to_dict() is no longer a thing. In most other places
it has been replaced by serialize_alert(), but looks like this was missed.
The reference to alert.to_dict in destinations/webhook.py has been replaced
by a similar call to serialize_alert.

This fixes broken webhook processing for me and I assume others.