### PR TITLE
FIX: Reject empty query name

### DIFF
--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -40,7 +40,7 @@ export class EditInPlace extends React.Component {
 
   stopEditing = () => {
     const newValue = this.inputRef.current.value;
-    const ignorableBlank = this.props.ignoreBlanks && this.props.value === '';
+    const ignorableBlank = this.props.ignoreBlanks && newValue === '';
     if (!ignorableBlank && newValue !== this.props.value) {
       this.props.onDone(newValue);
     }


### PR DESCRIPTION
Hi, folks

We can set empty query name for now on master branch.

I think this bug comes from migration from Angular to React.

The following link is previous version of implementation.

https://github.com/getredash/redash/blob/v5.0.2/client/app/components/edit-in-place.js#L62

Thanks,