### PR TITLE
Add extension points for data source links and config properties customization.

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -86,6 +86,7 @@
             {{ds.name}}
           </ui-select-choices>
         </ui-select>
+        <datasource-link datasource-id="query.data_source_id"></datasource-link>
       </div>
 
       <div class="editor__left__schema" ng-if="sourceMode">

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -51,6 +51,7 @@ class NotSupported(Exception):
 
 class BaseQueryRunner(object):
     noop_query = None
+    configuration_properties = None
 
     def __init__(self, configuration):
         self.syntax = 'sql'
@@ -75,6 +76,12 @@ class BaseQueryRunner(object):
     @classmethod
     def configuration_schema(cls):
         return {}
+
+    @classmethod
+    def add_configuration_property(cls, property, value):
+        if cls.configuration_properties is None:
+            raise NotImplementedError()
+        cls.configuration_properties[property] = value
 
     def test_connection(self):
         if self.noop_query is None:
@@ -149,25 +156,26 @@ class BaseHTTPQueryRunner(BaseQueryRunner):
     url_title = 'URL base path'
     username_title = 'HTTP Basic Auth Username'
     password_title = 'HTTP Basic Auth Password'
+    configuration_properties = {
+        'url': {
+            'type': 'string',
+            'title': url_title,
+        },
+        'username': {
+            'type': 'string',
+            'title': username_title,
+        },
+        'password': {
+            'type': 'string',
+            'title': password_title,
+        },
+    }
 
     @classmethod
     def configuration_schema(cls):
         schema = {
             'type': 'object',
-            'properties': {
-                'url': {
-                    'type': 'string',
-                    'title': cls.url_title,
-                },
-                'username': {
-                    'type': 'string',
-                    'title': cls.username_title,
-                },
-                'password': {
-                    'type': 'string',
-                    'title': cls.password_title,
-                },
-            },
+            'properties': cls.configuration_properties,
             'required': ['url'],
             'secret': ['password']
         }

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -82,6 +82,40 @@ def _get_query_results(jobs, project_id, location, job_id, start_index):
 
 class BigQuery(BaseQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        'projectId': {
+            'type': 'string',
+            'title': 'Project ID'
+        },
+        'jsonKeyFile': {
+            "type": "string",
+            'title': 'JSON Key File'
+        },
+        'totalMBytesProcessedLimit': {
+            "type": "number",
+            'title': 'Scanned Data Limit (MB)'
+        },
+        'userDefinedFunctionResourceUri': {
+            "type": "string",
+            'title': 'UDF Source URIs (i.e. gs://bucket/date_utils.js, gs://bucket/string_utils.js )'
+        },
+        'useStandardSql': {
+            "type": "boolean",
+            'title': "Use Standard SQL (Beta)",
+        },
+        'location': {
+            "type": "string",
+            "title": "Processing Location",
+        },
+        'loadSchema': {
+            "type": "boolean",
+            "title": "Load Schema"
+        },
+        'maximumBillingTier': {
+            "type": "number",
+            "title": "Maximum Billing Tier"
+        }
+    }
 
     @classmethod
     def enabled(cls):
