### PR TITLE
Feature: Refresh schedule - styling

### DIFF
--- a/client/app/assets/less/redash/ant.less
+++ b/client/app/assets/less/redash/ant.less
@@ -6,6 +6,7 @@
 @import '~antd/lib/tooltip/style/index.less';
 @import '~antd/lib/select/style/index.less';
 @import '~antd/lib/button/style/index.less';
+@import '~antd/lib/radio/style/index.less';
 
 // Overwritting Ant Design defaults to fit into Redash current style
 @font-family-no-number  : @redash-font;

--- a/client/app/assets/less/redash/ant.less
+++ b/client/app/assets/less/redash/ant.less
@@ -7,6 +7,7 @@
 @import '~antd/lib/select/style/index.less';
 @import '~antd/lib/button/style/index.less';
 @import '~antd/lib/radio/style/index.less';
+@import '~antd/lib/time-picker/style/index.less';
 
 // Overwritting Ant Design defaults to fit into Redash current style
 @font-family-no-number  : @redash-font;

--- a/client/app/components/queries/ScheduleDialog.css
+++ b/client/app/components/queries/ScheduleDialog.css
@@ -1,5 +1,5 @@
 .schedule {
-  width: 300px !important;
+  width: 449px !important;
   margin: 0 auto;
 }
 
@@ -7,7 +7,20 @@
   padding: 5px 0px;
 }
 
-.schedule-component > div {
-  padding-right: 5px;
-  float: left;
+.schedule-component > * {
+  display: inline-block;
+}
+
+.schedule-component h5 {
+  margin-right: 10px;
+  width: 87px;
+  text-align: right;
+}
+
+.schedule-component > div > *:not(:last-child) {
+  margin-right: 3px;
+}
+
+.schedule-component datepicker {
+  display: block;
 }

--- a/client/app/components/queries/ScheduleDialog.jsx
+++ b/client/app/components/queries/ScheduleDialog.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'antd/lib/modal';
 import DatePicker from 'antd/lib/date-picker';
+import Select from 'antd/lib/select';
+import Radio from 'antd/lib/radio';
 import { range, padStart, clone, isEqual } from 'lodash';
 import moment from 'moment';
 import { secondsToInterval, intervalToSeconds, IntervalEnum } from '@/filters';
@@ -23,6 +25,7 @@ const HOUR_OPTIONS = range(0, 24).map(x => padStart(x, 2, '0')); // [00, 01, 02,
 const MINUTE_OPTIONS = range(0, 60, 5).map(x => padStart(x, 2, '0')); // [00, 05, 10, ..]
 const DATE_FORMAT = 'YYYY-MM-DD';
 const HOUR_FORMAT = 'HH:mm';
+const Option = Select.Option;
 
 function localizeTime(time) {
   const [hrs, mins] = time.split(':');
@@ -47,6 +50,7 @@ class ScheduleDialog extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.initState;
+    this.modalRef = React.createRef(); // used by <Select>
   }
 
   get initState() {
@@ -110,8 +114,7 @@ class ScheduleDialog extends React.Component {
     });
   };
 
