### PR TITLE
Update to modern Redis for the docker images

### DIFF
--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       QUEUES: "queries"
       WORKERS_COUNT: 2
   redis:
-    image: redis:3.0-alpine
+    image: redis:5.0-alpine
     restart: always
   postgres:
     image: postgres:9.5.6-alpine


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Update Redis for the Docker images, as the current one (v3) is out of support.

In quick testing here, Redis 5 (as per this PR) is working fine.