### PR TITLE
Fix: Able to set out-of-range refresh interval

### DIFF
--- a/client/app/components/queries/ScheduleDialog.jsx
+++ b/client/app/components/queries/ScheduleDialog.jsx
@@ -69,10 +69,6 @@ class ScheduleDialog extends React.Component {
     };
   }
 
-  get counts() {
-    return range(1, INTERVAL_OPTIONS_MAP[this.state.interval]);
-  }
-
   get intervals() {
     const ret = this.props.refreshOptions
       .map((seconds) => {
@@ -95,6 +91,8 @@ class ScheduleDialog extends React.Component {
       newSchedule: Object.assign(this.state.newSchedule, newProps),
     });
   }
+
+  getCounts = interval => range(1, INTERVAL_OPTIONS_MAP[interval])
 
   setTime = (h, m) => {
     this.newSchedule = {
@@ -141,8 +139,14 @@ class ScheduleDialog extends React.Component {
       newSchedule.day_of_week = WEEKDAYS_FULL[0];
     }
 
+    // reset count if out of new interval count range
+    let count = this.state.count;
+    if (this.getCounts(newInterval).indexOf(Number(count)) === -1) {
+      count = '1';
+    }
+
     newSchedule.interval = newInterval
-      ? intervalToSeconds(Number(this.state.count), newInterval)
+      ? intervalToSeconds(Number(count), newInterval)
       : null;
 
     const [hour, minute] = newSchedule.time ?
@@ -151,7 +155,7 @@ class ScheduleDialog extends React.Component {
 
     this.setState({
       interval: newInterval,
-      count: newInterval !== IntervalEnum.NEVER ? this.state.count : '1',
+      count,
       hour,
       minute,
       dayOfWeek: newSchedule.day_of_week
@@ -222,7 +226,7 @@ class ScheduleDialog extends React.Component {
           <div>
             {interval !== IntervalEnum.NEVER ? (
               <Select value={count} onChange={this.setCount} {...selectProps}>
-                {this.counts.map(cnt => (
+                {this.getCounts(this.state.interval).map(cnt => (
                   <Option value={String(cnt)} key={cnt}>{cnt}</Option>
                 ))}
               </Select>


### PR DESCRIPTION
Closes #3249

#### The fix
Before setting `count` now code checks if out of range, and if so sets to "1".

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/486954/50657841-42b73e00-0fa0-11e9-8008-a2c8b250f8cb.gif)

#### Implementation notes
Had to convert getter to simple function in order to send the `newInterval` argument.
