### PR TITLE
Changed viz embed download menu to drop up

### DIFF
--- a/client/app/components/queries/visualization-embed.html
+++ b/client/app/components/queries/visualization-embed.html
@@ -31,7 +31,7 @@
           <span class="zmdi zmdi-link"></span>
         </a>
 
-        <div class="btn-group" uib-dropdown>
+        <div class="btn-group dropup" uib-dropdown>
           <button type="button" class="btn btn-default btn-sm dropdown-toggle" aria-haspopup="true" uib-dropdown-toggle
                   aria-expanded="false">
             Download Dataset <span class="caret"></span>


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description
Embeds show up in iframes which will cut off the overflowing dropdown menu.
So, made it drop up.

## Mobile & Desktop Screenshots

Before | After
------------ | -------------
![Screen Shot 2019-04-10 at 10 33 05](https://user-images.githubusercontent.com/486954/55860321-a2634d80-5b7c-11e9-872e-2cda283e9314.png) | ![Screen Shot 2019-04-10 at 10 31 35](https://user-images.githubusercontent.com/486954/55860335-a7c09800-5b7c-11e9-8d7d-f8cdd1261d96.png)
