### PR TITLE
Decouple extensions from Flask app.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,14 +107,14 @@ jobs:
           path: /tmp/artifacts/
   build-docker-image:
     docker:
-      - image: circleci/buildpack-deps:xenial
+      - image: circleci/node:8
     steps:
       - setup_remote_docker
       - checkout
       - run: sudo apt install python-pip
       - run: sudo pip install -r requirements_bundles.txt
-      - run: npm run bundle
       - run: .circleci/update_version
+      - run: npm run bundle
       - run: .circleci/docker_build
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,9 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
+      - run: sudo apt install python-pip
+      - run: sudo pip install -r requirements_bundles.txt
+      - run: npm run bundle
       - run: .circleci/update_version
       - run: .circleci/docker_build
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: Copy Test Results
           command: |
             mkdir -p /tmp/test-results/unit-tests
-            docker cp tests:/app/coverage.xml ./coverage.xml 
+            docker cp tests:/app/coverage.xml ./coverage.xml
             docker cp tests:/app/junit.xml /tmp/test-results/unit-tests/results.xml
       - store_test_results:
           path: /tmp/test-results
@@ -61,6 +61,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt install python-pip
+      - run: sudo pip install -r requirements_bundles.txt
       - run: npm install
       - run: npm run bundle
       - run: npm test
@@ -95,6 +96,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt install python-pip
+      - run: sudo pip install -r requirements_bundles.txt
       - run: npm install
       - run: .circleci/update_version
       - run: npm run bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG skip_ds_deps
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.
 COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./
-RUN pip install -r requirements.txt -r requirements_bundles.txt -r requirements_dev.txt
+RUN pip install -r requirements.txt -r requirements_dev.txt
 RUN if [ "x$skip_ds_deps" = "x" ] ; then pip install -r requirements_all_ds.txt ; else echo "Skipping pip install -r requirements_all_ds.txt" ; fi
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ARG skip_ds_deps
 
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.
-COPY requirements.txt requirements_dev.txt requirements_all_ds.txt ./
-RUN pip install -r requirements.txt -r requirements_dev.txt
+COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./
+RUN pip install -r requirements.txt -r requirements_bundles.txt -r requirements_dev.txt
 RUN if [ "x$skip_ds_deps" = "x" ] ; then pip install -r requirements_all_ds.txt ; else echo "Skipping pip install -r requirements_all_ds.txt" ; fi
 
 COPY . /app

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
 import os
-from subprocess import call
 from distutils.dir_util import copy_tree
 
-from pkg_resources import iter_entry_points, resource_filename, resource_isdir
-
+import importlib_metadata
+import importlib_resources
 
 
 # Make a directory for extensions and set it as an environment variable
@@ -19,21 +18,28 @@ if not os.path.exists(EXTENSIONS_DIRECTORY):
     os.makedirs(EXTENSIONS_DIRECTORY)
 os.environ["EXTENSIONS_DIRECTORY"] = EXTENSIONS_RELATIVE_PATH
 
-for entry_point in iter_entry_points('redash.extensions'):
-    # This is where the frontend code for an extension lives
-    # inside of its package.
-    content_folder_relative = os.path.join(
-        entry_point.name, 'bundle')
-    (root_module, _) = os.path.splitext(entry_point.module_name)
 
-    if not resource_isdir(root_module, content_folder_relative):
+def is_resource_dir(module, resource):
+    try:
+        return (
+            resource in importlib_resources.contents(module)
+            and not importlib_resources.is_resource(module, resource)
+        )
+    except TypeError:
+        # module isn't a package, so can't have a subdirectory/-package
+        return False
+
+
+for entry_point in importlib_metadata.entry_points().get('redash.extensions', []):
+
+    # Check if there is a "bundle" subdirectory/-package in the
+    # entrypoint's module and ignoring the entrypoint if not.
+    module_name = entry_point.pattern.match(entry_point.value).group('module')
+    if not is_resource_dir(module_name, 'bundle'):
         continue
 
