### PR TITLE
Add rate limits to user creation/update

### DIFF
--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from disposable_email_domains import blacklist
 from funcy import partial
 
-from redash import models
+from redash import models, limiter
 from redash.permissions import require_permission, require_admin_or_owner, is_admin_or_owner, \
     require_permission_or_owner, require_admin
 from redash.handlers.base import BaseResource, require_fields, get_object_or_404, paginate, order_results as _order_results
@@ -51,6 +51,9 @@ def invite_user(org, inviter, user, send_email=True):
 
 
 class UserListResource(BaseResource):
+    decorators = BaseResource.decorators + \
+        [limiter.limit('200/day;50/hour', methods=['POST'])]
+
     def get_users(self, disabled, pending, search_term):
         if disabled:
             users = models.User.all_disabled(self.current_org)
@@ -190,6 +193,9 @@ class UserRegenerateApiKeyResource(BaseResource):
 
 
 class UserResource(BaseResource):
+    decorators = BaseResource.decorators + \
+        [limiter.limit('50/hour', methods=['POST'])]
+
     def get(self, user_id):
         require_permission_or_owner('list_users', user_id)
         user = get_object_or_404(models.User.get_by_id_and_org, user_id, self.current_org)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ os.environ['REDASH_MULTI_ORG'] = "true"
 # Make sure rate limit is enabled
 os.environ['REDASH_RATELIMIT_ENABLED'] = "true"
 
-from redash import create_app
+from redash import create_app, limiter
 from redash import redis_connection
 from redash.models import db
 from redash.utils import json_dumps, json_loads
@@ -48,6 +48,7 @@ class BaseTestCase(TestCase):
         self.db = db
         self.app.config['TESTING'] = True
         self.app.config['SERVER_NAME'] = 'localhost'
+        limiter.enabled = False
         self.app_ctx = self.app.app_context()
         self.app_ctx.push()
         db.session.close()
@@ -115,7 +116,7 @@ class BaseTestCase(TestCase):
     def assertResponseEqual(self, expected, actual):
         for k, v in expected.iteritems():
             if isinstance(v, datetime.datetime) or isinstance(actual[k],
-                    datetime.datetime):
+                                                              datetime.datetime):
                 continue
 
             if isinstance(v, list):

--- a/tests/handlers/test_authentication.py
+++ b/tests/handlers/test_authentication.py
@@ -3,7 +3,7 @@ import time
 import mock
 from tests import BaseTestCase
 
-from redash import settings
+from redash import settings, limiter
 from redash.authentication.account import invite_token
 from redash.models import User
 
@@ -14,6 +14,7 @@ class TestResetPassword(BaseTestCase):
         token = invite_token(user)
         response = self.get_request('/reset/{}'.format(token), org=self.factory.org)
         self.assertEqual(response.status_code, 200)
+
 
 class TestInvite(BaseTestCase):
     def test_expired_invite_token(self):
@@ -82,6 +83,7 @@ class TestInvitePost(BaseTestCase):
 
 class TestLogin(BaseTestCase):
     def test_throttle_login(self):
+        limiter.enabled = True
         # Extract the limit from settings (ex: '50/day')
         limit = settings.THROTTLE_LOGIN_PATTERN.split('/')[0]
         for _ in range(0, int(limit)):

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -21,13 +21,13 @@ class QueryTest(BaseTestCase):
         return query
 
     def test_all_tags(self):
-        self.create_tagged_query(tags=['tag1'])
-        self.create_tagged_query(tags=['tag1', 'tag2'])
-        self.create_tagged_query(tags=['tag1', 'tag2', 'tag3'])
+        self.create_tagged_query(tags=[u'tag1'])
+        self.create_tagged_query(tags=[u'tag1', u'tag2'])
+        self.create_tagged_query(tags=[u'tag1', u'tag2', u'tag3'])
 
         self.assertEqual(
             list(Query.all_tags(self.factory.user)),
-            [('tag1', 3), ('tag2', 2), ('tag3', 1)]
+            [(u'tag1', 3), (u'tag2', 2), (u'tag3', 1)]
         )
 
     def test_search_finds_in_name(self):
@@ -52,9 +52,9 @@ class QueryTest(BaseTestCase):
         self.assertNotIn(q3, queries)
 
     def test_search_by_id_returns_query(self):
-        q1 = self.factory.create_query(description="Testing search")
-        q2 = self.factory.create_query(description="Testing searching")
-        q3 = self.factory.create_query(description="Testing sea rch")
+        q1 = self.factory.create_query(description=u"Testing search")
+        q2 = self.factory.create_query(description=u"Testing searching")
+        q3 = self.factory.create_query(description=u"Testing sea rch")
         db.session.flush()
         queries = Query.search(str(q3.id), [self.factory.default_group.id])
 
@@ -63,20 +63,20 @@ class QueryTest(BaseTestCase):
         self.assertNotIn(q2, queries)
 
     def test_search_by_number(self):
-        q = self.factory.create_query(description="Testing search 12345")
+        q = self.factory.create_query(description=u"Testing search 12345")
         db.session.flush()
         queries = Query.search('12345', [self.factory.default_group.id])
 
         self.assertIn(q, queries)
 
     def test_search_respects_groups(self):
-        other_group = Group(org=self.factory.org, name="Other Group")
+        other_group = Group(org=self.factory.org, name=u"Other Group")
         db.session.add(other_group)
         ds = self.factory.create_data_source(group=other_group)
 
-        q1 = self.factory.create_query(description="Testing search", data_source=ds)
-        q2 = self.factory.create_query(description="Testing searching")
-        q3 = self.factory.create_query(description="Testing sea rch")
+        q1 = self.factory.create_query(description=u"Testing search", data_source=ds)
+        q2 = self.factory.create_query(description=u"Testing searching")
+        q3 = self.factory.create_query(description=u"Testing sea rch")
 
         queries = list(Query.search("Testing", [self.factory.default_group.id]))
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This PR adds rate limits to `POST /api/users` and `POST /api/users/:user_id`. It's currently static, but we can make it configurable if needed.

Also changed tests not to use rate limits (except for the tests that need them).