### PR TITLE
Fix TypeError in edit-in-place component.

### DIFF
--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { react2angular } from 'react2angular';
 
-export default class EditInPlace extends React.Component {
+export class EditInPlace extends React.Component {
   static propTypes = {
     ignoreBlanks: PropTypes.bool,
     isEditable: PropTypes.bool,
@@ -82,4 +83,8 @@ export default class EditInPlace extends React.Component {
     }
     return this.renderNormal();
   }
+}
+
+export default function init(ngModule) {
+  ngModule.component('editInPlace', react2angular(EditInPlace));
 }

--- a/client/app/components/edit-in-place.js
+++ b/client/app/components/edit-in-place.js
@@ -1,6 +1,0 @@
-import { react2angular } from 'react2angular';
-import EditInPlace from './EditInPlace.jsx';
-
-export default function init(ngModule) {
-  ngModule.component('editInPlace', react2angular(EditInPlace));
-}


### PR DESCRIPTION
The issue being that the default export was called automatically and didn’t accept a ngModule.