### PR TITLE
Change placement (right/bottom) of chart legend depending on chart width

### DIFF
--- a/client/app/visualizations/chart/plotly/index.js
+++ b/client/app/visualizations/chart/plotly/index.js
@@ -35,8 +35,28 @@ const PlotlyChart = () => ({
     let data = [];
 
     const updateChartDimensions = () => {
-      if (updateDimensions(layout, plotlyElement, calculateMargins(plotlyElement))) {
+      const prevLegendOrientation = layout.legend.orientation;
+      const width = plotlyElement.offsetWidth;
+      if (width <= 600) {
+        layout.legend = {
+          orientation: 'h',
+          x: 0,
+          y: 0,
+        };
+      } else {
+        layout.legend = {
+          orientation: 'v',
+          x: 1,
+          y: 1,
+        };
+      }
+      if (
+        updateDimensions(layout, plotlyElement, calculateMargins(plotlyElement, layout)) ||
+        (prevLegendOrientation !== layout.legend.orientation)
+      ) {
+        const legend = layout.legend; // Plotly will delete `legend.layout` in `relayout` (wtf?)
         Plotly.relayout(plotlyElement, layout);
+        layout.legend = legend;
       }
     };
 
@@ -59,7 +79,9 @@ const PlotlyChart = () => ({
         // We need to catch only changes of traces visibility to update stacking
         if (isArray(updates) && isObject(updates[0]) && updates[0].visible) {
           updateData(data, scope.options);
+          const legend = layout.legend; // Plotly will delete `legend.layout` in `relayout` (wtf?)
           Plotly.relayout(plotlyElement, layout);
+          layout.legend = legend;
         }
       });
 


### PR DESCRIPTION
Issue getredash/redash#2796: When chart width is smaller than 600px (value chosen experimentally) place legend below the chart. 

Screenshots:

![image](https://user-images.githubusercontent.com/12139186/46092158-f4361e80-c1bc-11e8-913b-8e23157db824.png)
![image](https://user-images.githubusercontent.com/12139186/46092170-fac49600-c1bc-11e8-91a9-da78bcc6f3f7.png)

![image](https://user-images.githubusercontent.com/12139186/46092942-b0441900-c1be-11e8-8d7f-a281101a00a1.png)
![image](https://user-images.githubusercontent.com/12139186/46092951-b89c5400-c1be-11e8-9ce4-8942434968cc.png)

