### PR TITLE
Fix: TreasureData data source - deduplicate column names

### DIFF
--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -102,16 +102,13 @@ class TreasureData(BaseQueryRunner):
         cursor = connection.cursor()
         try:
             cursor.execute(query)
-            columns_data = [(row[0], cursor.show_job()['hive_result_schema'][i][1]) for i,row in enumerate(cursor.description)]
-
-            columns = [{'name': col[0],
-                'friendly_name': col[0],
-                'type': TD_TYPES_MAPPING.get(col[1], None)} for col in columns_data]
+            columns_tuples = [(row[0], cursor.show_job()['hive_result_schema'][i][1]) for i,row in enumerate(cursor.description)]
+            columns = self.fetch_columns(columns_tuples)
 
             if cursor.rowcount == 0:
                 rows = []
             else:
-                rows = [dict(zip(([c[0] for c in columns_data]), r)) for i, r in enumerate(cursor.fetchall())]
+                rows = [dict(zip(([c['name'] for c in columns]), r)) for i, r in enumerate(cursor.fetchall())]
             data = {'columns': columns, 'rows': rows}
             json_data = json.dumps(data, cls=JSONEncoder)
             error = None

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -102,7 +102,7 @@ class TreasureData(BaseQueryRunner):
         cursor = connection.cursor()
         try:
             cursor.execute(query)
-            columns_tuples = [(row[0], cursor.show_job()['hive_result_schema'][i][1]) for i,row in enumerate(cursor.description)]
+            columns_tuples = [(i[0], TD_TYPES_MAPPING.get(i[1], None)) for i in cursor.show_job()['hive_result_schema']]
             columns = self.fetch_columns(columns_tuples)
 
             if cursor.rowcount == 0:


### PR DESCRIPTION
The query `SELECT 'foo' AS column_name, 'bar' AS column_name;` against a TreasureData data source generates results: `('bar', 'bar')` instead of expected results: `('foo', 'bar')`.

![image](https://user-images.githubusercontent.com/1920858/46181658-1a190b80-c302-11e8-8a34-202dd1055a8d.png)

It seems to be the same cause as the problem of https://github.com/getredash/redash/issues/847.
I fixed it to rename duplicate column names like other data sources.