@@ -91,40 +125,7 @@ class BigQuery(BaseQueryRunner):
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'projectId': {
-                    'type': 'string',
-                    'title': 'Project ID'
-                },
-                'jsonKeyFile': {
-                    "type": "string",
-                    'title': 'JSON Key File'
-                },
-                'totalMBytesProcessedLimit': {
-                    "type": "number",
-                    'title': 'Scanned Data Limit (MB)'
-                },
-                'userDefinedFunctionResourceUri': {
-                    "type": "string",
-                    'title': 'UDF Source URIs (i.e. gs://bucket/date_utils.js, gs://bucket/string_utils.js )'
-                },
-                'useStandardSql': {
-                    "type": "boolean",
-                    'title': "Use Standard SQL (Beta)",
-                },
-                'location': {
-                    "type": "string",
-                    "title": "Processing Location",
-                },
-                'loadSchema': {
-                    "type": "boolean",
-                    "title": "Load Schema"
-                },
-                'maximumBillingTier': {
-                    "type": "number",
-                    "title": "Maximum Billing Tier"
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['jsonKeyFile', 'projectId'],
             "order": ['projectId', 'jsonKeyFile', 'loadSchema', 'useStandardSql', 'location', 'totalMBytesProcessedLimit', 'maximumBillingTier', 'userDefinedFunctionResourceUri'],
             'secret': ['jsonKeyFile']

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -23,6 +23,37 @@ class CassandraJSONEncoder(JSONEncoder):
 
 class Cassandra(BaseQueryRunner):
     noop_query = "SELECT dateof(now()) FROM system.local"
+    configuration_properties = {
+        'host': {
+            'type': 'string',
+        },
+        'port': {
+            'type': 'number',
+            'default': 9042,
+        },
+        'keyspace': {
+            'type': 'string',
+            'title': 'Keyspace name'
+        },
+        'username': {
+            'type': 'string',
+            'title': 'Username'
+        },
+        'password': {
+            'type': 'string',
+            'title': 'Password'
+        },
+        'protocol': {
+            'type': 'number',
+            'title': 'Protocol Version',
+            'default': 3
+        },
+        'timeout': {
+            'type': 'number',
+            'title': 'Timeout',
+            'default': 10
+        }
+    }
 
     @classmethod
     def enabled(cls):
@@ -32,37 +63,7 @@ class Cassandra(BaseQueryRunner):
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'host': {
-                    'type': 'string',
-                },
-                'port': {
-                    'type': 'number',
-                    'default': 9042,
-                },
-                'keyspace': {
-                    'type': 'string',
-                    'title': 'Keyspace name'
-                },
-                'username': {
-                    'type': 'string',
-                    'title': 'Username'
-                },
-                'password': {
-                    'type': 'string',
-                    'title': 'Password'
-                },
-                'protocol': {
-                    'type': 'number',
-                    'title': 'Protocol Version',
-                    'default': 3
-                },
-                'timeout': {
-                    'type': 'number',
-                    'title': 'Timeout',
-                    'default': 10
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['keyspace', 'host']
         }
 

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -32,22 +32,23 @@ types_map = {
 
 
 class DynamoDBSQL(BaseSQLQueryRunner):
+    configuration_properties = {
+        "region": {
+            "type": "string",
+            "default": "us-east-1"
+        },
+        "access_key": {
+            "type": "string",
+        },
+        "secret_key": {
+            "type": "string",
+        }
+    }
     @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "region": {
-                    "type": "string",
-                    "default": "us-east-1"
-                },
-                "access_key": {
-                    "type": "string",
-                },
-                "secret_key": {
-                    "type": "string",
-                }
-            },
+            "properties": cls.configuration_properties,
             "required": ["access_key", "secret_key"],
             "secret": ["secret_key"]
         }

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -45,25 +45,26 @@ PYTHON_TYPES_MAPPING = {
 
 class BaseElasticSearch(BaseQueryRunner):
     DEBUG_ENABLED = False
+    configuration_properties = {
+        'server': {
+            'type': 'string',
+            'title': 'Base URL'
+        },
+        'basic_auth_user': {
+            'type': 'string',
+            'title': 'Basic Auth User'
+        },
+        'basic_auth_password': {
+            'type': 'string',
+            'title': 'Basic Auth Password'
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'server': {
-                    'type': 'string',
-                    'title': 'Base URL'
-                },
-                'basic_auth_user': {
-                    'type': 'string',
-                    'title': 'Basic Auth User'
-                },
-                'basic_auth_password': {
-                    'type': 'string',
-                    'title': 'Basic Auth Password'
-                }
-            },
+            'properties': cls.configuration_properties,
             "secret": ["basic_auth_password"],
             "required": ["server"]
         }

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -147,6 +147,12 @@ class TimeoutSession(Session):
 
 
 class GoogleSpreadsheet(BaseQueryRunner):
+    configuration_properties = {
+        'jsonKeyFile': {
+            "type": "string",
+            'title': 'JSON Key File'
+        }
+    }
 
     @classmethod
     def annotate_query(cls):
@@ -164,12 +170,7 @@ class GoogleSpreadsheet(BaseQueryRunner):
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'jsonKeyFile': {
-                    "type": "string",
-                    'title': 'JSON Key File'
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['jsonKeyFile'],
             'secret': ['jsonKeyFile']
         }

--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -36,42 +36,43 @@ types_map = {
 
 class Hive(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "number"
+        },
+        "database": {
+            "type": "string"
+        },
+        "username": {
+            "type": "string"
+        },
+        "use_http": {
+            "type": "boolean",
+            "title": "Use HTTP transport"
+        },
+        "http_scheme": {
+            "type": "string",
+            "title": "Scheme when using HTTP transport",
+            "default": "https"
+        },
+        "http_path": {
+            "type": "string",
+            "title": "Path when using HTTP transport"
+        },
+        "http_password": {
+            "type": "string",
+            "title": "Password when using HTTP transport"
+        },
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "host": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "number"
-                },
-                "database": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                },
-                "use_http": {
-                    "type": "boolean",
-                    "title": "Use HTTP transport"
-                },
-                "http_scheme": {
-                    "type": "string",
-                    "title": "Scheme when using HTTP transport",
-                    "default": "https"
-                },
-                "http_path": {
-                    "type": "string",
-                    "title": "Path when using HTTP transport"
-                },
-                "http_password": {
-                    "type": "string",
-                    "title": "Password when using HTTP transport"
-                },
-            },
+            "properties": cls.configuration_properties,
             "required": ["host"]
         }
 

