### PR TITLE
Update Cypress to use Page Objects

### DIFF
--- a/client/app/components/app-header/app-header.html
+++ b/client/app/components/app-header/app-header.html
@@ -86,7 +86,7 @@
           <!--<a href="users" title="Settings"><i class="fa fa-cog"></i></a>-->
         <!--</li>-->
         <li class="dropdown" uib-dropdown>
-          <a href="#" class="dropdown-toggle dropdown--profile" uib-dropdown-toggle data-cy="dropdown-profile">
+          <a href="#" class="dropdown-toggle dropdown--profile" uib-dropdown-toggle data-testid="ProfileDropdown">
             <img ng-src="{{ $ctrl.currentUser.profile_image_url }}" class="profile__image--navbar" width="20"/>
             <span class="dropdown--profile__username" ng-bind="$ctrl.currentUser.name"></span> <span
             class="caret caret--nav"></span></a>

--- a/client/app/components/dynamic-form.html
+++ b/client/app/components/dynamic-form.html
@@ -1,7 +1,7 @@
-<form name="dynamicForm">
+<form name="dynamicForm" data-testid="DynamicForm">
     <div class="form-group required" ng-class='{"has-error": (dynamicForm.targetName | showError)}'>
         <label class="control-label" for="dataSourceName">Name</label>
-        <input type="string" class="form-control" name="targetName" ng-model="target.name" autofocus required>
+        <input type="string" class="form-control" name="targetName" ng-model="target.name" data-testid="TargetName" autofocus required>
         <error-messages input="dynamicForm.targetName" form="dynamicForm"></error-messages>
     </div>
     <hr>
@@ -9,12 +9,12 @@
         <label ng-if="field.property.type !== 'checkbox'" class="control-label">{{field.property.title || field.name | toHuman}}</label>
         <input name="input" type="{{field.property.type}}" class="form-control" ng-model="target.options[field.name]" ng-required="field.property.required"
                ng-if="field.property.type !== 'file' && field.property.type !== 'checkbox'" accesskey="tab" placeholder="{{field.property.default}}"
-               data-cy="{{field.property.title || field.name | toHuman}}">
+               data-testid="{{field.property.title || field.name | toHuman}}">
 
         <label ng-if="field.property.type=='checkbox'">
             <input name="input" type="{{field.property.type}}" ng-model="target.options[field.name]" ng-required="field.property.required"
                    ng-if="field.property.type !== 'file'" accesskey="tab" placeholder="{{field.property.default}}"
-                   data-cy="{{field.property.title || field.name | toHuman}}">
+                   data-testid="{{field.property.title || field.name | toHuman}}">
             {{field.property.title || field.name | toHuman}}
         </label>
 
@@ -25,7 +25,7 @@
         <error-messages input="inner.input" form="inner"></error-messages>
     </div>
 
-    <button class="btn btn-block btn-primary m-b-10" ng-disabled="!dynamicForm.$valid" ng-click="saveChanges()">Save</button>
+    <button class="btn btn-block btn-primary m-b-10" ng-disabled="!dynamicForm.$valid" ng-click="saveChanges()" data-testid="SaveButton">Save</button>
     <span ng-repeat="action in actions">
         <button class="btn"
                 ng-class="action.class"

--- a/client/app/components/type-picker.html
+++ b/client/app/components/type-picker.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="row">
-        <div class="col-lg-12 database-source">
+        <div class="col-lg-12 database-source" data-testid="DatabaseSourceList">
             <div class="visual-card" ng-repeat="type in $ctrl.types | filter:$ctrl.filter:strict" ng-click="$ctrl.onTypeSelect(type)">
             <img ng-src="{{$ctrl.imgRoot}}/{{type.type}}.png" alt="{{type.name}}">
             <h3>{{type.name}}</h3>

--- a/cypress/cypress-server.js
+++ b/cypress/cypress-server.js
@@ -17,10 +17,13 @@ function execSetup() {
   post(baseUrl + '/setup', { formData: setupData });
 }
 
