### PR TITLE
Add tag filters to backend-unit-tests to allow build-tarball to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: Copy Test Results
           command: |
             mkdir -p /tmp/test-results/unit-tests
-            docker cp tests:/app/coverage.xml ./coverage.xml 
+            docker cp tests:/app/coverage.xml ./coverage.xml
             docker cp tests:/app/junit.xml /tmp/test-results/unit-tests/results.xml
       - store_test_results:
           path: /tmp/test-results
@@ -110,6 +110,10 @@ workflows:
       - backend-unit-tests
       - frontend-unit-tests
       - frontend-e2e-tests
+      - backend-unit-tests:
+           filters:
+             tags:
+               only: /v[0-9]+(\.[0-9\-a-z]+)*/
       - build-tarball:
            requires:
              - backend-unit-tests


### PR DESCRIPTION
We ran into this issue in https://github.com/mozilla/redash/pull/807 and @jezdez mentioned this should be applied here as well.

Based on the CircleCI documentation for git tag workflows:

> if a job requires any other jobs (directly or indirectly), you must use regular expressions to specify tag filters for those jobs.

`build-tarball` job builds on tags and requires`backend-unit-tests` job however tag filters are not specified here. This change adds tag filters to the `backend-unit-tests` workflow so that `build-tarball` jobs are executed.

https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag to documentation.