### PR TITLE
Improve tag link colors and fix group tags on Users page

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -240,10 +240,10 @@ edit-in-place p.editable:hover {
 
 a.label-tag {
   background: fade(@redash-gray, 15%);
-  color: #333;
+  color: darken(@redash-gray, 15%);
 
   &:hover {
-    color: #333;
+    color: darken(@redash-gray, 15%);
     background: fade(@redash-gray, 25%);
   }
 }

--- a/client/app/pages/users/list.html
+++ b/client/app/pages/users/list.html
@@ -57,7 +57,7 @@
               <span class="text-muted"> ({{user.email}})</span>
             </td>
             <td>
-              <a ng-repeat="group in user.groups" class="label label-default" href="groups/{{group.id}}">{{group.name}}</a>
+              <a ng-repeat="group in user.groups" class="label label-tag" href="groups/{{group.id}}">{{group.name}}</a>
             </td>
             <td>
               <span am-time-ago="user.created_at"></span>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2378022/49239616-76340500-f403-11e8-9272-2b461b01fa2a.png)

After:
![image](https://user-images.githubusercontent.com/2378022/49239637-821fc700-f403-11e8-8904-4ff1c92784d5.png)
