### PR TITLE
Render LDAP and remote auth login links correctly when multi org mode is enabled.

### DIFF
--- a/redash/authentication/ldap_auth.py
+++ b/redash/authentication/ldap_auth.py
@@ -1,26 +1,28 @@
 import logging
-logger = logging.getLogger('ldap_auth')
+import sys
 
 from redash import settings
 
 from flask import flash, redirect, render_template, request, url_for, Blueprint
-from flask_login import current_user, login_required, login_user, logout_user
+from flask_login import current_user
 
 try:
-    from ldap3 import Server, Connection, SIMPLE, ANONYMOUS, NTLM
+    from ldap3 import Server, Connection
 except ImportError:
     if settings.LDAP_LOGIN_ENABLED:
-        logger.error("The ldap3 library was not found. This is required to use LDAP authentication (see requirements.txt).")
-        exit()
+        sys.exit("The ldap3 library was not found. This is required to use LDAP authentication (see requirements.txt).")
 
 from redash.authentication import create_and_login_user, logout_and_redirect_to_index, get_next_path
 from redash.authentication.org_resolving import current_org
+from redash.handlers.base import org_scoped_rule
+
+logger = logging.getLogger('ldap_auth')
 
 
 blueprint = Blueprint('ldap_auth', __name__)
 
 
-@blueprint.route("/ldap/login", methods=['GET', 'POST'])
+@blueprint.route(org_scoped_rule("/ldap/login"), methods=['GET', 'POST'])
 def login(org_slug=None):
     index_url = url_for("redash.index", org_slug=org_slug)
     unsafe_next_path = request.args.get('next', index_url)

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -25,11 +25,11 @@
     {% endif %}
 
     {% if show_remote_user_login %}
-      <a href="{{ url_for('remote_user_auth.login', next=next) }}" class="login-button btn btn-default btn-block">Remote User Login</a>
+      <a href="{{ url_for('remote_user_auth.login', org_slug=org_slug, next=next) }}" class="login-button btn btn-default btn-block">Remote User Login</a>
     {% endif %}
 
     {% if show_ldap_login %}
-      <a href="{{ url_for('ldap_auth.login', next=next) }}" class="login-button btn btn-default btn-block">LDAP/SSO Login</a>
+      <a href="{{ url_for('ldap_auth.login', org_slug=org_slug, next=next) }}" class="login-button btn btn-default btn-block">LDAP/SSO Login</a>
     {% endif %}
 
     {% if show_password_login %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix

## Description

When the multi org feature and remote or LDAP auth is enabled at the same time, the login links on the login landing page aren't correctly rendered since they are not passed the current org slug.

As an aside the LDAP auth handler isn't org scoped for some reason, and it's not clear if this was an oversight or deliberate decision.

## Related Tickets & Documents

https://github.com/getredash/redash/commit/3044c77309c864362dae69ffdeb9775654cdf0e5 added the URL reversal to login.html and seems to be the culprit of the missing org parameter.
