### PR TITLE
Percy: Update network idle timeout

### DIFF
--- a/client/cypress/cypress.js
+++ b/client/cypress/cypress.js
@@ -53,7 +53,7 @@ function runCypressCI() {
   }
 
   execSync(
-    'docker-compose run cypress ./node_modules/.bin/percy exec -- ./node_modules/.bin/cypress run --record',
+    'docker-compose run cypress ./node_modules/.bin/percy exec -t 300 -- ./node_modules/.bin/cypress run --record',
     { stdio: 'inherit' },
   );
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This increases the network idle timeout for Percy, leaving more time for it to discover assets (such as Font Awesome :laughing:).

Hopefully this will fix the false-positives due to the square icons on Percy, this was suggested after I pinged their support :slightly_smiling_face:.

## Related Tickets & Documents
--
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--