### PR TITLE
Add max-width to Notification description

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -252,11 +252,15 @@
   z-index: 1000; // make sure it doesn't cover drawer
 }
 
-// flexible width for notifications
+// Notification overrides
 .@{notification-prefix-cls} {
   // vertical centering
   &-notice-close {
     top: 20px;
     right: 20px;
+  }
+
+  &-notice-description {
+    max-width: 484px;
   }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This adds a `max-width` to Notification description, it seemed too flexible with specific long messages (see screenshots below).

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before**
![notification-before](https://user-images.githubusercontent.com/3356951/55329854-00e64880-5466-11e9-8086-810f8c2fcb0c.png)

**After**
![notification-after](https://user-images.githubusercontent.com/3356951/55329865-05aafc80-5466-11e9-9660-253551d9c8fe.png)


