### PR TITLE
Remove duplicate column information for late-binding views

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -261,8 +261,6 @@ class Redshift(PostgreSQL):
     def _get_tables(self, schema):
         # Use svv_columns to include internal & external (Spectrum) tables and views data for Redshift
         # https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_COLUMNS.html
-        # Use PG_GET_LATE_BINDING_VIEW_COLS to include schema for late binding views data for Redshift
-        # https://docs.aws.amazon.com/redshift/latest/dg/PG_GET_LATE_BINDING_VIEW_COLS.html
         # Use HAS_SCHEMA_PRIVILEGE(), SVV_EXTERNAL_SCHEMAS and HAS_TABLE_PRIVILEGE() to filter
         # out tables the current user cannot access.
         # https://docs.aws.amazon.com/redshift/latest/dg/r_HAS_SCHEMA_PRIVILEGE.html
@@ -276,13 +274,6 @@ class Redshift(PostgreSQL):
                             ordinal_position AS pos
             FROM svv_columns
             WHERE table_schema NOT IN ('pg_internal','pg_catalog','information_schema')
-            UNION ALL
-            SELECT DISTINCT view_name::varchar AS table_name,
-                            view_schema::varchar AS table_schema,
-                            col_name::varchar AS column_name,
-                            col_num AS pos
-            FROM pg_get_late_binding_view_cols()
-                 cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int)
         )
         SELECT table_name, table_schema, column_name
         FROM tables


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix

## Description
Fixes https://github.com/getredash/redash/issues/3536 by removing the second half of the `UNION` that was introducing duplicate columns. Given the circumstances, I don't feel like the front-end code needs adjustment here.

Looks like AWS added support for late-binding views to `svv_columns` around Dec 2017: https://forums.aws.amazon.com/thread.jspa?messageID=793893&#793893:
> Late binding views improvements. Added support for svv_columns, and new functions PG_GET_LATE_BINDING_VIEW_COLS and PG_GET_COL, to return column information for late binding views

Does Redash operate under the assumption of regular Redshift maintenance? Or should this fix really be simply using a `UNION` instead of `UNION ALL` for backwards compatibility?


## Related Tickets & Documents
https://github.com/getredash/redash/issues/3536
