### PR TITLE
Add @babel/polyfill to npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,27 @@
         }
       }
     },
+    "@babel/polyfill": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/runtime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://redash.io/",
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.3.13",
     "@types/react-dom": "^16.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ const config = {
   mode: isProduction ? "production" : "development",
   entry: {
     app: [
+      "@babel/polyfill",
       "./client/app/index.js",
       "./client/app/assets/less/main.less",
       "./client/app/assets/less/ant.less"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix

## Description
This adds `@babel/polyfill` to npm dependencies in order to support IE11 and some Edge versions.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
