### PR TITLE
Fixed notification alignment

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -251,9 +251,9 @@
 
 // flexible width for notifications
 .@{notification-prefix-cls} {
-  width: auto;
-
-  &-notice {
-    padding-right: 48px;
+  // vertical centering
+  &-notice-close {
+    top: 20px;
+    right: 20px;
   }
 }

--- a/client/app/assets/less/inc/ant-variables.less
+++ b/client/app/assets/less/inc/ant-variables.less
@@ -72,3 +72,9 @@
 @table-row-hover-bg: fade(@redash-gray, 5%);
 @table-padding-vertical: 7px;
 @table-padding-horizontal: 10px;
+
+/* --------------------------------------------------------
+    Notification
+-----------------------------------------------------------*/
+@notification-padding: @notification-padding-vertical 48px @notification-padding-vertical 17px;
+@notification-width: auto;


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
Notification alignment is off - the close button and left spacing.
Also, took the liberty to swap previous ant.less overrides for variable ones.

Font looked a little off but I checked it and it's redash font no doubt, so no change.

## Mobile & Desktop Screenshots
Looking betta

![Screen Shot 2019-03-27 at 18 08 38](https://user-images.githubusercontent.com/486954/55093426-05ed7580-50bd-11e9-9760-d596f9df42d7.png)

With desc the icon alignment is gross but there's no hooks for that so f**k it

![Screen Shot 2019-03-27 at 18 12 33](https://user-images.githubusercontent.com/486954/55093425-05ed7580-50bd-11e9-87ac-4d6828e6fd3d.png)
