### PR TITLE
Widget titles wrong rendering on public dashboards

### DIFF
--- a/client/app/assets/less/inc/bootstrap-overrides.less
+++ b/client/app/assets/less/inc/bootstrap-overrides.less
@@ -40,3 +40,10 @@
     vertical-align: top;
     margin-left: 0;
 }
+
+// Hide URLs next to links when printing (override `bootstrap` rules)
+@media print {
+    a[href]:after {
+        content: none !important;
+    }
+}

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -21,13 +21,9 @@
           </ul>
         </div>
         <div class="th-title">
-          <p class="hidden-print">
-            <span ng-hide="$ctrl.canViewQuery">{{$ctrl.widget.getQuery().name}}</span>
-            <query-link query="$ctrl.widget.getQuery()" visualization="$ctrl.widget.visualization" ng-show="$ctrl.canViewQuery"></query-link>
-          </p>
-          <p class="visible-print">
-            <span>{{$ctrl.widget.getQuery().name}}</span>
-            <visualization-name visualization="$ctrl.widget.visualization"/>
+          <p>
+            <query-link query="$ctrl.widget.getQuery()" visualization="$ctrl.widget.visualization"
+              readonly="!$ctrl.canViewQuery"></query-link>
           </p>
           <div class="text-muted query--description" ng-bind-html="$ctrl.widget.getQuery().description | markdown"></div>
         </div>

--- a/client/app/components/query-link.js
+++ b/client/app/components/query-link.js
@@ -18,9 +18,10 @@ export default function init(ngModule) {
     bindings: {
       query: '<',
       visualization: '<',
+      readonly: '<',
     },
     template: `
-      <a ng-href="{{$ctrl.link}}" class="query-link">
+      <a ng-href="{{$ctrl.readonly ? undefined : $ctrl.link}}" class="query-link">
         <visualization-name visualization="$ctrl.visualization"/> 
         <span>{{$ctrl.query.name}}</span>
       </a>


### PR DESCRIPTION
Issue getredash/redash#2854 (affects all types of visualizations - not only pivot table).

**Screenshots:**

In-app:
![image](https://user-images.githubusercontent.com/12139186/46196126-d973bf00-c30e-11e8-9ac7-0652e0a1df11.png)

Public:
![image](https://user-images.githubusercontent.com/12139186/46196146-e4c6ea80-c30e-11e8-82d7-bcac3cee163e.png)

Print:
![image](https://user-images.githubusercontent.com/12139186/46196166-ef817f80-c30e-11e8-990b-beea4b053f34.png)
