### PR TITLE
Fix: missing param fails for object values (like date range)

### DIFF
--- a/redash/handlers/embed.py
+++ b/redash/handlers/embed.py
@@ -11,7 +11,7 @@ from redash import models, utils
 from redash.handlers import routes
 from redash.handlers.base import (get_object_or_404, org_scoped_rule,
                                   record_event)
-from redash.handlers.query_results import collect_query_parameters
+from redash.utils import find_missing_params
 from redash.handlers.static import render_index
 from redash.utils import gen_query_hash, mustache_render
 
@@ -23,13 +23,11 @@ from redash.utils import gen_query_hash, mustache_render
 #             on the client side. Please don't reuse in other API handlers.
 #
 def run_query_sync(data_source, parameter_values, query_text, max_age=0):
-    query_parameters = set(collect_query_parameters(query_text))
-    missing_params = set(query_parameters) - set(parameter_values.keys())
+    missing_params = find_missing_params(query_text, parameter_values)
     if missing_params:
         raise Exception('Missing parameter value for: {}'.format(", ".join(missing_params)))
 
-    if query_parameters:
-        query_text = mustache_render(query_text, parameter_values)
+    query_text = mustache_render(query_text, parameter_values)
 
     if max_age <= 0:
         query_result = None

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -104,9 +104,13 @@ def parameter_names(parameter_values):
 
 def run_query(data_source, parameter_values, query_text, query_id, max_age=0):
     query_parameters = set(collect_query_parameters(query_text))
+    print set(query_parameters)
+
     missing_params = set(query_parameters) - set(parameter_names(parameter_values))
+    print missing_params
     if missing_params:
-        return error_response('Missing parameter value for: {}'.format(", ".join(missing_params)))
+        print "hello"
+        return error_response(u'Missing parameter value for: {}'.format(u", ".join(missing_params)))
 
     if data_source.paused:
         if data_source.pause_reason:

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -104,12 +104,9 @@ def parameter_names(parameter_values):
 
 def run_query(data_source, parameter_values, query_text, query_id, max_age=0):
     query_parameters = set(collect_query_parameters(query_text))
-    print set(query_parameters)
 
     missing_params = set(query_parameters) - set(parameter_names(parameter_values))
-    print missing_params
     if missing_params:
-        print "hello"
         return error_response(u'Missing parameter value for: {}'.format(u", ".join(missing_params)))
 
     if data_source.paused:

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -89,9 +89,22 @@ def run_query_sync(data_source, parameter_values, query_text, max_age=0):
             abort(503, message="Unable to get result from the database.")
         return None
 
+
+def parameter_names(parameter_values):
+    names = []
+    for key, value in parameter_values.iteritems():
+        if isinstance(value, dict):
+            for inner_key in value.keys():
+                names.append(u'{}.{}'.format(key, inner_key))
+        else:
+            names.append(key)
+    
+    return names
+
+
 def run_query(data_source, parameter_values, query_text, query_id, max_age=0):
     query_parameters = set(collect_query_parameters(query_text))
-    missing_params = set(query_parameters) - set(parameter_values.keys())
+    missing_params = set(query_parameters) - set(parameter_names(parameter_values))
     if missing_params:
         return error_response('Missing parameter value for: {}'.format(", ".join(missing_params)))
 

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -171,6 +171,23 @@ def collect_query_parameters(query):
     return keys
 
 
+def parameter_names(parameter_values):
+    names = []
+    for key, value in parameter_values.iteritems():
+        if isinstance(value, dict):
+            for inner_key in value.keys():
+                names.append(u'{}.{}'.format(key, inner_key))
+        else:
+            names.append(key)
+
+    return names
+
+
+def find_missing_params(query_text, parameter_values):
+    query_parameters = set(collect_query_parameters(query_text))
+    return set(query_parameters) - set(parameter_names(parameter_values))
+
+
 def collect_parameters_from_request(args):
     parameters = {}
 


### PR DESCRIPTION
Apparently, introducing `SQLQuery` broke Date Range parameters. This fixes the problem and DRYes the missing parameters code a bit.