### PR TITLE
Fix e-mail verification for multi org setups

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -99,7 +99,10 @@ def verify(token, org_slug=None):
     models.db.session.add(user)
     models.db.session.commit()
 
-    return render_template("verify.html", org_slug=org_slug)
+    template_context = { "org_slug": org_slug } if settings.MULTI_ORG else {}
+    next_url = url_for('redash.index', **template_context)
+
+    return render_template("verify.html", next_url=next_url)
 
 
 @routes.route(org_scoped_rule('/forgot'), methods=['GET', 'POST'])

--- a/redash/templates/verify.html
+++ b/redash/templates/verify.html
@@ -1,13 +1,13 @@
 {% extends "layouts/signed_out.html" %}
 {% block title %}E-mail Verified{% endblock %}
 {% block head %}
-<meta http-equiv="refresh" content="5;URL='{{ url_for('redash.index') }}'" />
+<meta http-equiv="refresh" content="5;URL='{{ next_url }}'" />
 {% endblock %}
 {% block content %}
 <div class="fixed-width-page">
   <div class="bg-white tiled">
       <div>
-          Thanks for verifying your email address. You will be redirected back to the app within a few seconds. <a href="{{ url_for('redash.index') }}">Click here</a> if you are not redirected.
+          Thanks for verifying your email address. You will be redirected back to the app within a few seconds. <a href="{{ next_url }}">Click here</a> if you are not redirected.
       </div>
   </div>
 </div>


### PR DESCRIPTION
`org_slugs` were not passed in to the verification template, which resulted in error in multi org setups. This PR fixes that so that multi org setups point to the org index upon approval, while non-multiorg setups point at the default org root.