### PR TITLE
Fix: forked query wasn't opening in MULTI_ORG env

### DIFF
--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -183,8 +183,8 @@ function QueryViewCtrl(
 
     $window.open('', tabName);
     Query.fork({ id: $scope.query.id }, (newQuery) => {
-      const url = newQuery.getSourceLink();
-      $window.open(url, tabName);
+      const queryUrl = newQuery.getUrl(true);
+      $window.open(queryUrl, tabName);
     });
   };
 
@@ -508,4 +508,3 @@ export default function init(ngModule) {
 }
 
 init.init = true;
-


### PR DESCRIPTION
`getSourceLink` returned an absolute url (starting with `/`) while `getUrl` returns one without. We can probably remove `getSourceLink` and just use `getUrl` but I didn't have the change to test it.