-    content_folder = resource_filename(root_module, content_folder_relative)
-
-    # This is where we place our extensions folder.
-    destination = os.path.join(
-        EXTENSIONS_DIRECTORY,
-        entry_point.name)
-
-    copy_tree(content_folder, destination)
+    with importlib_resources.path(module_name, 'bundle') as bundle_dir:
+        # Copy content of extension bundle into extensions directory
+        destination = os.path.join(EXTENSIONS_DIRECTORY, entry_point.name)
+        print("Copying {} to {}".format(bundle_dir, destination))
+        copy_tree(str(bundle_dir), destination)

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -1,35 +1,43 @@
 #!/usr/bin/env python
+"""Copy bundle extension files to the client/app/extension directory"""
 import os
-from distutils.dir_util import copy_tree
+from pathlib2 import Path
+from shutil import copy
 
-import importlib_metadata
-import importlib_resources
-
-from redash.extensions import BUNDLE_DIRECTORY, resource_isdir, entry_point_module
-
+from redash import create_app, extensions
 
 # Make a directory for extensions and set it as an environment variable
 # to be picked up by webpack.
-EXTENSIONS_RELATIVE_PATH = os.path.join('client', 'app', 'extensions')
-EXTENSIONS_DIRECTORY = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)),
-    EXTENSIONS_RELATIVE_PATH)
+extensions_relative_path = Path('client', 'app', 'extensions')
+extensions_directory = Path(__file__).parent.parent / extensions_relative_path
 
-if not os.path.exists(EXTENSIONS_DIRECTORY):
-    os.makedirs(EXTENSIONS_DIRECTORY)
-os.environ["EXTENSIONS_DIRECTORY"] = EXTENSIONS_RELATIVE_PATH
+if not extensions_directory.exists():
+    extensions_directory.mkdir()
+os.environ["EXTENSIONS_DIRECTORY"] = str(extensions_relative_path)
 
+# We need the app here for logging and to make sure the bundles have loaded.
+app = create_app()
 
-for entry_point in importlib_metadata.entry_points().get('redash.extensions', []):
-    # Check if there is a "bundle" subdirectory/-package in the
-    # entrypoint's module and ignoring the entrypoint if not.
-    module = entry_point_module(entry_point)
-    if not resource_isdir(module, BUNDLE_DIRECTORY):
+bundles = extensions.bundles.items()
+if bundles:
+    app.logger.info('Number of extension bundles found: %s', len(bundles))
+else:
+    app.logger.info('No extension bundles found.')
+
+for bundle_name, paths in extensions.bundles.items():
+    # Shortcut in case not paths were found for the bundle
+    if not paths:
+        app.logger.info('No paths found for bundle "%s".', bundle_name)
         continue
 
     # The destination for the bundle files with the entry point name as the subdirectory
-    destination = os.path.join(EXTENSIONS_DIRECTORY, entry_point.name)
+    destination = Path(extensions_directory, bundle_name)
+    if not destination.exists():
+        destination.mkdir()
+
     # Copy the bundle directory from the module to its destination.
-    with importlib_resources.path(module, BUNDLE_DIRECTORY) as bundle_dir:
-        print("Copying {} to {}".format(bundle_dir, destination))
-        copy_tree(str(bundle_dir), destination)
+    app.logger.info('Copying "%s" bundle to %s:', bundle_name, destination.resolve())
+    for src_path in paths:
+        dest_path = destination / src_path.name
+        app.logger.info(" - {} -> {}".format(src_path, dest_path))
+        copy(str(src_path), str(dest_path))

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -4,7 +4,7 @@ import os
 from pathlib2 import Path
 from shutil import copy
 
-from redash import create_app, extensions
+from redash import extensions
 
 # Make a directory for extensions and set it as an environment variable
 # to be picked up by webpack.
@@ -15,19 +15,17 @@ if not extensions_directory.exists():
     extensions_directory.mkdir()
 os.environ["EXTENSIONS_DIRECTORY"] = str(extensions_relative_path)
 
-# We need the app here for logging and to make sure the bundles have loaded.
-app = create_app()
 
 bundles = extensions.bundles.items()
 if bundles:
-    app.logger.info('Number of extension bundles found: %s', len(bundles))
+    print('Number of extension bundles found: {}'.format(len(bundles)))
 else:
