### PR TITLE
Fix Percy diff due to Api Key secret

### DIFF
--- a/client/cypress/integration/user/edit_profile_spec.js
+++ b/client/cypress/integration/user/edit_profile_spec.js
@@ -37,13 +37,11 @@ describe('Edit Profile', () => {
   });
 
   it('renders the page and takes a screenshot', () => {
+    cy.getByTestId('Groups').should('contain', 'admin');
     cy.getByTestId('ApiKey').then(($apiKey) => {
       $apiKey.val('secret');
+      cy.percySnapshot('User Profile');
     });
-
-    cy.getByTestId('Groups').should('contain', 'admin');
-
-    cy.percySnapshot('User Profile');
   });
 
   context('changing password', () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [ ] Bug Fix?
- [x] Other

## Description
This one passed unnoticed after #3450 since a visual diff was expected to the page. Groups were added to the UserEdit page and as they require a new load, the content was rendered again before Percy snapshot (the Api Key was also rendered again with it). To fix this the screenshot is now taken Right after changing the input value.

## Related Tickets & Documents
--
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--