### PR TITLE
Fix: Refresh schedule interval count doesn't adhere to permission rules

### DIFF
--- a/client/app/filters/index.js
+++ b/client/app/filters/index.js
@@ -20,6 +20,9 @@ export function localizeTime(time) {
 }
 
 export function secondsToInterval(seconds) {
+  if (!seconds) {
+    return { interval: IntervalEnum.NEVER };
+  }
   let interval = IntervalEnum.MINUTES;
   let count = seconds / 60;
   if (count >= 60) {

--- a/client/app/filters/index.js
+++ b/client/app/filters/index.js
@@ -30,7 +30,7 @@ export function secondsToInterval(seconds) {
     count /= 24;
     interval = IntervalEnum.DAYS;
   }
-  if (count >= 7 && interval === IntervalEnum.DAYS) {
+  if (count >= 7 && !(count % 7) && interval === IntervalEnum.DAYS) {
     count /= 7;
     interval = IntervalEnum.WEEKS;
   }


### PR DESCRIPTION
Fixes #3263.

#### The bug
Not a programatic bug but rather a wrong feature implementation.
Interval counts were set as hardcoded ranges instead of deriving from `props.refreshOptions`.

#### The fix
Now `intervals` returns grouped count by interval type.
```js
{
  [IntervalEnum: NEVER]: [],
  [IntervalEnum: MINUTES]: [1, 5, 10, 15, 30],
  [IntervalEnum: HOURS]: [1, .. , 12],
  [IntervalEnum: DAYS]: [1],
  [IntervalEnum: WEEKS]: [1, 2, 4.28],
}
```
:raised_back_of_hand: 'Days' has only one value, 'Weeks' has a fraction (30 days)

#### Bonus fix
The code assumed all interval types included a "1" count value. 