### PR TITLE
Make sure Flask app created in Celery's worker process

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -138,11 +138,3 @@ def create_app(load_admin=True):
     users.init_app(app)
 
     return app
-
-
-def safe_create_app():
-    """Return current_app or create a new one."""
-    if current_app:
-        return current_app
-
-    return create_app()

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -8,7 +8,7 @@ from flask import current_app
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_process_init
-from redash import safe_create_app, settings
+from redash import create_app, settings
 from redash.metrics import celery as celery_metrics
 
 celery = Celery('redash',
@@ -74,14 +74,14 @@ celery.Task = ContextTask
 # Create Flask app after forking a new worker, to make sure no resources are shared between processes.
 @worker_process_init.connect
 def init_celery_flask_app(**kwargs):
-    app = safe_create_app()
+    app = create_app()
     app.app_context().push()
 
 
 # Hook for extensions to add periodic tasks.
-@celery.on_after_configure.connect
-def add_periodic_tasks(sender, **kwargs):
-    app = safe_create_app()
-    periodic_tasks = getattr(app, 'periodic_tasks', {})
-    for params in periodic_tasks.values():
-        sender.add_periodic_task(**params)
+# @celery.on_after_configure.connect
+# def add_periodic_tasks(sender, **kwargs):
+#     app = safe_create_app()
+#     periodic_tasks = getattr(app, 'periodic_tasks', {})
+#     for params in periodic_tasks.values():
+#         sender.add_periodic_task(**params)

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -78,6 +78,7 @@ def init_celery_flask_app(**kwargs):
     app.app_context().push()
 
 
+# Commented until https://github.com/getredash/redash/issues/3466 is implemented.
 # Hook for extensions to add periodic tasks.
 # @celery.on_after_configure.connect
 # def add_periodic_tasks(sender, **kwargs):


### PR DESCRIPTION
For the past week or so we experienced very strange issues where BigQuery and Kylin queries would hang on a futex for no apparent reason. Luckily we could trace the issue to the time we deployed a new code version, so we could limit the search permitter. 

Because there were no changes to BigQuery's query runner, I assumed the issue was with one of the dependencies that got an upgrade between the releases. But there was no luck there: none of the changed dependencies were related.

Following some other ideas and more closely looking at code changes, I've noticed that our previous deployment had a modified `redash.worker` module where we had commented out `add_periodic_tasks`. Looking closer, I realized that `add_periodic_tasks` changed the behavior we tried to create with `init_celery_flask_app`: the Flask app was now created in the master Celery process and not the forked workers.

In turn this resulted in memory sharing between processes and fun dead locks...

I commented out `add_periodic_tasks` until we rewrite the extensions registry to not rely on a Flask app (#3466).