### PR TITLE
Prevent blank edit-in-place value

### DIFF
--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
+import { trim } from 'lodash';
 
 export class EditInPlace extends React.Component {
   static propTypes = {
@@ -40,7 +41,7 @@ export class EditInPlace extends React.Component {
   };
 
   stopEditing = () => {
-    const newValue = this.inputRef.current.value;
+    const newValue = trim(this.inputRef.current.value);
     const ignorableBlank = this.props.ignoreBlanks && newValue === '';
     if (!ignorableBlank && newValue !== this.props.value) {
       this.props.onDone(newValue);


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fiix

## Description
Edit-in-place component allows inserting empty spaces which can cause display problems across the app.

#### STR:
1. Edit query/dashboard/group name.
2. Insert "    ".
3. Click "enter".

Expected: Name unchanged
Actual: Control disappears.

### Fix
Since it already deals with an empty string, it's just a matter of trimming the set value.
