### PR TITLE
CircleCI configuration updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           name: Build Docker Images
           command: |
             set -x
+            docker pull redash/redash:preview
             docker-compose build --build-arg skip_ds_deps=true
             docker-compose up -d
             sleep 10

--- a/.circleci/docker-compose.circle.yml
+++ b/.circleci/docker-compose.circle.yml
@@ -1,7 +1,9 @@
-version: '3'
+version: "3"
 services:
   redash:
     build: ../
+    cache_from:
+      - redash/redash:preview
     command: manage version
     depends_on:
       - postgres

--- a/.circleci/docker-compose.circle.yml
+++ b/.circleci/docker-compose.circle.yml
@@ -1,9 +1,10 @@
-version: "3"
+version: "3.2"
 services:
   redash:
-    build: ../
-    cache_from:
-      - redash/redash:preview
+    build:
+      context: ../
+      cache_from:
+        - redash/redash:preview
     command: manage version
     depends_on:
       - postgres

--- a/.circleci/docker-compose.cypress.yml
+++ b/.circleci/docker-compose.cypress.yml
@@ -1,7 +1,9 @@
-version: '3'
+version: "3"
 services:
   server:
     build: ../
+    cache_from:
+      - redash/redash:preview
     command: dev_server
     depends_on:
       - postgres
@@ -15,6 +17,8 @@ services:
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
   worker:
     build: ../
+    cache_from:
+      - redash/redash:preview
     command: scheduler
     depends_on:
       - server

--- a/.circleci/docker-compose.cypress.yml
+++ b/.circleci/docker-compose.cypress.yml
@@ -1,9 +1,10 @@
-version: "3"
+version: "3.2"
 services:
   server:
-    build: ../
-    cache_from:
-      - redash/redash:preview
+    build:
+      context: ../
+      cache_from:
+        - redash/redash:preview
     command: dev_server
     depends_on:
       - postgres
@@ -16,9 +17,10 @@ services:
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
   worker:
-    build: ../
-    cache_from:
-      - redash/redash:preview
+    build:
+      context: ../
+      cache_from:
+        - redash/redash:preview
     command: scheduler
     depends_on:
       - server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:10 as frontend-builder
+FROM node:10-alpine as frontend-builder
+
+RUN apk add --no-cache git
 
 WORKDIR /frontend
 COPY package.json package-lock.json /frontend/


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Two changes to our Docker build and CircleCI setup:

* Use `cache_from` in Docker Compose build setup for Cypress/CircleCI (doesn't seem to have any affect).
* Switch to `node:10-alpine` image for smaller download size.