### PR TITLE
Plotly's toolbox covers part of the chart

### DIFF
--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -529,7 +529,7 @@ export function prepareLayout(element, seriesList, options, data) {
       l: 10,
       r: 10,
       b: 10,
-      t: 10,
+      t: 25,
       pad: 4,
     },
     width: Math.floor(element.offsetWidth),


### PR DESCRIPTION
Fixes getredash/redash#3022

Was:
![image](https://user-images.githubusercontent.com/12139186/47640630-a4a49300-db6c-11e8-8c0c-849597f14d28.png)

Became:
![image](https://user-images.githubusercontent.com/12139186/47640687-d0277d80-db6c-11e8-85d2-62999f322721.png)
