### PR TITLE
Support AWS IAM profile for Amazon Elasticsearch

### DIFF
--- a/redash/query_runner/amazon_elasticsearch.py
+++ b/redash/query_runner/amazon_elasticsearch.py
@@ -2,7 +2,8 @@ from .elasticsearch import ElasticSearch
 from . import register
 
 try:
-    from requests_aws4auth import AWS4Auth
+    from requests_aws_sign import AWSV4Sign
+    from botocore import session, credentials
     enabled = True
 except ImportError:
     enabled = False
@@ -40,17 +41,29 @@ class AmazonElasticsearchService(ElasticSearch):
                 'secret_key': {
                     'type': 'string',
                     'title': 'Secret Key'
+                },
+                'use_aws_iam_profile': {
+                    'type': 'boolean',
+                    'title': 'Use AWS IAM Profile'
                 }
             },
             "secret": ["secret_key"],
-            "order": ["server", "region", "access_key", "secret_key"],
-            "required": ['server', 'region', 'access_key', 'secret_key']
+            "order": ["server", "region", "access_key", "secret_key", "use_aws_iam_profile"],
+            "required": ['server', 'region']
         }
 
     def __init__(self, configuration):
         super(AmazonElasticsearchService, self).__init__(configuration)
 
-        self.auth = AWS4Auth(configuration['access_key'], configuration['secret_key'], configuration['region'], 'es')
+        region = configuration['region']
+        cred = None
+        if configuration.get('use_aws_iam_profile', False):
+            cred = credentials.get_credentials(session.Session())
+        else:
+            cred = credentials.Credentials(access_key=configuration.get('access_key', ''),
+                                           secret_key=configuration.get('secret_key', ''))
+
+        self.auth = AWSV4Sign(cred, region, 'es')
 
 
 register(AmazonElasticsearchService)

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -25,7 +25,7 @@ pymapd>=0.2.1
 qds-sdk>=1.9.6
 ibm-db>=2.0.9
 pydruid==0.4
-requests-aws4auth==0.9
+requests_aws_sign==0.1.4
 # certifi is needed to support MongoDB and SSL:
 certifi
 # We don't install snowflake connector by default, as it's causing conflicts with


### PR DESCRIPTION
To use Elasticsearch managed by AWS, Redash supports only the way to be permitted by IP addresses currently. but we want to use policy permissions by AWS IAM profile on EC2/ECS generally.

* This PR adds `Use AWS IAM profile` option to Amazon Elasticsearch settings.
* If the option is true, applying the IAM profile of the running environment to the requests.
