### PR TITLE
Use monospace font in query output log

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -172,6 +172,12 @@ edit-in-place p.editable:hover {
   }
 }
 
+.query-log-line {
+  font-family: monospace;
+  white-space: pre;
+  margin: 0;
+}
+
 .paginator-container {
   text-align: center;
 }

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -224,7 +224,7 @@
                 <div class="d-flex flex-column p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
                   <div class="p-10" ng-show="showLog">
                     <p>Log Information:</p>
-                    <p ng-repeat="l in queryResult.getLog()">{{l}}</p>
+                    <p class="query-log-line" ng-repeat="l in queryResult.getLog()">{{l}}</p>
                   </div>
                   <ul class="tab-nav">
                     <rd-tab ng-if="!query.visualizations.length" tab-id="table" name="Table" base-path="query.getUrl(sourceMode)"></rd-tab>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Query output log currently uses a regular sans-serif font. That is unreadable for some types of output, such as `pandas.DataFrame.head` (useful when debugging Python queries).

## Related Tickets & Documents

#3739
