### PR TITLE
Query Results fails to use query which has double quotes in column names

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -73,7 +73,7 @@ def create_tables_from_query_ids(user, connection, query_ids, cached_query_ids=[
 
 
 def fix_column_name(name):
-    return u'"{}"'.format(name.replace(':', '_').replace('.', '_').replace(' ', '_'))
+    return u'"{}"'.format(re.sub('[:."\s]', '_', name, flags=re.UNICODE))
 
 
 def create_table(connection, table_name, query_results):

--- a/tests/query_runner/test_query_results.py
+++ b/tests/query_runner/test_query_results.py
@@ -34,6 +34,14 @@ class TestCreateTable(TestCase):
         create_table(connection, table_name, results)
         connection.execute('SELECT 1 FROM query_123')
 
+    def test_creates_table_with_double_quotes_in_column_name(self):
+        connection = sqlite3.connect(':memory:')
+        results = {'columns': [{'name': 'ga:newUsers'}, {
+            'name': '"test2"'}], 'rows': [{'ga:newUsers': 123, '"test2"': 2}]}
+        table_name = 'query_123'
+        create_table(connection, table_name, results)
+        connection.execute('SELECT 1 FROM query_123')
+
     def test_creates_table(self):
         connection = sqlite3.connect(':memory:')
         results = {'columns': [{'name': 'test1'},


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

If source query contains column with double quote (`"`) - Query Results fails to build temporary table with "Syntax error" message.
