### PR TITLE
Prevent Query's updated_at from changing when it is linked to new query results

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -790,7 +790,8 @@ class QueryResult(db.Model, BelongsToOrgMixin):
             Query.data_source == data_source)
         for q in queries:
             q.latest_query_data = query_result
-            q.updated_at = q.updated_at + datetime.timedelta(milliseconds=1) # ugly hack to avoid Query's updated_at from changing in this specific scenario
+            # ugly hack to avoid Query's updated_at from changing in this specific scenario
+            q.updated_at = q.updated_at + datetime.timedelta(milliseconds=1)
             db.session.add(q)
         query_ids = [q.id for q in queries]
         logging.info("Updated %s queries with result (%s).", len(query_ids), query_hash)

--- a/redash/models.py
+++ b/redash/models.py
@@ -190,10 +190,17 @@ class MutableList(Mutable, list):
 
 
 class TimestampMixin(object):
-    updated_at = Column(db.DateTime(True), default=db.func.now(),
-                           onupdate=db.func.now(), nullable=False)
-    created_at = Column(db.DateTime(True), default=db.func.now(),
-                           nullable=False)
+    updated_at = Column(db.DateTime(True), default=db.func.now(), nullable=False)
+    created_at = Column(db.DateTime(True), default=db.func.now(), nullable=False)
+
+
+@listens_for(TimestampMixin, 'before_update', propagate=True)
+def timestamp_before_update(mapper, connection, target):
+    # Check if we really want to update the updated_at value
+    if hasattr(target, 'skip_updated_at'):
+        return
+
+    target.updated_at = db.func.now()
 
 
 class ChangeTrackingMixin(object):
@@ -790,8 +797,7 @@ class QueryResult(db.Model, BelongsToOrgMixin):
             Query.data_source == data_source)
         for q in queries:
             q.latest_query_data = query_result
-            # ugly hack to avoid Query's updated_at from changing in this specific scenario
-            q.updated_at = q.updated_at + datetime.timedelta(milliseconds=1)
+            q.skip_updated_at = True
             db.session.add(q)
         query_ids = [q.id for q in queries]
         logging.info("Updated %s queries with result (%s).", len(query_ids), query_hash)

--- a/redash/models.py
+++ b/redash/models.py
@@ -790,6 +790,7 @@ class QueryResult(db.Model, BelongsToOrgMixin):
             Query.data_source == data_source)
         for q in queries:
             q.latest_query_data = query_result
+            q.updated_at = q.updated_at + datetime.timedelta(milliseconds=1) # ugly hack to avoid Query's updated_at from changing in this specific scenario
             db.session.add(q)
         query_ids = [q.id for q in queries]
         logging.info("Updated %s queries with result (%s).", len(query_ids), query_hash)

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -8,9 +8,6 @@ from redash.utils import utcnow
 
 
 class QueryResultTest(BaseTestCase):
-    def setUp(self):
-        super(QueryResultTest, self).setUp()
-
     def test_get_latest_returns_none_if_not_found(self):
         found_query_result = models.QueryResult.get_latest(self.factory.data_source, "SELECT 1", 60)
         self.assertIsNone(found_query_result)

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -64,7 +64,7 @@ class QueryResultTest(BaseTestCase):
         self.assertEqual(found_query_result.id, qr.id)
 
     def test_store_result_does_not_modify_query_update_at(self):
-        original_updated_at = utcnow() - datetime.timedelta(weeks=1)
+        original_updated_at = utcnow() - datetime.timedelta(hours=1)
         query = self.factory.create_query(updated_at=original_updated_at)
 
         models.QueryResult.store_result(query.org_id, query.data_source, query.query_hash, query.query_text, "", 0, utcnow())

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -64,4 +64,9 @@ class QueryResultTest(BaseTestCase):
         self.assertEqual(found_query_result.id, qr.id)
 
     def test_store_result_does_not_modify_query_update_at(self):
-        pass
+        original_updated_at = utcnow() - datetime.timedelta(weeks=1)
+        query = self.factory.create_query(updated_at=original_updated_at)
+
+        models.QueryResult.store_result(query.org_id, query.data_source, query.query_hash, query.query_text, "", 0, utcnow())
+
+        assert original_updated_at.strftime("%X") == query.updated_at.strftime("%X")

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -66,4 +66,4 @@ class QueryResultTest(BaseTestCase):
 
         models.QueryResult.store_result(query.org_id, query.data_source, query.query_hash, query.query_text, "", 0, utcnow())
 
