### PR TITLE
Colors can now be controlled for bubble charts in UI.

### DIFF
--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -489,6 +489,7 @@ function prepareChartData(seriesList, options) {
 
     if (seriesOptions.type === 'bubble') {
       plotlySeries.marker = {
+        color: seriesColor,
         size: map(data, i => i.size),
       };
     } else if (seriesOptions.type === 'box') {


### PR DESCRIPTION
Bubble chart marker size override was previously clobbering seriesColor.