### PR TITLE
Fix for time based mongodb test

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,4 @@ pymongo[tls,srv]==3.6.1
 botocore==1.12.85
 PyAthena>=1.0.0
 ptvsd==4.2.3
+freezegun==0.3.11

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import TestCase
 
 from pytz import utc
+from freezegun import freeze_time
 
 from redash.query_runner.mongodb import parse_query_json, parse_results, _get_column_by_name
 from redash.utils import json_dumps, parse_human_time
@@ -95,6 +96,7 @@ class TestParseQueryJson(TestCase):
         self.assertEqual(query_data['test$undefined'], None)
         self.assertEqual(query_data['test$date'], datetime.datetime(2014, 10, 3, 0, 0).replace(tzinfo=utc))
 
+    @freeze_time('2019-01-01 12:00:00')
     def test_supports_relative_timestamps(self):
         query = {
             'ts': {'$humanTime': '1 hour ago'}


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
The following is flaky since if a second passes between the two time dependent commands, the test fails [as it did here](https://circleci.com/gh/getredash/redash/17746) resulting in:
```bash
=================================== FAILURES ===================================
_____________ TestParseQueryJson.test_supports_relative_timestamps _____________

self = <tests.query_runner.test_mongodb.TestParseQueryJson testMethod=test_supports_relative_timestamps>

    def test_supports_relative_timestamps(self):
        query = {
            'ts': {'$humanTime': '1 hour ago'}
        }
    
        one_hour_ago = parse_human_time("1 hour ago")
        query_data = parse_query_json(json_dumps(query))
>       self.assertEqual(query_data['ts'], one_hour_ago)
E       AssertionError: datetime.datetime(2019, 3, 21, 9, 24, 12) != datetime.datetime(2019, 3, 21, 9, 24, 11)
```

### Reproduce
Insert a 2 second sleep.
```py
one_hour_ago = parse_human_time("1 hour ago")
time.sleep(2) # <-- 2s delay
query_data = parse_query_json(json_dumps(query))
self.assertEqual(query_data['ts'], one_hour_ago) # <-- fails due to 2s delta
```

### The fix
Mock "now()" with [freezegun](http://stevepulec.com/freezegun/).
```py
@freeze_time('2019-01-01 12:00:00')
def test_supports_relative_timestamps(self):
    query = {
        'ts': {'$humanTime': '1 hour ago'}
    }

    one_hour_ago = parse_human_time("1 hour ago")
    time.sleep(2) # <-- 2s delay
    query_data = parse_query_json(json_dumps(query))
    self.assertEqual(query_data['ts'], one_hour_ago) # <-- passes
```
