### PR TITLE
Circle CI: Add flake8 tests to find syntax errors and undefined names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Run Flake8 Tests on Python 3.7.0
-          command: .circleci/flake8_tests
+          command: bash .circleci/flake8_tests
   flake8-tests-on-legacy-python:
     docker:
       - image: circleci/python:2.7.15
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - run:
           name: Run Flake8 Tests on Python 2.7.15
-          command: .circleci/flake8_tests
+          command: bash .circleci/flake8_tests
   unit-tests:
     environment:
       COMPOSE_FILE: .circleci/docker-compose.circle.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,6 @@ jobs:
       - setup_remote_docker
       - checkout
       - run:
-          name: Run Flake8 Tests
-          command: |
-            pip install flake8
-            # stop the build if there are Python syntax errors or undefined names
-            flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-            # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
-            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - run:
           name: Build Docker Images
           command: |
             set -x
@@ -28,7 +20,9 @@ jobs:
           command: docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;"
       - run:
           name: Run Tests
-          command: docker-compose run --name tests redash tests --junitxml=junit.xml tests/
+          command: |
+            .circleci/flake8_tests
+            docker-compose run --name tests redash tests --junitxml=junit.xml tests/
       - run:
           name: Copy Test Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   flake8-tests-on-python:
     docker:
-      image: circleci/python:3.7.0
+      - image: circleci/python:3.7.0
     steps:
       - checkout
       - run:
@@ -10,7 +10,7 @@ jobs:
           command: .circleci/flake8_tests
   flake8-tests-on-legacy-python:
     docker:
-      image: circleci/python:2.7.15
+      - image: circleci/python:2.7.15
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,23 @@
 version: 2.0
+
+flake8-steps: &steps
+  - checkout
+  - run: sudo pip install flake8
+  - run: python --version ; pip --version
+  # stop the build if there are Python syntax errors or undefined names
+  - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+  - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 jobs:
   flake8-tests-on-python:
     docker:
       - image: circleci/python:3.7.0
-    steps:
-      - checkout
-      - run:
-          name: Run Flake8 Tests on Python 3.7.0
-          command: bash .circleci/flake8_tests
+    steps: *steps
   flake8-tests-on-legacy-python:
     docker:
       - image: circleci/python:2.7.15
-    steps:
-      - checkout
-      - run:
-          name: Run Flake8 Tests on Python 2.7.15
-          command: bash .circleci/flake8_tests
+    steps: *steps
   unit-tests:
     environment:
       COMPOSE_FILE: .circleci/docker-compose.circle.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ jobs:
       - setup_remote_docker
       - checkout
       - run:
+          name: Run Flake8 Tests
+          command: |
+            pip install flake8
+            # stop the build if there are Python syntax errors or undefined names
+            flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+            # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - run:
           name: Build Docker Images
           command: |
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
   #             only: master
   build:
     jobs:
-      - flake8-tests-on-python
+      # - flake8-tests-on-python
       - flake8-tests-on-legacy-python
       - unit-tests
       - build-tarball:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,21 @@
 version: 2.0
 jobs:
+  flake8-tests-on-python:
+    docker:
+      image: circleci/python:3.7.0
+    steps:
+      - checkout
+      - run:
+          name: Run Flake8 Tests on Python 3.7.0
+          command: .circleci/flake8_tests
+  flake8-tests-on-legacy-python:
+    docker:
+      image: circleci/python:2.7.15
+    steps:
+      - checkout
+      - run:
+          name: Run Flake8 Tests on Python 2.7.15
+          command: .circleci/flake8_tests
   unit-tests:
     environment:
       COMPOSE_FILE: .circleci/docker-compose.circle.yml
@@ -20,9 +36,7 @@ jobs:
           command: docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;"
       - run:
           name: Run Tests
-          command: |
-            .circleci/flake8_tests
-            docker-compose run --name tests redash tests --junitxml=junit.xml tests/
+          command: docker-compose run --name tests redash tests --junitxml=junit.xml tests/
       - run:
           name: Copy Test Results
           command: |
@@ -107,6 +121,8 @@ workflows:
   #             only: master
   build:
     jobs:
+      - flake8-tests-on-python
+      - flake8-tests-on-legacy-python
       - unit-tests
       - build-tarball:
            requires:

--- a/.circleci/flake8_tests
+++ b/.circleci/flake8_tests
@@ -1,6 +1,0 @@
-#!/bin/bash
-pip install --upgrade --user flake8
-# stop the build if there are Python syntax errors or undefined names
-flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
-flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.circleci/flake8_tests
+++ b/.circleci/flake8_tests
@@ -1,0 +1,6 @@
+#!/bin/bash
+pip install flake8
+# stop the build if there are Python syntax errors or undefined names
+flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.circleci/flake8_tests
+++ b/.circleci/flake8_tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-pip install flake8
+pip install --upgrade --user flake8
 # stop the build if there are Python syntax errors or undefined names
 flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -1,5 +1,6 @@
 import base64
 from .hive_ds import Hive
+from redash.query_runner import register
 
 try:
     from pyhive import hive


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree