### PR TITLE
[Widget Params] Switched parameter list to table style (all parts)

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -13,6 +13,10 @@
 @import '~antd/lib/radio/style/index';
 @import '~antd/lib/time-picker/style/index';
 @import '~antd/lib/pagination/style/index';
+@import '~antd/lib/table/style/index';
+@import '~antd/lib/popover/style/index';
+@import '~antd/lib/icon/style/index';
+@import '~antd/lib/tag/style/index';
 @import 'inc/ant-variables';
 
 // Remove bold in labels for Ant checkboxes and radio buttons

--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -17,6 +17,7 @@
 @import '~antd/lib/popover/style/index';
 @import '~antd/lib/icon/style/index';
 @import '~antd/lib/tag/style/index';
+@import '~antd/lib/grid/style/index';
 @import 'inc/ant-variables';
 
 // Remove bold in labels for Ant checkboxes and radio buttons

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -1,11 +1,19 @@
 /* eslint react/no-multi-comp: 0 */
 
 import { extend, map, includes, findIndex, find, fromPairs } from 'lodash';
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Select from 'antd/lib/select';
+import Table from 'antd/lib/table';
+import Popover from 'antd/lib/popover';
+import Button from 'antd/lib/button';
+import Icon from 'antd/lib/icon';
+import Tag from 'antd/lib/tag';
 import { ParameterValueInput } from '@/components/ParameterValueInput';
 import { ParameterMappingType } from '@/services/widget';
+import { Parameter } from '@/services/query';
+
+import './ParameterMappingInput.less';
 
 const { Option } = Select;
 
@@ -208,16 +216,84 @@ export class ParameterMappingInput extends React.Component {
   render() {
     const { mapping } = this.props;
     return (
-      <div key={mapping.name} className="row">
-        <div className="col-xs-5">
-          <div className="form-control-static">{'{{ ' + mapping.name + ' }}'}</div>
-        </div>
-        <div className="col-xs-7">
-          {this.renderMappingTypeSelector()}
-          {this.renderInputBlock()}
-          {this.renderTitleInput()}
-        </div>
+      <div key={mapping.name}>
+        {this.renderMappingTypeSelector()}
+        {this.renderInputBlock()}
+        {this.renderTitleInput()}
       </div>
+    );
+  }
+}
+
+class EditMapping extends React.Component {
+  static propTypes = {
+    mapping: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    existingParamNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onChange: PropTypes.func.isRequired,
+    getContainerElement: PropTypes.func.isRequired,
+    clientConfig: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+    Query: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+  };
+
+  static defaultProps = {
+    clientConfig: null,
+    Query: null,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      visible: false,
+    };
+  }
+
+  onVisibleChange = (visible) => {
+    if (visible) this.show(); else this.hide();
+  }
+
+  get content() {
+    const { mapping, clientConfig, Query, onChange } = this.props;
+
+    return (
+      <div className="editMapping">
+        <header>Edit parameter</header>
+        <ParameterMappingInput
+          mapping={mapping}
+          existingParamNames={this.props.existingParamNames}
+          onChange={newMapping => onChange(mapping, newMapping)}
+          getContainerElement={() => this.wrapperRef.current}
+          clientConfig={clientConfig}
+          Query={Query}
+        />
+        <footer>
+          <Button onClick={this.hide}>Close</Button>
+        </footer>
+      </div>
+    );
+  }
+
+  show = () => {
+    this.setState({ visible: true });
+  }
+
+  hide = () => {
+    this.setState({ visible: false });
+  }
+
+  render() {
+    return (
+      <Popover
+        placement="right"
+        trigger="click"
+        content={this.content}
+        visible={this.state.visible}
+        onVisibleChange={this.onVisibleChange}
+        getPopupContainer={this.props.getContainerElement}
+      >
+        <Button size="small" type="dashed">
+          <Icon type="edit" theme="twoTone" />
+        </Button>
+      </Popover>
     );
   }
 }
@@ -242,6 +318,51 @@ export class ParameterMappingListInput extends React.Component {
     Query: null,
   };
 
