### PR TITLE
Fix query based parameter has value null when created

### DIFF
--- a/client/app/components/QueryBasedParameterInput.jsx
+++ b/client/app/components/QueryBasedParameterInput.jsx
@@ -35,10 +35,9 @@ export class QueryBasedParameterInput extends React.Component {
     this._loadOptions(this.props.queryId);
   }
 
-  // eslint-disable-next-line no-unused-vars
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.queryId !== this.props.queryId) {
-      this._loadOptions(nextProps.queryId, nextProps.value);
+  componentDidUpdate(prevProps) {
+    if (this.props.queryId !== prevProps.queryId) {
+      this._loadOptions(this.props.queryId);
     }
   }
 
@@ -68,7 +67,7 @@ export class QueryBasedParameterInput extends React.Component {
           className={className}
           disabled={loading || (options.length === 0)}
           loading={loading}
-          defaultValue={'' + value}
+          value={'' + value}
           onChange={onSelect}
           dropdownMatchSelectWidth={false}
           dropdownClassName="ant-dropdown-in-bootstrap-modal"

--- a/client/app/components/QueryBasedParameterInput.jsx
+++ b/client/app/components/QueryBasedParameterInput.jsx
@@ -1,4 +1,4 @@
-import { find, isFunction } from 'lodash';
+import { find, isFunction, toString } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
@@ -67,7 +67,7 @@ export class QueryBasedParameterInput extends React.Component {
           className={className}
           disabled={loading || (options.length === 0)}
           loading={loading}
-          value={'' + value}
+          value={toString(value)}
           onChange={onSelect}
           dropdownMatchSelectWidth={false}
           dropdownClassName="ant-dropdown-in-bootstrap-modal"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Whenever a new Query Based Parameter was created it started with a `null` value.

For this I noticed that the prop value starts with `null` and is updated after some time, the problem is that Antd's `defaultValue` only sets the value on the first time.

I also took the opportunity to replace `componentWillReceiveProps` to `componentDidUpdate` as the first one is deprecated.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**
![query-based-parameter-null](https://user-images.githubusercontent.com/3356951/56082232-aa292900-5dec-11e9-951a-7fb83b7b4500.gif)

**After**
![query-based-parameter-fixed](https://user-images.githubusercontent.com/3356951/56082234-b1e8cd80-5dec-11e9-93c5-8c837fb77964.gif)