### PR TITLE
Fix: accept integer values in dropdowns.

### DIFF
--- a/redash/utils/parameterized_query.py
+++ b/redash/utils/parameterized_query.py
@@ -109,7 +109,7 @@ class ParameterizedQuery(object):
             "text": lambda value: isinstance(value, basestring),
             "number": lambda value: isinstance(value, Number),
             "enum": lambda value: value in definition["enumOptions"],
-            "query": lambda value: value in [v["value"] for v in dropdown_values(definition["queryId"])],
+            "query": lambda value: unicode(value) in [v["value"] for v in dropdown_values(definition["queryId"])],
             "date": _is_date,
             "datetime-local": _is_date,
             "datetime-with-seconds": _is_date,

--- a/tests/utils/test_parameterized_query.py
+++ b/tests/utils/test_parameterized_query.py
@@ -119,6 +119,15 @@ class TestParameterizedQuery(TestCase):
 
         self.assertEquals("foo baz", query.text)
 
+    @patch('redash.utils.parameterized_query.dropdown_values', return_value=[{"value": "1"}])
+    def test_validation_accepts_integer_values_for_dropdowns(self, _):
+        schema = [{"name": "bar", "type": "query", "queryId": 1}]
+        query = ParameterizedQuery("foo {{bar}}", schema)
+
+        query.apply({"bar": 1})
+
+        self.assertEquals("foo 1", query.text)
+
     @patch('redash.utils.parameterized_query.dropdown_values')
     def test_raises_on_invalid_query_parameters(self, _):
         schema = [{"name": "bar", "type": "query", "queryId": 1}]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Following the change to turn into strings all the dropdown values, queries saved with a default value type integer no longer worked when first loading them. This change fixes this.

## Related Tickets & Documents

#3563
