### PR TITLE
Dashboard auto-saving

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -866,3 +866,7 @@ text.slicetext {
 .markdown strong {
   font-weight: bold;
 }
+
+.disabled-silent {
+  pointer-events: none;
+}

--- a/client/app/components/dashboards/gridstack/index.js
+++ b/client/app/components/dashboards/gridstack/index.js
@@ -69,6 +69,7 @@ function gridstack($parse, dashboardGridOptions) {
     scope: {
       editing: '=',
       batchUpdate: '=', // set by directive - for using in wrapper components
+      onLayoutChanged: '=',
       isOneColumnMode: '=',
     },
     controller() {
@@ -118,67 +119,6 @@ function gridstack($parse, dashboardGridOptions) {
           grid.maxWidth($element, item.maxSizeX);
           grid.minHeight($element, item.minSizeY);
           grid.maxHeight($element, item.maxSizeY);
-        });
-      };
-
-      this.batchUpdateWidgets = (items) => {
-        // This method is used to update multiple widgets with a single
-        // reflow (for example, restore positions when dashboard editing cancelled).
-        // "dirty" part of code: updating grid and DOM nodes directly.
-        // layout reflow is triggered by `batchUpdate`/`commit` calls
-        this.update((grid) => {
-          _.each(grid.grid.nodes, (node) => {
-            const item = items[node.id];
-            if (item) {
-              if (_.isNumber(item.col)) {
-                node.x = parseFloat(item.col);
-                node.el.attr('data-gs-x', node.x);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.row)) {
-                node.y = parseFloat(item.row);
-                node.el.attr('data-gs-y', node.y);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.sizeX)) {
-                node.width = parseFloat(item.sizeX);
-                node.el.attr('data-gs-width', node.width);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.sizeY)) {
-                node.height = parseFloat(item.sizeY);
-                node.el.attr('data-gs-height', node.height);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.minSizeX)) {
-                node.minWidth = parseFloat(item.minSizeX);
-                node.el.attr('data-gs-min-width', node.minWidth);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.maxSizeX)) {
-                node.maxWidth = parseFloat(item.maxSizeX);
-                node.el.attr('data-gs-max-width', node.maxWidth);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.minSizeY)) {
-                node.minHeight = parseFloat(item.minSizeY);
-                node.el.attr('data-gs-min-height', node.minHeight);
-                node._dirty = true;
-              }
-
-              if (_.isNumber(item.maxSizeY)) {
-                node.maxHeight = parseFloat(item.maxSizeY);
-                node.el.attr('data-gs-max-height', node.maxHeight);
-                node._dirty = true;
-              }
-            }
-          });
         });
       };
 
@@ -300,6 +240,7 @@ function gridstack($parse, dashboardGridOptions) {
             $(node.el).trigger('gridstack.changed', node);
           }
         });
+        $scope.onLayoutChanged();
         changedNodes = {};
       });
 

--- a/client/app/components/dashboards/gridstack/index.js
+++ b/client/app/components/dashboards/gridstack/index.js
@@ -175,9 +175,7 @@ function gridstack($parse, dashboardGridOptions) {
       };
     },
     link: ($scope, $element, $attr, controller) => {
-      const batchUpdateAssignable = _.isFunction($parse($attr.batchUpdate).assign);
-      const isOneColumnModeAssignable = _.isFunction($parse($attr.batchUpdate).assign);
-
+      const isOneColumnModeAssignable = _.isFunction($parse($attr.onLayoutChanged).assign);
       let enablePolling = true;
 
       $element.addClass('grid-stack');
@@ -240,7 +238,9 @@ function gridstack($parse, dashboardGridOptions) {
             $(node.el).trigger('gridstack.changed', node);
           }
         });
-        $scope.onLayoutChanged();
+        if ($scope.onLayoutChanged) {
+          $scope.onLayoutChanged();
+        }
         changedNodes = {};
       });
 
