### PR TITLE
Fix: triggers not created for queries.search_vector

### DIFF
--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -2,6 +2,7 @@ import time
 
 from flask.cli import AppGroup
 from flask_migrate import stamp
+import sqlalchemy
 from sqlalchemy.exc import DatabaseError
 
 manager = AppGroup(help="Manage the database (create/drop tables).")
@@ -25,6 +26,8 @@ def create_tables():
     from redash.models import db
 
     _wait_for_db_connection(db)
+    # To create triggers for searchable models, we need to call configure_mappers().
+    sqlalchemy.orm.configure_mappers()
     db.create_all()
 
     # Need to mark current DB as up to date


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

We had to call `sqlalchemy.orm.configure_mappers()` for the triggers to be created (or access the models). This explains why this works in tests.

## Related Tickets & Documents

#3602.