### PR TITLE
Show number of queries in queue while waiting for execution

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -208,7 +208,7 @@
                   <rd-timer timestamp="queryResult.getUpdatedAt()"></rd-timer>
                 </div>
                 <div class="alert alert-info m-t-15" ng-show="queryResult.getStatus() == 'waiting'">
-                  Query in queue&hellip;
+                  Query in queue (waiting on {{queryResult.job.queueLength}} quer<span ng-if="queryResult.job.queueLength === 1">y</span><span ng-if="queryResult.job.queueLength !== 1">ies</span>)&hellip;
                   <rd-timer timestamp="queryResult.getUpdatedAt()"></rd-timer>
                   <button type="button" class="btn btn-warning btn-xs pull-right" ng-disabled="cancelling" ng-click="cancelExecution()">Cancel
                   </button>

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -181,12 +181,21 @@ class QueryTask(object):
         else:
             query_result_id = None
 
+        queriesAhead = 0
+        if task_status == 'PENDING':
+            waiting = QueryTaskTracker.all(QueryTaskTracker.WAITING_LIST)
+            # find our job's index, return number of queries after it
+            for i, t in enumerate(waiting):
+                if t.data['task_id' ]== self._async_result.id:
+                    queriesAhead = len(waiting) - i - 1
+                    break
         return {
             'id': self._async_result.id,
             'updated_at': updated_at,
             'status': status,
             'error': error,
             'query_result_id': query_result_id,
+            'queueLength': queriesAhead,
         }
 
     @property


### PR DESCRIPTION
This invokes the same API used in the admin "Running Queries" page to ask redis how many jobs are in the 'waiting' state ahead of the current one.

I tested this locally by stopping the celery worker and executing several queries.