### PR TITLE
Fix disable error message

### DIFF
--- a/client/app/services/user.js
+++ b/client/app/services/user.js
@@ -39,11 +39,9 @@ function disableUser(user, toastr, $sanitize) {
       let message =
         response.data && response.data.message
           ? response.data.message
-          : response.statusText;
-      if (!isString(message)) {
-        message = 'Unknown error';
-      }
-      toastr.error(`Cannot disable user <b>${userName}</b><br>${message}`, { allowHtml: true });
+          : `Cannot disable user <b>${userName}</b><br>${response.statusText}`
+
+      toastr.error(message, { allowHtml: true });
     });
 }
 

--- a/client/app/services/user.js
+++ b/client/app/services/user.js
@@ -35,8 +35,11 @@ function disableUser(user, toastr, $sanitize) {
       user.profile_image_url = data.data.profile_image_url;
       return data;
     })
-    .catch((response) => {
-      let message = response instanceof Error ? response.message : response.statusText;
+    .catch(response => {
+      let message =
+        response.data && response.data.message
+          ? response.data.message
+          : response.statusText;
       if (!isString(message)) {
         message = 'Unknown error';
       }

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -219,7 +219,7 @@ class UserDisableResource(BaseResource):
         # admin cannot disable self; current user is an admin (`@require_admin`)
         # so just check user id
         if user.id == current_user.id:
-            abort(400, message="You cannot disable your own account. "
+            abort(403, message="You cannot disable your own account. "
                                "Please ask another admin to do this for you.")
         user.disable()
         models.db.session.commit()

--- a/tests/handlers/test_users.py
+++ b/tests/handlers/test_users.py
@@ -16,7 +16,7 @@ class TestUserListResourcePost(BaseTestCase):
 
         rv = self.make_request('post', '/api/users', data={'name': 'User'}, user=admin)
         self.assertEqual(rv.status_code, 400)
-    
+
     def test_returns_400_when_using_temporary_email(self):
         admin = self.factory.create_admin()
 
@@ -149,7 +149,7 @@ class TestUserResourcePost(BaseTestCase):
 
         user = models.User.query.get(self.factory.user.id)
         self.assertTrue(user.verify_password(new_password))
-    
+
     def test_returns_400_when_using_temporary_email(self):
         admin = self.factory.create_admin()
 
@@ -203,7 +203,7 @@ class TestUserDisable(BaseTestCase):
         self.assertFalse(admin_user.is_disabled)
 
         rv = self.make_request('post', "/api/users/{}/disable".format(admin_user.id), user=admin_user)
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 403)
 
         # user should stay enabled
         admin_user = models.User.query.get(admin_user.id)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/289488/49696393-103d3f80-fbb2-11e8-9238-8e1b55dfa149.png)

After:

![image](https://user-images.githubusercontent.com/289488/49696384-fc91d900-fbb1-11e8-8bf4-d625a0ee08e8.png)

Also, I changed the status code to 403 ("The request was valid, but the server is refusing action. The user might not have the necessary permissions for a resource, or may need an account of some sort."), which feels to me more suitable than a 400 ("The server cannot or will not process the request due to an apparent client error (e.g., malformed request syntax, size too large, invalid request message framing, or deceptive request routing)")