### PR TITLE
Update CodeClimate configuration format to Version 2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
-engines:
+version: "2"
+plugins:
   pep8:
     enabled: true
   eslint:
@@ -11,12 +12,8 @@ engines:
         enabled: false
       no-multiple-empty-lines: # TODO: Enable
         enabled: false
-ratings:
-  paths:
-  - "redash/**/*.py"
-  - "client/**/*.js"
-exclude_paths:
-- tests/**/*.py
-- migrations/**/*.py
-- setup/**/*
-- bin/**/*
+exclude_patterns:
+- "tests/**/*.py"
+- "migrations/**/*.py"
+- "setup/**/*"
+- "bin/**/*"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,3 +17,6 @@ exclude_patterns:
 - "migrations/**/*.py"
 - "setup/**/*"
 - "bin/**/*"
+- "**/node_modules/"
+- "client/dist/"
+- "**/*.pyc"


### PR DESCRIPTION
Hi there, this is the part of #3253.

- Update .codeclimate.yml version2
- Fix ignore pattern
- update channel eslint-4 for making the same as codebase


---

Currently(version 1), `codeclimate validate-config` shows warn and causes timeout due to no longer match ratings pattern

```
$ codeclimate validate-config
WARNING: 'engines' has been deprecated, please use 'plugins' instead
WARNING: 'exclude_paths' has been deprecated, please use 'exclude_patterns' instead
WARNING: 'ratings' has been deprecated, and will not be used
$ codeclimate analyze
...
error: (CC::CLI::Analyze::EngineFailure) engine structure ran for 900 seconds and was killed
```
