### PR TITLE
CircleCI: Flake8 tests passing on Python 2 and Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,23 @@
 version: 2.0
+
+flake8-steps: &steps
+  - checkout
+  - run: sudo pip install flake8
+  - run: python --version ; pip --version
+  # stop the build if there are Python syntax errors or undefined names
+  - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+  - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 jobs:
+  flake8-tests-on-python:
+    docker:
+      - image: circleci/python:3.7.0
+    steps: *steps
+  flake8-tests-on-legacy-python:
+    docker:
+      - image: circleci/python:2.7.15
+    steps: *steps
   unit-tests:
     environment:
       COMPOSE_FILE: .circleci/docker-compose.circle.yml
@@ -105,6 +123,8 @@ workflows:
   #             only: master
   build:
     jobs:
+      - flake8-tests-on-python
+      - flake8-tests-on-legacy-python
       - unit-tests
       - build-tarball:
            requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,7 @@ version: 2.0
 flake8-steps: &steps
   - checkout
   - run: sudo pip install flake8
-  - run: python --version ; pip --version
-  # stop the build if there are Python syntax errors or undefined names
-  - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
-  - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
+  - run: ./flake8_tests.sh
 jobs:
   flake8-tests-on-python:
     docker:

--- a/bin/get_changes.py
+++ b/bin/get_changes.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import sys
 import re
 import subprocess
@@ -32,4 +33,4 @@ if __name__ == '__main__':
     changes = get_change_log(previous_sha)
 
     for change in changes:
-        print change
+        print(change)

