### PR TITLE
Fix webpack config to work with symlinks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,12 +17,12 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const redashBackend = process.env.REDASH_BACKEND || "http://localhost:5000";
 
-const basePath = fs.realpathSync(path.join(__dirname, "client"));
-const appPath = fs.realpathSync(path.join(__dirname, "client", "app"));
+const basePath = path.join(__dirname, "client");
+const appPath = path.join(__dirname, "client", "app");
 
 const extensionsRelativePath = process.env.EXTENSIONS_DIRECTORY ||
   path.join("client", "app", "extensions");
-const extensionPath = fs.realpathSync(path.join(__dirname, extensionsRelativePath));
+const extensionPath = path.join(__dirname, extensionsRelativePath);
 
 const config = {
   mode: isProduction ? "production" : "development",
@@ -40,11 +40,12 @@ const config = {
     publicPath: "/static/"
   },
   resolve: {
+    symlinks: false,
     extensions: ['.js', '.jsx'],
     alias: {
       "@": appPath,
       "extensions": extensionPath
-    }
+    },
   },
   plugins: [
     new WebpackBuildNotifierPlugin({ title: "Redash" }),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Other

## Description

Don't resolve symlinks (resolving symlinks breaks `babel-loader` and other loaders because they receive wrong paths to files).