--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -34,38 +34,39 @@ types_map = {
 
 class Impala(BaseSQLQueryRunner):
     noop_query = "show schemas"
+    configuration_properties = {
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "number"
+        },
+        "protocol": {
+            "type": "string",
+            "title": "Please specify beeswax or hiveserver2"
+        },
+        "database": {
+            "type": "string"
+        },
+        "use_ldap": {
+            "type": "boolean"
+        },
+        "ldap_user": {
+            "type": "string"
+        },
+        "ldap_password": {
+            "type": "string"
+        },
+        "timeout": {
+            "type": "number"
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "host": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "number"
-                },
-                "protocol": {
-                    "type": "string",
-                    "title": "Please specify beeswax or hiveserver2"
-                },
-                "database": {
-                    "type": "string"
-                },
-                "use_ldap": {
-                    "type": "boolean"
-                },
-                "ldap_user": {
-                    "type": "string"
-                },
-                "ldap_password": {
-                    "type": "string"
-                },
-                "timeout": {
-                    "type": "number"
-                }
-            },
+            "properties": cls.configuration_properties,
             "required": ["host"],
             "secret": ["ldap_password"]
         }

--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -49,16 +49,17 @@ def _transform_result(results):
 
 class InfluxDB(BaseQueryRunner):
     noop_query = "show measurements limit 1"