-    app.logger.info('No extension bundles found.')
+    print('No extension bundles found.')
 
-for bundle_name, paths in extensions.bundles.items():
+for bundle_name, paths in bundles:
     # Shortcut in case not paths were found for the bundle
     if not paths:
-        app.logger.info('No paths found for bundle "%s".', bundle_name)
+        print('No paths found for bundle "{}".'.format(bundle_name))
         continue
 
     # The destination for the bundle files with the entry point name as the subdirectory
@@ -36,8 +34,8 @@ for bundle_name, paths in extensions.bundles.items():
         destination.mkdir()
 
     # Copy the bundle directory from the module to its destination.
-    app.logger.info('Copying "%s" bundle to %s:', bundle_name, destination.resolve())
+    print('Copying "{}" bundle to {}:'.format(bundle_name, destination.resolve()))
     for src_path in paths:
         dest_path = destination / src_path.name
-        app.logger.info(" - {} -> {}".format(src_path, dest_path))
+        print(" - {} -> {}".format(src_path, dest_path))
         copy(str(src_path), str(dest_path))

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-
 import os
 from distutils.dir_util import copy_tree
 
 import importlib_metadata
 import importlib_resources
+
+from redash.extensions import BUNDLE_DIRECTORY, resource_isdir, entry_point_module
 
 
 # Make a directory for extensions and set it as an environment variable
@@ -19,27 +20,16 @@ if not os.path.exists(EXTENSIONS_DIRECTORY):
 os.environ["EXTENSIONS_DIRECTORY"] = EXTENSIONS_RELATIVE_PATH
 
 
-def is_resource_dir(module, resource):
-    try:
-        return (
-            resource in importlib_resources.contents(module)
-            and not importlib_resources.is_resource(module, resource)
-        )
-    except TypeError:
-        # module isn't a package, so can't have a subdirectory/-package
-        return False
-
-
 for entry_point in importlib_metadata.entry_points().get('redash.extensions', []):
-
     # Check if there is a "bundle" subdirectory/-package in the
     # entrypoint's module and ignoring the entrypoint if not.
-    module_name = entry_point.pattern.match(entry_point.value).group('module')
-    if not is_resource_dir(module_name, 'bundle'):
+    module = entry_point_module(entry_point)
+    if not resource_isdir(module, BUNDLE_DIRECTORY):
         continue
 
-    with importlib_resources.path(module_name, 'bundle') as bundle_dir:
-        # Copy content of extension bundle into extensions directory
-        destination = os.path.join(EXTENSIONS_DIRECTORY, entry_point.name)
+    # The destination for the bundle files with the entry point name as the subdirectory
+    destination = os.path.join(EXTENSIONS_DIRECTORY, entry_point.name)
+    # Copy the bundle directory from the module to its destination.
+    with importlib_resources.path(module, BUNDLE_DIRECTORY) as bundle_dir:
         print("Copying {} to {}".format(bundle_dir, destination))
         copy_tree(str(bundle_dir), destination)

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -15,6 +15,8 @@ if not extensions_directory.exists():
     extensions_directory.mkdir()
 os.environ["EXTENSIONS_DIRECTORY"] = str(extensions_relative_path)
 
+# load bundles from entry points
+extensions.load_bundles()
 
 bundles = extensions.bundles.items()
 if bundles:

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -1,10 +1,20 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """Copy bundle extension files to the client/app/extension directory"""
+import logging
 import os
 from pathlib2 import Path
 from shutil import copy
+from collections import OrderedDict as odict
 
-from redash import extensions
+from importlib_metadata import entry_points
+from importlib_resources import contents, is_resource, path
+
+# Name of the subdirectory
+BUNDLE_DIRECTORY = "bundle"
+
+logger = logging.getLogger(__name__)
+
 
 # Make a directory for extensions and set it as an environment variable
 # to be picked up by webpack.
@@ -15,10 +25,75 @@ if not extensions_directory.exists():
     extensions_directory.mkdir()
 os.environ["EXTENSIONS_DIRECTORY"] = str(extensions_relative_path)
 
