### PR TITLE
Update user list when an user is created

### DIFF
--- a/client/app/pages/users/UsersList.jsx
+++ b/client/app/pages/users/UsersList.jsx
@@ -149,15 +149,13 @@ class UsersList extends React.Component {
 
   showCreateUserDialog = () => {
     if (policy.isCreateUserEnabled()) {
-      CreateUserDialog.showModal({ onCreate: this.createUser }).result.then((success) => {
-        if (success) {
-          this.props.controller.update();
-        }
-      }).finally(() => {
-        if (this.props.controller.params.isNewUserPage) {
-          navigateTo('users');
-        }
-      });
+      CreateUserDialog.showModal({ onCreate: this.createUser }).result
+        .then(() => this.props.controller.update())
+        .finally(() => {
+          if (this.props.controller.params.isNewUserPage) {
+            navigateTo('users');
+          }
+        });
     }
   };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
I've noticed the user list was not being updated when a new user is created (this is actually only noticeable when you are in the Pending Invitations tab :sweat_smile:).

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**
![update-user-list-before](https://user-images.githubusercontent.com/3356951/54454832-186cc400-4739-11e9-8702-1771a7a0f08d.gif)


**After**
![update-user-list](https://user-images.githubusercontent.com/3356951/54454824-16a30080-4739-11e9-94e4-4b4e86f63624.gif)
