### PR TITLE
Separate Bootstrap/Ant styling

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -17,6 +17,7 @@
 @code-family            : @redash-font;
 @font-size-base         : 13px;
 
+@input-height-base      : 35px;
 @border-radius-base     : 2px;
 @border-color-base      : #e8e8e8;
 

--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -1,3 +1,4 @@
+@import 'inc/variables';
 @import '~antd/lib/style/core/iconfont.less';
 @import '~antd/lib/style/core/motion.less';
 @import '~antd/lib/input/style/index.less';

--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -8,17 +8,19 @@
 @import '~antd/lib/button/style/index.less';
 @import '~antd/lib/radio/style/index.less';
 @import '~antd/lib/time-picker/style/index.less';
-@import 'inc/variables';
 
 // Overwritting Ant Design defaults to fit into Redash current style
+@redash-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
 @font-family-no-number  : @redash-font;
 @font-family            : @redash-font;
 @code-family            : @redash-font;
+@font-size-base         : 13px;
 
-@border-radius-base     : @redash-input-radius;
+@border-radius-base     : 2px;
 @border-color-base      : #e8e8e8;
 
-@primary-color          : @blue;
+@primary-color          : #2196F3;
 
 // Fix for disabled button styles inside Tooltip component.
 // Tooltip wraps disabled buttons with `<span>` and moves all styles

--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -16,8 +16,10 @@
 @font-family            : @redash-font;
 @code-family            : @redash-font;
 @font-size-base         : 13px;
+@text-color             : #767676;
 
 @input-height-base      : 35px;
+@input-color            : #9E9E9E;
 @border-radius-base     : 2px;
 @border-color-base      : #e8e8e8;
 

--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -1,4 +1,3 @@
-@import 'inc/variables';
 @import '~antd/lib/style/core/iconfont.less';
 @import '~antd/lib/style/core/motion.less';
 @import '~antd/lib/input/style/index.less';
@@ -9,6 +8,7 @@
 @import '~antd/lib/button/style/index.less';
 @import '~antd/lib/radio/style/index.less';
 @import '~antd/lib/time-picker/style/index.less';
+@import 'inc/variables';
 
 // Overwritting Ant Design defaults to fit into Redash current style
 @font-family-no-number  : @redash-font;

--- a/client/app/assets/less/inc/variables.less
+++ b/client/app/assets/less/inc/variables.less
@@ -25,6 +25,18 @@
 @boxed-width:                           1170px;
 @body-bg:                               #edecec;
 
+/* --------------------------------------------------------
+    Redash New Style (TODO: organize this better)
+-----------------------------------------------------------*/
+@redash-gray:                           rgba(102, 136, 153, 1);
+@redash-orange:                         rgba(255, 120, 100, 1);
+@redash-black:                          rgba(0, 0, 0, 1);
+@redash-yellow:                         rgba(252, 252, 161, 0.75);
+@redash-font:                           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+@spacing:                               15px;
+@redash-space:                          10px;
+@redash-radius:                         3px;
+@redash-input-radius:                   2px;
 
 /* --------------------------------------------------------
     Branding

--- a/client/app/assets/less/inc/variables.less
+++ b/client/app/assets/less/inc/variables.less
@@ -55,6 +55,7 @@
 /* --------------------------------------------------------
     Form
 -----------------------------------------------------------*/
+@input-color:                           #9E9E9E;
 @input-color-placeholder:               #b4b4b4;
 @input-border:                          #e8e8e8;
 @input-border-radius:                   0;

--- a/client/app/assets/less/inc/variables.less
+++ b/client/app/assets/less/inc/variables.less
@@ -25,18 +25,6 @@
 @boxed-width:                           1170px;
 @body-bg:                               #edecec;
 
-/* --------------------------------------------------------
-    Redash New Style (TODO: organize this better)
------------------------------------------------------------*/
-@redash-gray:                           rgba(102, 136, 153, 1);
-@redash-orange:                         rgba(255, 120, 100, 1);
-@redash-black:                          rgba(0, 0, 0, 1);
-@redash-yellow:                         rgba(252, 252, 161, 0.75);
-@redash-font:                           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-@spacing:                               15px;
-@redash-space:                          10px;
-@redash-radius:                         3px;
-@redash-input-radius:                   2px;
 
 /* --------------------------------------------------------
     Branding

--- a/client/app/assets/less/main.less
+++ b/client/app/assets/less/main.less
@@ -1,5 +1,3 @@
-@import 'redash/ant';
-
 /** LESS Plugins **/
 @import 'inc/less-plugins/for';
 

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -811,11 +811,9 @@ page-header, .page-header--new {
 // Forms
 .form-control {
   border-radius: @redash-input-radius;
-  color: #9E9E9E;
 
   &:focus {
     box-shadow: none !important;
-    color: #111;
     border-color: @blue;
   }
 

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -1,5 +1,20 @@
 @import (reference, less) '~bootstrap/less/labels.less';
 
+// Variables
+@redash-gray: rgba(102, 136, 153, 1);
+@redash-orange: rgba(255, 120, 100, 1);
+@redash-black: rgba(0, 0, 0, 1);
+@redash-yellow: rgba(252, 252, 161, 0.75);
+@redash-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+@spacing: 15px;
+
+//Default spacing (between tiles)
+@redash-space: 10px;
+
+@redash-radius: 3px;
+@redash-input-radius: 2px;
+
 // General
 body {
   padding-top: 0;

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -1,20 +1,5 @@
 @import (reference, less) '~bootstrap/less/labels.less';
 
-// Variables
-@redash-gray: rgba(102, 136, 153, 1);
-@redash-orange: rgba(255, 120, 100, 1);
-@redash-black: rgba(0, 0, 0, 1);
-@redash-yellow: rgba(252, 252, 161, 0.75);
-@redash-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-
-@spacing: 15px;
-
-//Default spacing (between tiles)
-@redash-space: 10px;
-
-@redash-radius: 3px;
-@redash-input-radius: 2px;
-
 // General
 body {
   padding-top: 0;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,11 @@ const extensionPath = fs.realpathSync(path.join(__dirname, extensionsRelativePat
 const config = {
   mode: isProduction ? "production" : "development",
   entry: {
-    app: ["./client/app/index.js", "./client/app/assets/less/main.less"],
+    app: [
+      "./client/app/index.js",
+      "./client/app/assets/less/main.less",
+      "./client/app/assets/less/ant.less"
+    ],
     server: ["./client/app/assets/less/server.less"]
   },
   output: {


### PR DESCRIPTION
## Description
This is a fix for #3258. It separates `ant.less` file in `webpack.config.js` in order to avoid variable conflict between Ant and Bootstrap.

## Comments
We will need to validate if those changes affect any styling on Redash (mainly on components that use Ant styling).

I thought about keeping all variables that should/could be shared in `inc/variables` (I still need to organize variables that I removed from `redash-newstyle.less`). Anyway, opening this so we can already start studying its impacts :ok_hand:.