### PR TITLE
Fix admin api recording

### DIFF
--- a/redash/handlers/admin.py
+++ b/redash/handlers/admin.py
@@ -1,12 +1,12 @@
 from flask import request
-from flask_login import login_required
+from flask_login import login_required, current_user
 
 from redash import models, redis_connection
+from redash.authentication import current_org
 from redash.handlers import routes
-from redash.handlers.base import json_response
+from redash.handlers.base import json_response, record_event
 from redash.permissions import require_super_admin
 from redash.serializers import QuerySerializer
-from redash.tasks import record_event
 from redash.tasks.queries import QueryTaskTracker
 from redash.utils import json_loads
 
@@ -26,7 +26,7 @@ def outdated_queries():
     else:
         outdated_queries = []
 
-    record_event({
+    record_event(current_org, current_user._get_current_object(), {
         'action': 'list',
         'object_type': 'outdated_queries',
     })
@@ -42,7 +42,7 @@ def outdated_queries():
 @require_super_admin
 @login_required
 def queries_tasks():
-    record_event({
+    record_event(current_org, current_user._get_current_object(), {
         'action': 'list',
         'object_id': 'admin/tasks',
         'object_type': 'celery_tasks'


### PR DESCRIPTION
An admin API fails when recording an event. Fixed it.

## `/api/admin/queries/outdated`

```
% curl "<mydomain>/api/admin/queries/outdated?api_key=<my_api_key>"
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.</p>
```

The log is the below.

```

  File "<redash_proj_path>/redash/tasks/general.py", line 14, in record_event
    event = models.Event.record(raw_event)
  File "<redash_proj_path>/redash/models.py", line 1512, in record
    org_id = event.pop('org_id')
KeyError: 'org_id'
[2018-10-13 20:17:38,169][PID:47598][INFO][metrics] method=GET path=/api/admin/queries/outdated endpoint=redash_outdated_queries status=500 content_type=? content_length=-1 duration=133.91 query_count=3 query_duration=7.69
[2018-10-13 20:17:38,169][PID:47598][INFO][werkzeug] <mydomain> - - [13/Oct/2018 20:17:38] "GET /api/admin/queries/outdated?api_key=<my_api_key> HTTP/1.1" 500 -
```

## `/api/admin/queries/tasks`

```
% curl "<mydomain>/api/admin/queries/tasks?api_key=<my_api_key>"
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.</p>
```

The log is the below.

```

  File "<redash_proj_path>/redash/tasks/general.py", line 14, in record_event
    event = models.Event.record(raw_event)
  File "<redash_proj_path>/redash/models.py", line 1512, in record
    org_id = event.pop('org_id')
KeyError: 'org_id'
[2018-10-13 20:22:21,167][PID:47598][INFO][metrics] method=GET path=/api/admin/queries/tasks endpoint=redash_queries_tasks status=500 content_type=? content_length=-1 duration=15.27 query_count=3 query_duration=5.60
[2018-10-13 20:22:21,167][PID:47598][INFO][werkzeug] <mydomain> - - [13/Oct/2018 20:22:21] "GET /api/admin/queries/tasks?api_key=<my_api_key> HTTP/1.1" 500 -
```