### PR TITLE
[Widget Params] Url prefix change p -> p_w

### DIFF
--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -194,7 +194,7 @@ function WidgetFactory($http, $location, Query, Visualization, dashboardGridOpti
           const result = param.clone();
           result.title = mapping.title || param.title;
           result.locals = [param];
-          result.urlPrefix = `w${this.id}_`;
+          result.urlPrefix = `p_w${this.id}_`;
           if (mapping.type === WidgetService.MappingType.StaticValue) {
             result.setValue(mapping.value);
           } else {


### PR DESCRIPTION
Requested by @arikfr in https://github.com/getredash/redash/pull/3334#issuecomment-459269626.

#### Logic
if dashboard query param url prefix is `p_keyword` then widget param should be `p_w##_keyword`.

Simple code change, seems to work ok.