### PR TITLE
Modal style adjustment

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -178,3 +178,21 @@
     }
   }
 }
+
+// styling for short modals (no lines)
+.@{dialog-prefix-cls}.shortModal {
+  .@{dialog-prefix-cls} {
+    &-header, &-footer {
+      border: none;
+      padding: 16px;
+    }
+    &-body {
+      padding: 10px 16px;
+    }
+    &-close-x {
+      width: 46px;
+      height: 46px;
+      line-height: 46px;
+    }
+  }
+}

--- a/client/app/components/tags-control/EditTagsDialog.jsx
+++ b/client/app/components/tags-control/EditTagsDialog.jsx
@@ -39,7 +39,12 @@ class EditTagsDialog extends React.Component {
     const { dialog } = this.props;
     const { loading, availableTags, result } = this.state;
     return (
-      <Modal {...dialog.props} onOk={() => dialog.close(result)} title="Add/Edit Tags">
+      <Modal
+        {...dialog.props}
+        onOk={() => dialog.close(result)}
+        title="Add/Edit Tags"
+        className="shortModal"
+      >
         <Select
           mode="tags"
           className="w-100"


### PR DESCRIPTION
The default ant modal style has lines and spacing that the team doesn't favor. Adjusted to a more of the previous modal look.

Before | After
------------ | -------------
<img width="541" alt="screen shot 2019-01-30 at 11 51 56" src="https://user-images.githubusercontent.com/486954/51973114-99bc1000-2485-11e9-818e-3c8aa3069b00.png"> | <img width="540" alt="screen shot 2019-01-30 at 11 26 22" src="https://user-images.githubusercontent.com/486954/51973127-9f195a80-2485-11e9-98f7-d466ea23741e.png">


Before | After
------------ | -------------
<img width="470" alt="screen shot 2019-01-30 at 11 52 32" src="https://user-images.githubusercontent.com/486954/51973195-bc4e2900-2485-11e9-8967-58828a478aca.png"> | <img width="470" alt="screen shot 2019-01-30 at 11 46 44" src="https://user-images.githubusercontent.com/486954/51973167-b2c4c100-2485-11e9-812f-afe281ee0013.png">
