### PR TITLE
Query page layout improvements for small screens

### DIFF
--- a/client/app/assets/less/redash/ant.less
+++ b/client/app/assets/less/redash/ant.less
@@ -12,3 +12,20 @@
 @border-color-base      : #e8e8e8;
 
 @primary-color          : @blue;
+
+// Fix for disabled button styles inside Tooltip component.
+// Tooltip wraps disabled buttons with `<span>` and moves all styles
+// and classes to that `<span>`. This resets all button styles and
+// turns it into simple inline element (because now it's wrapper is a button)
+.btn {
+  button[disabled] {
+    -moz-appearance: none !important;
+    -webkit-appearance: none !important;
+    appearance: none !important;
+    border: 0 !important;
+    outline: none !important;
+    background: transparent !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+}

--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -541,44 +541,25 @@ nav .rg-bottom {
     .schema-container {
       display: none;
     }
-  }
 
-  .query-page-wrapper {
-    .container {
-      margin-left: 0;
-      margin-right: 0;
+    .query-metadata__mobile {
+      border-bottom: 1px solid #efefef;
+      min-height: 0 !important;
+      flex-shrink: 0;
+      padding: 5px 15px;
+      display: flex;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      align-items: center;
+
+      .profile__image_thumb {
+        margin: 0 5px 0 0;
+      }
+
+      .query-metadata__property {
+        white-space: nowrap;
+      }
     }
-  }
-
-  .query-fullscreen .query-metadata__mobile {
-    display: block;
-    border-bottom: 1px solid #efefef;
-    padding: 10px 0;
-    min-height: 0 !important;
-    flex-shrink: 0;
-  }
-
-  a.navbar-brand {
-    display: none;
-  }
-
-  .page-header--query {
-    padding-left: 0px !important;
-
-    h3 {
-      line-height: 1.25;
-    }
-  }
-
-  .query-fullscreen .content {
-    height: 100%;
-  }
-
-  .datasource-small {
-    visibility: visible;
-  }
-
-  .query-fullscreen {
 
     main {
       flex-direction: column-reverse;
@@ -600,7 +581,39 @@ nav .rg-bottom {
 
     .content {
       width: 100%;
+      height: 100%;
+
+      .static-position__mobile {
+        position: static !important;
+      }
     }
+
+    .bottom-controller-container {
+      z-index: 9;
+    }
+  }
+
+  .query-page-wrapper {
+    .container {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  a.navbar-brand {
+    display: none;
+  }
+
+  .page-header--query {
+    padding-left: 0 !important;
+
+    h3 {
+      line-height: 1.25;
+    }
+  }
+
+  .datasource-small {
+    visibility: visible;
   }
 }
 

--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -95,10 +95,6 @@ edit-in-place p.editable:hover {
   margin-bottom: 10px;
 }
 
-.source-control {
-
-}
-
 .ace_editor.ace_autocomplete .ace_completion-highlight {
   text-shadow: none !important;
   background: #ffff005e;
@@ -231,11 +227,8 @@ edit-in-place p.editable:hover {
 }
 
 .page-header--query {
-  display: flex;
-  align-items: center;
-
-  h3 {
-    display: inline-block;
+  .page-title {
+    display: block;
   }
 }
 
@@ -530,6 +523,14 @@ nav .rg-bottom {
 // Smaller screens
 
 @media (max-width: 880px) {
+  .btn-publish {
+    display: none;
+  }
+
+  .tab-nav .tab-new-vis {
+    display: none;
+  }
+
   .query-fullscreen {
     flex-direction: column;
     overflow: hidden;
@@ -546,7 +547,7 @@ nav .rg-bottom {
       border-bottom: 1px solid #efefef;
       min-height: 0 !important;
       flex-shrink: 0;
-      padding: 5px 15px;
+      padding: 10px 15px;
       display: flex;
       flex-wrap: nowrap;
       justify-content: space-between;
@@ -602,14 +603,6 @@ nav .rg-bottom {
 
   a.navbar-brand {
     display: none;
-  }
-
-  .page-header--query {
-    padding-left: 0 !important;
-
-    h3 {
-      line-height: 1.25;
-    }
   }
 
   .datasource-small {

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -366,8 +366,8 @@ body {
 
 page-header, .page-header--new {
   h3 {
-    margin: 0;
-    line-height: 1.75;
+    margin: 0.2em 0;
+    line-height: 1.3;
     font-weight: 500;
   }
 }
@@ -812,10 +812,6 @@ text.slicetext {
   }
 
   .query-page-wrapper {
-    .page-header--query {
-      padding-bottom: 5px !important;
-    }
-
     h3 {
       font-size: 18px;
     }

--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -71,13 +71,13 @@ class QueryEditor extends React.Component {
     listenForResize: PropTypes.func.isRequired,
     listenForEditorCommand: PropTypes.func.isRequired,
 
-  }
+  };
 
   static defaultProps = {
     schema: null,
     dataSource: {},
     dataSources: [],
-  }
+  };
 
   constructor(props) {
     super(props);
@@ -163,6 +163,8 @@ class QueryEditor extends React.Component {
     // eslint-disable-next-line react/prop-types
     const modKey = this.props.KeyboardShortcuts.modKey;
 
+    const isExecuteDisabled = this.props.queryExecuting || !this.props.canExecuteQuery();
+
     return (
       <section style={{ height: '100%' }}>
         <div className="container p-15 m-b-10" style={{ height: '100%' }}>
@@ -200,7 +202,7 @@ class QueryEditor extends React.Component {
                 </button>
               </Tooltip>
               <Tooltip placement="top" title="Autocomplete">
-                <button type="button" className={'btn btn-default' + (this.state.autocompleteQuery ? ' active' : '')} onClick={() => this.setState({ autocompleteQuery: !this.state.autocompleteQuery })} >
+                <button type="button" className={'btn btn-default m-r-5' + (this.state.autocompleteQuery ? ' active' : '')} onClick={() => this.setState({ autocompleteQuery: !this.state.autocompleteQuery })} >
                   <span className="fa fa-magic" />
                 </button>
               </Tooltip>
@@ -210,15 +212,27 @@ class QueryEditor extends React.Component {
               {this.props.canEdit ?
                 <Tooltip placement="top" title={modKey + ' + S'}>
                   <button className="btn btn-default m-l-5" onClick={this.props.saveQuery} title="Save">
-                    <span className="fa fa-floppy-o" />&nbsp;
-                    <span className="hidden-xs">Save</span>
+                    <span className="fa fa-floppy-o" />
+                    <span className="hidden-xs m-l-5">Save</span>
                     {this.props.isDirty ? '*' : null}
                   </button>
                 </Tooltip> : null }
               <Tooltip placement="top" title={modKey + ' + Enter'}>
-                <button type="button" className="btn btn-primary m-l-5" disabled={this.props.queryExecuting || !this.props.canExecuteQuery()} onClick={this.props.executeQuery}>
-                  <span className="zmdi zmdi-play" />&nbsp;
-                  <span className="hidden-xs">Execute</span>
+                {/*
+                  Tooltip wraps disabled buttons with `<span>` and moves all styles
+                  and classes to that `<span>`. There is a piece of CSS that fixes
+                  button appearance, but also wwe need to add `disabled` class to
+                  disabled buttons so it will be assigned to wrapper and make it
+                  looking properly
+                */}
+                <button
+                  type="button"
+                  className={'btn btn-primary m-l-5' + (isExecuteDisabled ? ' disabled' : '')}
+                  disabled={isExecuteDisabled}
+                  onClick={this.props.executeQuery}
+                >
+                  <span className="zmdi zmdi-play" />
+                  <span className="hidden-xs m-l-5">Execute</span>
                 </button>
               </Tooltip>
             </div>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -136,7 +136,7 @@
 
     <div class="content">
       <div class="flex-fill p-relative">
-        <div class="p-absolute d-flex flex-column p-l-15 p-r-15" style="left: 0; top: 0; right: 0; bottom: 0;">
+        <div class="p-absolute d-flex flex-column p-l-15 p-r-15" style="left: 0; top: 0; right: 0; bottom: 0; overflow: auto">
           <div class="row editor" resizable r-directions="['bottom']" r-flex="true" resizable-toggle
                style="min-height: 11px; max-height: 70vh;" ng-if="sourceMode">
             <query-editor
@@ -161,29 +161,27 @@
           </div>
 
           <div class="row query-metadata__mobile">
-            <div class="col-xs-4 text-left">
-              <span class="m-r-5">Created by</span>
-              <img ng-src="{{ query.user.profile_image_url }}" class="profile__image_thumb">
-              <strong>
-                <rd-time-ago value="query.created_at"></rd-time-ago>
-              </strong>
+            <img ng-src="{{ query.user.profile_image_url }}" class="profile__image_thumb">
+            <div class="flex-fill m-r-10">
+              <strong class="meta__name" ng-class="{'text-muted': query.user.is_disabled}">{{query.user.name}}</strong>
+              created <rd-time-ago value="query.created_at"></rd-time-ago>
             </div>
-            <div class="col-xs-4 text-center">
-              <span class="m-r-5">Updated by</span>
-              <img ng-src="{{ query.last_modified_by.profile_image_url }}" class="profile__image_thumb">
-              <strong>
-                <rd-time-ago value="query.updated_at"></rd-time-ago>
-              </strong>
+
+            <img ng-src="{{ query.last_modified_by.profile_image_url }}" class="profile__image_thumb">
+            <div class="flex-fill m-r-10">
+              <strong class="meta__name" ng-class="{'text-muted': query.last_modified_by.is_disabled}">{{query.last_modified_by.name}}</strong>
+              updated <rd-time-ago value="query.updated_at"></rd-time-ago>
             </div>
-            <div class="col-xs-4 text-right">
-              <span class="query-metadata__property"></span> Refresh Schedule</span>
+
+            <div>
+              <span class="query-metadata__property">Refresh schedule:</span>
               <a ng-click="openScheduleForm()" ng-if="!query.isNew()">{{query.schedule | scheduleHumanize}}</a>
               <span ng-if="query.isNew()">Never</span>
             </div>
           </div>
 
-          <section class="flex-fill p-relative t-body">
-            <div class="d-flex flex-column p-b-15 p-absolute" style="left: 0; top: 0; right: 0; bottom: 0;">
+          <section class="row flex-fill p-relative t-body">
+            <div class="d-flex flex-column p-b-15 p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
               <div class="p-t-15 p-b-5" ng-if="query.getParametersDefs().length > 0">
                 <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"></parameters>
               </div>
@@ -215,7 +213,7 @@
 
               <!-- tabs and data -->
               <div ng-if="showDataset" class="flex-fill p-relative">
-                <div class="d-flex flex-column p-absolute" style="left: 0; top: 0; right: 0; bottom: 0;">
+                <div class="d-flex flex-column p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
                   <div class="p-10" ng-show="showLog">
                     <p>Log Information:</p>
                     <p ng-repeat="l in queryResult.getLog()">{{l}}</p>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -18,56 +18,61 @@
 
     <alert-unsaved-changes ng-if="canEdit" is-dirty="isDirty"></alert-unsaved-changes>
 
-    <div class="row p-l-15 p-b-10 m-l-0 m-r-0 page-header--new page-header--query">
-      <div class="page-title col-sm-8 col-xs-7 p-0">
-        <favorites-control ng-if="!query.isNew()" item="query"></favorites-control>
-        <h3>
-          <edit-in-place editable="canEdit" on-done="saveName" ignore-blanks="true" value="query.name" editor="'input'"></edit-in-place>
-        </h3>
-        <span class="label label-default" ng-if="query.is_draft && !query.is_archived">Unpublished</span>
-        <span class="label label-warning" ng-if="query.is_archived" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results."
-          popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
-        <tags-control class="hidden-xs" item="query" can-edit="isQueryOwner" get-available-tags="loadTags" on-edit="saveTags()"></tags-control>
-      </div>
+    <div class="p-b-10 m-l-0 m-r-0 page-header--new page-header--query">
+      <div class="page-title p-0">
+        <div class="d-flex flex-nowrap align-items-center">
+          <favorites-control ng-if="!query.isNew()" item="query"></favorites-control>
+          <h3>
+            <edit-in-place editable="canEdit" on-done="saveName" ignore-blanks="true" value="query.name" editor="'input'"></edit-in-place>
+          </h3>
 
-      <div class="col-sm-4 col-xs-5 p-0 source-control text-right">
+          <span class="flex-fill">&nbsp;</span>
 
-        <button class="btn btn-default btn-publish" ng-click="togglePublished()" ng-if="query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
-          <span class="fa fa-paper-plane"></span> Publish
-        </button>
+          <div class="p-0 source-control text-right text-nowrap align-self-start m-t-5">
+            <button class="btn btn-default btn-publish" ng-click="togglePublished()" ng-if="query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
+              <span class="fa fa-paper-plane"></span> Publish
+            </button>
 
-        <span ng-show="query.id && canViewSource">
-          <a ng-show="!sourceMode" ng-href="{{query.getUrl(true, selectedTab)}}" class="btn btn-default btn--showhide">
-            <i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit Source
-          </a>
-          <a ng-show="sourceMode" ng-href="{{query.getUrl(false, selectedTab)}}" class="btn btn-default btn--showhide">
-            <i class="fa fa-table" aria-hidden="true"></i> Show Data Only
-          </a>
-        </span>
+            <span ng-show="query.id && canViewSource">
+              <a ng-show="!sourceMode" ng-href="{{query.getUrl(true, selectedTab)}}" class="btn btn-default btn--showhide">
+                <i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit Source</i>
+              </a>
+              <a ng-show="sourceMode" ng-href="{{query.getUrl(false, selectedTab)}}" class="btn btn-default btn--showhide">
+                <i class="fa fa-table" aria-hidden="true"></i> Show Data Only</i>
+              </a>
+            </span>
 
-        <div ng-if="query.id != undefined" class="btn-group" role="group" uib-dropdown>
-          <button class="btn btn-default dropdown-toggle hidden-xs" uib-dropdown-toggle>
-            <span class="zmdi zmdi-more"></span>
-          </button>
-          <ul class="dropdown-menu pull-right" uib-dropdown-menu>
-            <li ng-class="{'disabled': query.id === undefined || !canForkQuery() }">
-              <a ng-click="duplicateQuery()"> Fork</a>
-            </li>
-            <li class="divider"></li>
-            <li ng-if="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
-              <a ng-click="archiveQuery()">Archive</a>
-            </li>
-            <li ng-if="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin')) && showPermissionsControl">
-              <a ng-click="showManagePermissionsModal()">Manage Permissions</a>
-            </li>
-            <li ng-if="!query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
-              <a ng-click="togglePublished()">Unpublish</a>
-            </li>
-            <li class="divider" ng-if="!query.is_archived"></li>
-            <li ng-if="query.id != undefined">
-              <a ng-click="showApiKey()">Show API Key</a>
-            </li>
-          </ul>
+            <div ng-if="query.id != undefined" class="btn-group" role="group" uib-dropdown>
+              <button class="btn btn-default dropdown-toggle hidden-xs" uib-dropdown-toggle>
+                <span class="zmdi zmdi-more"></span>
+              </button>
+              <ul class="dropdown-menu pull-right" uib-dropdown-menu>
+                <li ng-class="{'disabled': query.id === undefined || !canForkQuery() }">
+                  <a ng-click="duplicateQuery()"> Fork</a>
+                </li>
+                <li class="divider"></li>
+                <li ng-if="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
+                  <a ng-click="archiveQuery()">Archive</a>
+                </li>
+                <li ng-if="!query.is_archived && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin')) && showPermissionsControl">
+                  <a ng-click="showManagePermissionsModal()">Manage Permissions</a>
+                </li>
+                <li ng-if="!query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
+                  <a ng-click="togglePublished()">Unpublish</a>
+                </li>
+                <li class="divider" ng-if="!query.is_archived"></li>
+                <li ng-if="query.id != undefined">
+                  <a ng-click="showApiKey()">Show API Key</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div style="padding-left: 23px; margin-top: -5px;">
+          <span class="label label-default" ng-if="query.is_draft && !query.is_archived">Unpublished</span>
+          <span class="label label-warning" ng-if="query.is_archived" uib-popover="This query is archived and can't be used in dashboards, and won't appear in search results."
+            popover-placement="right" popover-trigger="'mouseenter'">Archived</span>
+          <tags-control item="query" can-edit="isQueryOwner" get-available-tags="loadTags" on-edit="saveTags()"></tags-control>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Issue getredash/redash#2796 (items related to query page).

1. Change layout with fixed blocks to scrollable; some blocks (header, footer) kept fixed; editor, query metadata and results are scrollable (see screenshots).
2. Query metadata block now is a bit smaller and compact (to save some space), but still well-readable.

Screenshots:

![image](https://user-images.githubusercontent.com/12139186/46735626-6ae41900-cc9f-11e8-9455-0e4f6fb57ec9.png)
![image](https://user-images.githubusercontent.com/12139186/46735644-7b948f00-cc9f-11e8-8121-7166316237fb.png)
![image](https://user-images.githubusercontent.com/12139186/46735654-85b68d80-cc9f-11e8-880a-4cbf89277db1.png)
![image](https://user-images.githubusercontent.com/12139186/46735672-96ff9a00-cc9f-11e8-8429-fe4301ee2c26.png)
![image](https://user-images.githubusercontent.com/12139186/46735686-a4b51f80-cc9f-11e8-8c80-89e512d8bf07.png)
