### PR TITLE
Fix: Static param value not editable for Text/Number

### DIFF
--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -1,8 +1,9 @@
-import { isNull, isUndefined } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import Select from 'antd/lib/select';
+import Input from 'antd/lib/input';
+import InputNumber from 'antd/lib/input-number';
 import { DateInput } from './DateInput';
 import { DateRangeInput } from './DateRangeInput';
 import { DateTimeInput } from './DateTimeInput';
@@ -127,14 +128,24 @@ export class ParameterValueInput extends React.Component {
     );
   }
 
-  renderTextInput() {
-    const { value, onSelect, type } = this.props;
+  renderNumberInput() {
+    const { value, onSelect, className } = this.props;
     return (
-      <input
-        type={type}
-        className={'form-control ' + this.props.className}
-        value={isNull(value) || isUndefined(value) ? '' : value}
-        onChange={event => onSelect(event.target.value)}
+      <InputNumber
+        className={'form-control ' + className}
+        defaultValue={!isNaN(value) && value || 0}
+        onChange={onSelect}
+      />
+    );
+  }
+
+  renderTextInput() {
+    const { value, onSelect, className } = this.props;
+    return (
+      <Input
+        className={'form-control ' + className}
+        defaultValue={value || ''}
+        onChange={onSelect}
       />
     );
   }
@@ -150,6 +161,7 @@ export class ParameterValueInput extends React.Component {
       case 'date-range': return this.renderDateRangeInput();
       case 'enum': return this.renderEnumInput();
       case 'query': return this.renderQueryBasedInput();
+      case 'number': return this.renderNumberInput();
       default: return this.renderTextInput();
     }
   }


### PR DESCRIPTION
Static parameters text and number cannot be edited.

STR:
1. Create a query with a textual static paramater
2. Create a widget from the this query
3. Choose static value as parameter type.
4. Type any value into bottom value text field.

Expected: field is editable.
Actual: you type but value stays the same.

#### Why?
#3357 changed the param value from `value` to `param.normalizedValue` but the `<input>` updates the `value` prop so it doesn't update it's content that still shows `param.normalizedValue`.

#### Why is this affecting only text and number types?
Because other param type elements implement an Ant component which gets fed the `defaultValue`, not `value`.

#### What's the fix?
I don't wanna risk touching the variable that's being fed or updated, instead I swapped the `<input>` for an Ant `<Input`> which takes a `defaultValue`. Had to split text and number types since they require different Ant components.