-  setInterval = (e) => {
-    const newInterval = e.target.value;
+  setInterval = (newInterval) => {
     const { newSchedule } = this.state;
 
     // resets to defaults
@@ -159,14 +162,13 @@ class ScheduleDialog extends React.Component {
     this.newSchedule = newSchedule;
   };
 
-  setCount = (e) => {
-    const newCount = e.target.value;
+  setCount = (newCount) => {
     const totalSeconds = intervalToSeconds(parseInt(newCount, 10), this.state.interval);
     this.setState({ count: newCount });
     this.newSchedule = { interval: totalSeconds };
   };
 
-  setScheduleUntil = (momentDate, date) => {
+  setScheduleUntil = (_, date) => {
     this.newSchedule = { until: date };
   };
 
@@ -177,6 +179,11 @@ class ScheduleDialog extends React.Component {
       day_of_week: dayOfWeek ? WEEKDAYS_FULL[WEEKDAYS_SHORT.indexOf(dayOfWeek)] : null,
     };
   };
+
+  setUntilToggle = (e) => {
+    const date = e.target.value ? moment().format(DATE_FORMAT) : null;
+    this.setScheduleUntil(null, date);
+  }
 
   save() {
     // save if changed
@@ -194,8 +201,13 @@ class ScheduleDialog extends React.Component {
 
   render() {
     const {
-      interval, minute, hour, until, count,
+      interval, minute, hour, count, newSchedule: { until },
     } = this.state;
+    const selectProps = {
+      getPopupContainer: () => this.modalRef.current,
+      className: 'input',
+      dropdownMatchSelectWidth: false,
+    };
 
     return (
       <Modal
@@ -205,60 +217,87 @@ class ScheduleDialog extends React.Component {
         onCancel={() => this.cancel()}
         onOk={() => this.save()}
       >
-        <div className="schedule-component">
-          <div>Refresh every</div>
-          {interval !== IntervalEnum.NEVER ? (
-            <select value={count} onChange={this.setCount}>
-              {this.counts.map(cnt => (
-                <option value={String(cnt)} key={cnt}>{cnt}</option>
+        <div className="schedule-component" ref={this.modalRef}>
+          <h5>Refresh every</h5>
+          <div>
+            {interval !== IntervalEnum.NEVER ? (
+              <Select value={count} onChange={this.setCount} {...selectProps}>
+                {this.counts.map(cnt => (
+                  <Option value={String(cnt)} key={cnt}>{cnt}</Option>
+                ))}
+              </Select>
+            ) : null}
+            <Select value={interval} onChange={this.setInterval} {...selectProps}>
+              {this.intervals.map(iv => (
+                <Option value={iv.name} key={iv.name}>{iv.name}</Option>
               ))}
-            </select>
-          ) : null}
-          <select value={interval} onChange={this.setInterval}>
-            {this.intervals.map(iv => (
-              <option value={iv.name} key={iv.name}>{iv.name}</option>
-            ))}
-          </select>
+            </Select>
+          </div>
         </div>
         {[IntervalEnum.DAYS, IntervalEnum.WEEKS].indexOf(interval) !== -1 ? (
           <div className="schedule-component">
-            <div>At the following time</div>
-            <select value={hour} onChange={e => this.setTime(e.target.value, minute)}>
-              {HOUR_OPTIONS.map(h => (
-                <option key={h} value={h}>{h}</option>
-              ))}
-            </select>
-            <select value={minute} onChange={e => this.setTime(hour, e.target.value)}>
-              {MINUTE_OPTIONS.map(m => (
-                <option key={m} value={m}>{m}</option>
-              ))}
-            </select>
-          </div>
-        ) : null}
-        {IntervalEnum.WEEKS === interval ? (
-          <div className="btn-toolbar schedule-component">
-            <div className="btn-group" data-toggle="buttons">
-              {WEEKDAYS_SHORT.map(day => (
-                <button
-                  className={`btn btn-xs btn-default${this.state.dayOfWeek === day ? ' active' : ''}`}
-                  onClick={this.setWeekday}
-                  key={day}
-                  value={day}
-                >
-                  {day}
-                </button>
-              ))}
+            <h5>On time</h5>
+            <div>
+              <Select
+                value={hour}
+                onChange={value => this.setTime(value, minute)}
+                {...selectProps}
+              >
+                {HOUR_OPTIONS.map(h => (
+                  <Option key={h} value={h}>{h}</Option>
+                ))}
+              </Select>
+              <Select
+                value={minute}
+                onChange={value => this.setTime(hour, value)}
+                {...selectProps}
+              >
+                {MINUTE_OPTIONS.map(m => (
+                  <Option key={m} value={m}>{m}</Option>
+                ))}
+              </Select>
             </div>
           </div>
         ) : null}
-        {interval ? (
+        {IntervalEnum.WEEKS === interval ? (
           <div className="schedule-component">
-            <div>Stop refresh on:</div>
-            <DatePicker
-              format={DATE_FORMAT}
-              placeholder={until || 'Select Date'}
-              onChange={this.setScheduleUntil}
-            />
+            <h5>On day</h5>
+            <Radio.Group
+              size="medium"
+              defaultValue={this.state.dayOfWeek}
+              onChange={this.setWeekday}
+            >
+              {WEEKDAYS_SHORT.map(day => (
+                <Radio.Button value={day} key={day} className="input">
+                  {day[0]}
+                </Radio.Button>
+              ))}
+            </Radio.Group>
+          </div>
+        ) : null}
+        {interval !== IntervalEnum.NEVER ? (
+          <div className="schedule-component">
+            <h5>Ends</h5>
+            <div className="ends">
+              <Radio.Group
+                size="medium"
+                value={!!until}
+                onChange={this.setUntilToggle}
+              >
+                <Radio value={false}>Never</Radio>
+                <Radio value>On</Radio>
+              </Radio.Group>
+              {until ? (
+                <DatePicker
+                  size="small"
+                  className="datepicker"
+                  value={moment(until)}
+                  allowClear={false}
+                  format={DATE_FORMAT}
+                  onChange={this.setScheduleUntil}
+                />
+              ) : null}
+            </div>
           </div>
         ) : null}
       </Modal>

--- a/client/app/components/queries/ScheduleDialog.jsx
+++ b/client/app/components/queries/ScheduleDialog.jsx
@@ -3,9 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'antd/lib/modal';
 import DatePicker from 'antd/lib/date-picker';
+import TimePicker from 'antd/lib/time-picker';
 import Select from 'antd/lib/select';
 import Radio from 'antd/lib/radio';
-import { range, padStart, clone, isEqual } from 'lodash';
+import { range, clone, isEqual } from 'lodash';
 import moment from 'moment';
 import { secondsToInterval, intervalToSeconds, IntervalEnum } from '@/filters';
 
@@ -21,8 +22,6 @@ const INTERVAL_OPTIONS_MAP = {
   [IntervalEnum.WEEKS]: 5,
 };
 
-const HOUR_OPTIONS = range(0, 24).map(x => padStart(x, 2, '0')); // [00, 01, 02, ..]
-const MINUTE_OPTIONS = range(0, 60, 5).map(x => padStart(x, 2, '0')); // [00, 05, 10, ..]
 const DATE_FORMAT = 'YYYY-MM-DD';
 const HOUR_FORMAT = 'HH:mm';
 const Option = Select.Option;
@@ -96,22 +95,10 @@ class ScheduleDialog extends React.Component {
     });
   }
 
-  setTime = (h, m) => {
+  setTime = (time) => {
     this.newSchedule = {
-      time:
-        h && m
-          ? moment()
-            .hour(h)
-            .minute(m)
-            .utc()
-            .format(HOUR_FORMAT)
-          : null,
+      time: moment(time).utc().format(HOUR_FORMAT),
     };
-
-    this.setState({
-      hour: h,
-      minute: m,
-    });
   };
 
   setInterval = (newInterval) => {
@@ -203,8 +190,9 @@ class ScheduleDialog extends React.Component {
     const {
       interval, minute, hour, count, newSchedule: { until },
     } = this.state;
+    const fixZIndex = { getPopupContainer: () => this.modalRef.current };
     const selectProps = {
-      getPopupContainer: () => this.modalRef.current,
+      ...fixZIndex,
       className: 'input',
       dropdownMatchSelectWidth: false,
     };
@@ -238,24 +226,14 @@ class ScheduleDialog extends React.Component {
           <div className="schedule-component">
             <h5>On time</h5>
             <div>
-              <Select
-                value={hour}
-                onChange={value => this.setTime(value, minute)}
-                {...selectProps}
-              >
-                {HOUR_OPTIONS.map(h => (
-                  <Option key={h} value={h}>{h}</Option>
-                ))}
-              </Select>
-              <Select
-                value={minute}
-                onChange={value => this.setTime(hour, value)}
-                {...selectProps}
-              >
-                {MINUTE_OPTIONS.map(m => (
-                  <Option key={m} value={m}>{m}</Option>
-                ))}
-              </Select>
+              <TimePicker
+                allowEmpty={false}
+                defaultValue={moment().hour(hour).minute(minute)}
+                format={HOUR_FORMAT}
+                minuteStep={5}
+                onChange={this.setTime}
+                {...fixZIndex}
+              />
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
This is part of a PR batch to finalize the refresh-schedule feature.
After merging all changes in to `feature/refresh-schedule/emtwo` it should be merged into master.

#### What's new
Made everything pretty with Ant components.

<img src="https://user-images.githubusercontent.com/486954/50647782-23111d00-0f82-11e9-9514-1ce92d067417.gif" width="320" />

Added TimePicker as well
<img width="320" alt="screen shot 2019-01-06 at 9 13 02" src="https://user-images.githubusercontent.com/486954/50733337-6cd15180-1194-11e9-988a-361868628c50.png">


#### Implementation notes
For `<Select>` to appear in correct z-index, I indicated the parent element it should be appended to with `getPopupContainer` and voila - no need to css override.