-# load bundles from entry points
-extensions.load_bundles()
 
-bundles = extensions.bundles.items()
+def resource_isdir(module, resource):
+    """Whether a given resource is a directory in the given module
+
+    https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-isdir
+    """
+    try:
+        return resource in contents(module) and not is_resource(module, resource)
+    except (ImportError, TypeError):
+        # module isn't a package, so can't have a subdirectory/-package
+        return False
+
+
+def entry_point_module(entry_point):
+    """Returns the dotted module path for the given entry point"""
+    return entry_point.pattern.match(entry_point.value).group("module")
+
+
+def load_bundles():
+    """"Load bundles as defined in Redash extensions.
+
+    The bundle entry point can be defined as a dotted path to a module
+    or a callable, but it won't be called but just used as a means
+    to find the files under its file system path.
+
+    The name of the directory it looks for files in is "bundle".
+
+    So a Python package with an extension bundle could look like this::
+
+        my_extensions/
+        ├── __init__.py
+        └── wide_footer
+            ├── __init__.py
+            └── bundle
+                ├── extension.js
+                └── styles.css
+
+    and would then need to register the bundle with an entry point
+    under the "redash.periodic_tasks" group, e.g. in your setup.py::
+
+        setup(
+            # ...
+            entry_points={
+                "redash.bundles": [
+                    "wide_footer = my_extensions.wide_footer",
+                ]
+                # ...
+            },
+            # ...
+        )
+
+    """
+    bundles = odict()
+    for entry_point in entry_points().get("redash.bundles", []):
+        logger.info('Loading Redash bundle "%s".', entry_point.name)
+        module = entry_point_module(entry_point)
+        # Try to get a list of bundle files
+        if not resource_isdir(module, BUNDLE_DIRECTORY):
+            logger.error(
+                'Redash bundle directory "%s" could not be found.', entry_point.name
+            )
+            continue
+        with path(module, BUNDLE_DIRECTORY) as bundle_dir:
+            bundles[entry_point.name] = list(bundle_dir.rglob("*"))
+
+    return bundles
+
+
+bundles = load_bundles().items()
 if bundles:
     print('Number of extension bundles found: {}'.format(len(bundles)))
 else:

--- a/redash/extensions.py
+++ b/redash/extensions.py
@@ -172,4 +172,4 @@ def load_periodic_tasks(logger):
 
 def init_app(app):
     load_extensions(app)
-    load_bundles(app)
+    load_bundles()

--- a/redash/extensions.py
+++ b/redash/extensions.py
@@ -37,7 +37,7 @@ def module_bundle_files(module):
 def init_app(app):
     """Load the Redash extensions for the given Redash Flask app.
 
-    The extension entry pooint can return any type of value but
+    The extension entry point can return any type of value but
     must take a Flask application object.
 
     E.g.::

--- a/redash/extensions.py
+++ b/redash/extensions.py
@@ -1,10 +1,37 @@
+from types import ModuleType
+from importlib_resources import contents, is_resource, path
 from importlib_metadata import entry_points
+
+BUNDLE_DIRECTORY = 'bundle'
 
 # The global Redash extension registry
 extensions = {}
 
-# The periodic Celery task registry
-periodic_tasks = {}
+
+def resource_isdir(module, resource):
+    """Whether a given resource is a directory in the given module
+
+    https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-isdir
+    """
+    try:
+        return resource in contents(module) and not is_resource(module, resource)
+    except (ImportError, TypeError):
+        # module isn't a package, so can't have a subdirectory/-package
+        return False
+
+
+def entry_point_module(entry_point):
+    """Returns the dotted module path for the given entry point"""
+    return entry_point.pattern.match(entry_point.value).group('module')
+
+
+def module_bundle_files(module):
+    if not resource_isdir(module, BUNDLE_DIRECTORY):
+        return
+
+    with path(module, BUNDLE_DIRECTORY) as bundle_dir:
+        # Copy content of extension bundle into extensions directory
+        return list(bundle_dir.rglob("*"))
 
 
 def init_app(app):
@@ -22,29 +49,24 @@ def init_app(app):
     """
     for entry_point in entry_points().get('redash.extensions', []):
         app.logger.info('Loading Redash extension %s.', entry_point.name)
