### PR TITLE
Add permissions to the result of "manage.py groups list" command

### DIFF
--- a/redash/cli/groups.py
+++ b/redash/cli/groups.py
@@ -95,8 +95,8 @@ def list(organization=None):
         if i > 0:
             print("-" * 20)
 
-        print("Id: {}\nName: {}\nType: {}\nOrganization: {}".format(
-            group.id, group.name, group.type, group.org.slug))
+        print("Id: {}\nName: {}\nType: {}\nOrganization: {}\nPermissions: [{}]".format(
+            group.id, group.name, group.type, group.org.slug, ",".join(group.permissions)))
 
         members = models.Group.members(group.id)
         user_names = [m.name for m in members]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,7 +189,6 @@ class DataSourceCommandTests(BaseTestCase):
 
 
 class GroupCommandTests(BaseTestCase):
-    maxDiff = None
     def test_create(self):
         gcount = Group.query.count()
         perms = ['create_query', 'edit_query', 'view_query']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,6 +189,7 @@ class DataSourceCommandTests(BaseTestCase):
 
 
 class GroupCommandTests(BaseTestCase):
+    maxDiff = None
     def test_create(self):
         gcount = Group.query.count()
         perms = ['create_query', 'edit_query', 'view_query']
@@ -234,30 +235,35 @@ class GroupCommandTests(BaseTestCase):
         Name: Agroup
         Type: regular
         Organization: default
+        Permissions: [list_dashboards]
         Users: 
         --------------------
         Id: 5
         Name: Bgroup
         Type: regular
         Organization: default
+        Permissions: [list_dashboards]
         Users: 
         --------------------
         Id: 1
         Name: admin
         Type: builtin
         Organization: default
+        Permissions: [admin,super_admin]
         Users: 
         --------------------
         Id: 2
         Name: default
         Type: builtin
         Organization: default
+        Permissions: [create_dashboard,create_query,edit_dashboard,edit_query,view_query,view_source,execute_query,list_users,schedule_query,list_dashboards,list_alerts,list_data_sources]
         Users: Fred Foobar
         --------------------
         Id: 3
         Name: test
         Type: regular
         Organization: default
+        Permissions: [list_dashboards]
         Users: 
         """
         self.assertMultiLineEqual(result.output,


### PR DESCRIPTION
I often change group's permissions via CLI, because web interface has only two alternatives(full-access vs view-only) and I have to make more detailed configurations according to each group's use case. 
But there isn't a way to check each group's current permissions, except by writing a query to PostgreSQL directly. I'd like to check it on CLI too.