### PR TITLE
Sharing disabled if dashboard has query params

### DIFF
--- a/client/app/pages/dashboards/ShareDashboardDialog.jsx
+++ b/client/app/pages/dashboards/ShareDashboardDialog.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Switch from 'antd/lib/switch';
 import Modal from 'antd/lib/modal';
 import Form from 'antd/lib/form';
+import Alert from 'antd/lib/alert';
 import { $http, toastr } from '@/services/ng';
 import { wrap as wrapDialog, DialogPropType } from '@/components/DialogWrapper';
 import InputWithCopy from '@/components/InputWithCopy';
@@ -14,6 +15,7 @@ const API_SHARE_URL = 'api/dashboards/{id}/share';
 class ShareDashboardDialog extends React.Component {
   static propTypes = {
     dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    hasQueryParams: PropTypes.bool.isRequired,
     dialog: DialogPropType.isRequired,
   };
 
@@ -25,10 +27,14 @@ class ShareDashboardDialog extends React.Component {
 
   constructor(props) {
     super(props);
+    const { dashboard } = this.props;
+
     this.state = {
       saving: false,
     };
-    this.apiUrl = replace(API_SHARE_URL, '{id}', props.dashboard.id);
+
+    this.apiUrl = replace(API_SHARE_URL, '{id}', dashboard.id);
+    this.disabled = this.props.hasQueryParams && !dashboard.publicAccessEnabled;
   }
 
   static get headerContent() {
@@ -43,7 +49,7 @@ class ShareDashboardDialog extends React.Component {
     );
   }
 
-  enable = () => {
+  enableAccess = () => {
     const { dashboard } = this.props;
     this.setState({ saving: true });
 
@@ -61,7 +67,7 @@ class ShareDashboardDialog extends React.Component {
       });
   }
 
-  disable = () => {
+  disableAccess = () => {
     const { dashboard } = this.props;
     this.setState({ saving: true });
 
@@ -81,9 +87,9 @@ class ShareDashboardDialog extends React.Component {
 
   onChange = (checked) => {
     if (checked) {
-      this.enable();
+      this.enableAccess();
     } else {
-      this.disable();
+      this.disableAccess();
     }
   };
 
@@ -97,11 +103,20 @@ class ShareDashboardDialog extends React.Component {
         footer={null}
       >
         <Form layout="horizontal">
+          {this.props.hasQueryParams && (
+            <Form.Item>
+              <Alert
+                message="Sharing is currently not supported for dashboards containing queries with parameters."
+                type="error"
+              />
+            </Form.Item>
+          )}
           <Form.Item label="Allow public access" {...this.formItemProps}>
             <Switch
               checked={dashboard.publicAccessEnabled}
               onChange={this.onChange}
               loading={this.state.saving}
+              disabled={this.disabled}
             />
           </Form.Item>
           {dashboard.public_url && (

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -392,7 +392,11 @@ function DashboardCtrl(
   }
 
   this.openShareForm = () => {
-    const hasQueryParams = _.some(this.dashboard.widgets, w => !_.isEmpty(w.options.parameterMappings));
+    // check if any of the wigets have query parameters
+    const hasQueryParams = _.some(
+      this.dashboard.widgets,
+      w => !_.isEmpty(w.getQuery() && w.getQuery().getParametersDefs()),
+    );
 
     ShareDashboardDialog.showModal({
       dashboard: this.dashboard,

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -392,7 +392,12 @@ function DashboardCtrl(
   }
 
   this.openShareForm = () => {
-    ShareDashboardDialog.showModal({ dashboard: this.dashboard });
+    const hasQueryParams = _.some(this.dashboard.widgets, w => !_.isEmpty(w.options.parameterMappings));
+
+    ShareDashboardDialog.showModal({
+      dashboard: this.dashboard,
+      hasQueryParams,
+    });
   };
 }
 


### PR DESCRIPTION
Following discussion in https://discuss.redash.io/t/ux-for-dashboard-sharing-constraints/3212, disabling sharing if dashboard has query params.

![screen shot 2019-02-14 at 19 51 12](https://user-images.githubusercontent.com/486954/52807955-84ee9780-3095-11e9-9aba-531add4c03fe.png)

For offending dashboards that are already shared, the alert would appear but the access would still be enabled both in backend and UI. Once switched off and closed, the UI won't allow re-enabling until dashboard clear of query param widgets.