-        init_extension = entry_point.load()
-        extensions[entry_point.name] = init_extension(app)
+        module = entry_point_module(entry_point)
+        # First of all, try to get a list of bundle files
+        extensions[entry_point.name]['resource_list'] = module_bundle_files(module)
 
+        try:
+            # Then try to load the entry point (import and getattr)
+            obj = entry_point.load()
+        except (ImportError, AttributeError):
+            # or move on
+            app.logger.error('Extension %s could not be found.', entry_point.name)
+            extensions[entry_point.name]['extension'] = None
+            continue
 
-def init_periodic_tasks(app):
-    """Load the Redash extensions for the given Redash Flask app.
-
-    The periodic task entry point needs to return a set of parameters
-    that can be passed to Celery's add_periodic_task:
-
-        https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#entries
-
-    E.g.::
-
-        def periodic_task():
-            return {
-                'name': 'add 2 and 2 every 10 seconds'
-                'sig': add.s(2, 2),
-                'schedule': 10.0,
-            }
-
-    """
-    for entry_point in entry_points().get('redash.periodic_tasks', []):
-        app.logger.info('Loading Redash periodic tasks %s.', entry_point.name)
-        init_periodic_task = entry_point.load()
-        periodic_tasks[entry_point.name] = init_periodic_task()
+        # Otherwise check if the loaded entry point is a module
+        if isinstance(obj, ModuleType):
+            app.logger.info('Extension %s is a module.', entry_point.name)
+            extensions[entry_point.name]['extension'] = obj
+        # or simply call the loaded entry point instead.
+        else:
+            app.logger.info('Extension %s is a callable.', entry_point.name)
+            extensions[entry_point.name]['extension'] = obj(app)

--- a/redash/extensions.py
+++ b/redash/extensions.py
@@ -1,11 +1,22 @@
-from types import ModuleType
+# -*- coding: utf-8 -*-
+from collections import OrderedDict as odict
+
 from importlib_resources import contents, is_resource, path
 from importlib_metadata import entry_points
 
 BUNDLE_DIRECTORY = 'bundle'
 
 # The global Redash extension registry
-extensions = {}
+extensions = odict()
+
+# The global Redash bundle registry
+bundles = odict()
+
+# The periodic Celery tasks as provided by Redash extensions.
+# This is separate from the internal periodic Celery tasks in
+# celery_schedule since the extension task discovery phase is
+# after the configuration has already happened.
+periodic_tasks = odict()
 
 
 def resource_isdir(module, resource):
@@ -25,16 +36,7 @@ def entry_point_module(entry_point):
     return entry_point.pattern.match(entry_point.value).group('module')
 
 
-def module_bundle_files(module):
-    if not resource_isdir(module, BUNDLE_DIRECTORY):
-        return
-
-    with path(module, BUNDLE_DIRECTORY) as bundle_dir:
-        # Copy content of extension bundle into extensions directory
-        return list(bundle_dir.rglob("*"))
-
-
-def init_app(app):
+def load_extensions(app):
     """Load the Redash extensions for the given Redash Flask app.
 
     The extension entry point can return any type of value but
@@ -48,25 +50,108 @@ def init_app(app):
 
     """
     for entry_point in entry_points().get('redash.extensions', []):
-        app.logger.info('Loading Redash extension %s.', entry_point.name)
-        module = entry_point_module(entry_point)
-        # First of all, try to get a list of bundle files
-        extensions[entry_point.name]['resource_list'] = module_bundle_files(module)
-
+        app.logger.info('Loading Redash extension "%s".', entry_point.name)
         try:
             # Then try to load the entry point (import and getattr)
             obj = entry_point.load()
         except (ImportError, AttributeError):
             # or move on
-            app.logger.error('Extension %s could not be found.', entry_point.name)
-            extensions[entry_point.name]['extension'] = None
+            app.logger.error('Redash extension "%s" could not be found.', entry_point.name)
             continue
 
