### PR TITLE
Fix output file name not changing after rename query

### DIFF
--- a/client/app/components/queries/query-results-link.js
+++ b/client/app/components/queries/query-results-link.js
@@ -5,7 +5,7 @@ function queryResultLink() {
     restrict: 'A',
     link(scope, element, attrs) {
       const fileType = attrs.fileType ? attrs.fileType : 'csv';
-      scope.$watch('queryResult && queryResult.getData()', (data) => {
+      scope.$watch('queryResult && queryResult.getData() && query.name', (data) => {
         if (!data) {
           return;
         }


### PR DESCRIPTION
Hi,
This PR solves the following:
![query-name](https://user-images.githubusercontent.com/3356951/46698230-e20ca500-cbec-11e8-81e5-084439dc1275.gif)

Note that changing the query name doesn't affect the filename when you download query results (unless you reload the page or execute the query again).

After the fix:
![query-name-after](https://user-images.githubusercontent.com/3356951/46698543-cc4baf80-cbed-11e8-895b-b44c102aa248.gif)
