### PR TITLE
Fix: make ClickHouse password and username truly optional

### DIFF
--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -68,12 +68,12 @@ class ClickHouse(BaseSQLQueryRunner):
 
     def _send_query(self, data, stream=False):
         r = requests.post(
-            self.configuration['url'],
+            self.configuration.get('url', "http://127.0.0.1:8123"),
             data=data.encode("utf-8"),
             stream=stream,
             timeout=self.configuration.get('timeout', 30),
             params={
-                'user': self.configuration['user'],
+                'user': self.configuration.get('user', "default"),
                 'password':  self.configuration.get('password', ""),
                 'database': self.configuration['dbname']
             }

--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -74,7 +74,7 @@ class ClickHouse(BaseSQLQueryRunner):
             timeout=self.configuration.get('timeout', 30),
             params={
                 'user': self.configuration['user'],
-                'password':  self.configuration['password'],
+                'password':  self.configuration.get('password', ""),
                 'database': self.configuration['dbname']
             }
         )


### PR DESCRIPTION
Fix #3289 