### PR TITLE
Update npm run to fix hpe_header_overflow in recent nodejs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The frontend part of Redash.",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "node --max-http-header-size=16385 ./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "bundle": "bin/bundle-extensions",
     "clean": "rm -rf ./client/dist/",
     "build": "npm run clean && NODE_ENV=production node --max-old-space-size=4096 node_modules/.bin/webpack",


### PR DESCRIPTION
The change is needed to fix hpe_header_overflow in recent nodejs versions.

Nodejs has set max header size to 8k in http_parser from v10.14.2 in LTS versions,
need to run webpack devServer with a larger header size to make the proxy work.

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Nodejs has set max header size to 8k in http_parser from v10.14.2 in LTS versions,
need to run webpack devServer with a larger header size to make the proxy work.
Issue is reported to webpack and workaround has been presented here:
https://github.com/webpack/webpack-dev-server/issues/1711

Not sure if existing dev documents should be updated to tell which version of nodejs should be used. The override as used in this change is only applicable to nodejs version higher than v10.15.0.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
