### PR TITLE
Fix: Query editor duplicates keystrokes (#2972)

### DIFF
--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -108,7 +108,14 @@ class QueryEditor extends React.Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     if (!nextProps.schema) {
-      return { keywords: [], liveAutocompleteDisabled: false };
+      return {
+        keywords: {
+          table: [],
+          column: [],
+          tableColumn: [],
+        },
+        liveAutocompleteDisabled: false,
+      };
     } else if (nextProps.schema !== prevState.schema) {
       const tokensCount = nextProps.schema.reduce((totalLength, table) => totalLength + table.columns.length, 0);
       return {


### PR DESCRIPTION
Bug in code caused js error which messed up the query editor.
`keywords` was set to empty array instead of the `table/column/tableColumn` structure.

Closes #2972.