### PR TITLE
[Widget Params] Split title and mapping editing (2 of 3)

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'no-param-reassign': 0,
     'no-mixed-operators': 0,
     'no-underscore-dangle': 0,
+    "object-curly-newline": "off",
     "prefer-destructuring": "off",
     "prefer-template": "off",
     "no-restricted-properties": "off",

--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -13,6 +13,10 @@
 @import '~antd/lib/radio/style/index';
 @import '~antd/lib/time-picker/style/index';
 @import '~antd/lib/pagination/style/index';
+@import '~antd/lib/table/style/index';
+@import '~antd/lib/popover/style/index';
+@import '~antd/lib/icon/style/index';
+@import '~antd/lib/tag/style/index';
 @import 'inc/ant-variables';
 
 // Remove bold in labels for Ant checkboxes and radio buttons

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -229,9 +229,14 @@ class EditMapping extends React.Component {
     existingParamNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     onChange: PropTypes.func.isRequired,
     getContainerElement: PropTypes.func.isRequired,
-    clientConfig: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
-    Query: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+    clientConfig: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+    Query: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   };
+
+  static defaultProps = {
+    clientConfig: null,
+    Query: null,
+  }
 
   constructor(props) {
     super(props);

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -3,6 +3,7 @@
 import { extend, map, includes, findIndex, find, fromPairs } from 'lodash';
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import Select from 'antd/lib/select';
 import Table from 'antd/lib/table';
 import Popover from 'antd/lib/popover';
@@ -12,6 +13,8 @@ import Tag from 'antd/lib/tag';
 import { ParameterValueInput } from '@/components/ParameterValueInput';
 import { ParameterMappingType } from '@/services/widget';
 import { Parameter } from '@/services/query';
+
+import './ParameterMappingInput.less';
 
 import './ParameterMappingInput.less';
 

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -342,7 +342,12 @@ export class ParameterMappingListInput extends React.Component {
   }
 
   static getDefaultValue(mapping) {
-    const value = Parameter.getValue(mapping.param);
+    // static type is different since it's fed param.normalizedValue
+    const param = mapping.type !== MappingType.StaticValue
+      ? mapping.param
+      : mapping.param.clone().setValue(mapping.value);
+
+    const value = Parameter.getValue(param);
 
     return this.getStringValue(value);
   }
@@ -364,26 +369,6 @@ export class ParameterMappingListInput extends React.Component {
     const dataSource = this.props.mappings.map(mapping => ({ mapping }));
 
     return (
-<<<<<<< HEAD
-      <div>
-        {this.props.mappings.map((mapping, index) => {
-          const existingParamsNames = this.props.existingParams
-            .filter(({ type }) => type === mapping.param.type) // exclude mismatching param types
-            .map(({ name }) => name); // keep names only
-
-          return (
-            <div key={mapping.name} className={(index === 0 ? '' : ' m-t-15')}>
-              <ParameterMappingInput
-                mapping={mapping}
-                existingParamNames={existingParamsNames}
-                onChange={newMapping => this.updateParamMapping(mapping, newMapping)}
-                clientConfig={clientConfig}
-                Query={Query}
-              />
-            </div>
-          );
-        })}
-=======
       <div ref={this.wrapperRef} className="paramMappingList">
         <Table
           dataSource={dataSource}
@@ -455,7 +440,6 @@ export class ParameterMappingListInput extends React.Component {
             }}
           />
         </Table>
->>>>>>> [Widget Params] Switched parameter list to table style
       </div>
     );
   }

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -3,7 +3,6 @@
 import { extend, map, includes, findIndex, find, fromPairs, clone } from 'lodash';
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import Select from 'antd/lib/select';
 import Table from 'antd/lib/table';
 import Popover from 'antd/lib/popover';
@@ -14,8 +13,6 @@ import Input from 'antd/lib/input';
 import { ParameterValueInput } from '@/components/ParameterValueInput';
 import { ParameterMappingType } from '@/services/widget';
 import { Parameter } from '@/services/query';
-
-import './ParameterMappingInput.less';
 
 import './ParameterMappingInput.less';
 

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -10,6 +10,7 @@ import Popover from 'antd/lib/popover';
 import Button from 'antd/lib/button';
 import Icon from 'antd/lib/icon';
 import Tag from 'antd/lib/tag';
+import Input from 'antd/lib/input';
 import { ParameterValueInput } from '@/components/ParameterValueInput';
 import { ParameterMappingType } from '@/services/widget';
 import { Parameter } from '@/services/query';
@@ -195,32 +196,12 @@ export class ParameterMappingInput extends React.Component {
     }
   }
 
-  renderTitleInput() {
-    const { mapping } = this.props;
-    if (mapping.type === MappingType.StaticValue) {
-      return null;
-    }
-    return (
-      <div className="m-t-10">
-        <label>Change parameter title (leave empty to use existing):</label>
-        <input
-          type="text"
-          className="form-control"
-          value={mapping.title}
-          onChange={event => this.updateParamMapping(mapping, { title: event.target.value })}
-          placeholder={mapping.param.title}
-        />
-      </div>
-    );
-  }
-
   render() {
     const { mapping } = this.props;
     return (
       <div key={mapping.name}>
         {this.renderMappingTypeSelector()}
         {this.renderInputBlock()}
-        {this.renderTitleInput()}
       </div>
     );
   }