@@ -255,10 +255,6 @@ function gridstack($parse, dashboardGridOptions) {
       $scope.$watch('editing', (value) => {
         controller.setEditing(!!value);
       });
-
-      if (batchUpdateAssignable) {
-        $scope.batchUpdate = controller.batchUpdateWidgets;
-      }
 
       $scope.$on('$destroy', () => {
         enablePolling = false;

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -88,8 +88,8 @@
   </div>
 
   <div style="padding-bottom: 5px;" ng-if="$ctrl.dashboard.widgets.length > 0">
-    <div gridstack editing="$ctrl.layoutEditing" batch-update="$ctrl.updateGridItems"
-      is-one-column-mode="$ctrl.isGridDisabled" class="dashboard-wrapper" on-layout-changed="$ctrl.onLayoutChanged"
+    <div gridstack editing="$ctrl.layoutEditing" on-layout-changed="$ctrl.onLayoutChanged"
+      is-one-column-mode="$ctrl.isGridDisabled" class="dashboard-wrapper"
       ng-class="{'preview-mode': !$ctrl.layoutEditing, 'editing-mode': $ctrl.layoutEditing}">
       <div class="dashboard-widget-wrapper"
         ng-repeat="widget in $ctrl.dashboard.widgets track by widget.id"

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -15,10 +15,9 @@
     </div>
     <div class="col-xs-4 col-sm-5 col-lg-5 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
-          <div ng-if="$ctrl.layoutEditing">
-            <span class="save-status" data-dirty="{{ $ctrl.isLayoutDirty && !$ctrl.saveInProgress }}">
-              Saved
-            </span>
+          <div ng-if="$ctrl.layoutEditing" ng-switch="$ctrl.isLayoutDirty || $ctrl.saveInProgress">
+            <span class="save-status" data-saving ng-switch-when="true">Saving</span>
+            <span class="save-status" ng-switch-default>Saved</span>
 
             <button type="button" class="btn btn-primary btn-sm"
               ng-disabled="$ctrl.isGridDisabled"

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -15,17 +15,15 @@
     </div>
     <div class="col-xs-4 col-sm-5 col-lg-5 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
-          <div class="btn-group">
+          <div ng-if="$ctrl.layoutEditing">
+            <span class="save-status" data-dirty="{{ $ctrl.isLayoutDirty && !$ctrl.saveInProgress }}">
+              Saved
+            </span>
+
             <button type="button" class="btn btn-primary btn-sm"
               ng-disabled="$ctrl.isGridDisabled"
-              ng-click="$ctrl.editLayout(false, true)" ng-if="$ctrl.layoutEditing">
-              <i class="zmdi zmdi-check"></i> Apply Changes
-            </button>
-
-            <button type="button" class="btn btn-default btn-sm"
-              ng-disabled="$ctrl.isGridDisabled"
-              ng-click="$ctrl.editLayout(false, false)" ng-if="$ctrl.layoutEditing">
-              <i class="zmdi zmdi-close"></i> Cancel
+              ng-click="$ctrl.editLayout(false)">
+              <i class="fa fa-check"></i> Done Editing
             </button>
           </div>
 
@@ -91,8 +89,8 @@
   </div>
 
   <div style="padding-bottom: 5px;" ng-if="$ctrl.dashboard.widgets.length > 0">
-    <div gridstack editing="$ctrl.layoutEditing && !$ctrl.saveInProgress" batch-update="$ctrl.updateGridItems"
-      is-one-column-mode="$ctrl.isGridDisabled" class="dashboard-wrapper"
+    <div gridstack editing="$ctrl.layoutEditing" batch-update="$ctrl.updateGridItems"
+      is-one-column-mode="$ctrl.isGridDisabled" class="dashboard-wrapper" on-layout-changed="$ctrl.onLayoutChanged"
       ng-class="{'preview-mode': !$ctrl.layoutEditing, 'editing-mode': $ctrl.layoutEditing}">
       <div class="dashboard-widget-wrapper"
         ng-repeat="widget in $ctrl.dashboard.widgets track by widget.id"

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -21,7 +21,8 @@
 
             <button type="button" class="btn btn-primary btn-sm"
               ng-disabled="$ctrl.isGridDisabled"
-              ng-click="$ctrl.editLayout(false)">
+              ng-click="$ctrl.editLayout(false)"
+              ng-class="{'disabled-silent': $ctrl.isLayoutDirty || $ctrl.saveInProgress }">
               <i class="fa fa-check"></i> Done Editing
             </button>
           </div>

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -75,7 +75,7 @@ function DashboardCtrl(
       });
   };
 
-  const saveDashboardLayoutDebounced = _.debounce(saveDashboardLayout, 1000);
+  const saveDashboardLayoutDebounced = _.debounce(saveDashboardLayout, 2000);
 
   this.layoutEditing = false;
   this.isFullscreen = false;

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -48,33 +48,34 @@ function DashboardCtrl(
 ) {
   this.saveInProgress = false;
 
-  const saveDashboardLayout = (widgets) => {
+  const saveDashboardLayout = () => {
     if (!this.dashboard.canEdit()) {
       return;
     }
 
+    // calc diff, bail if none
+    const changedWidgets = getWidgetsWithChangedPositions(this.dashboard.widgets);
+    if (!changedWidgets.length) {
+      this.isLayoutDirty = false;
+      $scope.$applyAsync();
+      return;
+    }
+
     this.saveInProgress = true;
-    const showMessages = true;
     return $q
-      .all(_.map(widgets, widget => widget.save()))
+      .all(_.map(changedWidgets, widget => widget.save()))
       .then(() => {
-        if (showMessages) {
-          notification.success('Changes saved.');
-        }
-        // Update original widgets positions
-        _.each(widgets, (widget) => {
-          _.extend(widget.$originalPosition, widget.options.position);
-        });
+        this.isLayoutDirty = false;
       })
       .catch(() => {
-        if (showMessages) {
-          notification.error('Error saving changes.');
-        }
+        notification.error('Error saving changes.');
       })
       .finally(() => {
         this.saveInProgress = false;
       });
   };
+
+  const saveDashboardLayoutDebounced = _.debounce(saveDashboardLayout, 1000);
 
   this.layoutEditing = false;
   this.isFullscreen = false;
@@ -84,6 +85,7 @@ function DashboardCtrl(
   this.showPermissionsControl = clientConfig.showPermissionsControl;
   this.globalParameters = [];
   this.isDashboardOwner = false;
+  this.isLayoutDirty = false;
 
   this.refreshRates = clientConfig.dashboardRefreshIntervals.map(interval => ({
     name: durationHumanize(interval),
@@ -242,28 +244,17 @@ function DashboardCtrl(
     });
   };
 
-  this.editLayout = (enableEditing, applyChanges) => {
-    if (!this.isGridDisabled) {
-      if (!enableEditing) {
-        if (applyChanges) {
-          const changedWidgets = getWidgetsWithChangedPositions(this.dashboard.widgets);
-          saveDashboardLayout(changedWidgets);
-        } else {
-          // Revert changes
-          const items = {};
-          _.each(this.dashboard.widgets, (widget) => {
-            _.extend(widget.options.position, widget.$originalPosition);
-            items[widget.id] = widget.options.position;
-          });
-          this.dashboard.widgets = Dashboard.prepareWidgetsForDashboard(this.dashboard.widgets);
-          if (this.updateGridItems) {
-            this.updateGridItems(items);
-          }
-        }
-      }
-
-      this.layoutEditing = enableEditing;
+  this.onLayoutChanged = () => {
+    // prevent unnecessary save when gridstack is loaded
+    if (!this.layoutEditing) {
+      return;
     }
+    this.isLayoutDirty = true;
+    saveDashboardLayoutDebounced();
+  };
+
+  this.editLayout = (enableEditing) => {
+    this.layoutEditing = enableEditing;
   };
 
   this.loadTags = () => getTags('api/dashboards/tags').then(tags => _.map(tags, t => t.name));
@@ -405,12 +396,11 @@ function DashboardCtrl(
   this.removeWidget = (widgetId) => {
     this.dashboard.widgets = this.dashboard.widgets.filter(w => w.id !== undefined && w.id !== widgetId);
     this.extractGlobalParameters();
+    $scope.$applyAsync();
+
     if (!this.layoutEditing) {
       // We need to wait a bit while `angular` updates widgets, and only then save new layout
-      $timeout(() => {
-        const changedWidgets = getWidgetsWithChangedPositions(this.dashboard.widgets);
-        saveDashboardLayout(changedWidgets);
-      }, 50);
+      $timeout(saveDashboardLayout, 50);
     }
   };
 

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -68,6 +68,8 @@ function DashboardCtrl(
         this.isLayoutDirty = false;
       })
       .catch(() => {
+        // in the off-chance that a widget got deleted mid-saving it's position, an error will occur
+        // currently left unhandled PR 3653#issuecomment-481699053
         notification.error('Error saving changes.');
       })
       .finally(() => {

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -117,15 +117,30 @@
     vertical-align: middle;
     margin-right: 7px;
     font-size: 12px;
-    position: relative;
+    text-align: left;
+    display: inline-block;
 
-    &[data-dirty="true"] {
+    &[data-saving] {
       opacity: 0.6;
+      width: 45px;
 
-      &::after {
-        content: "*";
+      &:after {
+        content: '';
+        animation: saving 2s linear infinite;
       }
     }
+  }
+}
+
+@keyframes saving {
+  0%, 100% {
+    content: '.';
+  }
+  33% {
+    content: '..';
+  }
+  66% {
+    content: '...';
   }
 }
 

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -112,6 +112,23 @@
   }
 }
 
+.dashboard__control {
+  .save-status {
+    vertical-align: middle;
+    margin-right: 7px;
+    font-size: 12px;
+    position: relative;
+
+    &[data-dirty="true"] {
+      opacity: 0.6;
+
+      &::after {
+        content: "*";
+      }
+    }
+  }
+}
+
 
 // Mobile fixes
 @media (max-width: 767px) {

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -92,6 +92,10 @@ function WidgetFactory($http, $location, Query, Visualization, dashboardGridOpti
         this.options.position.autoHeight = true;
       }
 
+      this.updateOriginalPosition();
+    }
+
+    updateOriginalPosition() {
       // Save original position (create a shallow copy)
       this.$originalPosition = extend({}, this.options.position);
     }
@@ -160,6 +164,8 @@ function WidgetFactory($http, $location, Query, Visualization, dashboardGridOpti
         each(response.data, (v, k) => {
           this[k] = v;
         });
+
+        this.updateOriginalPosition();
 
         return this;
       });

--- a/client/cypress/integration/dashboard/dashboard_spec.js
+++ b/client/cypress/integration/dashboard/dashboard_spec.js
@@ -360,46 +360,14 @@ describe('Dashboard', () => {
         });
       });
 
-      it('discards drag on cancel', () => {
-        let start;
-        cy.get('@textboxEl')
-          // save initial position, drag textbox 1 col
-          .then(($el) => {
-            start = $el.offset();
-            editDashboard();
-            return dragBy(cy.get('@textboxEl'), 200);
-          })
-          // cancel
-          .then(() => {
-            cy.get('.dashboard-header').within(() => {
-              cy.contains('button', 'Cancel').click();
-            });
-            return cy.get('@textboxEl');
-          })
-          // verify returned to original position
-          .then(($el) => {
-            expect($el.offset()).to.deep.eq(start);
-          });
-      });
+      it('auto saves after drag', () => {
+        cy.server();
+        cy.route('POST', 'api/widgets/*').as('WidgetSave');
 
-      it('saves drag on apply', () => {
-        let start;
-        cy.get('@textboxEl')
-          // save initial position, drag textbox 1 col
-          .then(($el) => {
-            start = $el.offset();
-            editDashboard();
-            return dragBy(cy.get('@textboxEl'), 200);
-          })
-          // apply
-          .then(() => {
-            cy.contains('button', 'Apply Changes').click();
-            return cy.get('@textboxEl');
-          })
-          // verify move
-          .then(($el) => {
-            expect($el.offset()).to.not.deep.eq(start);
-          });
+        editDashboard();
+        dragBy(cy.get('@textboxEl'), 330).then(() => {
+          cy.wait('@WidgetSave');
+        });
       });
     });
 
@@ -458,46 +426,14 @@ describe('Dashboard', () => {
         });
       });
 
-      it('discards resize on cancel', () => {
-        let start;
-        cy.get('@textboxEl')
-          // save initial position, resize textbox 1 col
-          .then(($el) => {
-            start = $el.height();
-            editDashboard();
-            return resizeBy(cy.get('@textboxEl'), 0, 200);
-          })
-          // cancel
-          .then(() => {
-            cy.get('.dashboard-header').within(() => {
-              cy.contains('button', 'Cancel').click();
-            });
-            return cy.get('@textboxEl');
-          })
-          // verify returned to original size
-          .then(($el) => {
-            expect($el.height()).to.eq(start);
-          });
-      });
+      it('auto saves after resize', () => {
+        cy.server();
+        cy.route('POST', 'api/widgets/*').as('WidgetSave');
 
-      it('saves resize on apply', () => {
-        let start;
-        cy.get('@textboxEl')
-          // save initial position, resize textbox 1 col
-          .then(($el) => {
-            start = $el.height();
-            editDashboard();
-            return resizeBy(cy.get('@textboxEl'), 0, 200);
-          })
-          // apply
-          .then(() => {
-            cy.contains('button', 'Apply Changes').click().should('not.exist');
-            return cy.get('@textboxEl');
-          })
-          // verify size change persists
-          .then(($el) => {
-            expect($el.height()).to.not.eq(start);
-          });
+        editDashboard();
+        resizeBy(cy.get('@textboxEl'), 200).then(() => {
+          cy.wait('@WidgetSave');
+        });
       });
     });
   });
