### PR TITLE
port hideParameters dashboard param upstream

### DIFF
--- a/client/app/components/parameters.html
+++ b/client/app/components/parameters.html
@@ -1,5 +1,5 @@
 <div class="parameter-container form-inline bg-white"
-  ng-if="parameters | notEmpty"
+  ng-if="hideParameters != 'true' && parameters | notEmpty"
   ui-sortable="{ 'ui-floating': true, 'disabled': !editable }"
   ng-model="parameters"
 >

--- a/client/app/components/parameters.js
+++ b/client/app/components/parameters.js
@@ -152,6 +152,8 @@ function ParametersDirective($location, $uibModal) {
           },
         });
       };
+
+      scope.hideParameters = $location.search().hideParameters;
     },
   };
 }


### PR DESCRIPTION
Original issue: https://github.com/mozilla/redash/issues/163
Issue to port upstream: https://github.com/mozilla/redash/issues/563

This allows you to add ?hideParameters=true to a dashboard to hide them in widgets.

Without this parameter:
![screenshot 2018-10-14 19 14 36](https://user-images.githubusercontent.com/1840865/46924080-693f8b80-cfe6-11e8-9bc5-4d79397e8142.png)

With parameter:
![screenshot 2018-10-14 19 17 10](https://user-images.githubusercontent.com/1840865/46924086-73fa2080-cfe6-11e8-951e-897dd4b9a4dc.png)