-        # Otherwise check if the loaded entry point is a module
-        if isinstance(obj, ModuleType):
-            app.logger.info('Extension %s is a module.', entry_point.name)
-            extensions[entry_point.name]['extension'] = obj
-        # or simply call the loaded entry point instead.
-        else:
-            app.logger.info('Extension %s is a callable.', entry_point.name)
-            extensions[entry_point.name]['extension'] = obj(app)
+        if not callable(obj):
+            app.logger.error('Redash extension "%s" is not a callable.', entry_point.name)
+            continue
+
+        # then simply call the loaded entry point.
+        extensions[entry_point.name] = obj(app)
+
+
+def load_bundles(app):
+    """"Load bundles as defined in Redash extensions.
+
+    The bundle entry point can be defined as a dotted path to a module
+    or a callable, but it won't be called but just used as a means
+    to find the files under its file system path.
+
+    The name of the directory it looks for files in is "bundle".
+
+    So a Python package with an extension bundle could look like this::
+
+        my_extensions/
+        ├── __init__.py
+        └── wide_footer
+            ├── __init__.py
+            └── bundle
+                ├── extension.js
+                └── styles.css
+
+    and would then need to register the bundle with an entry point
+    under the "redash.periodic_tasks" group, e.g. in your setup.py::
+
+        setup(
+            # ...
+            entry_points={
+                "redash.bundles": [
+                    "wide_footer = my_extensions.wide_footer",
+                ]
+                # ...
+            },
+            # ...
+        )
+
+    """
+    for entry_point in entry_points().get('redash.bundles', []):
+        app.logger.info('Loading Redash bundle "%s".', entry_point.name)
+        module = entry_point_module(entry_point)
+        # Try to get a list of bundle files
+        if not resource_isdir(module, BUNDLE_DIRECTORY):
+            app.logger.error('Redash bundle directory "%s" could not be found.', entry_point.name)
+            continue
+        with path(module, BUNDLE_DIRECTORY) as bundle_dir:
+            bundles[entry_point.name] = list(bundle_dir.rglob("*"))
+
+
+def load_periodic_tasks(logger):
+    """Load the periodic tasks as defined in Redash extensions.
+
+    The periodic task entry point needs to return a set of parameters
+    that can be passed to Celery's add_periodic_task:
+
+        https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#entries
+
+    E.g.::
+
+        def add_two_and_two():
+            return {
+                'name': 'add 2 and 2 every 10 seconds'
+                'sig': add.s(2, 2),
+                'schedule': 10.0,  # in seconds or a timedelta
+            }
+
+    and then registered with an entry point under the "redash.periodic_tasks"
+    group, e.g. in your setup.py::
+
+        setup(
+            # ...
+            entry_points={
+                "redash.periodic_tasks": [
+                    "add_two_and_two = calculus.addition:add_two_and_two",
+                ]
+                # ...
+            },
+            # ...
+        )
+    """
+    for entry_point in entry_points().get('redash.periodic_tasks', []):
+        logger.info('Loading periodic Redash tasks "%s" from "%s".', entry_point.name, entry_point.value)
+        try:
+            periodic_tasks[entry_point.name] = entry_point.load()
+        except (ImportError, AttributeError):
+            # and move on if it couldn't load it
+            logger.error('Periodic Redash task "%s" could not be found at "%s".', entry_point.name, entry_point.value)
+
+
+def init_app(app):
+    load_extensions(app)
+    load_bundles(app)

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -8,19 +8,12 @@ from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_process_init
 from celery.utils.log import get_logger
-from importlib_metadata import entry_points
 
-from redash import create_app, settings
+from redash import create_app, extensions, settings
 from redash.metrics import celery as celery_metrics  # noqa
 
 
 logger = get_logger(__name__)
