### PR TITLE
Fix invitation pending for existing users

### DIFF
--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -102,6 +102,7 @@ class UserListResource(BaseResource):
         user = models.User(org=self.current_org,
                            name=req['name'],
                            email=req['email'],
+                           is_invitation_pending=True,
                            group_ids=[self.current_org.default_group.id])
 
         try:

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -33,7 +33,7 @@ def sync_last_active_at():
     Update User model with the active_at timestamp from Redis. We first fetch
     all the user_ids to update, and then fetch the timestamp to minimize the
     time between fetching the value and updating the DB. This is because there
-    might be a more recent update we skip otherwise. 
+    might be a more recent update we skip otherwise.
     """
     user_ids = redis_connection.hkeys(LAST_ACTIVE_KEY)
     for user_id in user_ids:
@@ -96,7 +96,7 @@ class User(TimestampMixin, db.Model, BelongsToOrgMixin, UserMixin, PermissionsCh
                      server_default='{}', default={})
     active_at = json_cast_property(db.DateTime(True), 'details', 'active_at',
                                    default=None)
-    is_invitation_pending = json_cast_property(db.Boolean(True), 'details', 'is_invitation_pending', default=True)
+    is_invitation_pending = json_cast_property(db.Boolean(True), 'details', 'is_invitation_pending', default=False)
 
     __tablename__ = 'users'
     __table_args__ = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httplib2==0.10.3
 Flask-Admin==1.5.2
 Flask-RESTful==0.3.5
 Flask-Login==0.4.0
-Flask-OAuthLib==0.9.3
+Flask-OAuthLib==0.9.5
 Flask-SQLAlchemy==2.3.2
 Flask-Migrate==2.0.1
 flask-mail==0.9.1

--- a/tests/handlers/test_authentication.py
+++ b/tests/handlers/test_authentication.py
@@ -23,7 +23,8 @@ class TestInvite(BaseTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_valid_token(self):
-        token = invite_token(self.factory.user)
+        user = self.factory.create_user(is_invitation_pending=True)
+        token = invite_token(user)
         response = self.get_request('/invite/{}'.format(token), org=self.factory.org)
         self.assertEqual(response.status_code, 200)
 
@@ -56,11 +57,12 @@ class TestInvitePost(BaseTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_valid_password(self):
-        token = invite_token(self.factory.user)
+        user = self.factory.create_user(is_invitation_pending=True)
+        token = invite_token(user)
         password = 'test1234'
         response = self.post_request('/invite/{}'.format(token), data={'password': password}, org=self.factory.org)
         self.assertEqual(response.status_code, 302)
-        user = User.query.get(self.factory.user.id)
+        user = User.query.get(user.id)
         self.assertTrue(user.verify_password(password))
         self.assertFalse(user.is_invitation_pending)
 

--- a/tests/handlers/test_users.py
+++ b/tests/handlers/test_users.py
@@ -194,7 +194,7 @@ class TestUserResourcePost(BaseTestCase):
 
     def test_admin_can_delete_user(self):
         admin_user = self.factory.create_admin()
-        other_user = self.factory.create_user()
+        other_user = self.factory.create_user(is_invitation_pending=True)
 
         rv = self.make_request('delete', "/api/users/{}".format(other_user.id), user=admin_user)
 


### PR DESCRIPTION
default `is_invitation_pending` to false and actively set it to true when inviting users, so that existing users won't show "Invitation Pending"