+  constructor(props) {
+    super(props);
+    this.wrapperRef = React.createRef();
+  }
+
+  static getStringValue(value) {
+    // null
+    if (!value) {
+      return '';
+    }
+
+    // range
+    if (value instanceof Object && 'start' in value && 'end' in value) {
+      return `${value.start} ~ ${value.end}`;
+    }
+
+    // just to be safe, array or object
+    if (typeof value === 'object') {
+      return map(value, v => this.getStringValue(v)).join(', ');
+    }
+
+    // rest
+    return value.toString();
+  }
+
+  static getDefaultValue(mapping, existingParams) {
+    const { type, mapTo, name } = mapping;
+    let { param } = mapping;
+
+    // if mapped to another param, swap 'em
+    if (type === MappingType.DashboardMapToExisting && mapTo !== name) {
+      const mappedTo = find(existingParams, { name: mapTo });
+      if (mappedTo) { // just being safe
+        param = mappedTo;
+      }
+
+    // static type is different since it's fed param.normalizedValue
+    } else if (type === MappingType.StaticValue) {
+      param = param.clone().setValue(mapping.value);
+    }
+
+    const value = Parameter.getValue(param);
+    return this.getStringValue(value);
+  }
+
   updateParamMapping(oldMapping, newMapping) {
     const mappings = [...this.props.mappings];
     const index = findIndex(mappings, oldMapping);
@@ -255,28 +376,83 @@ export class ParameterMappingListInput extends React.Component {
   }
 
   render() {
-    const clientConfig = this.props.clientConfig; // eslint-disable-line react/prop-types
-    const Query = this.props.Query; // eslint-disable-line react/prop-types
+    const { clientConfig, Query, existingParams } = this.props; // eslint-disable-line react/prop-types
+    const dataSource = this.props.mappings.map(mapping => ({ mapping }));
 
     return (
-      <div>
-        {this.props.mappings.map((mapping, index) => {
-          const existingParamsNames = this.props.existingParams
-            .filter(({ type }) => type === mapping.param.type) // exclude mismatching param types
-            .map(({ name }) => name); // keep names only
+      <div ref={this.wrapperRef} className="paramMappingList">
+        <Table
+          dataSource={dataSource}
+          size="middle"
+          pagination={false}
+          rowKey={(record, idx) => `row${idx}`}
+        >
+          <Table.Column
+            title="Edit"
+            dataIndex="mapping"
+            key="edit"
+            render={(mapping) => {
+              const existingParamsNames = existingParams
+                .filter(({ type }) => type === mapping.param.type) // exclude mismatching param types
+                .map(({ name }) => name); // keep names only
 
-          return (
-            <div key={mapping.name} className={(index === 0 ? '' : ' m-t-15')}>
-              <ParameterMappingInput
-                mapping={mapping}
-                existingParamNames={existingParamsNames}
-                onChange={newMapping => this.updateParamMapping(mapping, newMapping)}
-                clientConfig={clientConfig}
-                Query={Query}
-              />
-            </div>
-          );
-        })}
+              return (
+                <EditMapping
+                  mapping={mapping}
+                  existingParamNames={existingParamsNames}
+                  onChange={(oldMapping, newMapping) => this.updateParamMapping(oldMapping, newMapping)}
+                  getContainerElement={() => this.wrapperRef.current}
+                  clientConfig={clientConfig}
+                  Query={Query}
+                />
+              );
+            }}
+          />
+          <Table.Column
+            title="Title"
+            dataIndex="mapping"
+            key="title"
+            render={mapping => mapping.title || mapping.param.title}
+          />
+          <Table.Column
+            title="Keyword"
+            dataIndex="mapping"
+            key="keyword"
+            className="keyword"
+            render={mapping => <code>{`{{ ${mapping.name} }}`}</code>}
+          />
+          <Table.Column
+            title="Default Value"
+            dataIndex="mapping"
+            key="value"
+            render={mapping => (
+              this.constructor.getDefaultValue(mapping, this.props.existingParams)
+            )}
+          />
+          <Table.Column
+            title="Value Source"
+            dataIndex="mapping"
+            key="source"
+            render={(mapping) => {
+              switch (mapping.type) {
+                case MappingType.DashboardAddNew:
+                case MappingType.DashboardMapToExisting:
+                  return (
+                    <Fragment>
+                      Dashboard parameter{' '}
+                      <Tag className="tag">{mapping.mapTo}</Tag>
+                    </Fragment>
+                  );
+                case MappingType.WidgetLevel:
+                  return 'Widget parameter';
+                case MappingType.StaticValue:
+                  return 'Static value';
+                default:
+                  return ''; // won't happen (typescript-ftw)
+              }
+            }}
+          />
+        </Table>
       </div>
     );
   }

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -1,0 +1,43 @@
+@import '~antd/lib/modal/style/index'; // for ant @vars
+
+.paramMappingList {
+  .keyword {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    code {
+      white-space: nowrap; // so the curly braces don't line break
+    }
+  }
+
+  // Ant <Tag> overrides
+  .tag {
+    margin: 0;
+    pointer-events: none; // unclickable
+
+    &:empty {
+      display: none;
+    }
+  }
+}
+
+.editMapping {
+  width: 340px;
+
+  header {
+    padding: 0 16px 10px;
+    margin: 0 -16px 20px;
+    border-bottom: @border-width-base @border-style-base @border-color-split;
+    font-size: @font-size-lg;
+    font-weight: 500;
+    color: @heading-color;
+  }
+
+  footer {
+    border-top: @border-width-base @border-style-base @border-color-split;
+    padding: 10px 16px 0;
+    margin: 20px -16px 0;
+    text-align: right;
+  }
+}

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -23,7 +23,17 @@
 }
 
 .editMapping {
-  width: 340px;
+  width: 390px;
+
+  .radio {
+    display: block;
+    height: 30px;
+    line-height: 30px;
+  }
+
+  .formItem {
+    margin-bottom: 10px;
+  }
 
   header {
     padding: 0 16px 10px;
@@ -37,7 +47,7 @@
   footer {
     border-top: @border-width-base @border-style-base @border-color-split;
     padding: 10px 16px 0;
-    margin: 20px -16px 0;
+    margin: 0 -16px;
     text-align: right;
 
     button {

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -39,5 +39,19 @@
     padding: 10px 16px 0;
     margin: 20px -16px 0;
     text-align: right;
+
+    button {
+      margin-left: 8px;
+    }
+  }
+}
+
+.editTitle {
+  input {
+    width: 100px;
+  }
+
+  button {
+    margin-left: 2px;
   }
 }

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -42,6 +42,8 @@
     font-size: @font-size-lg;
     font-weight: 500;
     color: @heading-color;
+    display: flex;
+    justify-content: space-between;
   }
 
   footer {

--- a/client/app/components/dashboards/AddWidgetDialog.jsx
+++ b/client/app/components/dashboards/AddWidgetDialog.jsx
@@ -308,6 +308,7 @@ class AddWidgetDialog extends React.Component {
         }}
         okText="Add to Dashboard"
         onCancel={this.close}
+        width={700}
       >
         {this.renderQueryInput()}
         {!this.state.selectedQuery && this.renderSearchQueryResults()}

--- a/client/app/components/dashboards/EditParameterMappingsDialog.jsx
+++ b/client/app/components/dashboards/EditParameterMappingsDialog.jsx
@@ -65,11 +65,6 @@ class EditParameterMappingsDialog extends React.Component {
   }
 
   render() {
-    const existingParams = map(
-      this.props.dashboard.getParametersDefs(),
-      ({ name, type }) => ({ name, type }),
-    );
-
     return (
       <Modal
         visible={this.state.showModal}
@@ -78,11 +73,12 @@ class EditParameterMappingsDialog extends React.Component {
         onOk={() => this.saveWidget()}
         okButtonProps={{ loading: this.state.saveInProgress }}
         onCancel={this.close}
+        width={700}
       >
         {(this.state.parameterMappings.length > 0) && (
           <ParameterMappingListInput
             mappings={this.state.parameterMappings}
-            existingParams={existingParams}
+            existingParams={this.props.dashboard.getParametersDefs()}
             onChange={mappings => this.updateParamMappings(mappings)}
           />
         )}

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -49,7 +49,7 @@ function isDateRangeParameter(paramType) {
   return includes(['date-range', 'datetime-range', 'datetime-range-with-seconds'], paramType);
 }
 
-class Parameter {
+export class Parameter {
   constructor(parameter) {
     this.title = parameter.title;
     this.name = parameter.name;
@@ -78,20 +78,25 @@ class Parameter {
   }
 
   getValue() {
-    const isEmptyValue = isNull(this.value) || isUndefined(this.value) || (this.value === '');
+    return this.constructor.getValue(this);
+  }
+
+  static getValue(param) {
+    const { value, type, useCurrentDateTime } = param;
+    const isEmptyValue = isNull(value) || isUndefined(value) || (value === '');
     if (isEmptyValue) {
       if (
-        includes(['date', 'datetime-local', 'datetime-with-seconds'], this.type) &&
-        this.useCurrentDateTime
+        includes(['date', 'datetime-local', 'datetime-with-seconds'], type) &&
+        useCurrentDateTime
       ) {
-        return moment().format(DATETIME_FORMATS[this.type]);
+        return moment().format(DATETIME_FORMATS[type]);
       }
       return null; // normalize empty value
     }
-    if (this.type === 'number') {
-      return normalizeNumericValue(this.value, null); // normalize empty value
+    if (type === 'number') {
+      return normalizeNumericValue(value, null); // normalize empty value
     }
-    return this.value;
+    return value;
   }
 
   setValue(value) {
@@ -135,6 +140,8 @@ class Parameter {
         local.setValue(this.value);
       });
     }
+
+    return this;
   }
 
   get normalizedValue() {


### PR DESCRIPTION
Play with it in https://deploy-preview-3332--redash-preview.netlify.com.

### What changed and why?
* Params in Table view and edit functions in popovers. Better UX.
* Source type dropdown changed to radio buttons. I think it's extremely valuable for clarity to have all options laid out instead of hidden inside the dropdown.
* When no existing params, instead of hiding the option, it is disabled and has info available.
* "OK" button disables on form error.
* Source type labels are more coherent. @susodapop lmk if you have any suggestions here.
* If current keyword not in existing params, don't show it as an option. This was possible before but makes no sense as it essentially means adding a new dashboard param.

<img width="446" alt="screen shot 2019-01-31 at 12 24 01" src="https://user-images.githubusercontent.com/486954/52048332-ce969880-2553-11e9-85f4-4b61de6526b2.png">
