### PR TITLE
Add error message when destination name already exists

### DIFF
--- a/redash/handlers/destinations.py
+++ b/redash/handlers/destinations.py
@@ -48,7 +48,7 @@ class DestinationResource(BaseResource):
             abort(400)
         except IntegrityError as e:
             if 'name' in e.message:
-                abort(400, message="Alert Destination with the name {} already exists.".format(req['name']))
+                abort(400, message=u"Alert Destination with the name {} already exists.".format(req['name']))
             abort(500)
 
         return destination.to_dict(all=True)

--- a/redash/handlers/destinations.py
+++ b/redash/handlers/destinations.py
@@ -1,5 +1,6 @@
 from flask import make_response, request
 from flask_restful import abort
+from sqlalchemy.exc import IntegrityError
 
 from redash import models
 from redash.destinations import (destinations,
@@ -45,6 +46,10 @@ class DestinationResource(BaseResource):
             models.db.session.commit()
         except ValidationError:
             abort(400)
+        except IntegrityError as e:
+            if 'name' in e.message:
+                abort(400, message="Alert Destination with the name {} already exists.".format(req['name']))
+            abort(500)
 
         return destination.to_dict(all=True)
 
@@ -102,6 +107,12 @@ class DestinationListResource(BaseResource):
                                                      options=config,
                                                      user=self.current_user)
 
-        models.db.session.add(destination)
-        models.db.session.commit()
+        try:
+            models.db.session.add(destination)
+            models.db.session.commit()        
+        except IntegrityError as e:
+            if 'name' in e.message:
+                abort(400, message="Alert Destination with the name {} already exists.".format(req['name']))
+            abort(500)
+
         return destination.to_dict(all=True)

--- a/redash/handlers/destinations.py
+++ b/redash/handlers/destinations.py
@@ -109,7 +109,7 @@ class DestinationListResource(BaseResource):
 
         try:
             models.db.session.add(destination)
-            models.db.session.commit()        
+            models.db.session.commit()
         except IntegrityError as e:
             if 'name' in e.message:
                 abort(400, message="Alert Destination with the name {} already exists.".format(req['name']))

--- a/redash/handlers/destinations.py
+++ b/redash/handlers/destinations.py
@@ -112,7 +112,7 @@ class DestinationListResource(BaseResource):
             models.db.session.commit()
         except IntegrityError as e:
             if 'name' in e.message:
-                abort(400, message="Alert Destination with the name {} already exists.".format(req['name']))
+                abort(400, message=u"Alert Destination with the name {} already exists.".format(req['name']))
             abort(500)
 
         return destination.to_dict(all=True)

--- a/tests/handlers/test_destinations.py
+++ b/tests/handlers/test_destinations.py
@@ -38,6 +38,17 @@ class TestDestinationListResource(BaseTestCase):
         rv = self.make_request('post', '/api/destinations', user=self.factory.user, data=data)
         self.assertEqual(rv.status_code, 403)
 
+    def test_returns_400_when_name_already_exists(self):
+        d1 = self.factory.create_destination()
+        data = {
+            'options': {'addresses': 'test@example.com'},
+            'name': d1.name,
+            'type': 'email'
+        }
+
+        rv = self.make_request('post', '/api/destinations', user=self.factory.create_admin(), data=data)
+        self.assertEqual(rv.status_code, 400)
+
 
 class TestDestinationResource(BaseTestCase):
     def test_get(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
It was returning 500 with no message ("Failed saving." in frontend). It was necessary to guess that the error was due to name duplicity.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![destinations-name-key](https://user-images.githubusercontent.com/3356951/54493353-d4e79680-48ad-11e9-9de7-20f37d9d15de.gif)
