### PR TITLE
Dashboard save fail indication

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -938,7 +938,3 @@ text.slicetext {
 .markdown strong {
   font-weight: bold;
 }
-
-.disabled-silent {
-  pointer-events: none;
-}

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -15,16 +15,29 @@
     </div>
     <div class="col-xs-4 col-sm-5 col-lg-5 text-right dashboard__control p-r-0">
       <span ng-if="!$ctrl.dashboard.is_archived && !public" class="hidden-print">
-          <div ng-if="$ctrl.layoutEditing" ng-switch="$ctrl.isLayoutDirty || $ctrl.saveInProgress">
-            <span class="save-status" data-saving ng-switch-when="true">Saving</span>
-            <span class="save-status" ng-switch-default>Saved</span>
-
-            <button type="button" class="btn btn-primary btn-sm"
-              ng-disabled="$ctrl.isGridDisabled"
-              ng-click="$ctrl.editLayout(false)"
-              ng-class="{'disabled-silent': $ctrl.isLayoutDirty || $ctrl.saveInProgress }">
-              <i class="fa fa-check"></i> Done Editing
-            </button>
+          <div ng-if="$ctrl.layoutEditing" ng-switch="$ctrl.isLayoutDirty">
+            <span ng-switch-when="true" ng-switch="$ctrl.saveInProgress || $ctrl.saveDelay">
+                <span ng-switch-when="true">
+                  <span class="save-status" data-saving>Saving</span>
+                  <button class="btn btn-primary btn-sm">
+                    <i class="fa fa-check"></i> Done Editing
+                  </button>
+                </span>
+                <span ng-switch-default>
+                  <span class="save-status" data-error>Saving Failed</span>
+                  <button class="btn btn-primary btn-sm" ng-click="$ctrl.saveDashboardLayout()">
+                    Retry
+                  </button>
+                </span>
+            </span>
+            <span ng-switch-default>
+              <span class="save-status">Saved</span>
+              <button class="btn btn-primary btn-sm"
+                ng-disabled="$ctrl.isGridDisabled"
+                ng-click="$ctrl.editLayout(false)">
+                <i class="fa fa-check"></i> Done Editing
+              </button>
+            </span>
           </div>
 
           <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.togglePublished()" tooltip="Publish Dashboard" ng-if="$ctrl.dashboard.is_draft && !$ctrl.layoutEditing">

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -19,8 +19,8 @@
             <span ng-switch-when="true" ng-switch="$ctrl.saveInProgress || $ctrl.saveDelay">
                 <span ng-switch-when="true">
                   <span class="save-status" data-saving>Saving</span>
-                  <button class="btn btn-primary btn-sm" ng-disabled="$ctrl.showSaveButtonProgress"  ng-click="$ctrl.showSaveButtonProgress = true">
-                    <i class="fa" ng-class="{'fa-check': !$ctrl.showSaveButtonProgress, 'fa-spinner fa-pulse': $ctrl.showSaveButtonProgress}"></i> Done Editing
+                  <button class="btn btn-primary btn-sm" ng-disabled="$ctrl.editBtnClickedWhileSaving" ng-click="$ctrl.editBtnClickedWhileSaving = true">
+                    <i class="fa fa-check" ng-class="{'fa-spinner fa-pulse': $ctrl.editBtnClickedWhileSaving}"></i> Done Editing
                   </button>
                 </span>
                 <span ng-switch-default>

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -19,8 +19,8 @@
             <span ng-switch-when="true" ng-switch="$ctrl.saveInProgress || $ctrl.saveDelay">
                 <span ng-switch-when="true">
                   <span class="save-status" data-saving>Saving</span>
-                  <button class="btn btn-primary btn-sm">
-                    <i class="fa fa-check"></i> Done Editing
+                  <button class="btn btn-primary btn-sm" ng-disabled="$ctrl.showSaveButtonProgress"  ng-click="$ctrl.showSaveButtonProgress = true">
+                    <i class="fa" ng-class="{'fa-check': !$ctrl.showSaveButtonProgress, 'fa-spinner fa-pulse': $ctrl.showSaveButtonProgress}"></i> Done Editing
                   </button>
                 </span>
                 <span ng-switch-default>

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -47,11 +47,14 @@ function DashboardCtrl(
   Events,
 ) {
   this.saveInProgress = false;
+  this.saveDelay = false;
 
-  const saveDashboardLayout = () => {
+  this.saveDashboardLayout = () => {
     if (!this.dashboard.canEdit()) {
       return;
     }
+
+    this.isLayoutDirty = true;
 
     // calc diff, bail if none
     const changedWidgets = getWidgetsWithChangedPositions(this.dashboard.widgets);
@@ -61,6 +64,7 @@ function DashboardCtrl(
       return;
     }
 
+    this.saveDelay = false;
     this.saveInProgress = true;
     return $q
       .all(_.map(changedWidgets, widget => widget.save()))
@@ -77,7 +81,10 @@ function DashboardCtrl(
       });
   };
 
-  const saveDashboardLayoutDebounced = _.debounce(saveDashboardLayout, 2000);
+  const saveDashboardLayoutDebounced = () => {
+    this.saveDelay = true;
+    return _.debounce(() => this.saveDashboardLayout(), 2000)();
+  };
 
   this.layoutEditing = false;
   this.isFullscreen = false;
@@ -402,7 +409,7 @@ function DashboardCtrl(
 
     if (!this.layoutEditing) {
       // We need to wait a bit while `angular` updates widgets, and only then save new layout
-      $timeout(saveDashboardLayout, 50);
+      $timeout(() => this.saveDashboardLayout(), 50);
     }
   };
 

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -70,6 +70,9 @@ function DashboardCtrl(
       .all(_.map(changedWidgets, widget => widget.save()))
       .then(() => {
         this.isLayoutDirty = false;
+        if (this.editBtnClickedWhileSaving) {
+          this.layoutEditing = false;
+        }
       })
       .catch(() => {
         // in the off-chance that a widget got deleted mid-saving it's position, an error will occur
@@ -78,7 +81,7 @@ function DashboardCtrl(
       })
       .finally(() => {
         this.saveInProgress = false;
-        this.showSaveButtonProgress = false;
+        this.editBtnClickedWhileSaving = false;
       });
   };
 
@@ -88,7 +91,7 @@ function DashboardCtrl(
   };
 
   this.saveDelay = false;
-  this.showSaveButtonProgress = false;
+  this.editBtnClickedWhileSaving = false;
   this.layoutEditing = false;
   this.isFullscreen = false;
   this.refreshRate = null;

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -78,6 +78,7 @@ function DashboardCtrl(
       })
       .finally(() => {
         this.saveInProgress = false;
+        this.showSaveButtonProgress = false;
       });
   };
 
@@ -86,6 +87,8 @@ function DashboardCtrl(
     return _.debounce(() => this.saveDashboardLayout(), 2000)();
   };
 
+  this.saveDelay = false;
+  this.showSaveButtonProgress = false;
   this.layoutEditing = false;
   this.isFullscreen = false;
   this.refreshRate = null;

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -129,6 +129,10 @@
         animation: saving 2s linear infinite;
       }
     }
+
+    &[data-error] {
+      color: #F44336;
+    }
   }
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description
Since dashboard auto-save #3653, in case of a failed save, there is a notification but it still says "Saved" at the top as @gabrieldutra [rightfully indicated](https://github.com/getredash/redash/pull/3653#discussion_r275966837).

This PR adds another boolean flag `saveDelay` to differentiate 3 states: Saved, Saving, Error.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
In this recording I block my server url (with developer tools), get error and then turn back on, to demonstrate the flow.

<img src="https://user-images.githubusercontent.com/486954/56374332-970ec280-620b-11e9-81ac-59b140a96887.gif" width=400 />