### PR TITLE
Show invitation link if email server not setup

### DIFF
--- a/client/app/pages/users/CreateUser.jsx
+++ b/client/app/pages/users/CreateUser.jsx
@@ -37,6 +37,19 @@ class CreateUser extends React.Component {
       { name: 'email', title: 'Email', type: 'email' },
     ].map(field => ({ required: true, readOnly: !!user, ...field }));
 
+    const message = (
+      <div>
+        <span>The user has been created and should receive an invite email soon.</span>
+        {user && user.invite_link && (
+          <div>
+            <br />
+            <span>You can use the following link to invite them yourself:</span>
+            <textarea className="form-control m-t-10" rows="3" readOnly>{user.invite_link}</textarea>
+          </div>
+        )}
+      </div>
+    );
+
     return (
       <div className="row">
         <EmailSettingsWarning featureName="invite emails" />
@@ -50,7 +63,7 @@ class CreateUser extends React.Component {
           />
           {user && (
             <Alert
-              message="The user has been created and should receive an invite email soon."
+              message={message}
               type="success"
               className="m-t-20"
             />

--- a/client/app/pages/users/CreateUser.jsx
+++ b/client/app/pages/users/CreateUser.jsx
@@ -37,18 +37,12 @@ class CreateUser extends React.Component {
       { name: 'email', title: 'Email', type: 'email' },
     ].map(field => ({ required: true, readOnly: !!user, ...field }));
 
-    const message = (
+    const message = user && user.invite_link ? (
       <div>
-        <span>The user has been created and should receive an invite email soon.</span>
-        {user && user.invite_link && (
-          <div>
-            <br />
-            <span>You can use the following link to invite them yourself:</span>
-            <textarea className="form-control m-t-10" rows="3" readOnly>{user.invite_link}</textarea>
-          </div>
-        )}
+        <span>The user has been created. You can use the following link to invite them:</span>
+        <textarea className="form-control m-t-10" rows="3" readOnly>{user.invite_link}</textarea>
       </div>
-    );
+    ) : <span>The user has been created and should receive an invite email soon.</span>;
 
     return (
       <div className="row">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix

## Description
If e-mail is not configured, there is no way to retrieve invitation links. This PR returns and shows invitation links when e-mail is not configured.

## Related Tickets & Documents
Solves #3507 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1088" alt="screen shot 2019-03-02 at 23 59 59" src="https://user-images.githubusercontent.com/289488/53688330-1115e580-3d4b-11e9-8395-8c05da7c6aef.png">
<img width="1088" alt="screen shot 2019-03-03 at 0 01 45" src="https://user-images.githubusercontent.com/289488/53688331-1115e580-3d4b-11e9-8dcf-ceacc6274448.png">