-function startServer() {
+function startServer(skipDependencies) {
   console.log('Starting the server...');
-            
-  execSync('docker-compose -p cypress build --build-arg skip_ds_deps=true', { stdio: 'inherit' });
+
+  if (skipDependencies) {
+    execSync('docker-compose -p cypress build --build-arg skip_ds_deps=true', { stdio: 'inherit' });
+  }
+
   execSync('docker-compose -p cypress up -d', { stdio: 'inherit' });
   execSync('docker-compose -p cypress run server create_db', { stdio: 'inherit' });
 }
@@ -34,11 +37,11 @@ const command = process.argv[2];
 
 switch (command) {
   case 'start':
-    startServer();
+    startServer(false);
     execSetup();
     break;
   case 'start-ci':
-    startServer();
+    startServer(true);
     break;
   case 'setup':
     execSetup();

--- a/cypress/integration/data-source/create_data_source_spec.js
+++ b/cypress/integration/data-source/create_data_source_spec.js
@@ -1,18 +1,23 @@
+import NewDataSourcePage from '../../pages/NewDataSourcePage';
+
 describe('Create Data Source', () => {
+  const newDataSourcePage = new NewDataSourcePage();
+
   beforeEach(() => {
     cy.login();
-    cy.visit('/data_sources');
+    newDataSourcePage.visit();
   });
 
   it('creates a new PostgreSQL data source', () => {
-    cy.contains('New Data Source').click();
-    cy.contains('PostgreSQL').click();
+    newDataSourcePage.selectSource('PostgreSQL');
 
-    cy.get('[name=targetName]').type('Redash');
-    cy.get('[data-cy=Host]').type('{selectall}localhost');
-    cy.get('[data-cy=User]').type('postgres');
-    cy.get('[data-cy=Password]').type('postgres');
-    cy.get('[data-cy="Database Name"]').type('postgres{enter}');
+    newDataSourcePage
+      .fill('TargetName', 'Redash')
+      .fill('Host', 'localhost')
+      .fill('User', 'postgres')
+      .fill('Password', 'postgres')
+      .fill('Database Name', 'postgres')
+      .submit();
 
     cy.contains('Saved.');
   });

--- a/cypress/integration/user/login_spec.js
+++ b/cypress/integration/user/login_spec.js
@@ -1,24 +1,31 @@
-describe('Login', () => {
-  beforeEach(() => {
-    cy.visit('/login');
-  });
+import LoginPage from '../../pages/LoginPage';
+import HomePage from '../../pages/HomePage';
 
-  it('greets the user', () => {
-    cy.contains('h3', 'Login to Redash');
+describe('Login', () => {
+  const loginPage = new LoginPage();
+
+  beforeEach(() => {
+    loginPage.visit();
   });
 
   it('shows message on failed login', () => {
-    cy.get('#inputEmail').type('admin@redash.io');
-    cy.get('#inputPassword').type('wrongpassword{enter}');
+    loginPage
+      .fillEmail('admin@redash.io')
+      .fillPassword('wrongpassword')
+      .submit();
 
-    cy.get('.alert').should('contain', 'Wrong email or password.');
+    cy.get(loginPage.errorMessage).contains('Wrong email or password.');
   });
 
   it('navigates to homepage with successful login', () => {
-    cy.get('#inputEmail').type('admin@redash.io');
-    cy.get('#inputPassword').type('password{enter}');
+    const homePage = new HomePage();
 
-    cy.title().should('eq', 'Redash');
+    loginPage
+      .fillEmail('admin@redash.io')
+      .fillPassword('password')
+      .submit();
+
+    homePage.validateTitle();
     cy.contains('Example Admin');
   });
 });

--- a/cypress/integration/user/logout_spec.js
+++ b/cypress/integration/user/logout_spec.js
@@ -1,13 +1,20 @@
+import LoginPage from '../../pages/LoginPage';
+import HomePage from '../../pages/HomePage';
+
 describe('Logout', () => {
+  const homePage = new HomePage();
+
   beforeEach(() => {
     cy.login();
-    cy.visit('/');
+    homePage.visit();
   });
 
   it('shows login page after logout', () => {
-    cy.get('[data-cy=dropdown-profile]').click();
+    const loginPage = new LoginPage();
+
+    cy.get(homePage.profileDropdown).click();
     cy.contains('Log out').click();
 
-    cy.title().should('eq', 'Login to Redash');
+    loginPage.validateTitle();
   });
 });

--- a/cypress/pages/HomePage.js
+++ b/cypress/pages/HomePage.js
@@ -1,0 +1,14 @@
+import Page from './Page';
+
+class HomePage extends Page {
+  constructor() {
+    super('/');
+    this.profileDropdown = '[data-testid=ProfileDropdown]';
+  }
+
+  validateTitle() {
+    cy.title().should('eq', 'Redash');
+  }
+}
+
+export default HomePage;

--- a/cypress/pages/LoginPage.js
+++ b/cypress/pages/LoginPage.js
@@ -1,0 +1,37 @@
+import Page from './Page';
+
+class LoginPage extends Page {
+  constructor() {
+    super('/login');
+    this.emailInput = '[data-testid=EmailInput]';
+    this.passwordInput = '[data-testid=PasswordInput]';
+    this.submitButton = '[data-testid=SubmitButton]';
+    this.errorMessage = '[data-testid=ErrorMessage]';
+  }
+
+  fillEmail(value) {
+    cy.get(this.emailInput)
+      .clear()
+      .type(value);
+
+    return this;
+  }
+
+  fillPassword(value) {
+    cy.get(this.passwordInput)
+      .clear()
+      .type(value);
+
+    return this;
+  }
+
+  submit() {
+    cy.get(this.submitButton).click();
+  }
+
+  validateTitle() {
+    cy.title().should('eq', 'Login to Redash');
+  }
+}
+
+export default LoginPage;

--- a/cypress/pages/NewDataSourcePage.js
+++ b/cypress/pages/NewDataSourcePage.js
@@ -1,0 +1,31 @@
+import Page from './Page';
+
+class NewDataSourcePage extends Page {
+  constructor() {
+    super('/data_sources/new');
+    this.databaseSourceList = '[data-testid=DatabaseSourceList]';
+    this.dynamicForm = '[data-testid=DynamicForm]';
+    this.saveButton = '[data-testid=SaveButton]';
+  }
+
+  selectSource(sourceName) {
+    cy.get(this.databaseSourceList)
+      .contains(sourceName)
+      .click();
+  }
+
+  fill(fieldName, value) {
+    cy.get(this.dynamicForm)
+      .get('[data-testid="' + fieldName + '"]')
+      .clear()
+      .type(value);
+
+    return this;
+  }
+
+  submit() {
+    cy.get(this.saveButton).click();
+  }
+}
+
+export default NewDataSourcePage;

--- a/cypress/pages/Page.js
+++ b/cypress/pages/Page.js
@@ -1,0 +1,11 @@
+class Page {
+  constructor(path) {
+    this.path = path;
+  }
+
+  visit() {
+    cy.visit(this.path);
+  }
+}
+
+export default Page;

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -8,7 +8,7 @@
     {% with messages = get_flashed_messages() %}
       {% if messages %}
         {% for message in messages %}
-          <div class="alert alert-danger" role="alert">{{ message }}</div>
+          <div class="alert alert-danger" role="alert" data-testid="ErrorMessage">{{ message }}</div>
         {% endfor %}
       {% endif %}
     {% endwith %}
@@ -41,14 +41,14 @@
       <input type="hidden" name="remember" value="on">
       <div class="form-group">
         <label for="inputEmail">{{ username_prompt or 'Email' }}</label>
-        <input type="text" class="form-control" id="inputEmail" name="email" value="{{email}}">
+        <input type="text" class="form-control" id="inputEmail" name="email" value="{{email}}" data-testid="EmailInput">
       </div>
       <div class="form-group">
         <label for="inputPassword">Password</label>
-        <input type="password" class="form-control" id="inputPassword" name="password">
+        <input type="password" class="form-control" id="inputPassword" name="password" data-testid="PasswordInput">
       </div>
 
-      <button type="submit" class="btn btn-primary btn-block m-t-25">Log In</button>
+      <button type="submit" class="btn btn-primary btn-block m-t-25" data-testid="SubmitButton">Log In</button>
     </form>
     {% if not hide_forgot_password %}
       <div class="m-t-25">


### PR DESCRIPTION
## Description
This updates Cypress tests to have a start on using Page Objects (#3055).

## Changes
- `npm run cypress:server start` was failing on dev environment because `--build-args` is not supported in version 2 of docker-compose - `--build-args` is now only used when running CI;
- Most of selectors were updated to use `data-testid` which is Cypress' recommended approach to select elements;
- Some page objects were created in order to start abstracting Pages.

Please give me your thoughts on what could be improved :grin: 