### PR TITLE
Override default number formats with environment variables

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -199,6 +199,13 @@ def date_format_config():
     }
 
 
+def number_format_config():
+    return {
+        'integerFormat': current_org.get_setting('integer_format'),
+        'floatFormat': current_org.get_setting('float_format'),
+    }
+
+
 def client_config():
     if not current_user.is_api_user() and current_user.is_authenticated:
         client_config = {
@@ -226,6 +233,7 @@ def client_config():
         'basePath': base_href()
     })
     client_config.update(date_format_config())
+    client_config.update(number_format_config())
 
     return client_config
 

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -17,6 +17,8 @@ SAML_NAMEID_FORMAT = os.environ.get("REDASH_SAML_NAMEID_FORMAT", "")
 SAML_LOGIN_ENABLED = SAML_METADATA_URL != ""
 
 DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
+INTEGER_FORMAT = os.environ.get("REDASH_INTEGER_FORMAT", "0,0")
+FLOAT_FORMAT = os.environ.get("REDASH_FLOAT_FORMAT", "0,0.00")
 
 JWT_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_JWT_LOGIN_ENABLED", "false"))
 JWT_AUTH_ISSUER = os.environ.get("REDASH_JWT_AUTH_ISSUER", "")
@@ -35,6 +37,8 @@ settings = {
     "auth_saml_metadata_url": SAML_METADATA_URL,
     "auth_saml_nameid_format": SAML_NAMEID_FORMAT,
     "date_format": DATE_FORMAT,
+    "integer_format": INTEGER_FORMAT,
+    "float_format": FLOAT_FORMAT,
     "auth_jwt_login_enabled": JWT_LOGIN_ENABLED,
     "auth_jwt_auth_issuer": JWT_AUTH_ISSUER,
     "auth_jwt_auth_public_certs_url": JWT_AUTH_PUBLIC_CERTS_URL,


### PR DESCRIPTION
This change lets the user override the default number formats with the environment variables `REDASH_INTEGER_FORMAT` and `REDASH_FLOAT_FORMAT`, following the pattern of `REDASH_DATE_FORMAT`.

Looking at: 
https://github.com/getredash/redash/blob/e8120c5f79cca01b5a011e8197c4cd604bf718d9/client/app/visualizations/table/index.js#L61-L64

It actually seems like this was a planned feature, but was just missing the option to populate `clientConfig` with the env variables.

Tested by setting:
```bash
export REDASH_INTEGER_FORMAT="00"
export REDASH_FLOAT_FORMAT="00.00"
```
![image](https://user-images.githubusercontent.com/16146623/51422577-e1799800-1b65-11e9-9bdc-3a1f73f76b16.png)
