### PR TITLE
Auto focus tag input

### DIFF
--- a/client/app/components/tags-control/modal-template.html
+++ b/client/app/components/tags-control/modal-template.html
@@ -4,7 +4,7 @@
 </div>
 <div class="modal-body">
   <ui-select multiple append-to-body tagging tagging-label=" "
-    ng-model="$ctrl.resolve.items" sortable="true">
+    ng-model="$ctrl.resolve.items" sortable="true" autofocus>
     <ui-select-match placeholder="Add some tags...">{{ $item }}</ui-select-match>
     <ui-select-choices repeat="value in $ctrl.resolve.availableTags | filter:$select.search">
       {{ value }}


### PR DESCRIPTION
Set focus on a tag input box when opened the modal.

Before:
<img width="606" alt="autofocus_tag_before" src="https://user-images.githubusercontent.com/3317191/46905011-3931b300-cf28-11e8-8341-9677df488c54.png">

After:
<img width="608" alt="autofocus_tag_after" src="https://user-images.githubusercontent.com/3317191/46905013-3e8efd80-cf28-11e8-9f7d-1b2abd7c9a3b.png">
