### PR TITLE
Don’t show “Add to dashboard” in dropdown to unsaved queries.

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -258,7 +258,7 @@
             </button>
             <ul class="dropdown-menu" uib-dropdown-menu>
               <li>
-                <a target="_self" ng-click="openAddToDashboardForm(selectedTab)" ng-if="!query.is_draft && !query.is_archived">
+                <a target="_self" ng-click="openAddToDashboardForm(selectedTab)" ng-if="!query.isNew() && (!query.is_draft || !query.is_archived)">
                   <span class="fa fa-plus-circle"></span> Add to Dashboard
                 </a>
               </li>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -264,7 +264,7 @@
               </li>
               <li>
                 <a ng-click="showEmbedDialog(query, selectedTab)" ng-if="!query.isNew()">
-                  <span class="zmdi zmdi-code"></span> Embed
+                  <span class="zmdi zmdi-code"></span> Embed elsewhere
                 </a>
               </li>
               <li>


### PR DESCRIPTION
This was missing in the original feature.

Here's the screenshot for the minor second commit about extending the text for the "Embed" menu item for visual consistency:

Fixes #2896.

### Before:

<img width="375" alt="screen-shot-2018-10-08-12-09-27 91" src="https://user-images.githubusercontent.com/1610/46603332-097f4700-caf3-11e8-8ff4-9107cd89848b.png">

### After:

<img width="371" alt="screen-shot-2018-10-08-12-06-16 32" src="https://user-images.githubusercontent.com/1610/46603268-e5236a80-caf2-11e8-9acb-48a9b40c3536.png">

