### PR TITLE
 [Widget Params] Migrated edit params + new widget dialog to Ant Modal

### DIFF
--- a/client/app/components/dashboards/AddWidgetDialog.jsx
+++ b/client/app/components/dashboards/AddWidgetDialog.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import Select from 'antd/lib/select';
+import Modal from 'antd/lib/modal';
 import highlight from '@/lib/highlight';
 import {
   MappingType,
@@ -19,15 +20,9 @@ const { Option, OptGroup } = Select;
 
 class AddWidgetDialog extends React.Component {
   static propTypes = {
-    dashboard: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    close: PropTypes.func,
-    dismiss: PropTypes.func,
-  };
-
-  static defaultProps = {
-    dashboard: null,
-    close: () => {},
-    dismiss: () => {},
+    dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    onClose: PropTypes.func.isRequired,
+    onAdded: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -40,12 +35,14 @@ class AddWidgetDialog extends React.Component {
       searchedQueries: [],
       selectedVis: null,
       parameterMappings: [],
+      showModal: false, // show only after recent queries populated to avoid height "jump"
     };
 
     // Don't show draft (unpublished) queries in recent queries.
     Query.recent().$promise.then((items) => {
       this.setState({
         recentQueries: items.filter(item => !item.is_draft),
+        showModal: true,
       });
     });
 
@@ -143,7 +140,8 @@ class AddWidgetDialog extends React.Component {
       .save()
       .then(() => {
         dashboard.widgets.push(widget);
-        this.props.close();
+        this.props.onAdded();
+        this.close();
       })
       .catch(() => {
         toastr.error('Widget can not be added');
@@ -151,6 +149,10 @@ class AddWidgetDialog extends React.Component {
       .finally(() => {
         this.setState({ saveInProgress: false });
       });
+  }
+
+  close = () => {
+    this.setState({ showModal: false });
   }
 
   updateParamMappings(parameterMappings) {
@@ -290,77 +292,41 @@ class AddWidgetDialog extends React.Component {
     );
 
     return (
-      <div>
-        <div className="modal-header">
-          <button
-            type="button"
-            className="close"
-            disabled={this.state.saveInProgress}
-            aria-hidden="true"
-            onClick={this.props.dismiss}
-          >
-            &times;
-          </button>
-          <h4 className="modal-title">Add Widget</h4>
-        </div>
-        <div className="modal-body">
-          {this.renderQueryInput()}
-          {!this.state.selectedQuery && this.renderSearchQueryResults()}
-          {this.state.selectedQuery && this.renderVisualizationInput()}
+      <Modal
+        visible={this.state.showModal}
+        afterClose={this.props.onClose}
+        title="Add Widget"
+        onOk={() => this.saveWidget()}
+        okButtonProps={{
+          loading: this.state.saveInProgress,
+          disabled: !this.state.selectedQuery,
+        }}
+        okText="Add to Dashboard"
+        onCancel={this.close}
+      >
+        {this.renderQueryInput()}
+        {!this.state.selectedQuery && this.renderSearchQueryResults()}
+        {this.state.selectedQuery && this.renderVisualizationInput()}
 
-          {
-            (this.state.parameterMappings.length > 0) && [
-              <label key="parameters-title" htmlFor="parameter-mappings">Parameters</label>,
-              <ParameterMappingListInput
-                key="parameters-list"
-                id="parameter-mappings"
-                mappings={this.state.parameterMappings}
-                existingParams={existingParams}
-                onChange={mappings => this.updateParamMappings(mappings)}
-              />,
-            ]
-          }
-        </div>
-
-        <div className="modal-footer">
-          <button
-            type="button"
-            className="btn btn-default"
-            disabled={this.state.saveInProgress}
-            onClick={this.props.dismiss}
-          >
-            Close
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={this.state.saveInProgress || !this.state.selectedQuery}
-            onClick={() => this.saveWidget()}
-          >
-            Add to Dashboard
-          </button>
-        </div>
-      </div>
+        {
+          (this.state.parameterMappings.length > 0) && [
+            <label key="parameters-title" htmlFor="parameter-mappings">Parameters</label>,
+            <ParameterMappingListInput
+              key="parameters-list"
+              id="parameter-mappings"
+              mappings={this.state.parameterMappings}
+              existingParams={existingParams}
+              onChange={mappings => this.updateParamMappings(mappings)}
+            />,
+          ]
+        }
+      </Modal>
     );
   }
 }
 
 export default function init(ngModule) {
-  ngModule.component('addWidgetDialog', {
-    template: `
-      <add-widget-dialog-impl 
-        dashboard="$ctrl.resolve.dashboard"
-        close="$ctrl.close"
-        dismiss="$ctrl.dismiss"
-      ></add-widget-dialog-impl>
-    `,
-    bindings: {
-      resolve: '<',
-      close: '&',
-      dismiss: '&',
-    },
-  });
-  ngModule.component('addWidgetDialogImpl', react2angular(AddWidgetDialog));
+  ngModule.component('addWidgetDialog', react2angular(AddWidgetDialog));
 }
 
 init.init = true;

--- a/client/app/components/dashboards/AddWidgetDialog.jsx
+++ b/client/app/components/dashboards/AddWidgetDialog.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'antd/lib/select';
 import Modal from 'antd/lib/modal';
+import ModalOpener from '@/hoc/ModalOpener';
 import highlight from '@/lib/highlight';
 import {
   MappingType,
@@ -14,7 +15,6 @@ import { QueryTagsControl } from '@/components/tags-control/QueryTagsControl';
 import { toastr } from '@/services/ng';
 import { Widget } from '@/services/widget';
 import { Query } from '@/services/query';
-import asUIBModal from '@/hoc/asUIBModal';
 
 const { Option, OptGroup } = Select;
 
@@ -330,4 +330,4 @@ class AddWidgetDialog extends React.Component {
   }
 }
 
-export default asUIBModal(AddWidgetDialog);
+export default ModalOpener(AddWidgetDialog);

--- a/client/app/components/dashboards/AddWidgetDialog.jsx
+++ b/client/app/components/dashboards/AddWidgetDialog.jsx
@@ -1,7 +1,6 @@
 import { debounce, each, values, map, includes, first } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { react2angular } from 'react2angular';
 import Select from 'antd/lib/select';
 import Modal from 'antd/lib/modal';
 import highlight from '@/lib/highlight';
@@ -15,14 +14,20 @@ import { QueryTagsControl } from '@/components/tags-control/QueryTagsControl';
 import { toastr } from '@/services/ng';
 import { Widget } from '@/services/widget';
 import { Query } from '@/services/query';
+import asUIBModal from '@/hoc/asUIBModal';
 
 const { Option, OptGroup } = Select;
 
 class AddWidgetDialog extends React.Component {
   static propTypes = {
     dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-    onClose: PropTypes.func.isRequired,
-    onAdded: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
+    onConfirm: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onClose: () => {},
+    onConfirm: () => {},
   };
 
   constructor(props) {
@@ -52,6 +57,10 @@ class AddWidgetDialog extends React.Component {
       this.setState({ searchTerm });
       searchQueries(searchTerm);
     };
+  }
+
+  close = () => {
+    this.setState({ showModal: false });
   }
 
   selectQuery(queryId) {
@@ -140,7 +149,7 @@ class AddWidgetDialog extends React.Component {
       .save()
       .then(() => {
         dashboard.widgets.push(widget);
-        this.props.onAdded();
+        this.props.onConfirm();
         this.close();
       })
       .catch(() => {
@@ -149,10 +158,6 @@ class AddWidgetDialog extends React.Component {
       .finally(() => {
         this.setState({ saveInProgress: false });
       });
-  }
-
-  close = () => {
-    this.setState({ showModal: false });
   }
 
   updateParamMappings(parameterMappings) {
@@ -325,8 +330,4 @@ class AddWidgetDialog extends React.Component {
   }
 }
 
-export default function init(ngModule) {
-  ngModule.component('addWidgetDialog', react2angular(AddWidgetDialog));
-}
-
-init.init = true;
+export default asUIBModal(AddWidgetDialog);

--- a/client/app/components/dashboards/EditParameterMappingsDialog.jsx
+++ b/client/app/components/dashboards/EditParameterMappingsDialog.jsx
@@ -2,20 +2,26 @@ import { map } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'antd/lib/modal';
-import { react2angular } from 'react2angular';
 import {
   ParameterMappingListInput,
   parameterMappingsToEditableMappings,
   editableMappingsToParameterMappings,
 } from '@/components/ParameterMappingInput';
+import asUIBModal from '@/hoc/asUIBModal';
 
 class EditParameterMappingsDialog extends React.Component {
   static propTypes = {
     dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
     widget: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-    onClose: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
+    onConfirm: PropTypes.func,
   };
+
+  static defaultProps = {
+    onClose: () => {},
+    onConfirm: () => {},
+  };
+
   constructor(props) {
     super(props);
     this.state = {
@@ -29,6 +35,10 @@ class EditParameterMappingsDialog extends React.Component {
     };
   }
 
+  close = () => {
+    this.setState({ showModal: false });
+  }
+
   saveWidget() {
     const toastr = this.props.toastr; // eslint-disable-line react/prop-types
     const widget = this.props.widget;
@@ -39,7 +49,7 @@ class EditParameterMappingsDialog extends React.Component {
     widget
       .save()
       .then(() => {
-        this.props.onChange();
+        this.props.onConfirm();
         this.close();
       })
       .catch(() => {
@@ -48,10 +58,6 @@ class EditParameterMappingsDialog extends React.Component {
       .finally(() => {
         this.setState({ saveInProgress: false });
       });
-  }
-
-  close = () => {
-    this.setState({ showModal: false });
   }
 
   updateParamMappings(parameterMappings) {
@@ -85,8 +91,4 @@ class EditParameterMappingsDialog extends React.Component {
   }
 }
 
-export default function init(ngModule) {
-  ngModule.component('editParameterMappingsDialog', react2angular(EditParameterMappingsDialog));
-}
-
-init.init = true;
+export default asUIBModal(EditParameterMappingsDialog);

--- a/client/app/components/dashboards/EditParameterMappingsDialog.jsx
+++ b/client/app/components/dashboards/EditParameterMappingsDialog.jsx
@@ -2,12 +2,12 @@ import { map } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'antd/lib/modal';
+import ModalOpener from '@/hoc/ModalOpener';
 import {
   ParameterMappingListInput,
   parameterMappingsToEditableMappings,
   editableMappingsToParameterMappings,
 } from '@/components/ParameterMappingInput';
-import asUIBModal from '@/hoc/asUIBModal';
 
 class EditParameterMappingsDialog extends React.Component {
   static propTypes = {
@@ -91,4 +91,4 @@ class EditParameterMappingsDialog extends React.Component {
   }
 }
 
-export default asUIBModal(EditParameterMappingsDialog);
+export default ModalOpener(EditParameterMappingsDialog);

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -21,7 +21,10 @@
 
             <li ng-if="$ctrl.canViewQuery || ($ctrl.dashboard.canEdit() && $ctrl.hasParameters())" class="divider"></li>
             <li ng-if="$ctrl.canViewQuery"><a ng-href="{{$ctrl.widget.getQuery().getUrl(true, $ctrl.widget.visualization.id)}}">View Query</a></li>
-            <li ng-if="$ctrl.dashboard.canEdit() && $ctrl.hasParameters()"><a ng-click="$ctrl.editParameterMappings()">Edit Parameters</a></li>
+            <li ng-if="$ctrl.dashboard.canEdit() && $ctrl.hasParameters()">
+              <a ng-click="$ctrl.openMappingsDialog()">Edit Parameters</a>
+              <edit-parameter-mappings-dialog ng-if="$ctrl.mappingsDialogOpened" dashboard="$ctrl.dashboard" widget="$ctrl.widget" on-close="$ctrl.closeMappingsDialog" on-change="$ctrl.onMappingsUpdated" />
+            </li>
 
             <li ng-if="$ctrl.dashboard.canEdit()" class="divider"></li>
             <li ng-if="$ctrl.dashboard.canEdit()"><a ng-click="$ctrl.deleteWidget()">Remove from Dashboard</a></li>

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -22,8 +22,7 @@
             <li ng-if="$ctrl.canViewQuery || ($ctrl.dashboard.canEdit() && $ctrl.hasParameters())" class="divider"></li>
             <li ng-if="$ctrl.canViewQuery"><a ng-href="{{$ctrl.widget.getQuery().getUrl(true, $ctrl.widget.visualization.id)}}">View Query</a></li>
             <li ng-if="$ctrl.dashboard.canEdit() && $ctrl.hasParameters()">
-              <a ng-click="$ctrl.openMappingsDialog()">Edit Parameters</a>
-              <edit-parameter-mappings-dialog ng-if="$ctrl.mappingsDialogOpened" dashboard="$ctrl.dashboard" widget="$ctrl.widget" on-close="$ctrl.closeMappingsDialog" on-change="$ctrl.onMappingsUpdated" />
+              <li ng-if="$ctrl.dashboard.canEdit() && $ctrl.hasParameters()"><a ng-click="$ctrl.editParameterMappings()">Edit Parameters</a></li>
             </li>
 
             <li ng-if="$ctrl.dashboard.canEdit()" class="divider"></li>

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -77,18 +77,20 @@ function DashboardWidgetCtrl($location, $uibModal, $window, $rootScope, Events, 
 
   this.hasParameters = () => this.widget.query.getParametersDefs().length > 0;
 
-  this.editParameterMappings = () => {
-    $uibModal.open({
-      component: 'editParameterMappingsDialog',
-      resolve: {
-        dashboard: this.dashboard,
-        widget: this.widget,
-      },
-      size: 'lg',
-    }).result.then(() => {
-      this.localParameters = null;
-      $rootScope.$broadcast('dashboard.update-parameters');
-    });
+  this.mappingsDialogOpened = false;
+
+  this.openMappingsDialog = () => {
+    this.mappingsDialogOpened = true;
+  };
+
+  this.closeMappingsDialog = () => {
+    this.mappingsDialogOpened = false;
+    $rootScope.$applyAsync();
+  };
+
+  this.onMappingsUpdated = () => {
+    this.localParameters = null;
+    $rootScope.$broadcast('dashboard.update-parameters');
   };
 
   this.localParametersDefs = () => {

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -2,6 +2,7 @@ import { filter } from 'lodash';
 import template from './widget.html';
 import editTextBoxTemplate from './edit-text-box.html';
 import widgetDialogTemplate from './widget-dialog.html';
+import editParameterMappingsDialog from '@/components/dashboards/EditParameterMappingsDialog';
 import './widget.less';
 import './widget-dialog.less';
 
@@ -77,20 +78,14 @@ function DashboardWidgetCtrl($location, $uibModal, $window, $rootScope, Events, 
 
   this.hasParameters = () => this.widget.query.getParametersDefs().length > 0;
 
-  this.mappingsDialogOpened = false;
-
-  this.openMappingsDialog = () => {
-    this.mappingsDialogOpened = true;
-  };
-
-  this.closeMappingsDialog = () => {
-    this.mappingsDialogOpened = false;
-    $rootScope.$applyAsync();
-  };
-
-  this.onMappingsUpdated = () => {
-    this.localParameters = null;
-    $rootScope.$broadcast('dashboard.update-parameters');
+  this.editParameterMappings = () => {
+    editParameterMappingsDialog.open({
+      dashboard: this.dashboard,
+      widget: this.widget,
+    }).result.then(() => {
+      this.localParameters = null;
+      $rootScope.$broadcast('dashboard.update-parameters');
+    });
   };
 
   this.localParametersDefs = () => {

--- a/client/app/hoc/ModalOpener.jsx
+++ b/client/app/hoc/ModalOpener.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-const asUIBModal = (WrappedComponent) => {
+const ModalOpener = (WrappedComponent) => {
   const container = document.createElement('div');
 
   const render = (component) => {
@@ -33,4 +33,4 @@ const asUIBModal = (WrappedComponent) => {
   };
 };
 
-export default asUIBModal;
+export default ModalOpener;

--- a/client/app/hoc/asUIBModal.jsx
+++ b/client/app/hoc/asUIBModal.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const asUIBModal = (WrappedComponent) => {
+  const container = document.createElement('div');
+
+  const render = (component) => {
+    ReactDOM.render(component, container);
+    document.body.appendChild(container);
+  };
+
+  const destroy = () => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+  };
+
+  const getResult = props => new Promise((resolve) => {
+    const component = (
+      <WrappedComponent
+        onClose={destroy}
+        onConfirm={resolve}
+        {...props}
+      />
+    );
+
+    render(component);
+  });
+
+  return {
+    open: props => ({
+      result: getResult(props),
+    }),
+  };
+};
+
+export default asUIBModal;

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -5,13 +5,13 @@
       <h3>
         <edit-in-place class="edit-in-place" is-editable="$ctrl.layoutEditing" on-done="$ctrl.saveName" ignore-blanks="true" value="$ctrl.dashboard.name" editor="'input'"></edit-in-place>
       </h3>
-      
+
       <img ng-src="{{$ctrl.dashboard.user.profile_image_url}}" class="profile__image_thumb--dashboard" alt="{{$ctrl.dashboard.user.name}}">
-      
+
       <dashboard-tags-control class="hidden-xs"
         tags="$ctrl.dashboard.tags" is-draft="$ctrl.dashboard.is_draft" is-archived="$ctrl.dashboard.is_archived"
         can-edit="$ctrl.isDashboardOwner" get-available-tags="$ctrl.loadTags" on-edit="$ctrl.saveTags"></dashboard-tags-control>
-      
+
     </div>
     <div class="col-xs-4 col-sm-5 col-lg-5 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
@@ -110,8 +110,9 @@
       <span class="hidden-xs hidden-sm">Widgets are individual query visualizations or text boxes you can place on your dashboard in various arrangements.</span>
     </h2>
     <div>
-      <a class="btn btn-default" ng-click="$ctrl.addWidget('textbox')">Add Textbox</a>
-      <a class="btn btn-primary m-l-10" ng-click="$ctrl.addWidget('widget')">Add Widget</a>
+      <a class="btn btn-default" ng-click="$ctrl.addTextBox()">Add Textbox</a>
+      <a class="btn btn-primary m-l-10" ng-click="$ctrl.openAddWidgetDialog()">Add Widget</a>
+      <add-widget-dialog ng-if="$ctrl.addWidgetDialogOpened" dashboard="$ctrl.dashboard" on-close="$ctrl.closeAddWidgetDialog" on-added="$ctrl.onWidgetAdded" />
     </div>
   </div>
 </div>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -110,9 +110,8 @@
       <span class="hidden-xs hidden-sm">Widgets are individual query visualizations or text boxes you can place on your dashboard in various arrangements.</span>
     </h2>
     <div>
-      <a class="btn btn-default" ng-click="$ctrl.addTextBox()">Add Textbox</a>
-      <a class="btn btn-primary m-l-10" ng-click="$ctrl.openAddWidgetDialog()">Add Widget</a>
-      <add-widget-dialog ng-if="$ctrl.addWidgetDialogOpened" dashboard="$ctrl.dashboard" on-close="$ctrl.closeAddWidgetDialog" on-added="$ctrl.onWidgetAdded" />
+      <a class="btn btn-default" ng-click="$ctrl.addTextBox">Add Textbox</a>
+      <a class="btn btn-primary m-l-10" ng-click="$ctrl.addWidget('widget')">Add Widget</a>
     </div>
   </div>
 </div>

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -318,26 +318,35 @@ function DashboardCtrl(
     );
   };
 
-  this.addWidget = (widgetType) => {
-    const widgetTypes = {
-      textbox: 'addTextboxDialog',
-      widget: 'addWidgetDialog',
-    };
+  this.addTextBox = () => {
     $uibModal
       .open({
-        component: widgetTypes[widgetType],
+        component: 'addTextboxDialog',
         resolve: {
           dashboard: () => this.dashboard,
         },
       })
-      .result.then(() => {
-        this.extractGlobalParameters();
-        // Save position of newly added widget (but not entire layout)
-        const widget = _.last(this.dashboard.widgets);
-        if (_.isObject(widget)) {
-          return widget.save();
-        }
-      });
+      .result.then(this.onWidgetAdded);
+  };
+
+  this.onWidgetAdded = () => {
+    this.extractGlobalParameters();
+    // Save position of newly added widget (but not entire layout)
+    const widget = _.last(this.dashboard.widgets);
+    if (_.isObject(widget)) {
+      return widget.save();
+    }
+  };
+
+  this.addWidgetDialogOpened = false;
+
+  this.openAddWidgetDialog = () => {
+    this.addWidgetDialogOpened = true;
+  };
+
+  this.closeAddWidgetDialog = () => {
+    this.addWidgetDialogOpened = false;
+    $scope.$applyAsync();
   };
 
   this.removeWidget = (widgetId) => {

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -347,11 +347,6 @@ function DashboardCtrl(
     }
   };
 
-  this.closeAddWidgetDialog = () => {
-    this.addWidgetDialogOpened = false;
-    $scope.$applyAsync();
-  };
-
   this.removeWidget = (widgetId) => {
     this.dashboard.widgets = this.dashboard.widgets.filter(w => w.id !== undefined && w.id !== widgetId);
     this.extractGlobalParameters();

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -5,6 +5,7 @@ import { policy } from '@/services/policy';
 import { durationHumanize } from '@/filters';
 import template from './dashboard.html';
 import shareDashboardTemplate from './share-dashboard.html';
+import AddWidgetDialog from '@/components/dashboards/AddWidgetDialog';
 import './dashboard.less';
 
 function isWidgetPositionChanged(oldPosition, newPosition) {
@@ -329,6 +330,14 @@ function DashboardCtrl(
       .result.then(this.onWidgetAdded);
   };
 
+  this.addWidget = () => {
+    AddWidgetDialog
+      .open({
+        dashboard: this.dashboard,
+      })
+      .result.then(this.onWidgetAdded);
+  };
+
   this.onWidgetAdded = () => {
     this.extractGlobalParameters();
     // Save position of newly added widget (but not entire layout)
@@ -336,12 +345,6 @@ function DashboardCtrl(
     if (_.isObject(widget)) {
       return widget.save();
     }
-  };
-
-  this.addWidgetDialogOpened = false;
-
-  this.openAddWidgetDialog = () => {
-    this.addWidgetDialogOpened = true;
   };
 
   this.closeAddWidgetDialog = () => {


### PR DESCRIPTION
#### The bug
In #3332 there is a use of popovers, which on "escape" keypress close the whole modal..

#### The fix
Converted the two relevant modals to Ant Modal which won't allow this to happen.
Notice this PR is meant to merge to master, as preparation for #3332.

#### A few visual changes:
* Dialogs not as wide as original. I think this default width looks better.
<img width="269" src="https://user-images.githubusercontent.com/486954/52161176-f9a2f880-26c9-11e9-8505-548b9c6fc804.png">

* When clicking "ok" or "Add to Dashboard", I added a loading indicator till the modal self closes. (Slowed down)
<img width="269" src="https://user-images.githubusercontent.com/486954/52161203-50103700-26ca-11e9-8710-06bfbb82f471.gif" />


* The previous modal disabled "cancel" buttons while widget was being saved - but I didn't implement that cause it's more code for sth unnecessary. Lmk if you think otherwise.
* Before, closing the modal would make it disappear immediately - now it has a pleasant closing animation.

@arikfr 117 additions / 178 deletions :P