### PR TITLE
Update to Celery 3.1.26 to improve compatibility with Celery 4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ wsgiref==0.1.2
 honcho==0.5.0
 statsd==2.1.2
 gunicorn==19.7.1
-celery==3.1.25
+celery==3.1.26.post2
 jsonschema==2.4.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0


### PR DESCRIPTION
See the comment at https://github.com/getredash/redash/pull/2773#issuecomment-424997730 for more details why this is useful to reduce the risk of worker failure in hybrid Celery clusters during upgrades.