### PR TITLE
Add: Docker entrypoint to do Celery healthchecks.

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -27,6 +27,10 @@ create_db() {
   exec /app/manage.py database create_tables
 }
 
+celery_healthcheck() {
+  exec /usr/local/bin/celery inspect ping --app=redash.worker -d celery@$HOSTNAME
+}
+
 help() {
   echo "Redash Docker."
   echo ""
@@ -36,6 +40,7 @@ help() {
   echo "server -- start Redash server (with gunicorn)"
   echo "worker -- start Celery worker"
   echo "scheduler -- start Celery worker with a beat (scheduler) process"
+  echo "celery_healthcheck -- runs a Celery healthcheck. Useful for Docker's HEALTHCHECK mechanism."
   echo ""
   echo "shell -- open shell"
   echo "dev_server -- start Flask development server with debugger and auto reload"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Added a Docker entrypoint to run a healthcheck on Celery. Can be used with Docker's HEALTHCHECK mechanism to detect and replace stuck workers.