### PR TITLE
Fix no tags shown when having empty set

### DIFF
--- a/client/app/components/NoTaggedObjectsFound.jsx
+++ b/client/app/components/NoTaggedObjectsFound.jsx
@@ -8,8 +8,8 @@ function NoTaggedObjectsFound({ objectType, tags }) {
     <BigMessage icon="fa-tags">
       No {objectType} found tagged with
       {Array.from(tags).map(tag => (
-        <span className="label label-tag" key={tag.name}>
-          {tag.name}
+        <span className="label label-tag" key={tag}>
+          {tag}
         </span>
       ))}.
     </BigMessage>


### PR DESCRIPTION
I noticed that no tags were being shown (you can see in the image below)
![captura de tela de 2018-10-15 16-13-19](https://user-images.githubusercontent.com/3356951/46972973-4e2c5480-d096-11e8-8871-0a21f495f8bf.png)

This started happening after PR #2833 because `tag-list.html` now calls `toggleTag()` with `tag.name` instead of `tag`. I changed `NoTaggedObjectsFound.jsx` to work as it receives the Tag Set now.

## After the changes
![captura de tela de 2018-10-15 16-14-17](https://user-images.githubusercontent.com/3356951/46972974-4e2c5480-d096-11e8-8005-0cd697a1f615.png)
