### PR TITLE
Use None as "not scheduled" default value of a query

### DIFF
--- a/client/app/components/proptypes.js
+++ b/client/app/components/proptypes.js
@@ -15,6 +15,20 @@ export const Table = PropTypes.shape({
 
 export const Schema = PropTypes.arrayOf(Table);
 
+export const RefreshScheduleType = PropTypes.shape({
+  interval: PropTypes.number,
+  time: PropTypes.string,
+  day_of_week: PropTypes.string,
+  until: PropTypes.string,
+});
+
+export const RefreshScheduleDefault = {
+  interval: null,
+  time: null,
+  day_of_week: null,
+  until: null,
+};
+
 export const Field = PropTypes.shape({
   name: PropTypes.string.isRequired,
   title: PropTypes.string,

--- a/client/app/components/queries/ScheduleDialog.jsx
+++ b/client/app/components/queries/ScheduleDialog.jsx
@@ -9,6 +9,7 @@ import Radio from 'antd/lib/radio';
 import { capitalize, clone, isEqual } from 'lodash';
 import moment from 'moment';
 import { secondsToInterval, durationHumanize, pluralize, IntervalEnum, localizeTime } from '@/filters';
+import { RefreshScheduleType, RefreshScheduleDefault } from '../proptypes';
 
 import './ScheduleDialog.css';
 
@@ -21,11 +22,14 @@ const { Option, OptGroup } = Select;
 export class ScheduleDialog extends React.Component {
   static propTypes = {
     show: PropTypes.bool.isRequired,
-    // eslint-disable-next-line react/forbid-prop-types
-    query: PropTypes.object.isRequired,
+    schedule: RefreshScheduleType,
     refreshOptions: PropTypes.arrayOf(PropTypes.number).isRequired,
     updateQuery: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    schedule: RefreshScheduleDefault,
   };
 
   constructor(props) {
@@ -35,7 +39,7 @@ export class ScheduleDialog extends React.Component {
   }
 
   get initState() {
-    const newSchedule = clone(this.props.query.schedule);
+    const newSchedule = clone(this.props.schedule || ScheduleDialog.defaultProps.schedule);
     const { time, interval: seconds, day_of_week: day } = newSchedule;
     const { interval } = secondsToInterval(seconds);
     const [hour, minute] = time ? localizeTime(time).split(':') : [null, null];
@@ -144,9 +148,15 @@ export class ScheduleDialog extends React.Component {
   }
 
   save() {
+    const { newSchedule } = this.state;
+
     // save if changed
-    if (!isEqual(this.state.newSchedule, this.props.query.schedule)) {
-      this.props.updateQuery({ schedule: clone(this.state.newSchedule) });
+    if (!isEqual(newSchedule, this.props.schedule)) {
+      if (newSchedule.interval) {
+        this.props.updateQuery({ schedule: clone(newSchedule) });
+      } else {
+        this.props.updateQuery({ schedule: null });
+      }
     }
     this.props.onClose();
   }

--- a/client/app/components/queries/ScheduleDialog.test.js
+++ b/client/app/components/queries/ScheduleDialog.test.js
@@ -1,17 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { ScheduleDialog } from './ScheduleDialog';
+import RefreshScheduleDefault from '../proptypes';
 
 const defaultProps = {
   show: true,
-  query: {
-    schedule: {
-      time: null,
-      until: null,
-      interval: null,
-      day_of_week: null,
-    },
-  },
+  schedule: RefreshScheduleDefault,
   refreshOptions: [
     60, 300, 600, // 1, 5 ,10 mins
     3600, 36000, 82800, // 1, 10, 23 hours
@@ -23,12 +17,11 @@ const defaultProps = {
 };
 
 function getWrapper(schedule = {}, props = {}) {
-  const defaultSchedule = defaultProps.query.schedule;
   props = Object.assign(
     {},
     defaultProps,
     props,
-    { query: { schedule: Object.assign({}, defaultSchedule, schedule) } },
+    { schedule: Object.assign({}, RefreshScheduleDefault, schedule) },
   );
   return [mount(<ScheduleDialog {...props} />), props];
 }
@@ -78,7 +71,7 @@ describe('ScheduleDialog', () => {
       const [wrapper] = getWrapper({
         interval: 1209600,
         time: '22:15',
-        day_of_week: 2,
+        day_of_week: 'Monday',
       });
 
       test('Sets to correct interval', () => {

--- a/client/app/components/queries/SchedulePhrase.jsx
+++ b/client/app/components/queries/SchedulePhrase.jsx
@@ -3,23 +3,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'antd/lib/tooltip';
 import { localizeTime, durationHumanize } from '@/filters';
+import { RefreshScheduleType, RefreshScheduleDefault } from '../proptypes';
 
 import './ScheduleDialog.css';
 
 class SchedulePhrase extends React.Component {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    schedule: PropTypes.object.isRequired,
+    schedule: RefreshScheduleType,
     isNew: PropTypes.bool.isRequired,
     isLink: PropTypes.bool,
   };
 
   static defaultProps = {
+    schedule: RefreshScheduleDefault,
     isLink: false,
   };
 
   get content() {
-    const { interval: seconds } = this.props.schedule;
+    const { interval: seconds } = this.props.schedule || SchedulePhrase.defaultProps.schedule;
     if (!seconds) {
       return ['Never'];
     }

--- a/client/app/components/queries/__snapshots__/ScheduleDialog.test.js.snap
+++ b/client/app/components/queries/__snapshots__/ScheduleDialog.test.js.snap
@@ -1632,6 +1632,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
 >
   <RadioGroup
     buttonStyle="outline"
+    defaultValue="Mon"
     disabled={false}
     onChange={[Function]}
     size="medium"
@@ -1700,7 +1701,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
         value="Mon"
       >
         <Radio
-          checked={false}
+          checked={true}
           className="input"
           disabled={false}
           onChange={[Function]}
@@ -1709,10 +1710,10 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
           value="Mon"
         >
           <label
-            className="input ant-radio-button-wrapper"
+            className="input ant-radio-button-wrapper ant-radio-button-wrapper-checked"
           >
             <Checkbox
-              checked={false}
+              checked={true}
               className=""
               defaultChecked={false}
               disabled={false}
@@ -1725,11 +1726,11 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
               value="Mon"
             >
               <span
-                className="ant-radio-button"
+                className="ant-radio-button ant-radio-button-checked"
                 style={Object {}}
               >
                 <input
-                  checked={false}
+                  checked={true}
                   className="ant-radio-button-input"
                   disabled={false}
                   onBlur={[Function]}
@@ -2375,7 +2376,6 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "Never" 1`] = `
     onChange={[Function]}
     showSearch={false}
     transitionName="slide-up"
-    value={null}
   >
     <Select
       allowClear={false}
@@ -2445,7 +2445,6 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "Never" 1`] = `
       tags={false}
       tokenSeparators={Array []}
       transitionName="slide-up"
-      value={null}
     >
       <SelectTrigger
         ariaId="test-uuid"
@@ -2478,11 +2477,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "Never" 1`] = `
         }
         showSearch={false}
         transitionName="slide-up"
-        value={
-          Array [
-            null,
-          ]
-        }
+        value={Array []}
         visible={false}
       >
         <Trigger
@@ -2577,11 +2572,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "Never" 1`] = `
               onMenuSelect={[Function]}
               onPopupFocus={[Function]}
               prefixCls="ant-select-dropdown"
-              value={
-                Array [
-                  null,
-                ]
-              }
+              value={Array []}
               visible={false}
             />
           }
@@ -2599,11 +2590,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "Never" 1`] = `
           }
           showSearch={false}
           transitionName="slide-up"
-          value={
-            Array [
-              null,
-            ]
-          }
+          value={Array []}
           visible={false}
         >
           <div
@@ -2631,21 +2618,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "Never" 1`] = `
             >
               <div
                 className="ant-select-selection__rendered"
-              >
-                <div
-                  className="ant-select-selection-selected-value"
-                  key="value"
-                  style={
-                    Object {
-                      "display": "block",
-                      "opacity": 1,
-                    }
-                  }
-                  title="Never"
-                >
-                  Never
-                </div>
-              </div>
+              />
               <span
                 className="ant-select-arrow"
                 key="arrow"

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -135,7 +135,7 @@
                 <span class="zmdi zmdi-refresh"></span> Refresh Schedule</span>
             </td>
             <td class="p-t-15 text-right">
-              <schedule-dialog show="showScheduleForm" query="query" refresh-options="refreshOptions" update-query="updateQueryMetadata" on-close="closeScheduleForm"></schedule-dialog>
+              <schedule-dialog show="showScheduleForm" schedule="query.schedule" refresh-options="refreshOptions" update-query="updateQueryMetadata" on-close="closeScheduleForm"></schedule-dialog>
               <schedule-phrase ng-click="openScheduleForm()" is-link="true" schedule="query.schedule" is-new="query.isNew()" />
             </td>
           </tr>

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -375,12 +375,7 @@ function QueryResource(
     return new Query({
       query: '',
       name: 'New Query',
-      schedule: {
-        time: null,
-        until: null,
-        interval: null,
-        day_of_week: null,
-      },
+      schedule: null,
       user: currentUser,
       options: {},
     });

--- a/migrations/versions/73beceabb948_bring_back_null_schedule.py
+++ b/migrations/versions/73beceabb948_bring_back_null_schedule.py
@@ -1,0 +1,56 @@
+"""bring_back_null_schedule
+
+Revision ID: 73beceabb948
+Revises: e7f8a917aa8e
+Create Date: 2019-01-17 13:22:21.729334
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table
+
+from redash.models import MutableDict, PseudoJSON
+
+# revision identifiers, used by Alembic.
+revision = '73beceabb948'
+down_revision = 'e7f8a917aa8e'
+branch_labels = None
+depends_on = None
+
+
+def is_empty_schedule(schedule):
+    if schedule is None:
+        return False
+
+    if schedule == {}:
+        return True
+
+    if schedule.get('interval') is None and schedule.get('until') is None and schedule.get('day_of_week') is None and schedule.get('time') is None:
+        return True
+
+    return False
+
+
+def upgrade():
+    op.alter_column('queries', 'schedule',
+                    nullable=True,
+                    server_default=None)
+
+    queries = table(
+        'queries',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('schedule', MutableDict.as_mutable(PseudoJSON)))
+
+    conn = op.get_bind()
+    for query in conn.execute(queries.select()):
+        if is_empty_schedule(query.schedule):
+            conn.execute(
+                queries
+                .update()
+                .where(queries.c.id == query.id)
+                .values(schedule=None))
+
+
+def downgrade():
+    pass

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -443,7 +443,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     def archive(self, user=None):
         db.session.add(self)
         self.is_archived = True
-        self.schedule = {}
+        self.schedule = None
 
         for vis in self.visualizations:
             for w in vis.widgets:
@@ -550,11 +550,11 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def outdated_queries(cls):
-        queries = (db.session.query(Query)
-                   .options(joinedload(Query.latest_query_data).load_only('retrieved_at'))
-                   .filter(Query.schedule != {})
-                   .order_by(Query.id))
-
+        queries = (Query.query
+                        .options(joinedload(Query.latest_query_data).load_only('retrieved_at'))
+                        .filter(Query.schedule.isnot(None))
+                        .order_by(Query.id))
+        
         now = utils.utcnow()
         outdated_queries = {}
         scheduled_queries_executions.refresh()

--- a/redash/models/types.py
+++ b/redash/models/types.py
@@ -24,6 +24,9 @@ class PseudoJSON(TypeDecorator):
     impl = db.Text
 
     def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+
         return json_dumps(value)
 
     def process_result_value(self, value, dialect):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -75,7 +75,7 @@ query_factory = ModelFactory(redash.models.Query,
                              user=user_factory.create,
                              is_archived=False,
                              is_draft=False,
-                             schedule={},
+                             schedule=None,
                              data_source=data_source_factory.create,
                              org_id=1)
 

--- a/tests/models/test_dashboards.py
+++ b/tests/models/test_dashboards.py
@@ -20,11 +20,11 @@ class DashboardTest(BaseTestCase):
         return dashboard
 
     def test_all_tags(self):
-        self.create_tagged_dashboard(tags=['tag1'])
-        self.create_tagged_dashboard(tags=['tag1', 'tag2'])
-        self.create_tagged_dashboard(tags=['tag1', 'tag2', 'tag3'])
+        self.create_tagged_dashboard(tags=[u'tag1'])
+        self.create_tagged_dashboard(tags=[u'tag1', u'tag2'])
+        self.create_tagged_dashboard(tags=[u'tag1', u'tag2', u'tag3'])
 
         self.assertEqual(
             list(Dashboard.all_tags(self.factory.org, self.factory.user)),
-            [('tag1', 3), ('tag2', 2), ('tag3', 1)]
+            [(u'tag1', 3), (u'tag2', 2), (u'tag3', 1)]
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -136,9 +136,12 @@ class QueryOutdatedQueriesTest(BaseTestCase):
     # TODO: this test can be refactored to use mock version of should_schedule_next to simplify it.
     def test_outdated_queries_skips_unscheduled_queries(self):
         query = self.factory.create_query(schedule={'interval':None, 'time': None, 'until':None, 'day_of_week':None})
+        query_with_none = self.factory.create_query(schedule=None)
+
         queries = models.Query.outdated_queries()
 
         self.assertNotIn(query, queries)
+        self.assertNotIn(query_with_none, queries)
 
     def test_outdated_queries_works_with_ttl_based_schedule(self):
         two_hours_ago = utcnow() - datetime.timedelta(hours=2)
@@ -318,7 +321,7 @@ class QueryArchiveTest(BaseTestCase):
 
         query.archive()
 
-        self.assertEqual({}, query.schedule)
+        self.assertIsNone(query.schedule)
 
     def test_deletes_alerts(self):
         subscription = self.factory.create_alert_subscription()


### PR DESCRIPTION
In #2426 we changed the default value for Query's schedule to a schedule object with all values set to null (`{time: null, until: null, interval: null, day_of_week: null}`). When querying for scheduled queries, the test was to look for queries with an empty schedule object (`{}`).

The result of this is that the scheduler will always iterate over _all_ the queries. While in small deployments it's not an issue in larger deployments it is.

~As part of fixing this, I decided to take advantage of the field being nullable and use null as the default value instead of an empty object.~

Apparently there is a discrepancy between the definition of the column in `redash.models` and how it was created in the migration. 😒 The migration creates a non nullable column, while the models code still defines a nullable column. I will probably drop this constraint in the new migration...

TODO:

- [x] New migration to change all queries with a schedule object with all values set to null to a null value.
- [x] Adapt the UI to support this.

Closes #3294.