### PR TITLE
Preventing open redirection

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -246,6 +246,8 @@ def create_and_login_user(org, name, email, picture=None):
 
 
 def get_next_path(unsafe_next_path):
+    if not unsafe_next_path:
+        return ''
 
     # Preventing open redirection attacks
     parts = list(urlsplit(unsafe_next_path))

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -6,6 +6,7 @@ import time
 import logging
 
 from flask import redirect, request, jsonify, url_for
+from urlparse import urlsplit, urlunsplit
 from werkzeug.exceptions import Unauthorized
 
 from redash import models, settings
@@ -242,3 +243,14 @@ def create_and_login_user(org, name, email, picture=None):
     login_user(user_object, remember=True)
 
     return user_object
+
+
+def get_next_path(unsafe_next_path):
+
+    # Preventing open redirection attacks
+    parts = list(urlsplit(unsafe_next_path))
+    parts[0] = ''  # clear scheme
+    parts[1] = ''  # clear netloc
+    safe_next_path = urlunsplit(parts)
+
+    return safe_next_path

--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -4,7 +4,7 @@ from flask import redirect, url_for, Blueprint, flash, request, session
 from flask_oauthlib.client import OAuth
 
 from redash import models, settings
-from redash.authentication import create_and_login_user, logout_and_redirect_to_index
+from redash.authentication import create_and_login_user, logout_and_redirect_to_index, get_next_path
 from redash.authentication.org_resolving import current_org
 
 logger = logging.getLogger('google_oauth')
@@ -102,6 +102,7 @@ def authorized():
     if user is None:
         return logout_and_redirect_to_index()
 
-    next_path = request.args.get('state') or url_for("redash.index", org_slug=org.slug)
+    unsafe_next_path = request.args.get('state') or url_for("redash.index", org_slug=org.slug)
+    next_path = get_next_path(unsafe_next_path)
 
     return redirect(next_path)

--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -13,7 +13,7 @@ except ImportError:
         logger.error("The ldap3 library was not found. This is required to use LDAP authentication (see requirements.txt).")
         exit()
 
-from redash.authentication import create_and_login_user, logout_and_redirect_to_index
+from redash.authentication import create_and_login_user, logout_and_redirect_to_index, get_next_path
 from redash.authentication.org_resolving import current_org
 
 
@@ -23,7 +23,8 @@ blueprint = Blueprint('ldap_auth', __name__)
 @blueprint.route("/ldap/login", methods=['GET', 'POST'])
 def login(org_slug=None):
     index_url = url_for("redash.index", org_slug=org_slug)
-    next_path = request.args.get('next', index_url)
+    unsafe_next_path = request.args.get('next', index_url)
+    next_path = get_next_path(unsafe_next_path)
 
     if not settings.LDAP_LOGIN_ENABLED:
         logger.error("Cannot use LDAP for login without being enabled in settings")

--- a/redash/authentication/remote_user_auth.py
+++ b/redash/authentication/remote_user_auth.py
@@ -1,6 +1,6 @@
 import logging
 from flask import redirect, url_for, Blueprint, request
-from redash.authentication import create_and_login_user, logout_and_redirect_to_index
+from redash.authentication import create_and_login_user, logout_and_redirect_to_index, get_next_path
 from redash.authentication.org_resolving import current_org
 from redash.handlers.base import org_scoped_rule
 from redash import settings
@@ -11,7 +11,8 @@ blueprint = Blueprint('remote_user_auth', __name__)
 
 @blueprint.route(org_scoped_rule("/remote_user/login"))
 def login(org_slug=None):
-    next_path = request.args.get('next')
+    unsafe_next_path = request.args.get('next')
+    next_path = get_next_path(unsafe_next_path)
 
     if not settings.REMOTE_USER_LOGIN_ENABLED:
         logger.error("Cannot use remote user for login without being enabled in settings")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,3 +1,4 @@
+from passlib.apps import custom_app_context as pwd_context
 import redash.models
 from redash.models import db
 from redash.permissions import ACCESS_TYPE_MODIFY
@@ -41,6 +42,7 @@ class Sequence(object):
 
 user_factory = ModelFactory(redash.models.User,
                             name='John Doe', email=Sequence(u'test{}@example.com'),
+                            password_hash=pwd_context.encrypt('test1234'),
                             group_ids=[2],
                             org_id=1)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -185,6 +185,34 @@ class TestGetLoginUrl(BaseTestCase):
         with self.app.test_request_context('/{}_notexists/'.format(self.factory.org.slug)):
             self.assertEqual(get_login_url(next=None), '/')
 
+
+class TestRedirectToUrlAfterLoggingIn(BaseTestCase):
+    def setUp(self):
+        super(TestRedirectToUrlAfterLoggingIn, self).setUp()
+        self.user = self.factory.user
+        self.password = 'test1234'
+
+    def test_no_next_param(self):
+        response = self.post_request('/login', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
+        self.assertEqual(response.location, 'http://localhost/{}/'.format(self.user.org.slug))
+
+    def test_simple_path_in_next_param(self):
+        response = self.post_request('/login?next=queries', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
+        self.assertEqual(response.location, 'http://localhost/queries')
+
+    def test_starts_scheme_url_in_next_param(self):
+        response = self.post_request('/login?next=https://redash.io', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
+        self.assertEqual(response.location, 'http://localhost/')
+
+    def test_without_scheme_url_in_next_param(self):
+        response = self.post_request('/login?next=//redash.io', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
+        self.assertEqual(response.location, 'http://localhost/')
+
+    def test_without_scheme_with_path_url_in_next_param(self):
+        response = self.post_request('/login?next=//localhost/queries', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
+        self.assertEqual(response.location, 'http://localhost/queries')
+
+
 class TestRemoteUserAuth(BaseTestCase):
     DEFAULT_SETTING_OVERRIDES = {
         'REDASH_REMOTE_USER_LOGIN_ENABLED': 'true'


### PR DESCRIPTION
Fix #2822

The issue is an Open Redirect Vulnerability.

## Changes

Change redirecting URL after logging in. Remove scheme and [netloc](https://docs.python.org/2.7/library/urlparse.html#module-urlparse)(domain and port) from next param value.

The following table shows examples of the login path and the redirect to path.

| login path | redirect to |
| ---- | ---------- |
| `/login` | `/{org.slug}` |
| `/login?next=queries` | `/queries` |
| `/login?next=https://redash.io` | `/` |
| `/login?next=//redash.io` | `/` |
| `/login?next=//{domain}/queries` | `/queries` |