+    configuration_properties = {
+        'url': {
+            'type': 'string'
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'url': {
-                    'type': 'string'
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['url']
         }
 

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -117,24 +117,25 @@ def parse_results(results):
 
 
 class MongoDB(BaseQueryRunner):
+    configuration_properties = {
+        'connectionString': {
+            'type': 'string',
+            'title': 'Connection String'
+        },
+        'dbName': {
+            'type': 'string',
+            'title': "Database Name"
+        },
+        'replicaSetName': {
+            'type': 'string',
+            'title': 'Replica Set Name'
+        },
+    }
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'connectionString': {
-                    'type': 'string',
-                    'title': 'Connection String'
-                },
-                'dbName': {
-                    'type': 'string',
-                    'title': "Database Name"
-                },
-                'replicaSetName': {
-                    'type': 'string',
-                    'title': 'Replica Set Name'
-                },
-            },
+            'properties': cls.configuration_properties,
             'required': ['connectionString', 'dbName']
         }
 

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -27,41 +27,42 @@ types_map = {
 
 class SqlServer(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        "user": {
+            "type": "string"
+        },
+        "password": {
+            "type": "string"
+        },
+        "server": {
+            "type": "string",
+            "default": "127.0.0.1"
+        },
+        "port": {
+            "type": "number",
+            "default": 1433
+        },
+        "tds_version": {
+            "type": "string",
+            "default": "7.0",
+            "title": "TDS Version"
+        },
+        "charset": {
+            "type": "string",
+            "default": "UTF-8",
+            "title": "Character Set"
+        },
+        "db": {
+            "type": "string",
+            "title": "Database Name"
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "user": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "server": {
-                    "type": "string",
-                    "default": "127.0.0.1"
-                },
-                "port": {
-                    "type": "number",
-                    "default": 1433
-                },
-                "tds_version": {
-                    "type": "string",
-                    "default": "7.0",
-                    "title": "TDS Version"
-                },
-                "charset": {
-                    "type": "string",
-                    "default": "UTF-8",
-                    "title": "Character Set"
-                },
-                "db": {
-                    "type": "string",
-                    "title": "Database Name"
-                }
-            },
+            "properties": cls.configuration_properties,
             "required": ["db"],
             "secret": ["password"]
         }

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -28,6 +28,27 @@ types_map = {
 
 class Mysql(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        'host': {
+            'type': 'string',
+            'default': '127.0.0.1'
+        },
+        'user': {
+            'type': 'string'
+        },
+        'passwd': {
+            'type': 'string',
+            'title': 'Password'
+        },
+        'db': {
+            'type': 'string',
+            'title': 'Database name'
+        },
+        'port': {
+            'type': 'number',
+            'default': 3306,
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
@@ -35,27 +56,7 @@ class Mysql(BaseSQLQueryRunner):
 
         schema = {
             'type': 'object',
-            'properties': {
-                'host': {
-                    'type': 'string',
-                    'default': '127.0.0.1'
-                },
-                'user': {
-                    'type': 'string'
-                },
-                'passwd': {
-                    'type': 'string',
-                    'title': 'Password'
-                },
-                'db': {
-                    'type': 'string',
-                    'title': 'Database name'
-                },
-                'port': {
-                    'type': 'number',
-                    'default': 3306,
-                }
-            },
+            'properties': cls.configuration_properties,
             "order": ['host', 'port', 'user', 'passwd', 'db'],
             'required': ['db'],
             'secret': ['passwd']

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 
 class Oracle(BaseSQLQueryRunner):
     noop_query = "SELECT 1 FROM dual"
+    configuration_properties = {
+        "user": {
+            "type": "string"
+        },
+        "password": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "number"
+        },
+        "servicename": {
+            "type": "string",
+            "title": "DSN Service Name"
+        }
+    }
 
     @classmethod
     def get_col_type(cls, col_type, scale):
@@ -47,24 +65,7 @@ class Oracle(BaseSQLQueryRunner):
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "user": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "host": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "number"
-                },
-                "servicename": {
-                    "type": "string",
-                    "title": "DSN Service Name"
-                }
-            },
+            "properties": cls.configuration_properties,
             "required": ["servicename", "user", "password", "host", "port"],
             "secret": ["password"]
         }

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -46,36 +46,37 @@ def _wait(conn, timeout=None):
 
 class PostgreSQL(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        "user": {
+            "type": "string"
+        },
+        "password": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string",
+            "default": "127.0.0.1"
+        },
+        "port": {
+            "type": "number",
+            "default": 5432
+        },
+        "dbname": {
+            "type": "string",
+            "title": "Database Name"
+        },
+        "sslmode": {
+           "type": "string",
+           "title": "SSL Mode",
+           "default": "prefer"
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "user": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "host": {
-                    "type": "string",
-                    "default": "127.0.0.1"
-                },
-                "port": {
-                    "type": "number",
-                    "default": 5432
-                },
-                "dbname": {
-                    "type": "string",
-                    "title": "Database Name"
-                },
-                "sslmode": {
-                   "type": "string",
-                   "title": "SSL Mode",
-                   "default": "prefer"
-                }
-            },
+            "properties": cls.configuration_properties,
             "order": ['host', 'port', 'user', 'password'],
             "required": ["dbname"],
             "secret": ["password"]
@@ -186,6 +187,30 @@ class PostgreSQL(BaseSQLQueryRunner):
 
 
 class Redshift(PostgreSQL):
+    configuration_properties = {
+        "user": {
+            "type": "string"
+        },
+        "password": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "number"
+        },
+        "dbname": {
+            "type": "string",
+            "title": "Database Name"
+        },
+        "sslmode": {
+           "type": "string",
+           "title": "SSL Mode",
+           "default": "prefer"
+        }
+    }
+
     @classmethod
     def type(cls):
         return "redshift"
