### PR TITLE
Fix Cypress E2E failing in CI

### DIFF
--- a/.circleci/Dockerfile.cypress
+++ b/.circleci/Dockerfile.cypress
@@ -3,7 +3,7 @@ FROM cypress/browsers:chrome67
 ENV APP /usr/src/app
 WORKDIR $APP
 
-RUN npm install --no-save cypress @percy/cypress > /dev/null
+RUN npm install --no-save puppeteer@1.10.0 cypress@^3.1.5 @percy/cypress@^0.2.3 > /dev/null
 
 COPY cypress $APP/cypress
 COPY cypress.json $APP/cypress.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --config ./client/.eslintrc.js --ext .js --ext .jsx ./client/app",
     "test": "TZ=Asia/Jerusalem jest",
     "test:watch": "jest --watch",
-    "cypress:install": "npm install --no-save cypress @percy/cypress",
+    "cypress:install": "npm install --no-save cypress@^3.1.5 @percy/cypress@^0.2.3",
     "cypress": "node cypress/cypress.js"
   },
   "repository": {


### PR DESCRIPTION
This fixes Cypress E2E tests failing in CI. The puppeteer version was probably being solved to `puppeteer@1.12.x` (which was updated recently and probably caused Percy to fail in CI).

I couldn't reproduce this issue locally, though I'll try a bit more and open an issue to them in case I get to the root cause.

## Extra
@kravets-levko set some versions in `npm install` for `cypress` and `@percy/cypress` and I agree they should be kept.