### PR TITLE
Snowflake: add support for regions and enable by default

### DIFF
--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -199,6 +199,7 @@ default_query_runners = [
     'redash.query_runner.kylin',
     'redash.query_runner.drill',
     'redash.query_runner.uptycs',
+    'redash.query_runner.snowflake',
 ]
 
 enabled_query_runners = array_from_string(os.environ.get("REDASH_ENABLED_QUERY_RUNNERS", ",".join(default_query_runners)))

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -26,9 +26,6 @@ qds-sdk>=1.9.6
 ibm-db>=2.0.9
 pydruid==0.4
 requests_aws_sign==0.1.4
+snowflake_connector_python==1.6.10
 # certifi is needed to support MongoDB and SSL:
 certifi
-# We don't install snowflake connector by default, as it's causing conflicts with
-# other packages. To properly support it we probably need to switch from pyOpenSSL
-# to the other package snowflake is using (that's compatible with it).
-# snowflake_connector_python==1.6.10


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature
- [x] Other

## Description

* Snowflake returns from its exile and now enabled by default.
* Add support for region parameter.

## Related Tickets & Documents

#1912