--- a/flake8_tests.sh
+++ b/flake8_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+flake8 --version ; pip --version
+# stop the build if there are Python syntax errors or undefined names
+flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/migrations/versions/969126bd800f_.py
+++ b/migrations/versions/969126bd800f_.py
@@ -5,6 +5,7 @@ Revises: 6b5be7e0a0ef
 Create Date: 2018-01-31 15:20:30.396533
 
 """
+from __future__ import print_function
 import json
 from alembic import op
 import sqlalchemy as sa
@@ -22,25 +23,25 @@ depends_on = None
 def upgrade():
     # Update widgets position data:
     column_size = 3
-    print "Updating dashboards position data:"
+    print("Updating dashboards position data:")
     for dashboard in Dashboard.query:
-        print "  Updating dashboard: {}".format(dashboard.id)
+        print("  Updating dashboard: {}".format(dashboard.id))
         layout = json.loads(dashboard.layout)
 
-        print "    Building widgets map:"
+        print("    Building widgets map:")
         widgets = {}
         for w in dashboard.widgets:
-            print "    Widget: {}".format(w.id)
+            print("    Widget: {}".format(w.id))
             widgets[w.id] = w
 
-        print "    Iterating over layout:"
+        print("    Iterating over layout:")
         for row_index, row in enumerate(layout):
-            print "      Row: {} - {}".format(row_index, row)
+            print("      Row: {} - {}".format(row_index, row))
             if row is None:
                 continue
 
             for column_index, widget_id in enumerate(row):
-                print "      Column: {} - {}".format(column_index, widget_id)
+                print("      Column: {} - {}".format(column_index, widget_id))
                 widget = widgets.get(widget_id)
 
                 if widget is None:

--- a/old_migrations/0003_update_data_source_config.py
+++ b/old_migrations/0003_update_data_source_config.py
@@ -3,6 +3,7 @@ import json
 import jsonschema
 from jsonschema import ValidationError
 
+from six import string_types
 from redash import query_runner
 from redash.models import DataSource
 
@@ -13,7 +14,7 @@ def validate_configuration(query_runner_type, configuration_json):
         return False
 
     try:
-        if isinstance(configuration_json, basestring):
+        if isinstance(configuration_json, string_types):
             configuration = json.loads(configuration_json)
         else:
             configuration = configuration_json

--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -4,6 +4,7 @@ import json
 
 import click
 from flask.cli import AppGroup
+from six import text_type
 from sqlalchemy.orm.exc import NoResultFound
 
 from redash import models
@@ -102,7 +103,7 @@ def new(name=None, type=None, options=None, organization='default'):
 
     if options is None:
         types = {
-            'string': unicode,
+            'string': text_type,
             'number': int,
             'boolean': bool
         }

--- a/redash/cli/users.py
+++ b/redash/cli/users.py
@@ -3,6 +3,7 @@ from sys import exit
 
 from click import BOOL, argument, option, prompt
 from flask.cli import AppGroup
+from six import string_types
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
 
@@ -13,7 +14,7 @@ manager = AppGroup(help="Users management commands.")
 
 
 def build_groups(org, groups, is_admin):
-    if isinstance(groups, basestring):
+    if isinstance(groups, string_types):
         groups = groups.split(',')
         groups.remove('')  # in case it was empty string
         groups = [int(g) for g in groups]

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -3,6 +3,7 @@ import logging
 from flask import make_response, request
 from flask_restful import abort
 from funcy import project
+from six import text_type
 from sqlalchemy.exc import IntegrityError
 
 from redash import models
@@ -213,6 +214,6 @@ class DataSourceTestResource(BaseResource):
         try:
             data_source.query_runner.test_connection()
         except Exception as e:
-            return {"message": unicode(e), "ok": False}
+            return {"message": text_type(e), "ok": False}
         else:
             return {"message": "success", "ok": True}

--- a/redash/models.py
+++ b/redash/models.py
@@ -605,7 +605,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
         return d
 
     def __str__(self):
-        return self.name
+        return text_type(self.name)
 
     @classmethod
     def create_with_group(cls, *args, **kwargs):
@@ -1586,7 +1586,7 @@ class NotificationDestination(BelongsToOrgMixin, db.Model):
         return d
 
     def __str__(self):
-        return self.name
+        return text_type(self.name)
 
     @property
     def destination(self):

--- a/redash/models.py
+++ b/redash/models.py
@@ -9,7 +9,7 @@ import logging
 import time
 from functools import reduce
 
-from six import string_types, text_type
+from six import python_2_unicode_compatible, string_types, text_type
 import xlsxwriter
 from flask import current_app as app, url_for
 from flask_login import AnonymousUserMixin, UserMixin
@@ -293,6 +293,7 @@ class ApiUser(UserMixin, PermissionsCheckMixin):
         return False
 
 
+@python_2_unicode_compatible
 class Organization(TimestampMixin, db.Model):
     SETTING_GOOGLE_APPS_DOMAINS = 'google_apps_domains'
     SETTING_IS_PUBLIC = "is_public"
@@ -310,7 +311,7 @@ class Organization(TimestampMixin, db.Model):
     def __repr__(self):
         return u"<Organization: {}, {}>".format(self.id, self.name)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s (%s)' % (self.name, self.id)
 
     @classmethod
@@ -367,6 +368,7 @@ class Organization(TimestampMixin, db.Model):
         return self.users.filter(User.email == email).count() == 1
 
 
+@python_2_unicode_compatible
 class Group(db.Model, BelongsToOrgMixin):
     DEFAULT_PERMISSIONS = ['create_dashboard', 'create_query', 'edit_dashboard', 'edit_query',
                            'view_query', 'view_source', 'execute_query', 'list_users', 'schedule_query',
@@ -410,10 +412,11 @@ class Group(db.Model, BelongsToOrgMixin):
         result = cls.query.filter(cls.org == org, cls.name.in_(group_names))
         return list(result)
 
-    def __unicode__(self):
+    def __str__(self):
         return text_type(self.id)
 
 
+@python_2_unicode_compatible
 class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCheckMixin):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey('organizations.id'))
@@ -525,7 +528,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
     def find_by_email(cls, email):
         return cls.query.filter(cls.email == email)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s (%s)' % (self.name, self.email)
 
     def hash_password(self, password):
@@ -555,6 +558,7 @@ class Configuration(TypeDecorator):
         return ConfigurationContainer.from_json(value)
 
 
+@python_2_unicode_compatible
 class DataSource(BelongsToOrgMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey('organizations.id'))
@@ -600,7 +604,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
         return d
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @classmethod
@@ -714,6 +718,7 @@ class DataSourceGroup(db.Model):
     __tablename__ = "data_source_groups"
 
 
+@python_2_unicode_compatible
 class QueryResult(db.Model, BelongsToOrgMixin):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey('organizations.id'))
@@ -792,7 +797,7 @@ class QueryResult(db.Model, BelongsToOrgMixin):
 
         return query_result, query_ids
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%d | %s | %s" % (self.id, self.query_hash, self.retrieved_at)
 
     @property
@@ -857,6 +862,7 @@ def should_schedule_next(previous_iteration, now, schedule, failures):
     return now > next_iteration
 
 
+@python_2_unicode_compatible
 class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
     version = Column(db.Integer, default=1)
@@ -1100,7 +1106,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         "The SQLAlchemy expression for the property above."
         return func.lower(cls.name)
 
-    def __unicode__(self):
+    def __str__(self):
         return text_type(self.id)
 
     def __repr__(self):
@@ -1326,6 +1332,7 @@ def generate_slug(ctx):
     return slug
 
 
+@python_2_unicode_compatible
 class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
     version = Column(db.Integer)
@@ -1417,10 +1424,11 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
         "The SQLAlchemy expression for the property above."
         return func.lower(cls.name)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s=%s" % (self.id, self.name)
 
 
+@python_2_unicode_compatible
 class Visualization(TimestampMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
     type = Column(db.String(100))
@@ -1439,7 +1447,7 @@ class Visualization(TimestampMixin, db.Model):
             cls.id == visualization_id,
             Query.org == org).one()
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s %s" % (self.id, self.type)
 
     def copy(self):
@@ -1451,6 +1459,7 @@ class Visualization(TimestampMixin, db.Model):
         }
 
 
+@python_2_unicode_compatible
 class Widget(TimestampMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
     visualization_id = Column(db.Integer, db.ForeignKey('visualizations.id'), nullable=True)
@@ -1462,7 +1471,7 @@ class Widget(TimestampMixin, db.Model):
 
     __tablename__ = 'widgets'
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s" % self.id
 
     @classmethod
@@ -1470,6 +1479,7 @@ class Widget(TimestampMixin, db.Model):
         return db.session.query(cls).join(Dashboard).filter(cls.id == widget_id, Dashboard.org == org).one()
 
 
+@python_2_unicode_compatible
 class Event(db.Model):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey("organizations.id"))
@@ -1484,7 +1494,7 @@ class Event(db.Model):
 
     __tablename__ = 'events'
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s,%s,%s,%s" % (self.user_id, self.action, self.object_type, self.object_id)
 
     def to_dict(self):
@@ -1544,6 +1554,7 @@ class ApiKey(TimestampMixin, GFKBase, db.Model):
         return k
 
 
+@python_2_unicode_compatible
 class NotificationDestination(BelongsToOrgMixin, db.Model):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey("organizations.id"))
@@ -1574,7 +1585,7 @@ class NotificationDestination(BelongsToOrgMixin, db.Model):
 
         return d
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @property
@@ -1665,6 +1676,7 @@ class QuerySnippet(TimestampMixin, db.Model, BelongsToOrgMixin):
         }
 
         return d
+
 
 _gfk_types = {'queries': Query, 'dashboards': Dashboard}
 

--- a/redash/models.py
+++ b/redash/models.py
@@ -9,7 +9,7 @@ import logging
 import time
 from functools import reduce
 
-import six
+from six import string_types, text_type
 import xlsxwriter
 from flask import current_app as app, url_for
 from flask_login import AnonymousUserMixin, UserMixin
@@ -269,7 +269,7 @@ class AnonymousUser(AnonymousUserMixin, PermissionsCheckMixin):
 class ApiUser(UserMixin, PermissionsCheckMixin):
     def __init__(self, api_key, org, groups, name=None):
         self.object = None
-        if isinstance(api_key, basestring):
+        if isinstance(api_key, string_types):
             self.id = api_key
             self.name = name
         else:
@@ -411,7 +411,7 @@ class Group(db.Model, BelongsToOrgMixin):
         return list(result)
 
     def __unicode__(self):
-        return unicode(self.id)
+        return text_type(self.id)
 
 
 class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCheckMixin):
@@ -1101,7 +1101,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         return func.lower(cls.name)
 
     def __unicode__(self):
-        return unicode(self.id)
+        return text_type(self.id)
 
     def __repr__(self):
         return '<Query %s: "%s">' % (self.id, self.name or 'untitled')
@@ -1148,7 +1148,7 @@ class Favorite(TimestampMixin, db.Model):
         if not objects:
             return []
 
-        object_type = six.text_type(objects[0].__class__.__name__)
+        object_type = text_type(objects[0].__class__.__name__)
         return map(lambda fav: fav.object_id, cls.query.filter(cls.object_id.in_(map(lambda o: o.id, objects)), cls.object_type == object_type, cls.user_id == user))
 
 

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -1,5 +1,6 @@
 import base64
 from .hive_ds import Hive
+from redash.query_runner import register
 
 try:
     from pyhive import hive
@@ -18,5 +19,6 @@ class DataBricks(Hive):
     @classmethod
     def enabled(cls):
         return enabled
+
 
 register(DataBricks)

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -146,7 +146,7 @@ class PostgreSQL(BaseSQLQueryRunner):
                                       port=self.configuration.get('port'),
                                       dbname=self.configuration.get('dbname'),
                                       sslmode=self.configuration.get('sslmode'),
-                                      async=True)
+                                      async_=True)
 
         return connection
 
@@ -201,7 +201,7 @@ class Redshift(PostgreSQL):
                                       dbname=self.configuration.get('dbname'),
                                       sslmode=self.configuration.get('sslmode', 'prefer'),
                                       sslrootcert=sslrootcert_path,
-                                      async=True)
+                                      async_=True)
 
         return connection
 

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -5,6 +5,7 @@ import re
 import sqlite3
 
 from dateutil import parser
+from six import text_type
 
 from redash import models
 from redash.permissions import has_access, not_view_only
@@ -30,7 +31,7 @@ def _guess_type(value):
     if isinstance(value, float):
         return TYPE_FLOAT
 
-    if unicode(value).lower() in ('true', 'false'):
+    if text_type(value).lower() in ('true', 'false'):
         return TYPE_BOOLEAN
 
     try:

--- a/redash/query_runner/sqlite.py
+++ b/redash/query_runner/sqlite.py
@@ -3,6 +3,8 @@ import logging
 import sqlite3
 import sys
 
+from six import reraise
+
 from redash.query_runner import BaseSQLQueryRunner
 from redash.query_runner import register
 
@@ -87,7 +89,7 @@ class Sqlite(BaseSQLQueryRunner):
             err_class = sys.exc_info()[1].__class__
             err_args = [arg.decode('utf-8') for arg in sys.exc_info()[1].args]
             unicode_err = err_class(*err_args)
-            raise unicode_err, None, sys.exc_info()[2]
+            reraise(unicode_err, None, sys.exc_info()[2])
         finally:
             connection.close()
         return json_data, error

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import os
 from .helpers import parse_boolean
 
 if os.environ.get("REDASH_SAML_LOCAL_METADATA_PATH") is not None:
-    print "DEPRECATION NOTICE:\n"
-    print "SAML_LOCAL_METADATA_PATH is no longer supported. Only URL metadata is supported now, please update"
-    print "your configuration and reload."
+    print("DEPRECATION NOTICE:\n")
+    print("SAML_LOCAL_METADATA_PATH is no longer supported. Only URL metadata is supported now, please update")
+    print("your configuration and reload.")
     raise SystemExit(1)
 
 

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -9,6 +9,7 @@ import redis
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from celery.result import AsyncResult
 from celery.utils.log import get_task_logger
+from six import text_type
 from redash import models, redis_connection, settings, statsd_client, utils
 from redash.query_runner import InterruptException
 from redash.utils import gen_query_hash
@@ -454,7 +455,7 @@ class QueryExecutor(object):
         try:
             data, error = query_runner.run_query(annotated_query, self.user)
         except Exception as e:
-            error = unicode(e)
+            error = text_type(e)
             data = None
             logging.warning('Unexpected error while running query:', exc_info=1)
 

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -13,6 +13,7 @@ import os
 import simplejson
 
 from funcy import distinct, select_values
+from six import string_types
 from sqlalchemy.orm.query import Query
 
 from .human_time import parse_human_time
@@ -134,7 +135,7 @@ class UnicodeWriter:
         self.encoder = codecs.getincrementalencoder(encoding)()
 
     def _encode_utf8(self, val):
-        if isinstance(val, (unicode, str)):
+        if isinstance(val, string_types):
             return val.encode(WRITER_ENCODING, WRITER_ERRORS)
 
         return val

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pytz==2016.7
 PyYAML==3.12
 redis==2.10.5
 requests==2.11.1
-six==1.10.0
+six==1.11.0
 SQLAlchemy==1.2.7
 SQLAlchemy-Searchable==0.10.6
 SQLAlchemy-Utils>=0.29.0

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -3,6 +3,7 @@ import time
 
 from flask import request
 from mock import patch
+from six.moves import reload_module
 from sqlalchemy.orm.exc import NoResultFound
 from tests import BaseTestCase
 
@@ -212,11 +213,11 @@ class TestRemoteUserAuth(BaseTestCase):
         variables = self.DEFAULT_SETTING_OVERRIDES.copy()
         variables.update(overrides or {})
         with patch.dict(os.environ, variables):
-            reload(settings)
+            reload_module(settings)
 
         # Queue a cleanup routine that reloads the settings without overrides
         # once the test ends
-        self.addCleanup(lambda: reload(settings))
+        self.addCleanup(lambda: reload_module(settings))
 
     def assert_correct_user_attributes(self, user, email='test@example.com', name='test@example.com', groups=None, org=None):
         """Helper to assert that the user attributes are correct."""


### PR DESCRIPTION
Fixes #2842

Combines the changes in #2879 and #2880 with changes using the __six__ module to make the code syntax compatible with both Python 2.7 and 3.7 and passing the flake8 _showstopper_ tests on both.

Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree