### PR TITLE
Fix export query results output file name

### DIFF
--- a/client/app/components/queries/query-results-link.js
+++ b/client/app/components/queries/query-results-link.js
@@ -24,7 +24,7 @@ function queryResultLink() {
           element.attr('href', url);
           element.attr(
             'download',
-            `${scope.query.name.replace(' ', '_') +
+            `${scope.query.name.replace(/ /g, '_') +
               moment(scope.queryResult.getUpdatedAt()).format('_YYYY_MM_DD')}.${fileType}`,
           );
         }


### PR DESCRIPTION
Hello again!

Well, this is actually the same issue as in my [PR#2610](https://github.com/getredash/redash/pull/2610), only that I missed one file :sweat_smile: 

Now I searched and the only place that has `replace(' ', '_')` is a `.py` file and in python it works as we want it to.

The problem can be seen in the following image:
![underscore](https://user-images.githubusercontent.com/3356951/46693636-c8fdf700-cbe0-11e8-8dc4-34b5f768c0ab.gif)
