### PR TITLE
Added SSL settings for PostgreSQL

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -74,9 +74,22 @@ class PostgreSQL(BaseSQLQueryRunner):
                     "type": "string",
                     "title": "SSL Mode",
                     "default": "prefer"
+                },
+                "sslrootcert": {
+                    "type": "string",
+                    "title": "Path to server certificate file (SSL)"
+                },
+                "sslcert": {
+                    "type": "string",
+                    "title": "Path to client public key certificate file (SSL)"
+                },
+                "sslkey": {
+                    "type": "string",
+                    "title": "Path to client private key file (SSL)"
                 }
             },
-            "order": ['host', 'port', 'user', 'password'],
+            "order": ["host", "port", "user", "password", "dbname",
+                      "sslmode", "sslrootcert", "sslcert", "sslkey"],
             "required": ["dbname"],
             "secret": ["password"]
         }
@@ -147,6 +160,9 @@ class PostgreSQL(BaseSQLQueryRunner):
             port=self.configuration.get('port'),
             dbname=self.configuration.get('dbname'),
             sslmode=self.configuration.get('sslmode'),
+            sslrootcert=self.configuration.get('sslrootcert'),
+            sslcert=self.configuration.get('sslcert'),
+            sslkey=self.configuration.get('sslkey'),
             async_=True)
 
         return connection

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -71,9 +71,9 @@ class PostgreSQL(BaseSQLQueryRunner):
                     "title": "Database Name"
                 },
                 "sslmode": {
-                   "type": "string",
-                   "title": "SSL Mode",
-                   "default": "prefer"
+                    "type": "string",
+                    "title": "SSL Mode",
+                    "default": "prefer"
                 }
             },
             "order": ['host', 'port', 'user', 'password'],
@@ -95,7 +95,8 @@ class PostgreSQL(BaseSQLQueryRunner):
 
         for row in results['rows']:
             if row['table_schema'] != 'public':
-                table_name = u'{}.{}'.format(row['table_schema'], row['table_name'])
+                table_name = u'{}.{}'.format(
+                    row['table_schema'], row['table_name'])
             else:
                 table_name = row['table_name']
 
@@ -139,13 +140,14 @@ class PostgreSQL(BaseSQLQueryRunner):
         return schema.values()
 
     def _get_connection(self):
-        connection = psycopg2.connect(user=self.configuration.get('user'),
-                                      password=self.configuration.get('password'),
-                                      host=self.configuration.get('host'),
-                                      port=self.configuration.get('port'),
-                                      dbname=self.configuration.get('dbname'),
-                                      sslmode=self.configuration.get('sslmode'),
-                                      async_=True)
+        connection = psycopg2.connect(
+            user=self.configuration.get('user'),
+            password=self.configuration.get('password'),
+            host=self.configuration.get('host'),
+            port=self.configuration.get('port'),
+            dbname=self.configuration.get('dbname'),
+            sslmode=self.configuration.get('sslmode'),
+            async_=True)
 
         return connection
 
@@ -160,8 +162,10 @@ class PostgreSQL(BaseSQLQueryRunner):
             _wait(connection)
 
             if cursor.description is not None:
-                columns = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in cursor.description])
-                rows = [dict(zip((c['name'] for c in columns), row)) for row in cursor]
+                columns = self.fetch_columns([(i[0], types_map.get(i[1], None))
+                                              for i in cursor.description])
+                rows = [dict(zip((c['name'] for c in columns), row))
+                        for row in cursor]
 
                 data = {'columns': columns, 'rows': rows}
                 error = None
@@ -191,16 +195,18 @@ class Redshift(PostgreSQL):
         return "redshift"
 
     def _get_connection(self):
-        sslrootcert_path = os.path.join(os.path.dirname(__file__), './files/redshift-ca-bundle.crt')
+        sslrootcert_path = os.path.join(
+            os.path.dirname(__file__), './files/redshift-ca-bundle.crt')
 
-        connection = psycopg2.connect(user=self.configuration.get('user'),
-                                      password=self.configuration.get('password'),
-                                      host=self.configuration.get('host'),
-                                      port=self.configuration.get('port'),
-                                      dbname=self.configuration.get('dbname'),
-                                      sslmode=self.configuration.get('sslmode', 'prefer'),
-                                      sslrootcert=sslrootcert_path,
-                                      async_=True)
+        connection = psycopg2.connect(
+            user=self.configuration.get('user'),
+            password=self.configuration.get('password'),
+            host=self.configuration.get('host'),
+            port=self.configuration.get('port'),
+            dbname=self.configuration.get('dbname'),
+            sslmode=self.configuration.get('sslmode', 'prefer'),
+            sslrootcert=sslrootcert_path,
+            async_=True)
 
         return connection
 
@@ -227,9 +233,9 @@ class Redshift(PostgreSQL):
                     "title": "Database Name"
                 },
                 "sslmode": {
-                   "type": "string",
-                   "title": "SSL Mode",
-                   "default": "prefer"
+                    "type": "string",
+                    "title": "SSL Mode",
+                    "default": "prefer"
                 }
             },
             "order": ['host', 'port', 'user', 'password'],


### PR DESCRIPTION
First commit fixes various spacing styles. Second commit adds `sslrootcert`, `sslcert`, and `sslkey` parameters to support various PostgreSQL SSL settings: https://www.postgresql.org/docs/current/libpq-ssl.html

See https://github.com/getredash/redash/issues/2000. 