### PR TITLE
Treat repeated BigQuery fields as arrays

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -31,29 +31,27 @@ types_map = {
     'TIMESTAMP': TYPE_DATETIME,
 }
 
+def transform_cell(field_type, cell_value):
+    if field_type == 'INTEGER':
+        return int(cell_value)
+    elif field_type == 'FLOAT':
+        return float(cell_value)
+    elif field_type == 'BOOLEAN':
+        return cell_value.lower() == "true"
+    elif field_type == 'TIMESTAMP':
+        return datetime.datetime.fromtimestamp(float(cell_value))
 
 def transform_row(row, fields):
-    column_index = 0
     row_data = {}
 
-    for cell in row["f"]:
+    for column_index, cell in enumerate(row["f"]):
         field = fields[column_index]
-        cell_value = cell['v']
-
-        if cell_value is None:
-            pass
-        # Otherwise just cast the value
-        elif field['type'] == 'INTEGER':
-            cell_value = int(cell_value)
-        elif field['type'] == 'FLOAT':
-            cell_value = float(cell_value)
-        elif field['type'] == 'BOOLEAN':
-            cell_value = cell_value.lower() == "true"
-        elif field['type'] == 'TIMESTAMP':
-            cell_value = datetime.datetime.fromtimestamp(float(cell_value))
+        if field['mode'] == 'REPEATED':
+            cell_value = [transform_cell(field['type'], item['v']) for item in cell['v']]
+        else:
+            cell_value = transform_cell(field['type'], cell['v'])
 
         row_data[field["name"]] = cell_value
-        column_index += 1
 
     return row_data
 
@@ -221,9 +219,12 @@ class BigQuery(BaseQueryRunner):
 
             query_reply = jobs.getQueryResults(**query_result_request).execute()
 
-        columns = [{'name': f["name"],
-                    'friendly_name': f["name"],
-                    'type': types_map.get(f['type'], "string")} for f in query_reply["schema"]["fields"]]
+        columns = [{
+            'name': f["name"],
+            'friendly_name': f["name"],
+            'type': "string" if f['mode'] == "REPEATED"
+            else types_map.get(f['type'], "string")
+        } for f in query_reply["schema"]["fields"]]
 
         data = {
             "columns": columns,

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -31,7 +31,10 @@ types_map = {
     'TIMESTAMP': TYPE_DATETIME,
 }
 
+
 def transform_cell(field_type, cell_value):
+    if cell_value is None:
+        return None
     if field_type == 'INTEGER':
         return int(cell_value)
     elif field_type == 'FLOAT':
@@ -40,6 +43,8 @@ def transform_cell(field_type, cell_value):
         return cell_value.lower() == "true"
     elif field_type == 'TIMESTAMP':
         return datetime.datetime.fromtimestamp(float(cell_value))
+    return cell_value
+
 
 def transform_row(row, fields):
     row_data = {}


### PR DESCRIPTION
The BigQuery runner doesn't check if fields are repeated and so produces errors trying to coerce them with `int()`, `float()` etc.