### PR TITLE
Closes #3294: Set schedule appropriately for forked queries.

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -623,7 +623,14 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         forked_list = ['org', 'data_source', 'latest_query_data', 'description',
                        'query_text', 'query_hash', 'options']
         kwargs = {a: getattr(self, a) for a in forked_list}
+        default_schedule = MutableDict({
+            'interval': None,
+            'until': None,
+            'day_of_week': None,
+            'time': None
+        })
         forked_query = Query.create(name=u'Copy of (#{}) {}'.format(self.id, self.name),
+                                    schedule=default_schedule,
                                     user=user, **kwargs)
 
         for v in self.visualizations:


### PR DESCRIPTION
Set the `schedule` to empty values when forking. This allows the UI to correctly handle an "empty" schedule

Note @arikfr I'm aware that this might look different once https://github.com/getredash/redash/pull/3277 is ready. But this is a quick fix we can have for now.