### PR TITLE
Fix: Avoid error on embed links for unparameterized queries

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -296,6 +296,10 @@ class Parameters {
   }
 
   toUrlParams() {
+    if (this.get().length === 0) {
+      return '';
+    }
+
     const params = Object.assign(...this.get().map(p => p.toUrlParams()));
     return Object
       .keys(params)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
After #3495, embed urls for queries without parameters were broken. This is a small fix for that.

## Related Tickets & Documents
Discovered by @HenroRitchie [here](https://github.com/getredash/redash/pull/3495#issuecomment-480208986) thanks!

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
