### PR TITLE
Add global options for data sources.

### DIFF
--- a/client/app/components/dynamic-form/DynamicForm.jsx
+++ b/client/app/components/dynamic-form/DynamicForm.jsx
@@ -225,10 +225,19 @@ export const DynamicForm = Form.create()(class DynamicForm extends React.Compone
 
 export default function init(ngModule) {
   ngModule.component('dynamicForm', react2angular((props) => {
-    const fields = helper.getFields(props.type.configuration_schema, props.target);
+    let globalFields = [];
+    const globalProperties = props.type.global_options_schema.properties;
+    if (globalProperties && Object.keys(globalProperties).length > 0) {
+      globalFields = helper.getFields(
+        props.type.global_options_schema, props.target.name, props.target.global_options,
+      );
+    }
+    const fields = helper.getFields(
+      props.type.configuration_schema, props.target.name, props.target.options,
+    );
 
     const onSubmit = (values, onSuccess, onError) => {
-      helper.updateTargetWithValues(props.target, values);
+      helper.updateTargetWithValues(props.target, props.type, values);
       props.target.$save(
         () => {
           onSuccess('Saved.');
@@ -244,7 +253,7 @@ export default function init(ngModule) {
     };
 
     const updatedProps = {
-      fields,
+      fields: fields.concat(globalFields),
       actions: props.target.id ? props.actions : [],
       feedbackIcons: true,
       onSubmit,

--- a/client/app/components/dynamic-form/dynamicFormHelper.js
+++ b/client/app/components/dynamic-form/dynamicFormHelper.js
@@ -57,9 +57,9 @@ function setDefaultValueForCheckboxes(configurationSchema, options = {}) {
   }
 }
 
-function getFields(configurationSchema, target = {}) {
+function getFields(configurationSchema, targetName, targetOptions) {
   normalizeSchema(configurationSchema);
-  setDefaultValueForCheckboxes(configurationSchema, target.options);
+  setDefaultValueForCheckboxes(configurationSchema, targetOptions);
 
   const inputs = [
     {
@@ -67,19 +67,22 @@ function getFields(configurationSchema, target = {}) {
       title: 'Name',
       type: 'text',
       required: true,
-      initialValue: target.name,
+      initialValue: targetName,
     },
-    ...orderedInputs(configurationSchema.properties, configurationSchema.order, target.options),
+    ...orderedInputs(configurationSchema.properties, configurationSchema.order, targetOptions),
   ];
 
   return inputs;
 }
 
-function updateTargetWithValues(target, values) {
+function updateTargetWithValues(target, type, values) {
   target.name = values.name;
   Object.keys(values).forEach((key) => {
-    if (key !== 'name') {
+    if (key in type.configuration_schema.properties) {
       target.options[key] = values[key];
+    } else if (type.global_options_schema.properties &&
+               key in type.global_options_schema.properties) {
+      target.global_options[key] = values[key];
     }
   });
 }

--- a/client/app/pages/data-sources/show.js
+++ b/client/app/pages/data-sources/show.js
@@ -100,7 +100,7 @@ export default function init(ngModule) {
         dataSource: (DataSource) => {
           'ngInject';
 
-          return new DataSource({ options: {} });
+          return new DataSource({ options: {}, global_options: {} });
         },
         types: ($http) => {
           'ngInject';

--- a/cypress/seed-data.js
+++ b/cypress/seed-data.js
@@ -29,6 +29,7 @@ exports.seedData = [
         sslmode: 'prefer',
         user: 'postgres',
       },
+      global_options: {},
       type: 'pg',
     },
   },

--- a/migrations/versions/80c6ebf0ac52_.py
+++ b/migrations/versions/80c6ebf0ac52_.py
@@ -1,0 +1,31 @@
+"""Add global options field for data sources
+
+Revision ID: 80c6ebf0ac52
+Revises: e5c7a4e2df4d
+Create Date: 2019-03-06 16:02:14.171877
+
+"""
+import json
+from alembic import op
+import sqlalchemy as sa
+
+from redash.models import MutableDict, PseudoJSON
+
+
+# revision identifiers, used by Alembic.
+revision = '80c6ebf0ac52'
+down_revision = 'e5c7a4e2df4d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('data_sources', sa.Column(
+		'global_options',
+		MutableDict.as_mutable(PseudoJSON),
+		nullable=False,
+		server_default=json.dumps({})
+    ))
+
+def downgrade():
+    op.drop_column('data_sources', 'global_options')

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -45,6 +45,7 @@ class DataSourceResource(BaseResource):
         try:
             data_source.options.set_schema(schema)
             data_source.options.update(filter_none(req['options']))
+            data_source.global_options = req['global_options']
         except ValidationError:
             abort(400)
 
@@ -107,7 +108,7 @@ class DataSourceListResource(BaseResource):
     @require_admin
     def post(self):
         req = request.get_json(True)
-        required_fields = ('options', 'name', 'type')
+        required_fields = ('options', 'global_options', 'name', 'type')
         for f in required_fields:
             if f not in req:
                 abort(400)
@@ -126,7 +127,8 @@ class DataSourceListResource(BaseResource):
             datasource = models.DataSource.create_with_group(org=self.current_org,
                                                              name=req['name'],
                                                              type=req['type'],
-                                                             options=config)
+                                                             options=config,
+                                                             global_options=req['global_options'])
 
             models.db.session.commit()
         except IntegrityError as e:

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -75,6 +75,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
     name = Column(db.String(255))
     type = Column(db.String(255))
     options = Column('encrypted_options', ConfigurationContainer.as_mutable(EncryptedConfiguration(db.Text, settings.SECRET_KEY, FernetEngine)))
+    global_options = Column(MutableDict.as_mutable(PseudoJSON), default={})
     queue_name = Column(db.String(255), default="queries")
     scheduled_queue_name = Column(db.String(255), default="scheduled_queries")
     created_at = Column(db.DateTime(True), default=db.func.now())
@@ -101,6 +102,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
             schema = get_configuration_schema_for_query_runner_type(self.type)
             self.options.set_schema(schema)
             d['options'] = self.options.to_dict(mask_secrets=True)
+            d['global_options'] = self.global_options
             d['queue_name'] = self.queue_name
             d['scheduled_queue_name'] = self.scheduled_queue_name
             d['groups'] = self.groups

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -54,6 +54,7 @@ class NotSupported(Exception):
 
 class BaseQueryRunner(object):
     noop_query = None
+    global_options_schema = {}
 
     def __init__(self, configuration):
         self.syntax = 'sql'
@@ -78,6 +79,10 @@ class BaseQueryRunner(object):
     @classmethod
     def configuration_schema(cls):
         return {}
+
+    @classmethod
+    def add_global_option(cls, option, schema):
+        cls.global_options_schema["properties"][option] = schema
 
     def test_connection(self):
         if self.noop_query is None:
@@ -123,7 +128,8 @@ class BaseQueryRunner(object):
         return {
             'name': cls.name(),
             'type': cls.type(),
-            'configuration_schema': cls.configuration_schema()
+            'configuration_schema': cls.configuration_schema(),
+            'global_options_schema': cls.global_options_schema
         }
 
 

--- a/tests/handlers/test_data_sources.py
+++ b/tests/handlers/test_data_sources.py
@@ -59,15 +59,25 @@ class TestDataSourceResourcePost(BaseTestCase):
         admin = self.factory.create_admin()
         new_name = 'New Name'
         new_options = {"dbname": "newdb"}
-        rv = self.make_request('post', self.path,
-                               data={'name': new_name, 'type': 'pg', 'options': new_options},
-                               user=admin)
+        new_global_options = {"some_key": "some_val"}
+        rv = self.make_request(
+            'post',
+            self.path,
+            data={
+                'name': new_name,
+                'type': 'pg',
+                'options': new_options,
+                'global_options': new_global_options
+            },
+            user=admin
+        )
 
         self.assertEqual(rv.status_code, 200)
         data_source = DataSource.query.get(self.factory.data_source.id)
 
         self.assertEqual(data_source.name, new_name)
         self.assertEqual(data_source.options.to_dict(), new_options)
+        self.assertEqual(data_source.global_options, new_global_options)
 
 
 class TestDataSourceResourceDelete(BaseTestCase):
@@ -100,8 +110,16 @@ class TestDataSourceListResourcePost(BaseTestCase):
 
     def test_creates_data_source(self):
         admin = self.factory.create_admin()
-        rv = self.make_request('post', '/api/data_sources',
-                               data={'name': 'DS 1', 'type': 'pg', 'options': {"dbname": "redash"}}, user=admin)
+        rv = self.make_request(
+            'post',
+            '/api/data_sources',
+            data={
+                'name': 'DS 1',
+                'type': 'pg',
+                'options': {"dbname": "redash"},
+                'global_options': {"doc_url": "www.example.com"}
+            },
+            user=admin)
 
         self.assertEqual(rv.status_code, 200)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description
This is an implementation (to the best of my understanding) of the suggestion proposed here: https://github.com/getredash/redash/pull/2892#issuecomment-438164929 @arikfr I wasn't 100% clear on what you had in mind for this, so I figured I can put up some code to see if we're on the same page.

Essentially there is another `global_options` field that is added to a data source. It behaves very similarly to `options` except it applies to all data sources, it's not encrypted, and there is an extension point `add_global_option()` which can be used by extensions to easily add more of these options.

## Related Tickets & Documents
Discussion for this started here: https://github.com/getredash/redash/pull/2892

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1040" alt="screen shot 2019-03-08 at 11 04 30 am" src="https://user-images.githubusercontent.com/784781/54039873-01a2fc00-4192-11e9-85f8-8dc938a586df.png">

Global options are added to the bottom of the data source page and look the same as the other options (this one has a doc url at the bottom as an example)


