### PR TITLE
Improve list pages layout

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -58,24 +58,6 @@ body {
   border-left-color: #1b809e;
 }
 
-.list-content {
-  @media (min-width: 992px) {
-    padding-right: 0;
-  }
-}
-
-.list-control-r-b {
-  @media (max-width: 992px) {
-    display: none;
-  }
-}
-
-.list-control-t {
-  @media (min-width: 992px) {
-    display: none;
-  }
-}
-
 // Fixed width layout for specific pages
 @media (min-width: 768px) {
   settings-screen, home-page, page-dashboard-list, page-queries-list, alerts-list-page, alert-page, queries-search-results-page, .fixed-container {

--- a/client/app/components/groups/DetailsPageSidebar.jsx
+++ b/client/app/components/groups/DetailsPageSidebar.jsx
@@ -38,7 +38,7 @@ export default function DetailsPageSidebar({
       {canRemove && (
         <React.Fragment>
           <Divider dashed className="m-t-10 m-b-10" />
-          <DeleteGroupButton className="w-100 m-b-15" group={group} onClick={onGroupDeleted}>Delete Group</DeleteGroupButton>
+          <DeleteGroupButton className="w-100" group={group} onClick={onGroupDeleted}>Delete Group</DeleteGroupButton>
         </React.Fragment>
       )}
     </React.Fragment>

--- a/client/app/components/layouts/ContentWithSidebar.jsx
+++ b/client/app/components/layouts/ContentWithSidebar.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import './content-with-sidebar.less';
+
+const propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const defaultProps = {
+  className: null,
+  children: null,
+};
+
+// Sidebar
+
+function Sidebar({ className, children, ...props }) {
+  return (
+    <div className={classNames('layout-sidebar', className)} {...props}>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+Sidebar.propTypes = propTypes;
+Sidebar.defaultProps = defaultProps;
+
+// Content
+
+function Content({ className, children, ...props }) {
+  return (
+    <div className={classNames('layout-content', className)} {...props}>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+Content.propTypes = propTypes;
+Content.defaultProps = defaultProps;
+
+// Layout
+
+export default function Layout({ className, children, ...props }) {
+  return <div className={classNames('layout-with-sidebar', className)} {...props}>{children}</div>;
+}
+
+Layout.propTypes = propTypes;
+Layout.defaultProps = defaultProps;
+
+Layout.Sidebar = Sidebar;
+Layout.Content = Content;

--- a/client/app/components/layouts/content-with-sidebar.less
+++ b/client/app/components/layouts/content-with-sidebar.less
@@ -1,0 +1,42 @@
+.layout-with-sidebar {
+  @spacing: 15px;
+  position: relative;
+
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  flex-direction: row;
+  margin: 0;
+
+  > .layout-content {
+    flex: 0 0 auto;
+    width: 75%;
+    order: 0;
+    margin: 0;
+  }
+
+  > .layout-sidebar {
+    flex: 0 0 auto;
+    width: 25%;
+    order: 1;
+    margin: 0;
+    padding: 0 0 0 @spacing;
+  }
+
+  @media (max-width: 990px) {
+    flex-direction: column;
+
+    > .layout-content {
+      width: 100%;
+      order: 1;
+      margin: 0;
+    }
+
+    > .layout-sidebar {
+      width: 100%;
+      order: 0;
+      margin: 0 0 @spacing 0;
+      padding: 0;
+    }
+  }
+}

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -13,6 +13,8 @@ import LoadingState from '@/components/items-list/components/LoadingState';
 import * as Sidebar from '@/components/items-list/components/Sidebar';
 import ItemsTable, { Columns } from '@/components/items-list/components/ItemsTable';
 
+import Layout from '@/components/layouts/ContentWithSidebar';
+
 import { Dashboard } from '@/services/dashboard';
 import navigateTo from '@/services/navigateTo';
 import { routesToAngularRoutes } from '@/lib/utils';
@@ -68,35 +70,27 @@ class DashboardList extends React.Component {
 
   onTableRowClick = (event, item) => navigateTo('dashboard/' + item.slug);
 
-  renderSidebar() {
-    const { controller } = this.props;
-    return (
-      <React.Fragment>
-        <Sidebar.SearchInput
-          placeholder="Search Dashboards..."
-          value={controller.searchTerm}
-          onChange={controller.updateSearch}
-        />
-        <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
-        <Sidebar.Tags url="api/dashboards/tags" onChange={controller.updateSelectedTags} />
-        <Sidebar.PageSizeSelect
-          options={controller.pageSizeOptions}
-          value={controller.itemsPerPage}
-          onChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
-        />
-      </React.Fragment>
-    );
-  }
-
   render() {
-    const sidebar = this.renderSidebar();
     const { controller } = this.props;
     return (
       <div className="container">
         <PageHeader title={controller.params.title} />
-        <div className="row">
-          <div className="col-md-3 list-control-t">{sidebar}</div>
-          <div className="list-content col-md-9">
+        <Layout className="m-l-15 m-r-15">
+          <Layout.Sidebar className="m-b-0">
+            <Sidebar.SearchInput
+              placeholder="Search Dashboards..."
+              value={controller.searchTerm}
+              onChange={controller.updateSearch}
+            />
+            <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
+            <Sidebar.Tags url="api/dashboards/tags" onChange={controller.updateSelectedTags} />
+            <Sidebar.PageSizeSelect
+              options={controller.pageSizeOptions}
+              value={controller.itemsPerPage}
+              onChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
+            />
+          </Layout.Sidebar>
+          <Layout.Content>
             {!controller.isLoaded && <LoadingState />}
             {
               controller.isLoaded && controller.isEmpty && (
@@ -127,9 +121,8 @@ class DashboardList extends React.Component {
                 </div>
               )
             }
-          </div>
-          <div className="col-md-3 list-control-r-b">{sidebar}</div>
-        </div>
+          </Layout.Content>
+        </Layout>
       </div>
     );
   }

--- a/client/app/pages/groups/GroupDataSources.jsx
+++ b/client/app/pages/groups/GroupDataSources.jsx
@@ -20,6 +20,7 @@ import { DataSourcePreviewCard } from '@/components/PreviewCard';
 import GroupName from '@/components/groups/GroupName';
 import ListItemAddon from '@/components/groups/ListItemAddon';
 import Sidebar from '@/components/groups/DetailsPageSidebar';
+import Layout from '@/components/layouts/ContentWithSidebar';
 
 import { toastr } from '@/services/ng';
 import { currentUser } from '@/services/auth';
@@ -164,23 +165,21 @@ class GroupDataSources extends React.Component {
 
   render() {
     const { controller } = this.props;
-    const sidebar = (
-      <Sidebar
-        controller={controller}
-        group={this.group}
-        items={this.sidebarMenu}
-        canAddDataSources={currentUser.isAdmin}
-        onAddDataSourcesClick={this.addDataSources}
-        onGroupDeleted={() => navigateTo('/groups', true)}
-      />
-    );
-
     return (
       <div data-test="Group">
         <GroupName className="d-block m-t-0 m-b-15" group={this.group} onChange={() => this.forceUpdate()} />
-        <div className="row">
-          <div className="col-md-3 list-control-t">{sidebar}</div>
-          <div className="list-content col-md-9">
+        <Layout>
+          <Layout.Sidebar>
+            <Sidebar
+              controller={controller}
+              group={this.group}
+              items={this.sidebarMenu}
+              canAddDataSources={currentUser.isAdmin}
+              onAddDataSourcesClick={this.addDataSources}
+              onGroupDeleted={() => navigateTo('/groups', true)}
+            />
+          </Layout.Sidebar>
+          <Layout.Content>
             {!controller.isLoaded && <LoadingState className="" />}
             {controller.isLoaded && controller.isEmpty && (
               <div className="text-center">
@@ -215,9 +214,8 @@ class GroupDataSources extends React.Component {
                 </div>
               )
             }
-          </div>
-          <div className="col-md-3 list-control-r-b">{sidebar}</div>
-        </div>
+          </Layout.Content>
+        </Layout>
       </div>
     );
   }

--- a/client/app/pages/groups/GroupMembers.jsx
+++ b/client/app/pages/groups/GroupMembers.jsx
@@ -17,6 +17,7 @@ import { UserPreviewCard } from '@/components/PreviewCard';
 import GroupName from '@/components/groups/GroupName';
 import ListItemAddon from '@/components/groups/ListItemAddon';
 import Sidebar from '@/components/groups/DetailsPageSidebar';
+import Layout from '@/components/layouts/ContentWithSidebar';
 
 import { toastr } from '@/services/ng';
 import { currentUser } from '@/services/auth';
@@ -129,23 +130,21 @@ class GroupMembers extends React.Component {
 
   render() {
     const { controller } = this.props;
-    const sidebar = (
-      <Sidebar
-        controller={controller}
-        group={this.group}
-        items={this.sidebarMenu}
-        canAddMembers={currentUser.isAdmin}
-        onAddMembersClick={this.addMembers}
-        onGroupDeleted={() => navigateTo('/groups', true)}
-      />
-    );
-
     return (
       <div data-test="Group">
         <GroupName className="d-block m-t-0 m-b-15" group={this.group} onChange={() => this.forceUpdate()} />
-        <div className="row">
-          <div className="col-md-3 list-control-t">{sidebar}</div>
-          <div className="list-content col-md-9">
+        <Layout>
+          <Layout.Sidebar>
+            <Sidebar
+              controller={controller}
+              group={this.group}
+              items={this.sidebarMenu}
+              canAddMembers={currentUser.isAdmin}
+              onAddMembersClick={this.addMembers}
+              onGroupDeleted={() => navigateTo('/groups', true)}
+            />
+          </Layout.Sidebar>
+          <Layout.Content>
             {!controller.isLoaded && <LoadingState className="" />}
             {controller.isLoaded && controller.isEmpty && (
               <div className="text-center">
@@ -180,9 +179,8 @@ class GroupMembers extends React.Component {
                 </div>
               )
             }
-          </div>
-          <div className="col-md-3 list-control-r-b">{sidebar}</div>
-        </div>
+          </Layout.Content>
+        </Layout>
       </div>
     );
   }

--- a/client/app/pages/queries-list/QueriesList.jsx
+++ b/client/app/pages/queries-list/QueriesList.jsx
@@ -14,6 +14,8 @@ import LoadingState from '@/components/items-list/components/LoadingState';
 import * as Sidebar from '@/components/items-list/components/Sidebar';
 import ItemsTable, { Columns } from '@/components/items-list/components/ItemsTable';
 
+import Layout from '@/components/layouts/ContentWithSidebar';
+
 import { Query } from '@/services/query';
 import { currentUser } from '@/services/auth';
 import navigateTo from '@/services/navigateTo';
@@ -84,35 +86,27 @@ class QueriesList extends React.Component {
 
   onTableRowClick = (event, item) => navigateTo('queries/' + item.id);
 
-  renderSidebar() {
-    const { controller } = this.props;
-    return (
-      <React.Fragment>
-        <Sidebar.SearchInput
-          placeholder="Search Queries..."
-          value={controller.searchTerm}
-          onChange={controller.updateSearch}
-        />
-        <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
-        <Sidebar.Tags url="api/queries/tags" onChange={controller.updateSelectedTags} />
-        <Sidebar.PageSizeSelect
-          options={controller.pageSizeOptions}
-          value={controller.itemsPerPage}
-          onChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
-        />
-      </React.Fragment>
-    );
-  }
-
   render() {
-    const sidebar = this.renderSidebar();
     const { controller } = this.props;
     return (
       <div className="container">
         <PageHeader title={controller.params.title} />
-        <div className="row">
-          <div className="col-md-3 list-control-t">{sidebar}</div>
-          <div className="list-content col-md-9">
+        <Layout className="m-l-15 m-r-15">
+          <Layout.Sidebar className="m-b-0">
+            <Sidebar.SearchInput
+              placeholder="Search Queries..."
+              value={controller.searchTerm}
+              onChange={controller.updateSearch}
+            />
+            <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
+            <Sidebar.Tags url="api/queries/tags" onChange={controller.updateSelectedTags} />
+            <Sidebar.PageSizeSelect
+              options={controller.pageSizeOptions}
+              value={controller.itemsPerPage}
+              onChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
+            />
+          </Layout.Sidebar>
+          <Layout.Content>
             {!controller.isLoaded && <LoadingState />}
             {
               controller.isLoaded && controller.isEmpty && (
@@ -143,9 +137,8 @@ class QueriesList extends React.Component {
                 </div>
               )
             }
-          </div>
-          <div className="col-md-3 list-control-r-b">{sidebar}</div>
-        </div>
+          </Layout.Content>
+        </Layout>
       </div>
     );
   }

--- a/client/app/pages/users/UsersList.jsx
+++ b/client/app/pages/users/UsersList.jsx
@@ -17,6 +17,8 @@ import EmptyState from '@/components/items-list/components/EmptyState';
 import * as Sidebar from '@/components/items-list/components/Sidebar';
 import ItemsTable, { Columns } from '@/components/items-list/components/ItemsTable';
 
+import Layout from '@/components/layouts/ContentWithSidebar';
+
 import settingsMenu from '@/services/settingsMenu';
 import { currentUser } from '@/services/auth';
 import { policy } from '@/services/policy';
@@ -156,33 +158,25 @@ class UsersList extends React.Component {
     );
   }
 
-  renderSidebar() {
-    const { controller } = this.props;
-    return (
-      <React.Fragment>
-        <Sidebar.SearchInput
-          value={controller.searchTerm}
-          onChange={controller.updateSearch}
-        />
-        <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
-        <Sidebar.PageSizeSelect
-          options={controller.pageSizeOptions}
-          value={controller.itemsPerPage}
-          onChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
-        />
-      </React.Fragment>
-    );
-  }
-
   render() {
-    const sidebar = this.renderSidebar();
     const { controller } = this.props;
     return (
       <React.Fragment>
         {this.renderPageHeader()}
-        <div className="row">
-          <div className="col-md-3 list-control-t">{sidebar}</div>
-          <div className="list-content col-md-9">
+        <Layout>
+          <Layout.Sidebar className="m-b-0">
+            <Sidebar.SearchInput
+              value={controller.searchTerm}
+              onChange={controller.updateSearch}
+            />
+            <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
+            <Sidebar.PageSizeSelect
+              options={controller.pageSizeOptions}
+              value={controller.itemsPerPage}
+              onChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
+            />
+          </Layout.Sidebar>
+          <Layout.Content>
             {!controller.isLoaded && <LoadingState className="" />}
             {controller.isLoaded && controller.isEmpty && <EmptyState className="" />}
             {
@@ -206,9 +200,8 @@ class UsersList extends React.Component {
                 </div>
               )
             }
-          </div>
-          <div className="col-md-3 list-control-r-b">{sidebar}</div>
-        </div>
+          </Layout.Content>
+        </Layout>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
List pages (Dashboard, Queries, Users, Group Members, Group Data Sources) has a layout with sidebar. On large screens content (table with items) is on left and takes 3/4 of width, and sidebar is next to it and takes 1/4 of width. On small screens sidebar is placed above the table, and both of them are full width.

Previously it was implemented by rendering sidebar twice: sidebar, table, sidebar again. On large screens first sidebar was hidden and second one visible, on small screens they swapped - to keep visual order of blocks. That was bugging me for a while, and then I realized that CSS Flexbox can to do what we need - using `order` property: on large screens we set `order: 0` to table and `order: 1` to sidebar, on smaller screens we swap them - and actual order in DOM does not matter.

Also added some wrappers to do all the dirty job: `Layout`, `Layout.Content` and `Layout.Sidebar` component.

Visually nothing changed (at most - few pixels difference in width comparing to Bootstrap classes).