### PR TITLE
Make it possible to move up one line by Ctrl+P on macOS

### DIFF
--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -104,7 +104,8 @@ class QueryEditor extends React.Component {
       editor.commands.bindKey('Cmd+L', null);
       editor.commands.bindKey('Ctrl+L', null);
 
-      editor.commands.bindKey('Ctrl+P', 'golineup');
+      // golineup only mac
+      editor.commands.bindKey({ win: null, mac: 'Ctrl+P' }, 'golineup');
 
       // eslint-disable-next-line react/prop-types
       this.props.QuerySnippet.query((snippets) => {

--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -102,8 +102,9 @@ class QueryEditor extends React.Component {
     this.onLoad = (editor) => {
       // Release Cmd/Ctrl+L to the browser
       editor.commands.bindKey('Cmd+L', null);
-      editor.commands.bindKey('Ctrl+P', null);
       editor.commands.bindKey('Ctrl+L', null);
+
+      editor.commands.bindKey('Ctrl+P', 'golineup');
 
       // eslint-disable-next-line react/prop-types
       this.props.QuerySnippet.query((snippets) => {

--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -104,7 +104,9 @@ class QueryEditor extends React.Component {
       editor.commands.bindKey('Cmd+L', null);
       editor.commands.bindKey('Ctrl+L', null);
 
-      // golineup only mac
+      // Ignore Ctrl+P to open new parameter dialog
+      editor.commands.bindKey({ win: 'Ctrl+P', mac: null }, null);
+      // Lineup only mac
       editor.commands.bindKey({ win: null, mac: 'Ctrl+P' }, 'golineup');
 
       // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
Ctrl+P in Query Editor, the cursor will move up one line.

Other directions keyboard shortcuts are already available.

Ref: [Mac keyboard shortcuts \- Apple Support](https://support.apple.com/en-us/HT201236)
- Control-F: Move one character forward.
- Control-B: Move one character backward.
- Control-N: Move down one line.

I have only tested this feature on Chrome with macOS.