### PR TITLE
Fix Flask reloading

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 pytest==3.2.3
 pytest-cov==2.5.1
-pytest-watch==4.1.0
 coverage==4.0.3
 mock==2.0.0
 


### PR DESCRIPTION
Flask reloading seemed shaky, so I looked into it.

_Flask_ depends on _werkzeug_, which in the presence of _watchdog_ uses it to detect file changes in order to reload the app. If _watchdog_ is not present, _stat_ is used instead. Although _watchdog_ offers superior performance and results, it seems to be shaky on our Dockers.

There were several ways to resolve this:

1. Explicitly remove _watchdog_ after `pip install` 👎
2. Set `reloader_type` to _stat_ - wasn't possible since we use the Flask constructor which does not delegate options to _werkzeug_'s `run_simple` 👎
3. Get rid of _pytest_watch_, which is the source of the `watchdog` dependency 🤪