### PR TITLE
Fix schema refresh fails to work on MySQL 8

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -98,9 +98,9 @@ class Mysql(BaseSQLQueryRunner):
 
     def _get_tables(self, schema):
         query = """
-        SELECT col.table_schema,
-               col.table_name,
-               col.column_name
+        SELECT col.table_schema as table_schema,
+               col.table_name as table_name,
+               col.column_name as column_name
         FROM `information_schema`.`columns` col
         WHERE col.table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
         """


### PR DESCRIPTION
Currently MySQL 8 returns capitalized column headers for schema refreshing query. This causes schema refreshing to fail for MySQL 8.
This PR adds a fix for that problem.

Tested on local MySQL v8.0.13 and RDS MySQL 8.