### PR TITLE
Fix DynamicForm ignoring default value for checkboxes

### DIFF
--- a/client/app/components/dynamic-form/dynamicFormHelper.js
+++ b/client/app/components/dynamic-form/dynamicFormHelper.js
@@ -1,4 +1,4 @@
-import { each, includes } from 'lodash';
+import { each, includes, isUndefined } from 'lodash';
 
 function orderedInputs(properties, order, targetOptions) {
   const inputs = new Array(order.length);
@@ -46,8 +46,21 @@ function normalizeSchema(configurationSchema) {
   configurationSchema.order = configurationSchema.order || [];
 }
 
-function getFields(configurationSchema, target) {
+function setDefaultValueForCheckboxes(configurationSchema, options = {}) {
+  if (Object.keys(options).length === 0) {
+    const properties = configurationSchema.properties;
+    Object.keys(properties).forEach((property) => {
+      if (!isUndefined(properties[property].default) && properties[property].type === 'checkbox') {
+        options[property] = properties[property].default;
+      }
+    });
+  }
+}
+
+function getFields(configurationSchema, target = {}) {
   normalizeSchema(configurationSchema);
+  setDefaultValueForCheckboxes(configurationSchema, target.options);
+
   const inputs = [
     {
       name: 'name',


### PR DESCRIPTION
## Description
Closes #3486.

During DynamicForm migration the `setDefaults` method was removed for better UX (using placeholders instead). However, checkboxes don't have placeholders :man_shrugging:. This brings back the method, but applying it only to checkboxes.

## Preview
![checkboxes-dynamic-form](https://user-images.githubusercontent.com/3356951/53299879-04f7c880-381f-11e9-950f-b8e4601a94fe.gif)

