### PR TITLE
Fix: Refresh schedule durations not pluralized sufficiently

### DIFF
--- a/client/app/components/queries/ScheduleDialog.jsx
+++ b/client/app/components/queries/ScheduleDialog.jsx
@@ -8,7 +8,7 @@ import Select from 'antd/lib/select';
 import Radio from 'antd/lib/radio';
 import { capitalize, clone, isEqual } from 'lodash';
 import moment from 'moment';
-import { secondsToInterval, IntervalEnum, localizeTime } from '@/filters';
+import { secondsToInterval, durationHumanize, pluralize, IntervalEnum, localizeTime } from '@/filters';
 
 import './ScheduleDialog.css';
 
@@ -182,9 +182,9 @@ class ScheduleDialog extends React.Component {
             <Select value={seconds} onChange={this.setInterval} {...selectProps}>
               <Option value={null} key="never">Never</Option>
               {Object.keys(this.intervals).map(int => (
-                <OptGroup label={capitalize(int)} key={int}>
+                <OptGroup label={capitalize(pluralize(int))} key={int}>
                   {this.intervals[int].map(([cnt, secs]) => (
-                    <Option value={secs} key={cnt}>{cnt} {int}</Option>
+                    <Option value={secs} key={cnt}>{durationHumanize(secs)}</Option>
                   ))}
                 </OptGroup>
                 ))}

--- a/client/app/components/queries/SchedulePhrase.jsx
+++ b/client/app/components/queries/SchedulePhrase.jsx
@@ -2,7 +2,7 @@ import { react2angular } from 'react2angular';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'antd/lib/tooltip';
-import { localizeTime, secondsToInterval } from '@/filters';
+import { localizeTime, durationHumanize } from '@/filters';
 
 import './ScheduleDialog.css';
 
@@ -23,9 +23,9 @@ class SchedulePhrase extends React.Component {
     if (!seconds) {
       return ['Never'];
     }
-    const { count, interval } = secondsToInterval(seconds);
-    const short = `Every ${count} ${interval}`;
-    let full = `Refreshes every ${count} ${interval}`;
+    const humanized = durationHumanize(seconds);
+    const short = `Every ${humanized}`;
+    let full = `Refreshes every ${humanized}`;
 
     const { time, day_of_week: dayOfWeek } = this.props.schedule;
     if (time) {

--- a/client/app/components/queries/SchedulePhrase.jsx
+++ b/client/app/components/queries/SchedulePhrase.jsx
@@ -23,7 +23,9 @@ class SchedulePhrase extends React.Component {
     if (!seconds) {
       return ['Never'];
     }
-    const humanized = durationHumanize(seconds);
+    const humanized = durationHumanize(seconds, {
+      omitSingleValueNumber: true,
+    });
     const short = `Every ${humanized}`;
     let full = `Refreshes every ${humanized}`;
 

--- a/client/app/filters/index.js
+++ b/client/app/filters/index.js
@@ -3,10 +3,11 @@ import { capitalize as _capitalize, isEmpty } from 'lodash';
 
 export const IntervalEnum = {
   NEVER: 'Never',
-  MINUTES: 'minute(s)',
-  HOURS: 'hour(s)',
-  DAYS: 'day(s)',
-  WEEKS: 'week(s)',
+  SECONDS: 'second',
+  MINUTES: 'minute',
+  HOURS: 'hour',
+  DAYS: 'day',
+  WEEKS: 'week',
 };
 
 export function localizeTime(time) {
@@ -19,12 +20,16 @@ export function localizeTime(time) {
     .format('HH:mm');
 }
 
-export function secondsToInterval(seconds) {
-  if (!seconds) {
+export function secondsToInterval(count) {
+  if (!count) {
     return { interval: IntervalEnum.NEVER };
   }
-  let interval = IntervalEnum.MINUTES;
-  let count = seconds / 60;
+
+  let interval = IntervalEnum.SECONDS;
+  if (count >= 60) {
+    count /= 60;
+    interval = IntervalEnum.MINUTES;
+  }
   if (count >= 60) {
     count /= 60;
     interval = IntervalEnum.HOURS;
@@ -61,29 +66,18 @@ export function intervalToSeconds(count, interval) {
   return intervalInSeconds * count;
 }
 
-export function durationHumanize(duration) {
-  let humanized = '';
+export function pluralize(text, count) {
+  const should = count !== 1;
+  return text + (should ? 's' : '');
+}
 
-  if (duration === undefined || duration === null) {
-    humanized = '-';
-  } else if (duration < 60) {
-    const seconds = Math.round(duration);
-    humanized = `${seconds} seconds`;
-  } else if (duration > 3600 * 24) {
-    const days = Math.round(parseFloat(duration) / 60.0 / 60.0 / 24.0);
-    humanized = `${days} days`;
-  } else if (duration === 3600) {
-    humanized = '1 hour';
-  } else if (duration >= 3600) {
-    const hours = Math.round(parseFloat(duration) / 60.0 / 60.0);
-    humanized = `${hours} hours`;
-  } else if (duration === 60) {
-    humanized = '1 minute';
-  } else {
-    const minutes = Math.round(parseFloat(duration) / 60.0);
-    humanized = `${minutes} minutes`;
+export function durationHumanize(duration) {
+  if (!duration) {
+    return '-';
   }
-  return humanized;
+  const { interval, count } = secondsToInterval(duration);
+  const rounded = Math.round(count);
+  return `${rounded} ${pluralize(interval, rounded)}`;
 }
 
 export function toHuman(text) {

--- a/client/app/filters/index.js
+++ b/client/app/filters/index.js
@@ -71,13 +71,18 @@ export function pluralize(text, count) {
   return text + (should ? 's' : '');
 }
 
-export function durationHumanize(duration) {
+export function durationHumanize(duration, options = {}) {
   if (!duration) {
     return '-';
   }
+  let ret = '';
   const { interval, count } = secondsToInterval(duration);
   const rounded = Math.round(count);
-  return `${rounded} ${pluralize(interval, rounded)}`;
+  if (rounded !== 1 || !options.omitSingleValueNumber) {
+    ret = `${rounded} `;
+  }
+  ret += pluralize(interval, rounded);
+  return ret;
 }
 
 export function toHuman(text) {


### PR DESCRIPTION
"Week(s)" is nice and all but let's do this right. It's especially prominent in the refresh interval dropdown as of #3265.

#### Result
Refresh Scheduler
<img width="476" alt="screen shot 2019-01-10 at 15 41 16" src="https://user-images.githubusercontent.com/486954/50972455-5ce8a300-14ef-11e9-8b71-6717953ac720.png">

Refresh phrase
<img width="224" alt="screen shot 2019-01-10 at 15 43 25" src="https://user-images.githubusercontent.com/486954/50972454-5c500c80-14ef-11e9-909e-1d6c121e7d98.png">

Query list
<img width="497" alt="screen shot 2019-01-10 at 15 46 06" src="https://user-images.githubusercontent.com/486954/50972452-59edb280-14ef-11e9-990b-1a3c2939a751.png">

NOTE: "24 hours" is now "1 day". @arikfr lmk if you want this corrected.
<img width="193" alt="screen shot 2019-01-10 at 15 44 19" src="https://user-images.githubusercontent.com/486954/50972450-59edb280-14ef-11e9-8243-e668226bbc6e.png">
