### PR TITLE
Tests for find_missing_params

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from unittest import TestCase
 
 from redash.utils import (build_url, collect_parameters_from_request,
-                          collect_query_parameters, filter_none,
+                          find_missing_params, filter_none,
                           json_dumps, generate_token)
 
 DummyRequest = namedtuple('DummyRequest', ['host', 'scheme'])
@@ -23,6 +23,33 @@ class TestBuildUrl(TestCase):
         self.assertEqual("http://example.com/test", build_url(DummyRequest("example.com:80", "http"), "example.com", "/test"))
         self.assertEqual("https://example.com:80/test", build_url(DummyRequest("example.com:80", "https"), "example.com", "/test"))
         self.assertEqual("http://example.com:443/test", build_url(DummyRequest("example.com:443", "http"), "example.com", "/test"))
+
+
+class TestFindMissingParams(TestCase):
+    def test_returns_empty_list_for_regular_query(self):
+        query = u"SELECT 1"
+        self.assertEqual(set([]), find_missing_params(query, {}))
+
+    def test_finds_all_params_when_missing(self):
+        query = u"SELECT {{param}} FROM {{table}}"
+        self.assertEqual(set(['param', 'table']), find_missing_params(query, {}))
+
+    def test_finds_all_params(self):
+        query = u"SELECT {{param}} FROM {{table}}"
+        self.assertEqual(set([]), find_missing_params(query, {'param': 'value', 'table': 'value'}))
+
+    def test_deduplicates_params(self):
+        query = u"SELECT {{param}}, {{param}} FROM {{table}}"
+        self.assertEqual(set([]), find_missing_params(query, {'param': 'value', 'table': 'value'}))
+
+    def test_handles_nested_params(self):
+        query = u"SELECT {{param}}, {{param}} FROM {{table}} -- {{#test}} {{nested_param}} {{/test}}"
+        self.assertEqual(set(['test', 'nested_param']),
+                find_missing_params(query, {'param': 'value', 'table': 'value'}))
+
+    def test_handles_objects(self):
+        query = u"SELECT * FROM USERS WHERE created_at between '{{ created_at.start }}' and '{{ created_at.end }}'"
+        self.assertEqual(set([]), find_missing_params(query, {'created_at': {'start': 1, 'end': 2}}))
 
 
 class TestCollectParametersFromRequest(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,27 +25,6 @@ class TestBuildUrl(TestCase):
         self.assertEqual("http://example.com:443/test", build_url(DummyRequest("example.com:443", "http"), "example.com", "/test"))
 
 
-class TestCollectParametersFromQuery(TestCase):
-    def test_returns_empty_list_for_regular_query(self):
-        query = u"SELECT 1"
-        self.assertEqual([], collect_query_parameters(query))
-
-    def test_finds_all_params(self):
-        query = u"SELECT {{param}} FROM {{table}}"
-        params = ['param', 'table']
-        self.assertEqual(params, collect_query_parameters(query))
-
-    def test_deduplicates_params(self):
-        query = u"SELECT {{param}}, {{param}} FROM {{table}}"
-        params = ['param', 'table']
-        self.assertEqual(params, collect_query_parameters(query))
-
-    def test_handles_nested_params(self):
-        query = u"SELECT {{param}}, {{param}} FROM {{table}} -- {{#test}} {{nested_param}} {{/test}}"
-        params = ['param', 'table', 'test', 'nested_param']
-        self.assertEqual(params, collect_query_parameters(query))
-
-
 class TestCollectParametersFromRequest(TestCase):
     def test_ignores_non_prefixed_values(self):
         self.assertEqual({}, collect_parameters_from_request({'test': 1}))


### PR DESCRIPTION
Since `collect_query_parameters` is now hidden in `find_missing_params`, we don't really care about testing it, and instead we test the exposed function - `find_missing_params`.

This also adds a test for missing object params.