### PR TITLE
Cypress: Fix Stuck E2E test - create_query_spec

### DIFF
--- a/client/cypress/integration/query/create_query_spec.js
+++ b/client/cypress/integration/query/create_query_spec.js
@@ -4,8 +4,7 @@ describe('Create Query', () => {
     cy.visit('/queries/new');
   });
 
-  // https://github.com/getredash/redash/issues/3688
-  it.skip('executes the query', () => {
+  it('executes the query', () => {
     cy.getByTestId('SelectDataSource')
       .click()
       .contains('Test PostgreSQL').click();
@@ -18,5 +17,10 @@ describe('Create Query', () => {
 
     cy.getByTestId('DynamicTable').should('exist');
     cy.percySnapshot('Edit Query');
+
+    // https://github.com/cypress-io/cypress/issues/2118
+    cy.window().then((win) => {
+      win.onbeforeunload = null;
+    });
   });
 });

--- a/client/cypress/integration/query/create_query_spec.js
+++ b/client/cypress/integration/query/create_query_spec.js
@@ -4,7 +4,7 @@ describe('Create Query', () => {
     cy.visit('/queries/new');
   });
 
-  it('executes the query', () => {
+  it('executes and saves a query', () => {
     cy.getByTestId('SelectDataSource')
       .click()
       .contains('Test PostgreSQL').click();
@@ -18,9 +18,7 @@ describe('Create Query', () => {
     cy.getByTestId('DynamicTable').should('exist');
     cy.percySnapshot('Edit Query');
 
-    // https://github.com/cypress-io/cypress/issues/2118
-    cy.window().then((win) => {
-      win.onbeforeunload = null;
-    });
+    cy.getByTestId('SaveButton').click();
+    cy.url().should('match', /\/queries\/\d+\/source/);
   });
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
After a bug that could be avoided by Percy (#3744) I took a time to investigate #3688. It turns out this was getting stuck due to the `onbeforeunload` confirm dialog :sleepy:.

This fix is a workaround for cypress-io/cypress#2118

## Related Tickets & Documents
Closes #3688

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--