### PR TITLE
Bolder markdown in textbox

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -872,3 +872,7 @@ text.slicetext {
   display: inline-block;
   max-width: 135px;
 }
+
+.markdown strong {
+  font-weight: bold;
+}

--- a/client/app/components/dashboards/TextboxDialog.jsx
+++ b/client/app/components/dashboards/TextboxDialog.jsx
@@ -102,7 +102,7 @@ class TextboxDialog extends React.Component {
               <strong className="preview-title">Preview:</strong>
               <p
                 dangerouslySetInnerHTML={{ __html: this.state.preview }} // eslint-disable-line react/no-danger
-                className="preview"
+                className="preview markdown"
               />
             </React.Fragment>
           )}

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -101,6 +101,6 @@
         </ul>
       </div>
     </div>
-    <div class="body-row-auto scrollbox tiled t-body p-15" ng-bind-html="$ctrl.widget.text | markdown"></div>
+    <div class="body-row-auto scrollbox tiled t-body p-15 markdown" ng-bind-html="$ctrl.widget.text | markdown"></div>
   </div>
 </div>


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
Following https://discuss.redash.io/t/no-bold-in-dashboard-text-boxes/3542 made markdown bold the initial bold.

## Mobile & Desktop Screenshots

Before:

![Screen Shot 2019-04-07 at 20 21 56](https://user-images.githubusercontent.com/486954/55687525-7b3b2f00-5976-11e9-88f8-c811f02882d7.png)

After:

![Screen Shot 2019-04-07 at 20 29 55](https://user-images.githubusercontent.com/486954/55687526-7b3b2f00-5976-11e9-9c79-82e679a3e47d.png)

And

![Screen Shot 2019-04-07 at 20 30 25](https://user-images.githubusercontent.com/486954/55687527-7b3b2f00-5976-11e9-9de8-d584fe40103d.png)
