### PR TITLE
BigQuery should correctly handle tables that do not have a schema key

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -235,7 +235,7 @@ class BigQuery(BaseQueryRunner):
 
     def _get_columns_schema(self, table_data):
         columns = []
-        for column in table_data['schema']['fields']:
+        for column in table_data.get('schema', {}).get('fields', []):
             columns.extend(self._get_columns_schema_column(column))
 
         project_id = self._get_project_id()


### PR DESCRIPTION
We've noticed in our Mozilla fork that BigQuery often doesn't load the schema. Upon digging into this, it was failing when we tried to load tables without a schema.

In this PR I'm just adding extra care when trying to access keys and not assuming that the keys will be there.