### PR TITLE
Handle InterruptException in Athena query runnner

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -197,7 +197,7 @@ class Athena(BaseQueryRunner):
             }
             json_data = json_dumps(data, ignore_nan=True)
             error = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, InterruptException):
             if cursor.query_id:
                 cursor.cancel()
             error = "Query cancelled by user."


### PR DESCRIPTION
This is a follow-up to https://github.com/getredash/redash/pull/1753 where handling this exception was added to the Presto query runner. It turns out we have some [anecdotal evidence](https://github.com/mozilla/redash/issues/775) that the Athena query runner also triggers that exception and requires additional help to cancel the query.