### PR TITLE
Fix Impala connection issue while enables LDAP

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,6 +1,6 @@
 google-api-python-client==1.5.1
 gspread==0.6.2
-impyla==0.10.0
+impyla==0.14.2.2
 influxdb==2.7.1
 MySQL-python==1.2.5
 oauth2client==3.0.0
@@ -14,7 +14,7 @@ dynamo3==0.4.7
 boto3==1.9.85
 botocore==1.12.85
 sasl>=0.1.3
-thrift>=0.8.0
+thrift==0.11.0
 thrift_sasl>=0.1.0
 cassandra-driver==3.11.0
 memsql==2.16.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix

## Description

Failed to connect to Impala server with LDAP enabled. Got error message:

```
Error running query: Could not start SASL: Error in sasl_client_start (-4) SASL(-4): no mechanism available: No worthy mechs found
```

This is caused by a bug from the impyla package, we should upgrade to the latest version and use `PLAIN` rather than `LDAP` as `auth_mechanism`.

## Related Tickets & Documents

- [cloudera/impyla#290](https://github.com/cloudera/impyla/issues/290)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
