### PR TITLE
Fix for parameter mapping bug #3581

### DIFF
--- a/client/app/components/dashboards/EditParameterMappingsDialog.jsx
+++ b/client/app/components/dashboards/EditParameterMappingsDialog.jsx
@@ -37,16 +37,22 @@ class EditParameterMappingsDialog extends React.Component {
     dialog: DialogPropType.isRequired,
   };
 
+  originalParameterMappings = null
+
   constructor(props) {
     super(props);
 
+    const parameterMappings = parameterMappingsToEditableMappings(
+      props.widget.options.parameterMappings,
+      props.widget.query.getParametersDefs(),
+      map(this.props.dashboard.getParametersDefs(), p => p.name),
+    );
+
+    this.originalParameterMappings = parameterMappings;
+
     this.state = {
       saveInProgress: false,
-      parameterMappings: parameterMappingsToEditableMappings(
-        props.widget.options.parameterMappings,
-        props.widget.query.getParametersDefs(),
-        map(this.props.dashboard.getParametersDefs(), p => p.name),
-      ),
+      parameterMappings,
     };
   }
 
@@ -56,14 +62,13 @@ class EditParameterMappingsDialog extends React.Component {
 
     this.setState({ saveInProgress: true });
 
-    const prevMappings = widget.options.parameterMappings;
     const newMappings = editableMappingsToParameterMappings(this.state.parameterMappings);
     widget.options.parameterMappings = newMappings;
 
     const dashboardParameters = this.props.dashboard.getParametersDefs();
     const valuesChanged = !isMatch(
-      getParamValuesSnapshot(prevMappings, dashboardParameters),
-      getParamValuesSnapshot(newMappings, dashboardParameters),
+      getParamValuesSnapshot(this.originalParameterMappings, dashboardParameters),
+      getParamValuesSnapshot(this.state.parameterMappings, dashboardParameters),
     );
 
     const widgetsToSave = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
#### Background
In #3445 we introduced auto-refreshing a widget if parameter value has changed. It's determined by collecting all param values from prev and next state and comparing them.

#### The bug
Some crucial parameter mapping data (`mapping.param`) is stripped out when processed with `editableMappingsToParameterMappings`, which the #3445 code assumed would be available.

#### The Fix
Now comparing the pre-processed data.

#### Test it
Do the same STR from #3581 
* [With bug](https://redash-preview.netlify.com/dashboard/test?p_test=2019-03-27&p_test11=2019-03-27)
* [Fixed](https://deploy-preview-3582--redash-preview.netlify.com/dashboard/test?p_test=2019-03-27&p_test11=2019-03-27)

## Related Tickets & Documents
Fixes #3581



