### PR TITLE
Moved widget and dashboard save logic out of dialog

### DIFF
--- a/client/app/components/dashboards/AddWidgetDialog.jsx
+++ b/client/app/components/dashboards/AddWidgetDialog.jsx
@@ -7,13 +7,11 @@ import { wrap as wrapDialog, DialogPropType } from '@/components/DialogWrapper';
 import {
   MappingType,
   ParameterMappingListInput,
-  editableMappingsToParameterMappings,
-  synchronizeWidgetTitles,
 } from '@/components/ParameterMappingInput';
 import { QuerySelector } from '@/components/QuerySelector';
 
 import { toastr } from '@/services/ng';
-import { Widget } from '@/services/widget';
+
 import { Query } from '@/services/query';
 
 const { Option, OptGroup } = Select;
@@ -22,6 +20,7 @@ class AddWidgetDialog extends React.Component {
   static propTypes = {
     dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
     dialog: DialogPropType.isRequired,
+    onConfirm: PropTypes.func.isRequired,
   };
 
   state = {
@@ -76,34 +75,12 @@ class AddWidgetDialog extends React.Component {
   }
 
   saveWidget() {
-    const dashboard = this.props.dashboard;
+    const { selectedVis, parameterMappings } = this.state;
 
     this.setState({ saveInProgress: true });
 
-    const widget = new Widget({
-      visualization_id: this.state.selectedVis && this.state.selectedVis.id,
-      dashboard_id: dashboard.id,
-      options: {
-        isHidden: false,
-        position: {},
-        parameterMappings: editableMappingsToParameterMappings(this.state.parameterMappings),
-      },
-      visualization: this.state.selectedVis,
-      text: '',
-    });
-
-    const position = dashboard.calculateNewWidgetPosition(widget);
-    widget.options.position.col = position.col;
-    widget.options.position.row = position.row;
-
-    const widgetsToSave = [
-      widget,
-      ...synchronizeWidgetTitles(widget.options.parameterMappings, dashboard.widgets),
-    ];
-
-    Promise.all(map(widgetsToSave, w => w.save()))
+    this.props.onConfirm(selectedVis, parameterMappings)
       .then(() => {
-        dashboard.widgets.push(widget);
         this.props.dialog.close();
       })
       .catch(() => {

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -110,8 +110,8 @@
       <span class="hidden-xs hidden-sm">Widgets are individual query visualizations or text boxes you can place on your dashboard in various arrangements.</span>
     </h2>
     <div>
-      <a class="btn btn-default" ng-click="$ctrl.addTextBox()">Add Textbox</a>
-      <a class="btn btn-primary m-l-10" ng-click="$ctrl.addWidget('widget')">Add Widget</a>
+      <a class="btn btn-default" ng-click="$ctrl.showAddTextboxDialog()">Add Textbox</a>
+      <a class="btn btn-primary m-l-10" ng-click="$ctrl.showAddWidgetDialog()">Add Widget</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix

## Description
Was always bothered that AddWidgetDialog did the actual widget saving.
My reasoning is that dialogs should be treated as functional parts - input > output and nothing more.

In this PR I just moved the widget save logic into dashboard.js where I think it belongs.
Also, renamed `addWidget` -> showAddWidgetDialog` and `addTextBox` > `showAddTextboxDialog`.