### PR TITLE
Support overriding the default Celery schedule database file

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -12,10 +12,11 @@ worker() {
 scheduler() {
   WORKERS_COUNT=${WORKERS_COUNT:-1}
   QUEUES=${QUEUES:-celery}
+  SCHEDULE_DB=${SCHEDULE_DB:-celerybeat-schedule}
 
   echo "Starting scheduler and $WORKERS_COUNT workers for queues: $QUEUES..."
 
-  exec /usr/local/bin/celery worker --app=redash.worker --beat -c$WORKERS_COUNT -Q$QUEUES -linfo --maxtasksperchild=10 -Ofair
+  exec /usr/local/bin/celery worker --app=redash.worker --beat -s$SCHEDULE_DB -c$WORKERS_COUNT -Q$QUEUES -linfo --maxtasksperchild=10 -Ofair
 }
 
 server() {


### PR DESCRIPTION
Support overriding the default Celery schedule database file via SCHEDULE_DB environment variable.

By default Celery will use a file celerybeat-schedule in the current directory.
This is an issue in a Kubernetes/Openshift environment as the file may be lost or even impossible to write.