@@ -209,29 +234,7 @@ class Redshift(PostgreSQL):
 
         return {
             "type": "object",
-            "properties": {
-                "user": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "host": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "number"
-                },
-                "dbname": {
-                    "type": "string",
-                    "title": "Database Name"
-                },
-                "sslmode": {
-                   "type": "string",
-                   "title": "SSL Mode",
-                   "default": "prefer"
-                }
-            },
+            "properties": cls.configuration_properties,
             "order": ['host', 'port', 'user', 'password'],
             "required": ["dbname", "user", "password", "host", "port"],
             "secret": ["password"]

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -31,28 +31,29 @@ PRESTO_TYPES_MAPPING = {
 
 class Presto(BaseQueryRunner):
     noop_query = 'SHOW TABLES'
+    configuration_properties = {
+        'host': {
+            'type': 'string'
+        },
+        'port': {
+            'type': 'number'
+        },
+        'schema': {
+            'type': 'string'
+        },
+        'catalog': {
+            'type': 'string'
+        },
+        'username': {
+            'type': 'string'
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'host': {
-                    'type': 'string'
-                },
-                'port': {
-                    'type': 'number'
-                },
-                'schema': {
-                    'type': 'string'
-                },
-                'catalog': {
-                    'type': 'string'
-                },
-                'username': {
-                    'type': 'string'
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['host']
         }
 

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -44,19 +44,21 @@ class Python(BaseQueryRunner):
         'tuple', 'set', 'list', 'dict', 'bool',
     )
 
+    configuration_properties = {
+        'allowedImportModules': {
+            'type': 'string',
+            'title': 'Modules to import prior to running the script'
+        },
+        'additionalModulesPaths': {
+            'type': 'string'
+        }
+    }
+
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'allowedImportModules': {
-                    'type': 'string',
-                    'title': 'Modules to import prior to running the script'
-                },
-                'additionalModulesPaths': {
-                    'type': 'string'
-                }
-            },
+            'properties': cls.configuration_properties,
         }
 
     @classmethod

--- a/redash/query_runner/script.py
+++ b/redash/query_runner/script.py
@@ -29,6 +29,17 @@ def run_script(script, shell):
 
 
 class Script(BaseQueryRunner):
+    configuration_properties = {
+        'path': {
+            'type': 'string',
+            'title': 'Scripts path'
+        },
+        'shell': {
+            'type': 'boolean',
+            'title': 'Execute command through the shell'
+        }
+    }
+
     @classmethod
     def annotate_query(cls):
         return False
@@ -41,16 +52,7 @@ class Script(BaseQueryRunner):
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'path': {
-                    'type': 'string',
-                    'title': 'Scripts path'
-                },
-                'shell': {
-                    'type': 'boolean',
-                    'title': 'Execute command through the shell'
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['path']
         }
 

