### PR TITLE
Fix long tag labels breaking table layout

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -972,3 +972,8 @@ text.slicetext {
 .select-option-divider {
   margin: 10px 0 !important;
 }
+
+.table-data .label-tag {
+  display: inline-block;
+  max-width: 135px;
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix

## Description
Makes sure long tag labels get cut sufficiently and word break.

## Related Tickets & Documents
Complimentary to https://github.com/getredash/redash/pull/3541.
Fixes #3521. 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![screen shot 2019-03-07 at 10 13 10](https://user-images.githubusercontent.com/486954/53946391-58460280-40cc-11e9-9f8f-9b7e1ba837b5.png)