-
-# The periodic Celery tasks as provided by Redash extensions.
-# This is separate from the internal periodic Celery tasks in
-# celery_schedule since the extension task discovery phase is
-# after the configuration has already happened.
-extensions_schedule = {}
 
 
 celery = Celery('redash',
@@ -92,44 +85,9 @@ def init_celery_flask_app(**kwargs):
 
 @celery.on_after_configure.connect
 def add_periodic_tasks(sender, **kwargs):
-    """Load the periodic tasks as defined in Redash extensions.
-
-    The periodic task entry point needs to return a set of parameters
-    that can be passed to Celery's add_periodic_task:
-
-        https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#entries
-
-    E.g.::
-
-        def add_two_and_two():
-            return {
-                'name': 'add 2 and 2 every 10 seconds'
-                'sig': add.s(2, 2),
-                'schedule': 10.0,  # in seconds or a timedelta
-            }
-
-    and then registered with an entry point under the "redash.periodic_tasks"
-    group, e.g. in your setup.py::
-
-        setup(
-            # ...
-            entry_points={
-                "redash.periodic_tasks": [
-                    "add_two_and_two = calculus.addition:add_two_and_two",
-                ]
-                # ...
-            },
-            # ...
-        )
-    """
-    for entry_point in entry_points().get('redash.periodic_tasks', []):
-        logger.info('Loading periodic Redash tasks %s from %s.', entry_point.name, entry_point.value)
-        try:
-            params = entry_point.load()
-            # Keep a record of our periodic tasks
-            extensions_schedule[entry_point.name] = params
-            # and add it to Celery's periodic task registry, too.
-            sender.add_periodic_task(**params)
-        except (ImportError, AttributeError):
-            # and move on if it couldn't load it
-            logger.error('Periodic Redash task %s could not be found at %s.', entry_point.name, entry_point.value)
+    """Load all periodic tasks from extensions and add them to Celery."""
+    # Populate the redash.extensions.periodic_tasks dictionary
+    extensions.load_periodic_tasks(logger)
+    for params in extensions.periodic_tasks.values():
+        # Add it to Celery's periodic task registry, too.
+        sender.add_periodic_task(**params)

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -9,7 +9,7 @@ from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_process_init
 
-from redash import create_app, settings
+from redash import create_app, extensions, settings
 from redash.metrics import celery as celery_metrics  # noqa
 
 
@@ -76,11 +76,8 @@ def init_celery_flask_app(**kwargs):
     app.app_context().push()
 
 
-# Commented until https://github.com/getredash/redash/issues/3466 is implemented.
 # Hook for extensions to add periodic tasks.
-# @celery.on_after_configure.connect
-# def add_periodic_tasks(sender, **kwargs):
-#     app = safe_create_app()
-#     periodic_tasks = getattr(app, 'periodic_tasks', {})
-#     for params in periodic_tasks.values():
-#         sender.add_periodic_task(**params)
+@celery.on_after_configure.connect
+def add_periodic_tasks(sender, **kwargs):
+    for params in extensions.periodic_tasks.values():
+        sender.add_periodic_task(**params)

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-
 from datetime import timedelta
 from random import randint
 
@@ -8,15 +7,27 @@ from flask import current_app
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_process_init
+from celery.utils.log import get_logger
+from importlib_metadata import entry_points
 
-from redash import create_app, extensions, settings
+from redash import create_app, settings
 from redash.metrics import celery as celery_metrics  # noqa
+
+
+logger = get_logger(__name__)
+
+# The periodic Celery tasks as provided by Redash extensions.
+# This is separate from the internal periodic Celery tasks in
+# celery_schedule since the extension task discovery phase is
+# after the configuration has already happened.
+extensions_schedule = {}
 
 
 celery = Celery('redash',
                 broker=settings.CELERY_BROKER,
                 include='redash.tasks')
 
+# The internal periodic Celery tasks to automatically schedule.
 celery_schedule = {
     'refresh_queries': {
         'task': 'redash.tasks.refresh_queries',
@@ -69,15 +80,56 @@ class ContextTask(TaskBase):
 celery.Task = ContextTask
 
 
-# Create Flask app after forking a new worker, to make sure no resources are shared between processes.
 @worker_process_init.connect
 def init_celery_flask_app(**kwargs):
+    """Create the Flask app after forking a new worker.
+
+    This is to make sure no resources are shared between processes.
+    """
     app = create_app()
     app.app_context().push()
 
 
-# Hook for extensions to add periodic tasks.
 @celery.on_after_configure.connect
 def add_periodic_tasks(sender, **kwargs):
-    for params in extensions.periodic_tasks.values():
-        sender.add_periodic_task(**params)
+    """Load the periodic tasks as defined in Redash extensions.
+
+    The periodic task entry point needs to return a set of parameters
+    that can be passed to Celery's add_periodic_task:
+
+        https://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#entries
+
+    E.g.::
+
+        def add_two_and_two():
+            return {
+                'name': 'add 2 and 2 every 10 seconds'
+                'sig': add.s(2, 2),
+                'schedule': 10.0,  # in seconds or a timedelta
+            }
+
+    and then registered with an entry point under the "redash.periodic_tasks"
+    group, e.g. in your setup.py::
+
+        setup(
+            # ...
+            entry_points={
+                "redash.periodic_tasks": [
+                    "add_two_and_two = calculus.addition:add_two_and_two",
+                ]
+                # ...
+            },
+            # ...
+        )
+    """
+    for entry_point in entry_points().get('redash.periodic_tasks', []):
+        logger.info('Loading periodic Redash tasks %s from %s.', entry_point.name, entry_point.value)
+        try:
+            params = entry_point.load()
+            # Keep a record of our periodic tasks
+            extensions_schedule[entry_point.name] = params
+            # and add it to Celery's periodic task registry, too.
+            sender.add_periodic_task(**params)
+        except (ImportError, AttributeError):
+            # and move on if it couldn't load it
+            logger.error('Periodic Redash task %s could not be found at %s.', entry_point.name, entry_point.value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,7 @@ disposable-email-domains
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
 gevent==1.4.0
+
+# Install the dependencies of the bin/bundle-extensions script here.
+# It has its own requirements file to simplify the frontend client build process
+-r requirements_bundles.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,5 +61,6 @@ disposable-email-domains
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
 gevent==1.4.0
-importlib-metadata==0.8
-importlib_resources==1.0.2
+# These can be removed when upgrading to Python 3.x
+importlib-metadata==0.8  # remove when on 3.8
+importlib_resources==1.0.2 # remove when on 3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,5 @@ disposable-email-domains
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
 gevent==1.4.0
+importlib-metadata==0.8
+importlib_resources==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,4 +63,5 @@ disposable-email-domains
 gevent==1.4.0
 # These can be removed when upgrading to Python 3.x
 importlib-metadata==0.9  # remove when on 3.8
-importlib_resources==1.0.2 # remove when on 3.7
+importlib_resources==1.0.2  # remove when on 3.7
+pathlib2==2.3.3  # remove when on 3.x

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,5 @@ disposable-email-domains
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
 gevent==1.4.0
-# These can be removed when upgrading to Python 3.x
-importlib-metadata==0.9  # remove when on 3.8
-importlib_resources==1.0.2  # remove when on 3.7
-pathlib2==2.3.3  # remove when on 3.x
+# Requirements for the extension bundle loading
+-r requirements_bundles.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,5 +62,5 @@ disposable-email-domains
 # ldap3==2.2.4
 gevent==1.4.0
 # These can be removed when upgrading to Python 3.x
-importlib-metadata==0.8  # remove when on 3.8
+importlib-metadata==0.9  # remove when on 3.8
 importlib_resources==1.0.2 # remove when on 3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,5 +61,3 @@ disposable-email-domains
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
 gevent==1.4.0
-# Requirements for the extension bundle loading
--r requirements_bundles.txt

--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -1,0 +1,9 @@
+# These are the requirements that the extension bundle
+# loading mechanism need on Python 2 and can be removed
+# when moved to Python 3.
+# It's automatically installed when running npm run bundle
+
+# These can be removed when upgrading to Python 3.x
+importlib-metadata==0.9  # remove when on 3.8
+importlib_resources==1.0.2  # remove when on 3.7
+pathlib2==2.3.3  # remove when on 3.x


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor
- [x] Feature
- [X] Bug Fix

## Description

This separates the extension registry from the Flask app and also introduces a separate registry for preriodic tasks.

## Related Tickets & Documents

Fixes #3466.
Example change in redash-stmo: https://github.com/mozilla/redash-stmo/pull/25