### PR TITLE
Mustache: don't html-escape query parameters values

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -3,8 +3,10 @@ import debug from 'debug';
 import Mustache from 'mustache';
 import {
   each, zipObject, isEmpty, map, filter, includes, union, uniq, has,
-  isNull, isUndefined, isArray, isObject,
+  isNull, isUndefined, isArray, isObject, identity,
 } from 'lodash';
+
+Mustache.escape = identity; // do not html-escape values
 
 const logger = debug('redash:services:query');
 

--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import logging
 import time
 
-import pystache
 from flask import request
 
 from .authentication import current_org
@@ -14,7 +13,7 @@ from redash.handlers.base import (get_object_or_404, org_scoped_rule,
                                   record_event)
 from redash.handlers.query_results import collect_query_parameters
 from redash.handlers.static import render_index
-from redash.utils import gen_query_hash
+from redash.utils import gen_query_hash, mustache_render
 
 
 #
@@ -30,7 +29,7 @@ def run_query_sync(data_source, parameter_values, query_text, max_age=0):
         raise Exception('Missing parameter value for: {}'.format(", ".join(missing_params)))
 
     if query_parameters:
-        query_text = pystache.render(query_text, parameter_values)
+        query_text = mustache_render(query_text, parameter_values)
 
     if max_age <= 0:
         query_result = None

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-import pystache
 from flask import make_response, request
 from flask_login import current_user
 from flask_restful import abort
@@ -13,7 +12,8 @@ from redash.utils import (collect_query_parameters,
                           collect_parameters_from_request,
                           gen_query_hash,
                           json_dumps,
-                          utcnow)
+                          utcnow,
+                          mustache_render)
 from redash.tasks.queries import enqueue_query
 
 
@@ -34,7 +34,7 @@ def run_query_sync(data_source, parameter_values, query_text, max_age=0):
         raise Exception('Missing parameter value for: {}'.format(", ".join(missing_params)))
 
     if query_parameters:
-        query_text = pystache.render(query_text, parameter_values)
+        query_text = mustache_render(query_text, parameter_values)
 
     if max_age <= 0:
         query_result = None
@@ -85,7 +85,7 @@ def run_query(data_source, parameter_values, query_text, query_id, max_age=0):
         return error_response(message)
 
     if query_parameters:
-        query_text = pystache.render(query_text, parameter_values)
+        query_text = mustache_render(query_text, parameter_values)
 
     if max_age == 0:
         query_result = None

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -2,7 +2,6 @@ import logging
 import signal
 import time
 
-import pystache
 import redis
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from celery.result import AsyncResult
@@ -12,7 +11,7 @@ from six import text_type
 from redash import models, redis_connection, settings, statsd_client
 from redash.query_runner import InterruptException
 from redash.tasks.alerts import check_alerts_for_query
-from redash.utils import gen_query_hash, json_dumps, json_loads, utcnow
+from redash.utils import gen_query_hash, json_dumps, json_loads, utcnow, mustache_render
 from redash.worker import celery
 
 logger = get_task_logger(__name__)
@@ -285,7 +284,7 @@ def refresh_queries():
                 if query.options and len(query.options.get('parameters', [])) > 0:
                     query_params = {p['name']: p.get('value')
                                     for p in query.options['parameters']}
-                    query_text = pystache.render(query.query_text, query_params)
+                    query_text = mustache_render(query.query_text, query_params)
                 else:
                     query_text = query.query_text
 

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -98,6 +98,11 @@ def json_dumps(data, *args, **kwargs):
     return simplejson.dumps(data, *args, **kwargs)
 
 
+def mustache_render(template, context=None, **kwargs):
+    renderer = pystache.Renderer(escape=lambda u: u)
+    return renderer.render(template, context, **kwargs)
+
+
 def build_url(request, host, path):
     parts = request.host.split(':')
     if len(parts) > 1:


### PR DESCRIPTION
When using `{{ param }}` syntax, Mustache by-default will html-escape them. Possible work-around is to use `{{{ param }}}` syntax to render unescaped value, but most users don't know about it. Also, html-escaping is meaningless in SQL or JSON. This fix allows to use `{{ param }}` syntax to render unescaped values.

`mustache.js` does not have any options to affect this behavior; it uses `Mustache.escape` function to escape values, so we'll monkey-patch it with function that just returns it's argument.

`pystache` has an option to disable html-escaping.