### PR TITLE
Download Query Result links: use query name for downloaded filename

### DIFF
--- a/client/app/components/queries/query-results-link.js
+++ b/client/app/components/queries/query-results-link.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 function queryResultLink() {
   return {
     restrict: 'A',
@@ -22,11 +20,6 @@ function queryResultLink() {
             url = `api/query_results/${scope.queryResult.getId()}.${fileType}`;
           }
           element.attr('href', url);
-          element.attr(
-            'download',
-            `${scope.query.name.replace(/ /g, '_') +
-              moment(scope.queryResult.getUpdatedAt()).format('_YYYY_MM_DD')}.${fileType}`,
-          );
         }
       });
     },

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -96,13 +96,13 @@ def run_query(query, parameters, data_source, query_id, max_age=0):
         return {'job': job.to_dict()}
 
 
-def get_download_filename(query_result, query=None, filetype='json'):
-    str_date = query_result.retrieved_at.strftime("%Y-%m-%d")
-    if query is not None:
-        str_filename = to_filename(query.name) if query.name != '' else str(query.id)
+def get_download_filename(query_result, query, filetype):
+    retrieved_at = query_result.retrieved_at.strftime("%Y_%m_%d")
+    if query:
+        filename = to_filename(query.name) if query.name != '' else str(query.id)
     else:
-        str_filename = str(query_result.id)
-    return u"{}.{}.{}".format(str_filename, str_date, filetype)
+        filename = str(query_result.id)
+    return u"{}_{}.{}".format(filename, retrieved_at, filetype)
 
 
 class QueryResultListResource(BaseResource):

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -10,7 +10,7 @@ from redash.permissions import (has_access, not_view_only, require_access,
                                 require_permission, view_only)
 from redash.tasks import QueryTask
 from redash.tasks.queries import enqueue_query
-from redash.utils import (collect_parameters_from_request, gen_query_hash, json_dumps, utcnow)
+from redash.utils import (collect_parameters_from_request, gen_query_hash, json_dumps, utcnow, to_filename)
 from redash.utils.parameterized_query import ParameterizedQuery, InvalidParameterError, dropdown_values
 
 
@@ -94,6 +94,15 @@ def run_query(query, parameters, data_source, query_id, max_age=0):
             "Query ID": query_id
         })
         return {'job': job.to_dict()}
+
+
+def get_download_filename(query_result, query=None, filetype='json'):
+    str_date = query_result.retrieved_at.strftime("%Y-%m-%d")
+    if query is not None:
+        str_filename = to_filename(query.name) if query.name != '' else str(query.id)
+    else:
+        str_filename = str(query_result.id)
+    return u"{}.{}.{}".format(str_filename, str_date, filetype)
 
 
 class QueryResultListResource(BaseResource):
@@ -281,15 +290,12 @@ class QueryResultResource(BaseResource):
             if should_cache:
                 response.headers.add_header('Cache-Control', 'private,max-age=%d' % ONE_YEAR)
 
-            str_date = query_result.retrieved_at.strftime("%Y_%m_%d")
-            str_id = None
-            if query is not None:
-                str_id = str(query.id)
-            else:
-                str_id = str(query_result.id)
-            filename = "{}_{}.{}".format(str_id, str_date, filetype,)
+            filename = get_download_filename(query_result, query, filetype)
 
-            response.headers.add_header("Content-Disposition", 'attachment; filename="{}"'.format(filename,))
+            response.headers.add_header(
+                "Content-Disposition",
+                'attachment; filename="{}"'.format(filename.encode("utf-8"))
+            )
 
             return response
 

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -189,9 +189,6 @@ def filter_none(d):
 
 
 def to_filename(s):
-    # replace characters forbidden in filename with whitespace to process them with next regex
     s = re.sub('[<>:"\\\/|?*]+', " ", s, flags=re.UNICODE)
-    # collapse whitespaces (incl. NUL symbol and newlines) - whitespaces are allowed in filenames
-    s = re.sub("\s+", " ", s, flags=re.UNICODE)
-    # strip whitespaces from beginning and end
-    return s.strip()
+    s = re.sub("\s+", "_", s, flags=re.UNICODE)
+    return s.strip("_")

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -186,3 +186,12 @@ def base_url(org):
 
 def filter_none(d):
     return select_values(lambda v: v is not None, d)
+
+
+def to_filename(s):
+    # replace characters forbidden in filename with whitespace to process them with next regex
+    s = re.sub('[<>:"\\\/|?*]+', " ", s, flags=re.UNICODE)
+    # collapse whitespaces (incl. NUL symbol and newlines) - whitespaces are allowed in filenames
+    s = re.sub("\s+", " ", s, flags=re.UNICODE)
+    # strip whitespaces from beginning and end
+    return s.strip()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Fixes getredash/redash#3554. Set filename of downloaded file using query name (if possible). Also, previously used "slugify" algorithm replaced with more permissive one (removes only characters forbidden in Windows/Linux/Unix filesystems, and optimizes whitespaces a bit) - because downloaded filename is not a part of URL, therefore it can contain wider characters range (in fact - almost everything).

![image](https://user-images.githubusercontent.com/12139186/54082409-04325c80-431e-11e9-92d1-5ac9921c27b8.png)
