### PR TITLE
Show Sort Y only when type is Heatmap

### DIFF
--- a/client/app/visualizations/chart/chart-editor.html
+++ b/client/app/visualizations/chart/chart-editor.html
@@ -243,7 +243,7 @@
         <input ng-model="yAxis.rangeMax" type="number" step="any" placeholder="Auto" class="form-control">
       </div>
 
-      <div class="checkbox">
+      <div class="checkbox" ng-if="options.globalSeriesType == 'heatmap'">
         <label>
           <input type="checkbox" ng-model="options.sortY">
           <i class="input-helper"></i> Sort Values


### PR DESCRIPTION
fixes #3204.

Could not think of other cases where y-axis values that benefit from sorting. 

We should come back when we think about horizontal bar charts and horizontal box plots, etc.