### PR TITLE
Show query execution status at page load if query is running

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -446,6 +446,12 @@ function QueryResource(
       return new QueryResultError("Can't execute empty query.");
     }
 
+    if (this.job) {
+      const q = new QueryResult({ job: { id: this.job } });
+      q.refreshStatus(this);
+      return q;
+    }
+
     const parameters = this.getParameters();
     const missingParams = parameters.getMissing();
 

--- a/redash/serializers.py
+++ b/redash/serializers.py
@@ -83,6 +83,7 @@ class QuerySerializer(Serializer):
 
 
 def serialize_query(query, with_stats=False, with_visualizations=False, with_user=True, with_last_modified_by=True):
+    from redash.tasks.queries import find_job_for_query
     d = {
         'id': query.id,
         'latest_query_data_id': query.latest_query_data_id,
@@ -100,6 +101,7 @@ def serialize_query(query, with_stats=False, with_visualizations=False, with_use
         'options': query.options,
         'version': query.version,
         'tags': query.tags or [],
+        'job': find_job_for_query(query.query_hash, query.data_source_id),
     }
 
     if with_user:

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -204,6 +204,10 @@ class QueryTask(object):
         return self._async_result.revoke(terminate=True, signal='SIGINT')
 
 
+def find_job_for_query(query_hash, data_source_id):
+    return redis_connection.get(_job_lock_id(query_hash, data_source_id))
+
+
 def enqueue_query(query, data_source, user_id, scheduled_query=None, metadata={}):
     query_hash = gen_query_hash(query)
     logging.info("Inserting job for %s with metadata=%s", query_hash, metadata)


### PR DESCRIPTION
On initial page load, check Redis to see if a job is running for this query. If so, immediately show it as executing.