@@ -678,7 +614,7 @@ describe('Dashboard', () => {
 
     it('disables edit mode', function () {
       cy.visit(this.dashboardEditUrl);
-      cy.contains('button', 'Apply Changes')
+      cy.contains('button', 'Done Editing')
         .as('saveButton')
         .should('be.disabled');
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description
UX discussion https://discuss.redash.io/t/auto-saving-dashboard-layout/3506
Demo https://deploy-preview-3653--redash-preview.netlify.com/dashboard/artists

### Motivation
Currently when in dashboard edit mode, there are “Apply Changes” and “Cancel” buttons which are inconsistent (only apply to resize and drag - not to added / deleted widgets) and buggy (there is a scenario causing widget overlap).

### The Change
Ditch cancellability and embrace auto-save, ala-Google Docs.
One button to switch off edit mode, next to it a save status indicator.

### How it works
Each layout change marks a dirty state, showing a "Saving..." indication (although technically not yet saving) and triggers a server save to each changed widgets, debounced by 2 seconds.

Any error saving yields the appropriate notification and dirty indication persists.

### Updated tests

![Screen Shot 2019-04-12 at 11 00 18](https://user-images.githubusercontent.com/486954/56021503-3f0b2400-5d12-11e9-9027-1d3999f7a3b1.png)


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/486954/55883561-38b06700-5baf-11e9-8719-0b98b6bb4e8a.gif)

