### PR TITLE
Fail query task properly even if error message is empty

### DIFF
--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -323,7 +323,7 @@ class QueryExecutor(object):
 
         _unlock(self.query_hash, self.data_source.id)
 
-        if error:
+        if error is not None and data is None:
             result = QueryExecutionError(error)
             if self.scheduled_query is not None:
                 self.scheduled_query = models.db.session.merge(self.scheduled_query, load=False)


### PR DESCRIPTION
Query runners may fail with empty error messages; this was not handled as a failure and so `store_result` was invoked with `data=None`. This makes the check for error conditions explicit. (This was causing https://github.com/getredash/redash/issues/3280 )