### PR TITLE
Revert "Add SAML scheme override env var"

### DIFF
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -20,12 +20,7 @@ def get_saml_client(org):
     """
     metadata_url = org.get_setting("auth_saml_metadata_url")
     entity_id = org.get_setting("auth_saml_entity_id")
-
-    if settings.SAML_SCHEME_OVERRIDE:
-        acs_url = url_for("saml_auth.idp_initiated", org_slug=org.slug, _external=True,
-                          _scheme=settings.SAML_SCHEME_OVERRIDE)
-    else:
-        acs_url = url_for("saml_auth.idp_initiated", org_slug=org.slug, _external=True)
+    acs_url = url_for("saml_auth.idp_initiated", org_slug=org.slug, _external=True)
 
     saml_settings = {
         'metadata': {

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -59,13 +59,6 @@ GOOGLE_CLIENT_ID = os.environ.get("REDASH_GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.environ.get("REDASH_GOOGLE_CLIENT_SECRET", "")
 GOOGLE_OAUTH_ENABLED = bool(GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET)
 
-# If Redash is behind a proxy it might sometimes receive a X-Forwarded-Proto of HTTP
-# even if your actual Redash URL scheme is HTTPS. This will cause Flask to build
-# the SAML redirect URL incorrect thus failing auth. This is especially common if
-# you're behind a SSL/TCP configured AWS ELB or similar.
-# This setting will force the URL scheme.
-SAML_SCHEME_OVERRIDE = os.environ.get("REDASH_SAML_SCHEME_OVERRIDE", "")
-
 # Enables the use of an externally-provided and trusted remote user via an HTTP
 # header.  The "user" must be an email address.
 #


### PR DESCRIPTION
Reverts getredash/redash#2947: it isn't working (uses `settings` which isn't imported).