-        assert original_updated_at.strftime("%X") == query.updated_at.strftime("%X")
+        assert original_updated_at == query.updated_at

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -1,0 +1,67 @@
+#encoding: utf8
+import datetime
+
+from tests import BaseTestCase
+
+from redash import models
+from redash.utils import utcnow
+
+
+class QueryResultTest(BaseTestCase):
+    def setUp(self):
+        super(QueryResultTest, self).setUp()
+
+    def test_get_latest_returns_none_if_not_found(self):
+        found_query_result = models.QueryResult.get_latest(self.factory.data_source, "SELECT 1", 60)
+        self.assertIsNone(found_query_result)
+
+    def test_get_latest_returns_when_found(self):
+        qr = self.factory.create_query_result()
+        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, 60)
+
+        self.assertEqual(qr, found_query_result)
+
+    def test_get_latest_doesnt_return_query_from_different_data_source(self):
+        qr = self.factory.create_query_result()
+        data_source = self.factory.create_data_source()
+        found_query_result = models.QueryResult.get_latest(data_source, qr.query_text, 60)
+
+        self.assertIsNone(found_query_result)
+
+    def test_get_latest_doesnt_return_if_ttl_expired(self):
+        yesterday = utcnow() - datetime.timedelta(days=1)
+        qr = self.factory.create_query_result(retrieved_at=yesterday)
+
+        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, max_age=60)
+
+        self.assertIsNone(found_query_result)
+
+    def test_get_latest_returns_if_ttl_not_expired(self):
+        yesterday = utcnow() - datetime.timedelta(seconds=30)
+        qr = self.factory.create_query_result(retrieved_at=yesterday)
+
+        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, max_age=120)
+
+        self.assertEqual(found_query_result, qr)
+
+    def test_get_latest_returns_the_most_recent_result(self):
+        yesterday = utcnow() - datetime.timedelta(seconds=30)
+        old_qr = self.factory.create_query_result(retrieved_at=yesterday)
+        qr = self.factory.create_query_result()
+
+        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, 60)
+
+        self.assertEqual(found_query_result.id, qr.id)
+
+    def test_get_latest_returns_the_last_cached_result_for_negative_ttl(self):
+        yesterday = utcnow() + datetime.timedelta(days=-100)
+        very_old = self.factory.create_query_result(retrieved_at=yesterday)
+
+        yesterday = utcnow() + datetime.timedelta(days=-1)
+        qr = self.factory.create_query_result(retrieved_at=yesterday)
+        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, -1)
+
+        self.assertEqual(found_query_result.id, qr.id)
+
+    def test_store_result_does_not_modify_query_update_at(self):
+        pass

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -66,4 +66,4 @@ class QueryResultTest(BaseTestCase):
 
         models.QueryResult.store_result(query.org_id, query.data_source, query.query_hash, query.query_text, "", 0, utcnow())
 
-        assert original_updated_at == query.updated_at
+        self.assertEqual(original_updated_at, query.updated_at)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -246,63 +246,6 @@ class QueryArchiveTest(BaseTestCase):
         self.assertEqual(db.session.query(models.AlertSubscription).get(subscription.id), None)
 
 
-class QueryResultTest(BaseTestCase):
-    def setUp(self):
-        super(QueryResultTest, self).setUp()
-
-    def test_get_latest_returns_none_if_not_found(self):
-        found_query_result = models.QueryResult.get_latest(self.factory.data_source, "SELECT 1", 60)
-        self.assertIsNone(found_query_result)
-
-    def test_get_latest_returns_when_found(self):
-        qr = self.factory.create_query_result()
-        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, 60)
-
-        self.assertEqual(qr, found_query_result)
-
-    def test_get_latest_doesnt_return_query_from_different_data_source(self):
-        qr = self.factory.create_query_result()
-        data_source = self.factory.create_data_source()
-        found_query_result = models.QueryResult.get_latest(data_source, qr.query_text, 60)
-
-        self.assertIsNone(found_query_result)
-
-    def test_get_latest_doesnt_return_if_ttl_expired(self):
-        yesterday = utcnow() - datetime.timedelta(days=1)
-        qr = self.factory.create_query_result(retrieved_at=yesterday)
-
-        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, max_age=60)
-
-        self.assertIsNone(found_query_result)
-
-    def test_get_latest_returns_if_ttl_not_expired(self):
-        yesterday = utcnow() - datetime.timedelta(seconds=30)
-        qr = self.factory.create_query_result(retrieved_at=yesterday)
-
-        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, max_age=120)
-
-        self.assertEqual(found_query_result, qr)
-
-    def test_get_latest_returns_the_most_recent_result(self):
-        yesterday = utcnow() - datetime.timedelta(seconds=30)
-        old_qr = self.factory.create_query_result(retrieved_at=yesterday)
-        qr = self.factory.create_query_result()
-
-        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, 60)
-
-        self.assertEqual(found_query_result.id, qr.id)
-
-    def test_get_latest_returns_the_last_cached_result_for_negative_ttl(self):
-        yesterday = utcnow() + datetime.timedelta(days=-100)
-        very_old = self.factory.create_query_result(retrieved_at=yesterday)
-
-        yesterday = utcnow() + datetime.timedelta(days=-1)
-        qr = self.factory.create_query_result(retrieved_at=yesterday)
-        found_query_result = models.QueryResult.get_latest(qr.data_source, qr.query_text, -1)
-
-        self.assertEqual(found_query_result.id, qr.id)
-
-
 class TestUnusedQueryResults(BaseTestCase):
     def test_returns_only_unused_query_results(self):
         two_weeks_ago = utcnow() - datetime.timedelta(days=14)


### PR DESCRIPTION
Solves #2978, but in a way that makes chewing street chalk feel pleasant.

Basically, the updated_at column was important to keep for all changes _other than_ the change of associated query data, and the only way I could find to override `TimestampMixin`'s onupdate logic was to assign a new value in that same transaction. This is the closest value I could find 🤦‍♂️

Please let me know if you can find a better solution.