### PR TITLE
Pin pymapd version to 0.7.1

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -21,7 +21,7 @@ memsql==2.16.0
 atsd_client==2.0.12
 simple_salesforce==0.72.2
 PyAthena>=1.0.0
-pymapd>=0.2.1
+pymapd==0.7.1
 qds-sdk>=1.9.6
 ibm-db>=2.0.9
 pydruid==0.4


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Newer versions of pymapd dropped support for Python 2.

## Related Tickets & Documents

Closes #3542.