### PR TITLE
Add an error message in query_results.

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -183,6 +183,11 @@ class Results(BaseQueryRunner):
             connection.cancel()
             error = "Query cancelled by user."
             json_data = None
+        except Exception as error:
+            connection.cancel()
+            if 'no such column' == re.search('no such column', error.message).group():
+                error = "{} Note: If the column names contain colon, dot, or whitespace, they are converted to underscores".format(error.message)
+                json_data = None
         finally:
             connection.close()
         return json_data, error


### PR DESCRIPTION
There is a rule which converts colon( , ) and period( . ), white space into underscore( _ ) in query results.
But the users which unknown the rule get confused when the users select columns which include colon and period, white space.
So,  I added add an error message in query_results. The error message has occurred only when `no such column` has occurred.
`no such column: XX Note: If the column names contain colon, dot, or white space, they are converted to underscores`