### PR TITLE
Fix an invalid prop type of `newVersionAvailable` warning

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -167,7 +167,7 @@ def date_format_config():
 def client_config():
     if not current_user.is_api_user() and current_user.is_authenticated:
         client_config = {
-            'newVersionAvailable': get_latest_version(),
+            'newVersionAvailable': bool(get_latest_version()),
             'version': __version__
         }
     else:


### PR DESCRIPTION
Fix the following warning.

<img width="685" alt="invalid_prop_type" src="https://user-images.githubusercontent.com/3317191/47251679-c9648080-d471-11e8-85cd-a5fe9f00fb9c.png">

According to the type check, `clientConfig.newVersionAvailable` must be boolean.

https://github.com/getredash/redash/blob/master/client/app/components/Footer.jsx#L34

