### PR TITLE
Fix forked query is opened in the same tab

### DIFF
--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -178,7 +178,9 @@ function QueryViewCtrl(
   };
 
   $scope.duplicateQuery = () => {
-    const tabName = 'duplicatedQueryTab';
+    // To prevent opening the same tab, name must be unique for each browser
+    const tabName = 'duplicatedQueryTab' + Math.random().toString();
+
     $window.open('', tabName);
     Query.fork({ id: $scope.query.id }, (newQuery) => {
       const url = newQuery.getSourceLink();


### PR DESCRIPTION
Fix #3118.

The value of `tabName` must be unique for each browser. 

`Math.random()` actually isn't strictly unique. But I think it's enough in this case.