### PR TITLE
Fix: Selected item in dropdown unreadable

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -953,7 +953,7 @@ text.slicetext {
   }
 }
 
-.ui-select-choices-row > span {
+.ui-select-choices-row.disabled > span {
   background-color: inherit !important;
 }
 


### PR DESCRIPTION
Regression from #3347.

####The bug
The "disabled" look leaked into the regular selected item style.
<img width="318" src="https://user-images.githubusercontent.com/486954/52275302-d7260f00-2957-11e9-8fb0-7fed8071b27c.png" />

#### The fix
Made it disabled specific.
Tested manually in query page->data source selection (selected item) and Alerts (unpublished query item).