--- a/redash/query_runner/sqlite.py
+++ b/redash/query_runner/sqlite.py
@@ -12,17 +12,18 @@ logger = logging.getLogger(__name__)
 
 class Sqlite(BaseSQLQueryRunner):
     noop_query = "pragma quick_check"
+    configuration_properties = {
+        "dbpath": {
+            "type": "string",
+            "title": "Database Path"
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {
-                "dbpath": {
-                    "type": "string",
-                    "title": "Database Path"
-                }
-            },
+            "properties": cls.configuration_properties,
             "required": ["dbpath"],
         }
 

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -35,31 +35,32 @@ TD_TYPES_MAPPING = {
 
 class TreasureData(BaseQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        'endpoint': {
+            'type': 'string'
+        },
+        'apikey': {
+            'type': 'string'
+        },
+        'type': {
+            'type': 'string'
+        },
+        'db': {
+            'type': 'string',
+            'title': 'Database Name'
+        },
+        'get_schema': {
+            'type': 'boolean',
+            'title': 'Auto Schema Retrieval',
+            'default': False
+        }
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'endpoint': {
-                    'type': 'string'
-                },
-                'apikey': {
-                    'type': 'string'
-                },
-                'type': {
-                    'type': 'string'
-                },
-                'db': {
-                    'type': 'string',
-                    'title': 'Database Name'
-                },
-                'get_schema': {
-                    'type': 'boolean',
-                    'title': 'Auto Schema Retrieval',
-                    'default': False
-                }
-            },
+            'properties': cls.configuration_properties,
             'required': ['apikey','db']
         }
 

--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -29,34 +29,35 @@ types_map = {
 
 class Vertica(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
+    configuration_properties = {
+        'host': {
+            'type': 'string'
+        },
+        'user': {
+            'type': 'string'
+        },
+        'password': {
+            'type': 'string',
+            'title': 'Password'
+        },
+        'database': {
+            'type': 'string',
+            'title': 'Database name'
+        },
+        "port": {
+            "type": "number"
+        },
+        "read_timeout": {
+            "type": "number",
+            "title": "Read Timeout"
+        },
+    }
 
     @classmethod
     def configuration_schema(cls):
         return {
             'type': 'object',
-            'properties': {
-                'host': {
-                    'type': 'string'
-                },
-                'user': {
-                    'type': 'string'
-                },
-                'password': {
-                    'type': 'string',
-                    'title': 'Password'
-                },
-                'database': {
-                    'type': 'string',
-                    'title': 'Database name'
-                },
-                "port": {
-                    "type": "number"
-                },
-                "read_timeout": {
-                    "type": "number",
-                    "title": "Read Timeout"
-                },
-            },
+            'properties': cls.configuration_properties,
             'required': ['database'],
             'secret': ['password']
         }

--- a/tests/query_runner/test_http.py
+++ b/tests/query_runner/test_http.py
@@ -11,6 +11,18 @@ class RequiresAuthQueryRunner(BaseHTTPQueryRunner):
 
 class TestBaseHTTPQueryRunner(TestCase):
 
+    def test_add_configuration_property(self):
+        config_properties = BaseHTTPQueryRunner.configuration_properties
+        self.assertEqual(3, len(config_properties))
+        self.assertIn('url', config_properties)
+        self.assertIn('username', config_properties)
+        self.assertIn('password', config_properties)
+
+        BaseHTTPQueryRunner.add_configuration_property(
+            "new_property", "some value")
+        self.assertEqual(4, len(config_properties))
+        self.assertIn('new_property', config_properties)
+
     def test_requires_authentication_default(self):
         self.assertFalse(BaseHTTPQueryRunner.requires_authentication)
         schema = BaseHTTPQueryRunner.configuration_schema()


### PR DESCRIPTION
This PR places 2 extension points for someone interested in writing an extension that would provide a link for data source documentation.

It also adds the ability to add configuration properties which could be used, for example, to let someone input their desired data source URL from the admin page.

Here is an example of this usage: https://github.com/mozilla/redash-stmo/blob/master/src/redash_stmo/datasource_link.py#L61