### PR TITLE
Move Ant styles into a central location.

### DIFF
--- a/client/app/assets/less/main.less
+++ b/client/app/assets/less/main.less
@@ -1,6 +1,3 @@
-@import '~antd/lib/style/core/iconfont.less';
-@import '~antd/lib/input/style/index.less';
-@import '~antd/lib/date-picker/style/index.less';
 @import 'redash/ant';
 
 /** LESS Plugins **/

--- a/client/app/assets/less/redash/ant.less
+++ b/client/app/assets/less/redash/ant.less
@@ -1,3 +1,8 @@
+@import '~antd/lib/style/core/iconfont.less';
+@import '~antd/lib/input/style/index.less';
+@import '~antd/lib/date-picker/style/index.less';
+@import '~antd/lib/tooltip/style/index.less';
+
 // Overwritting Ant Design defaults to fit into Redash current style
 @font-family-no-number  : @redash-font;
 @font-family            : @redash-font;

--- a/client/app/components/DateRangeInput.jsx
+++ b/client/app/components/DateRangeInput.jsx
@@ -4,9 +4,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import { RangePicker } from 'antd/lib/date-picker';
-import 'antd/lib/style/core/iconfont.less';
-import 'antd/lib/input/style/index.less';
-import 'antd/lib/date-picker/style/index.less';
 
 function DateRangeInput({
   value,

--- a/client/app/components/DateTimeRangeInput.jsx
+++ b/client/app/components/DateTimeRangeInput.jsx
@@ -4,9 +4,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import { RangePicker } from 'antd/lib/date-picker';
-import 'antd/lib/style/core/iconfont.less';
-import 'antd/lib/input/style/index.less';
-import 'antd/lib/date-picker/style/index.less';
 
 function DateTimeRangeInput({
   value,

--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { map } from 'lodash';
 import Tooltip from 'antd/lib/tooltip';
-import 'antd/lib/tooltip/style';
 import { react2angular } from 'react2angular';
 
 import AceEditor from 'react-ace';


### PR DESCRIPTION
This is to ensure that we include our override after loading Ant's styles.