### PR TITLE
Updated Cypress default timeout values

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,7 @@
   "pluginsFile": "client/cypress/plugins/index.js",
   "screenshotsFolder": "client/cypress/screenshots",
   "videosFolder": "client/cypress/videos",
-  "supportFile": "client/cypress/support/index.js"
+  "supportFile": "client/cypress/support/index.js",
+  "defaultCommandTimeout": 20000,
+  "requestTimeout": 15000
 }


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
Getting timeouts on requests and dom waits. Updated default timeouts:
```js
{
  ...,
  "defaultCommandTimeout": 20000, // default 4000
  "requestTimeout": 15000 // default 5000
}
```
