### PR TITLE
Feature: Refresh schedule - save/cancel actions

### DIFF
--- a/client/app/assets/less/redash/ant.less
+++ b/client/app/assets/less/redash/ant.less
@@ -5,6 +5,7 @@
 @import '~antd/lib/modal/style/index.less';
 @import '~antd/lib/tooltip/style/index.less';
 @import '~antd/lib/select/style/index.less';
+@import '~antd/lib/button/style/index.less';
 
 // Overwritting Ant Design defaults to fit into Redash current style
 @font-family-no-number  : @redash-font;


### PR DESCRIPTION
This is part of a PR batch to finalize the refresh-schedule feature.
After merging all changes in to `feature/refresh-schedule/emtwo` it should be merged into master.

#### What changed
Currently any change to schedule params saves it.
Was requested to add footer buttons instead - save on "OK", cancel on "X"/"Cancel".

#### Test it out
1. In query page, click the refresh scheduler (usually "Never")
2. Make some changes, click **cancel**, make sure scheduler remains unchanged.
3. Make some changes, click **ok**, make sure scheduler changed accordingly.

    <img src="https://user-images.githubusercontent.com/486954/50643227-1e466c00-0f76-11e9-89de-9b9d6278d347.gif " width="320" />

#### Implementation notes
Instead of updating `props.query` on every form input change, I let it update a clone of `props.query.schedule` which upon **ok** triggers update and upon **cancel** resets the state to the original schedule stored in `props.query`.

Extra feature - clicking on **ok** without any change will not trigger a **save**. For UX reasons.
