### PR TITLE
Fix tarball build failure.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
       - image: circleci/node:8
     steps:
       - checkout
+      - run: sudo apt install python-pip
       - run: npm install
       - run: npm run bundle
       - run: npm run build


### PR DESCRIPTION
Follow up to https://github.com/getredash/redash/pull/2799#issuecomment-429624969

It seems that the image used for creating the tarball, `circleci/node:8`, does not have the correct python tools to run the bundle script.

Adding this resolves the issue: https://circleci.com/gh/getredash/redash/5385?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link