@@ -284,7 +265,7 @@ class EditMapping extends React.Component {
   render() {
     return (
       <Popover
-        placement="right"
+        placement="left"
         trigger="click"
         content={this.content}
         visible={this.state.visible}
@@ -292,7 +273,81 @@ class EditMapping extends React.Component {
         getPopupContainer={this.props.getContainerElement}
       >
         <Button size="small" type="dashed">
-          <Icon type="edit" theme="twoTone" />
+          <Icon type="edit" />
+        </Button>
+      </Popover>
+    );
+  }
+}
+
+class EditTitle extends React.Component {
+  static propTypes = {
+    mapping: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    onChange: PropTypes.func.isRequired,
+    getContainerElement: PropTypes.func.isRequired,
+  };
+
+  state = {
+    visible: false,
+    title: this.props.mapping.title,
+  }
+
+  onVisibleChange = (visible) => {
+    this.setState({
+      visible,
+      title: this.props.mapping.title, // reset title
+    });
+  }
+
+  onTitleChange = (event) => {
+    this.setState({ title: event.target.value });
+  }
+
+  get popover() {
+    const { param: { title: paramTitle } } = this.props.mapping;
+
+    return (
+      <div className="editTitle">
+        <Input
+          size="small"
+          value={this.state.title}
+          placeholder={paramTitle}
+          onChange={this.onTitleChange}
+          onPressEnter={this.save}
+          autoFocus
+        />
+        <Button size="small" type="dashed" onClick={this.hide}>
+          <Icon type="close" />
+        </Button>
+        <Button size="small" type="dashed" onClick={this.save}>
+          <Icon type="check" />
+        </Button>
+      </div>
+    );
+  }
+
+  save = () => {
+    const newMapping = extend({}, this.props.mapping, { title: this.state.title });
+    this.props.onChange(newMapping);
+    this.hide();
+  }
+
+  hide = () => {
+    this.setState({ visible: false });
+  }
+
+  render() {
+    return (
+      <Popover
+        placement="right"
+        trigger="click"
+        content={this.popover}
+        visible={this.state.visible}
+        onVisibleChange={this.onVisibleChange}
+        getPopupContainer={this.props.getContainerElement}
+      >
+        <Button size="small" type="dashed">
+          <Icon type="edit" />
         </Button>
       </Popover>
     );
@@ -355,6 +410,25 @@ export class ParameterMappingListInput extends React.Component {
     return this.getStringValue(value);
   }
 
+  static getSourceTypeLabel({ type, mapTo }) {
+    switch (type) {
+      case MappingType.DashboardAddNew:
+      case MappingType.DashboardMapToExisting:
+        return (
+          <Fragment>
+            Dashboard parameter{' '}
+            <Tag className="tag">{mapTo}</Tag>
+          </Fragment>
+        );
+      case MappingType.WidgetLevel:
+        return 'Widget parameter';
+      case MappingType.StaticValue:
+        return 'Static value';
+      default:
+        return ''; // won't happen (typescript-ftw)
+    }
+  }
+
   updateParamMapping(oldMapping, newMapping) {
     const mappings = [...this.props.mappings];
     const index = findIndex(mappings, oldMapping);
@@ -380,31 +454,22 @@ export class ParameterMappingListInput extends React.Component {
           rowKey={(record, idx) => `row${idx}`}
         >
           <Table.Column
-            title="Edit"
-            dataIndex="mapping"
-            key="edit"
-            render={(mapping) => {
-              const existingParamsNames = existingParams
-                .filter(({ type }) => type === mapping.param.type) // exclude mismatching param types
-                .map(({ name }) => name); // keep names only
-
-              return (
-                <EditMapping
-                  mapping={mapping}
-                  existingParamNames={existingParamsNames}
-                  onChange={(oldMapping, newMapping) => this.updateParamMapping(oldMapping, newMapping)}
-                  getContainerElement={() => this.wrapperRef.current}
-                  clientConfig={clientConfig}
-                  Query={Query}
-                />
-              );
-            }}
-          />
-          <Table.Column
             title="Title"
             dataIndex="mapping"
             key="title"
-            render={mapping => mapping.title || mapping.param.title}
+            render={(mapping) => {
+              const { title, param: { title: paramTitle } } = mapping;
+              return (
+                <Fragment>
+                  {title || paramTitle}{' '}
+                  <EditTitle
+                    mapping={mapping}
+                    onChange={newMapping => this.updateParamMapping(mapping, newMapping)}
+                    getContainerElement={() => this.wrapperRef.current}
+                  />
+                </Fragment>
+              );
+            }}
           />
           <Table.Column
             title="Keyword"
@@ -424,22 +489,23 @@ export class ParameterMappingListInput extends React.Component {
             dataIndex="mapping"
             key="source"
             render={(mapping) => {
-              switch (mapping.type) {
-                case MappingType.DashboardAddNew:
-                case MappingType.DashboardMapToExisting:
-                  return (
-                    <Fragment>
-                      Dashboard parameter{' '}
-                      <Tag className="tag">{mapping.mapTo}</Tag>
-                    </Fragment>
-                  );
-                case MappingType.WidgetLevel:
-                  return 'Widget parameter';
-                case MappingType.StaticValue:
-                  return 'Static value';
-                default:
-                  return ''; // won't happen (typescript-ftw)
-              }
+              const existingParamsNames = existingParams
+                .filter(({ type }) => type === mapping.param.type) // exclude mismatching param types
+                .map(({ name }) => name); // keep names only
+
+              return (
+                <Fragment>
+                  {this.constructor.getSourceTypeLabel(mapping)}{' '}
+                  <EditMapping
+                    mapping={mapping}
+                    existingParamNames={existingParamsNames}
+                    onChange={(oldMapping, newMapping) => this.updateParamMapping(oldMapping, newMapping)}
+                    getContainerElement={() => this.wrapperRef.current}
+                    clientConfig={clientConfig}
+                    Query={Query}
+                  />
+                </Fragment>
+              );
             }}
           />
         </Table>

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -1,6 +1,6 @@
 /* eslint react/no-multi-comp: 0 */
 
-import { extend, map, includes, findIndex, find, fromPairs } from 'lodash';
+import { extend, map, includes, findIndex, find, fromPairs, clone } from 'lodash';
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -112,7 +112,7 @@ export class ParameterMappingInput extends React.Component {
       <div>
         <Select
           className="w-100"
-          defaultValue={mapping.type}
+          value={mapping.type}
           onChange={type => this.updateParamMapping(mapping, { type })}
           dropdownClassName="ant-dropdown-in-bootstrap-modal"
         >
@@ -154,7 +154,7 @@ export class ParameterMappingInput extends React.Component {
       <div className="m-t-10">
         <Select
           className="w-100"
-          defaultValue={mapping.mapTo}
+          value={mapping.mapTo}
           onChange={mapTo => this.updateParamMapping(mapping, { mapTo })}
           disabled={existingParamNames.length === 0}
           dropdownClassName="ant-dropdown-in-bootstrap-modal"
@@ -226,6 +226,7 @@ class EditMapping extends React.Component {
     super(props);
     this.state = {
       visible: false,
+      mapping: clone(this.props.mapping),
     };
   }
 
@@ -233,8 +234,13 @@ class EditMapping extends React.Component {
     if (visible) this.show(); else this.hide();
   }
 
+  onChange = (mapping) => {
+    this.setState({ mapping });
+  }
+
   get content() {
-    const { mapping, clientConfig, Query, onChange } = this.props;
+    const { mapping } = this.state;
+    const { clientConfig, Query } = this.props;
 
     return (
       <div className="editMapping">
@@ -242,20 +248,29 @@ class EditMapping extends React.Component {
         <ParameterMappingInput
           mapping={mapping}
           existingParamNames={this.props.existingParamNames}
-          onChange={newMapping => onChange(mapping, newMapping)}
+          onChange={this.onChange}
           getContainerElement={() => this.wrapperRef.current}
           clientConfig={clientConfig}
           Query={Query}
         />
         <footer>
-          <Button onClick={this.hide}>Close</Button>
+          <Button onClick={this.hide}>Cancel</Button>
+          <Button onClick={this.save} type="primary">OK</Button>
         </footer>
       </div>
     );
   }
 
+  save = () => {
+    this.props.onChange(this.props.mapping, this.state.mapping);
+    this.hide();
+  }
+
   show = () => {
-    this.setState({ visible: true });
+    this.setState({
+      visible: true,
+      mapping: clone(this.props.mapping), // restore original state
+    });
   }
 
   hide = () => {

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -3,7 +3,6 @@
 import { extend, map, includes, findIndex, find, fromPairs } from 'lodash';
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import Select from 'antd/lib/select';
 import Table from 'antd/lib/table';
 import Popover from 'antd/lib/popover';
@@ -12,6 +11,7 @@ import Icon from 'antd/lib/icon';
 import Tag from 'antd/lib/tag';
 import { ParameterValueInput } from '@/components/ParameterValueInput';
 import { ParameterMappingType } from '@/services/widget';
+import { Parameter } from '@/services/query';
 
 import './ParameterMappingInput.less';
 
@@ -322,16 +322,14 @@ export class ParameterMappingListInput extends React.Component {
       return '';
     }
 
-    // array
-    if (value instanceof Array) {
-      const arr = value.map(v => this.getStringValue(v));
-      const delimiter = moment.isMoment(value[0]) ? ' ~ ' : ', ';
-      return arr.join(delimiter);
+    // range
+    if (value instanceof Object && 'start' in value && 'end' in value) {
+      return `${value.start} ~ ${value.end}`;
     }
 
-    // moment
-    if (moment.isMoment(value)) {
-      return value.format('DD/MM/YY');
+    // just to be safe, array or object
+    if (typeof value === 'object') {
+      return map(value, v => this.getStringValue(v)).join(', ');
     }
 
     // rest
@@ -339,9 +337,7 @@ export class ParameterMappingListInput extends React.Component {
   }
 
   static getDefaultValue(mapping) {
-    const value = mapping.type === MappingType.StaticValue
-      ? mapping.value || mapping.param.normalizedValue
-      : mapping.param.normalizedValue;
+    const value = Parameter.getValue(mapping.param);
 
     return this.getStringValue(value);
   }

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -39,6 +39,10 @@
     padding: 10px 16px 0;
     margin: 20px -16px 0;
     text-align: right;
+
+    button {
+      margin-left: 8px;
+    }
   }
 }
 

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -1,0 +1,43 @@
+@import '~antd/lib/modal/style/index'; // for ant @vars
+
+.paramMappingList {
+  .keyword {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    code {
+      white-space: nowrap; // so the curly braces don't line break
+    }
+  }
+
+  // Ant <Tag> overrides
+  .tag {
+    margin: 0;
+    pointer-events: none; // unclickable
+
+    &:empty {
+      display: none;
+    }
+  }
+}
+
+.editMapping {
+  width: 340px;
+
+  header {
+    padding: 0 16px 10px;
+    margin: 0 -16px 20px;
+    border-bottom: @border-width-base @border-style-base @border-color-split;
+    font-size: @font-size-lg;
+    font-weight: 500;
+    color: @heading-color;
+  }
+
+  footer {
+    border-top: @border-width-base @border-style-base @border-color-split;
+    padding: 10px 16px 0;
+    margin: 20px -16px 0;
+    text-align: right;
+  }
+}

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -41,3 +41,13 @@
     text-align: right;
   }
 }
+
+.editTitle {
+  input {
+    width: 100px;
+  }
+
+  button {
+    margin-left: 2px;
+  }
+}

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -49,7 +49,7 @@ function isDateRangeParameter(paramType) {
   return includes(['date-range', 'datetime-range', 'datetime-range-with-seconds'], paramType);
 }
 
-class Parameter {
+export class Parameter {
   constructor(parameter) {
     this.title = parameter.title;
     this.name = parameter.name;
@@ -78,20 +78,25 @@ class Parameter {
   }
 
   getValue() {
-    const isEmptyValue = isNull(this.value) || isUndefined(this.value) || (this.value === '');
+    return this.constructor.getValue(this);
+  }
+
+  static getValue(param) {
+    const { value, type, useCurrentDateTime } = param;
+    const isEmptyValue = isNull(value) || isUndefined(value) || (value === '');
     if (isEmptyValue) {
       if (
-        includes(['date', 'datetime-local', 'datetime-with-seconds'], this.type) &&
-        this.useCurrentDateTime
+        includes(['date', 'datetime-local', 'datetime-with-seconds'], type) &&
+        useCurrentDateTime
       ) {
-        return moment().format(DATETIME_FORMATS[this.type]);
+        return moment().format(DATETIME_FORMATS[type]);
       }
       return null; // normalize empty value
     }
-    if (this.type === 'number') {
-      return normalizeNumericValue(this.value, null); // normalize empty value
+    if (type === 'number') {
+      return normalizeNumericValue(value, null); // normalize empty value
     }
-    return this.value;
+    return value;
   }
 
   setValue(value) {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -140,6 +140,8 @@ export class Parameter {
         local.setValue(this.value);
       });
     }
+
+    return this;
   }
 
   get normalizedValue() {


### PR DESCRIPTION
This is the second of a batch of 3 commits that change UX of widget params.

#### Why?
Currently, there is one edit button per parameter, opening a popover that allows editing both source type and title. A better user experience is to have edit buttons per editable content - one for title, one for source type.

#### How it looks
Title edit
<img width="309" alt="screen shot 2019-01-24 at 13 50 03" src="https://user-images.githubusercontent.com/486954/51676439-45c1af00-1fdf-11e9-9414-bfef862ef0a7.png">

Source type edit
<img width="434" alt="screen shot 2019-01-24 at 13 51 33" src="https://user-images.githubusercontent.com/486954/51676445-4bb79000-1fdf-11e9-86e4-e32d5e2b7b63.png">

#### Implementation notes
Since now popovers open to the right of the content, affecting data as you type makes the popover jump horizontally as the position of the edit button shifts.
So, I implemented a "cancel/save" to each popover, hence the underlying table stays put during editing.