### PR TITLE
Remove missing coverage from pytest terminal output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;"
       - run:
           name: Run Tests
-          command: docker-compose run --name tests redash tests --junitxml=junit.xml tests/
+          command: docker-compose run --name tests redash tests --junitxml=junit.xml --cov-report xml --cov=redash --cov-config .coveragerc tests/
       - run:
           name: Copy Test Results
           command: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-addopts = --cov-report xml --cov=redash --cov-config .coveragerc
 norecursedirs = *.egg .eggs dist build docs .tox

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov-report xml --cov-report=term-missing --cov=redash --cov-config .coveragerc
+addopts = --cov-report xml --cov=redash --cov-config .coveragerc
 norecursedirs = *.egg .eggs dist build docs .tox


### PR DESCRIPTION
Don't know about you, but when I run pytest, I don't feel like seeing a wall of text with missing coverage is insightful in any way. I'd rather cleanly see the test output. WDYT?