### PR TITLE
athena&presto support column type and partition key

### DIFF
--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -38,8 +38,18 @@ function buildKeywordsFromSchema(schema) {
   schema.forEach((table) => {
     keywords[table.name] = 'Table';
     table.columns.forEach((c) => {
-      keywords[c] = 'Column';
-      keywords[`${table.name}.${c}`] = 'Column';
+      if (typeof c === 'string') {
+        keywords[c] = 'Column';
+        keywords[`${table.name}.${c}`] = 'Column';
+      } else if (typeof c === 'object') {
+        c.forEach((a, b) => {
+          if (a === 'column_name') {
+            const columnName = b;
+            keywords[columnName] = 'Column';
+            keywords[`${table.name}.${columnName}`] = 'Column';
+          }
+        });
+      }
     });
   });
 

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -20,9 +20,9 @@
           ng-click="$ctrl.itemSelected($event, [table.name])"></i>
       </div>
       <div uib-collapse="table.collapsed">
-        <div ng-repeat="column in table.columns | filter:$ctrl.schemaFilterColumn track by column" class="table-open">{{column}}
+        <div ng-repeat="column in table.columns[0] | filter:$ctrl.schemaFilterColumn track by column.column_name" class="table-open"><span ng-if="column.extra_info == 'partition key'"><i class="fa fa-key" aria-hidden="true"></i></span> {{column.column_name}} <span ng-if="column.column_type"> ({{column.column_type}})</span>
           <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
-            ng-click="$ctrl.itemSelected($event, [column])"></i>
+            ng-click="$ctrl.itemSelected($event, [column.column_name])"></i>
         </div>
       </div>
     </div>

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -131,10 +131,10 @@ class Athena(BaseQueryRunner):
                 columns = []
                 if table_name not in schema:
                     schema[table_name] = {'name': table_name, 'columns': []}
-                
+
                 for partition in table.get('PartitionKeys', []):
                     columns.append({
-                        'column_name':partition['Name'],
+                        'column_name': partition['Name'],
                         'extra_info': 'partition key'
                     })
                 for column in table['StorageDescriptor']['Columns']:

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -28,6 +28,7 @@ PRESTO_TYPES_MAPPING = {
     "date": TYPE_DATE,
 }
 
+
 def format_schema(results):
     """
     This function formats the schema, table, and columns of Athena and Presto

--- a/tests/query_runner/test_athena.py
+++ b/tests/query_runner/test_athena.py
@@ -72,7 +72,7 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['row_id'], 'name': 'test1.jdbc_table'}]
+            assert query_runner.get_schema() == [{'columns': [[{'column_name':'row_id','column_type':'int'}]], 'name': 'test1.jdbc_table'}]
 
     def test_partitioned_table(self):
         """
@@ -118,7 +118,7 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['sk', 'category'], 'name': 'test1.partitioned_table'}]
+            assert query_runner.get_schema() == [{'columns': [[{'extra_info':'partition key','column_name':'category'},{'column_type':'int','column_name':'sk'}]], 'name': 'test1.partitioned_table'}]
 
     def test_view(self):
         query_runner = Athena({'glue': True, 'region': 'mars-east-1'})
@@ -150,7 +150,7 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['sk'], 'name': 'test1.view'}]
+            assert query_runner.get_schema() == [{'columns': [[{'column_name':'sk', 'column_type':'int'}]], 'name': 'test1.view'}]
 
     def test_dodgy_table_does_not_break_schema_listing(self):
         """
@@ -187,4 +187,4 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['region'], 'name': 'test1.csv'}]
+            assert query_runner.get_schema() == [{'columns': [[{'column_name':'region','column_type':'string'}]], 'name': 'test1.csv'}]


### PR DESCRIPTION
Original issue: mozilla#185
Original PR: mozilla#201

Issue to post this upstream: mozilla#430
Previous PR code reviews trying to port this upstream: #2655 #2764 #2826

This PR adds the key font awesome icon to partition keys and column type in the schema browser for Presto and Athena data sources.

Image (with forced partition key):
![screenshot 2018-10-28 13 46 17](https://user-images.githubusercontent.com/1840865/47620818-ca725f00-dabc-11e8-932d-ccbcebd8fa52.png)
