### PR TITLE
Switch BigQuery Standard SQL as the default

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -110,7 +110,8 @@ class BigQuery(BaseQueryRunner):
                 },
                 'useStandardSql': {
                     "type": "boolean",
-                    'title': "Use Standard SQL (Beta)",
+                    'title': "Use Standard SQL",
+                    "default": True,
                 },
                 'location': {
                     "type": "string",
@@ -238,7 +239,9 @@ class BigQuery(BaseQueryRunner):
         for column in table_data['schema']['fields']:
             columns.extend(self._get_columns_schema_column(column))
 
-        return {'name': table_data['id'], 'columns': columns}
+        project_id = self._get_project_id()
+        table_name = table_data['id'].replace("%s:" % project_id, "")
+        return {'name': table_name, 'columns': columns}
 
     def _get_columns_schema_column(self, column):
         columns = []
@@ -339,7 +342,8 @@ class BigQueryGCE(BigQuery):
                 },
                 'useStandardSql': {
                     "type": "boolean",
-                    'title': "Use Standard SQL (Beta)",
+                    'title': "Use Standard SQL",
+                    "default": True,
                 },
                 'location': {
                     "type": "string",


### PR DESCRIPTION
Fix #2770

According to [the document](https://cloud.google.com/bigquery/docs/reference/legacy-sql),  project_name is optional in SQL. Moreover,  schema browser becomes simpler.

Because of that, deleted project_name in schema browser.

## Screenshot

Add Data Source

| Before | After |
| ------ | ----- |
| <img width="410" alt="ds_before" src="https://user-images.githubusercontent.com/3317191/48547892-fe4be200-e90e-11e8-82fa-55c9078c715c.png"> |  <img width="408" alt="ds_after" src="https://user-images.githubusercontent.com/3317191/48547891-fe4be200-e90e-11e8-8049-311902a9bf74.png"> |

Schema Browser

| Before | After |
| ------ | ----- |
| <img width="363" alt="table_name1" src="https://user-images.githubusercontent.com/3317191/48547491-1d963f80-e90e-11e8-8980-b6eb2e847117.png"> | <img width="264" alt="table_name2" src="https://user-images.githubusercontent.com/3317191/48547492-1d963f80-e90e-11e8-8ae2-d8558c41dc1e.png"> |
