### PR TITLE
Fix Percy data source page always showing diff

### DIFF
--- a/cypress/integration/data-source/create_data_source_spec.js
+++ b/cypress/integration/data-source/create_data_source_spec.js
@@ -14,6 +14,8 @@ describe('Create Data Source', () => {
     cy.getByTestId('Database Name').type('postgres{enter}');
 
     cy.contains('Saved.');
+
+    cy.wait(1000);
     cy.percySnapshot('Create Data Source page');
   });
 });


### PR DESCRIPTION
## Description
This snapshot is taken after submitting the form and a redirect happens at this moment. This was causing Percy diffs due to loading differences (such as the loading bar). I added some waiting time to avoid this.

I don't think the best practice would be to use `cy.wait` for this purpose, but I still haven't figured a way out of this haha.

~WIP: Testing if this actually works~ :slightly_smiling_face: 
Edit: Yep, no loading bar :grin: 