### PR TITLE
Show accessible tables only in New Query view for PostgreSQL

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -126,38 +126,12 @@ class PostgreSQL(BaseSQLQueryRunner):
             schema[table_name]['columns'].append(row['column_name'])
 
     def _get_tables(self, schema):
-        '''
-        relkind constants per https://www.postgresql.org/docs/10/static/catalog-pg-class.html
-        r = regular table
-        v = view
-        m = materialized view
-        f = foreign table
-        p = partitioned table (new in 10)
-        ---
-        i = index
-        S = sequence
-        t = TOAST table
-        c = composite type
-        '''
-
         query = """
-        SELECT s.nspname as table_schema,
-               c.relname as table_name,
-               a.attname as column_name
-        FROM pg_class c
-        JOIN pg_namespace s
-        ON c.relnamespace = s.oid
-        AND s.nspname IN (
-            SELECT table_schema
-            FROM information_schema.table_privileges
-            WHERE grantee = (SELECT current_user)
-            AND table_schema NOT IN ('pg_catalog', 'information_schema')
-            GROUP BY table_schema)
-        JOIN pg_attribute a
-        ON a.attrelid = c.oid
-        AND a.attnum > 0
-        AND NOT a.attisdropped
-        WHERE c.relkind IN ('r', 'v', 'm', 'f', 'p')
+        SELECT table_schema,
+               table_name,
+               column_name
+        FROM information_schema.columns
+        WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
         """
 
         self._get_definitions(schema, query)

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -126,7 +126,36 @@ class PostgreSQL(BaseSQLQueryRunner):
             schema[table_name]['columns'].append(row['column_name'])
 
     def _get_tables(self, schema):
+        '''
+        relkind constants per https://www.postgresql.org/docs/10/static/catalog-pg-class.html
+        r = regular table
+        v = view
+        m = materialized view
+        f = foreign table
+        p = partitioned table (new in 10)
+        ---
+        i = index
+        S = sequence
+        t = TOAST table
+        c = composite type
+        '''
+
         query = """
+        SELECT s.nspname as table_schema,
+               c.relname as table_name,
+               a.attname as column_name
+        FROM pg_class c
+        JOIN pg_namespace s
+        ON c.relnamespace = s.oid
+        AND s.nspname NOT IN ('pg_catalog', 'information_schema')
+        JOIN pg_attribute a
+        ON a.attrelid = c.oid
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        WHERE c.relkind IN ('m', 'f', 'p')
+
+        UNION
+
         SELECT table_schema,
                table_name,
                column_name

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -147,7 +147,12 @@ class PostgreSQL(BaseSQLQueryRunner):
         FROM pg_class c
         JOIN pg_namespace s
         ON c.relnamespace = s.oid
-        AND s.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND s.nspname IN (
+            SELECT table_schema
+            FROM information_schema.table_privileges
+            WHERE grantee = (SELECT current_user)
+            AND table_schema NOT IN ('pg_catalog', 'information_schema')
+            GROUP BY table_schema)
         JOIN pg_attribute a
         ON a.attrelid = c.oid
         AND a.attnum > 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

#### Background

Left pane of `New Query` view shows table list. The list includes tables which user can not access.
Tables which user can not access should be hidden.

#### The bug

Function `redash.query_runner.pg.PostgreSQL._get_tables` does not consider privileges of a user for tables.

#### The Fix

Get tables for which `current_user` of PostgreSQL have privileges. 


## Related Tickets & Documents

--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

--