### PR TITLE
Update webpack-build-notifier to dismiss warn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,16 +3025,6 @@
         "rsvp": "^3.3.3"
       }
     },
-    "cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~1.0.0"
-      }
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3291,33 +3281,6 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        }
-      }
-    },
-    "cli-usage": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
-      "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
-      "dev": true,
-      "requires": {
-        "marked": "^0.3.6",
-        "marked-terminal": "^1.6.2"
       }
     },
     "cli-width": {
@@ -6515,7 +6478,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6880,7 +6844,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6928,6 +6893,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6966,11 +6932,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10700,64 +10668,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "lodash._arraycopy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
-      "dev": true
-    },
-    "lodash._arrayeach": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
-      "dev": true
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._baseclone": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true,
-      "requires": {
-        "lodash._arraycopy": "^3.0.0",
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basefor": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basefor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
-      "dev": true
-    },
     "lodash._baseget": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/lodash._baseget/-/lodash._baseget-3.7.2.tgz",
       "integrity": "sha1-G2rh1frPPCVTI1ChPBGXy4u2dPQ=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true
     },
     "lodash._getnative": {
@@ -10773,12 +10687,6 @@
       "requires": {
         "lodash.isarray": "^3.0.0"
       }
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -10848,12 +10756,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -11065,55 +10967,6 @@
       "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
       "requires": {
         "nopt": "~2.1.1"
-      }
-    },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-      "dev": true
-    },
-    "marked-terminal": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
-      "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
-      "dev": true,
-      "requires": {
-        "cardinal": "^1.0.0",
-        "chalk": "^1.1.3",
-        "cli-table": "^0.3.1",
-        "lodash.assign": "^4.2.0",
-        "node-emoji": "^1.4.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
     "mat4-decompose": {
@@ -11941,15 +11794,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "node-emoji": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-      "dev": true,
-      "requires": {
-        "lodash.toarray": "^4.4.0"
-      }
-    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -12068,30 +11912,15 @@
       }
     },
     "node-notifier": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
-      "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "cli-usage": "^0.1.1",
-        "growly": "^1.2.0",
-        "lodash.clonedeep": "^3.0.0",
-        "minimist": "^1.1.1",
-        "semver": "^5.1.0",
-        "shellwords": "^0.1.0",
-        "which": "^1.0.5"
-      },
-      "dependencies": {
-        "lodash.clonedeep": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-          "dev": true,
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0"
-          }
-        }
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "nopt": {
@@ -14755,23 +14584,6 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
-      }
-    },
-    "redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "dev": true,
-      "requires": {
-        "esprima": "~3.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
-          "dev": true
-        }
       }
     },
     "reduce-css-calc": {
@@ -18158,25 +17970,14 @@
       }
     },
     "webpack-build-notifier": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/webpack-build-notifier/-/webpack-build-notifier-0.1.16.tgz",
-      "integrity": "sha512-DzMoWeMgwATLLh2j3W/gfZ2wNuywoMfBJ6+rdf5ulvKoCuafQNDCNGE80MPRmaYu2zmnH5YtCSn64bYJGzt4QQ==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/webpack-build-notifier/-/webpack-build-notifier-0.1.30.tgz",
+      "integrity": "sha512-HeZ4Wr8XP7W0kSmPQkZCXARQVIjVFNPyJBdUqkqcE0ySYNjr6vOH3ufHESLPuy5KmMRUjHJdqJ6y3McDfCjJxQ==",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0",
-        "node-notifier": "^4.1.0",
+        "node-notifier": "5.2.1",
         "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
     "webpack-bundle-analyzer": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "request": "^2.88.0",
     "url-loader": "^0.5.9",
     "webpack": "^4.20.2",
-    "webpack-build-notifier": "^0.1.16",
+    "webpack-build-notifier": "^0.1.30",
     "webpack-bundle-analyzer": "^2.11.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.9",


### PR DESCRIPTION
Hi ✋ Fix warn on `npm run build` 

```
(node:5736) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```

refs: https://github.com/RoccoC/webpack-build-notifier/pull/24