### PR TITLE
monitor "schemas" queue to run refresh_schema

### DIFF
--- a/.circleci/docker-compose.cypress.yml
+++ b/.circleci/docker-compose.cypress.yml
@@ -23,7 +23,7 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      QUEUES: "queries,scheduled_queries,celery"
+      QUEUES: "queries,scheduled_queries,celery,schemas"
       WORKERS_COUNT: 2
   cypress:
     build:

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,7 +3,7 @@ set -e
 
 worker() {
   WORKERS_COUNT=${WORKERS_COUNT:-2}
-  QUEUES=${QUEUES:-queries,scheduled_queries,celery}
+  QUEUES=${QUEUES:-queries,scheduled_queries,celery,schemas}
 
   echo "Starting $WORKERS_COUNT workers for queues: $QUEUES..."
   exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo --maxtasksperchild=10 -Ofair

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -30,7 +30,7 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      QUEUES: "queries,scheduled_queries,celery"
+      QUEUES: "queries,scheduled_queries,celery,schemas"
       WORKERS_COUNT: 2
     restart: always
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      QUEUES: "queries,scheduled_queries,celery"
+      QUEUES: "queries,scheduled_queries,celery,schemas"
       WORKERS_COUNT: 2
   redis:
     image: redis:3-alpine

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -24,13 +24,13 @@ services:
     <<: *redash-service
     command: worker
     environment:
-      QUEUES: "scheduled_queries"
+      QUEUES: "scheduled_queries,schemas"
       WORKERS_COUNT: 1
   adhoc_worker:
     <<: *redash-service
     command: worker
     environment:
-      QUEUES: "queries,schemas"
+      QUEUES: "queries"
       WORKERS_COUNT: 2
   redis:
     image: redis:3.0-alpine

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     <<: *redash-service
     command: worker
     environment:
-      QUEUES: "queries"
+      QUEUES: "queries,schemas"
       WORKERS_COUNT: 2
   redis:
     image: redis:3.0-alpine


### PR DESCRIPTION
`refresh_schema` tasks won't run because "schemas" queue isn't consumed
with default settings.
and it cause leaking redis storage, a "schemas" list is growing with time.

this PR fix it, adds "schemas" queue to monitor by celery.

----

Where adding `refresh_schema` tasks to "schemas" queue.
https://github.com/getredash/redash/blob/8fc2ecf55c2d9ecd94b391d6d80d58c33fed9373/redash/tasks/queries.py#L412