### PR TITLE
Dashboard Grid #3 - Auto Height

### DIFF
--- a/client/app/components/dashboards/AutoHeightController.js
+++ b/client/app/components/dashboards/AutoHeightController.js
@@ -9,14 +9,14 @@ const WIDGET_CONTENT_SELECTOR = [
   '.spinner-container', // loading state
   '.tile__bottom-control', // footer
 ].join(',');
-const INTERVAL = 500;
+const INTERVAL = 200;
 
 export default class AutoHeightController {
-  widgets = {}
+  widgets = {};
 
-  interval = null
+  interval = null;
 
-  onHeightChange = null
+  onHeightChange = null;
 
   constructor(handler) {
     this.onHeightChange = handler;
@@ -61,7 +61,7 @@ export default class AutoHeightController {
         }, 0);
       },
     ];
-  }
+  };
 
   remove = (id) => {
     // not actually deleting from this.widgets to prevent case of unwanted re-adding
@@ -70,11 +70,11 @@ export default class AutoHeightController {
     if (this.isEmpty()) {
       this.stop();
     }
-  }
+  };
 
-  exists = id => !!this.widgets[id.toString()]
+  exists = id => !!this.widgets[id.toString()];
 
-  isEmpty = () => !some(this.widgets)
+  isEmpty = () => !some(this.widgets);
 
   checkHeightChanges = () => {
     Object.keys(this.widgets).forEach((id) => {
@@ -85,22 +85,22 @@ export default class AutoHeightController {
         this.onHeightChange(id, height); // dispatch
       }
     });
-  }
+  };
 
   start = () => {
     this.stop();
     this.interval = setInterval(this.checkHeightChanges, INTERVAL);
-  }
+  };
 
   stop = () => {
     clearInterval(this.interval);
-  }
+  };
 
   resume = () => {
     if (!this.isEmpty()) {
       this.start();
     }
-  }
+  };
 
   destroy = () => {
     this.stop();

--- a/client/app/components/dashboards/AutoHeightController.js
+++ b/client/app/components/dashboards/AutoHeightController.js
@@ -1,0 +1,109 @@
+
+import { includes, reduce, some } from 'lodash';
+
+const WIDGET_SELECTOR = '[data-widgetid="{0}"]';
+const WIDGET_CONTENT_SELECTOR = [
+  '.widget-header', // header
+  'visualization-renderer', // visualization
+  '.scrollbox .alert', // error state
+  '.spinner-container', // loading state
+  '.tile__bottom-control', // footer
+].join(',');
+const INTERVAL = 500;
+
+export default class AutoHeightController {
+  widgets = {}
+
+  interval = null
+
+  onHeightChange = null
+
+  constructor(handler) {
+    this.onHeightChange = handler;
+  }
+
+  update(widgets) {
+    const newWidgetIds = widgets
+      .filter(widget => widget.options.position.autoHeight)
+      .map(widget => widget.id.toString());
+
+    // added
+    newWidgetIds
+      .filter(id => !includes(Object.keys(this.widgets), id))
+      .forEach(this.add);
+
+    // removed
+    Object.keys(this.widgets)
+      .filter(id => !includes(newWidgetIds, id))
+      .forEach(this.remove);
+  }
+
+  add = (id) => {
+    if (this.isEmpty()) {
+      this.start();
+    }
+
+    const selector = WIDGET_SELECTOR.replace('{0}', id);
+    this.widgets[id] = [
+      function getHeight() {
+        const widgetEl = document.querySelector(selector);
+        if (!widgetEl) {
+          return undefined; // safety
+        }
+
+        // get all content elements
+        const els = widgetEl.querySelectorAll(WIDGET_CONTENT_SELECTOR);
+
+        // calculate accumulated height
+        return reduce(els, (acc, el) => {
+          const height = el ? el.getBoundingClientRect().height : 0;
+          return acc + height;
+        }, 0);
+      },
+    ];
+  }
+
+  remove = (id) => {
+    // not actually deleting from this.widgets to prevent case of unwanted re-adding
+    this.widgets[id.toString()] = false;
+
+    if (this.isEmpty()) {
+      this.stop();
+    }
+  }
+
+  exists = id => !!this.widgets[id.toString()]
+
+  isEmpty = () => !some(this.widgets)
+
+  checkHeightChanges = () => {
+    Object.keys(this.widgets).forEach((id) => {
+      const [getHeight, prevHeight] = this.widgets[id];
+      const height = getHeight();
+      if (height && height !== prevHeight) {
+        this.widgets[id][1] = height; // save
+        this.onHeightChange(id, height); // dispatch
+      }
+    });
+  }
+
+  start = () => {
+    this.stop();
+    this.interval = setInterval(this.checkHeightChanges, INTERVAL);
+  }
+
+  stop = () => {
+    clearInterval(this.interval);
+  }
+
+  resume = () => {
+    if (!this.isEmpty()) {
+      this.start();
+    }
+  }
+
+  destroy = () => {
+    this.stop();
+    this.widgets = null;
+  }
+}

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -1,7 +1,7 @@
 <div class="widget-wrapper">
   <div class="tile body-container widget-visualization" ng-if="$ctrl.type=='visualization'" ng-class="$ctrl.type"
     ng-switch="$ctrl.widget.getQueryResult().getStatus()">
-    <div class="body-row">
+    <div class="body-row widget-header">
       <div class="t-header widget clearfix">
         <div class="dropdown pull-right widget-menu-remove"  ng-if="!$ctrl.public && $ctrl.dashboard.canEdit()">
           <div class="actions">

--- a/client/app/components/dashboards/widget.less
+++ b/client/app/components/dashboards/widget.less
@@ -106,7 +106,7 @@ visualization-name {
     z-index: 3;
   }
 
-  // autoHeight animation
+  // auto-height animation
   &.cssTransforms:not(.resizing) {
     transition-property: transform, height; // added ", height"
   }

--- a/client/app/components/dashboards/widget.less
+++ b/client/app/components/dashboards/widget.less
@@ -105,4 +105,9 @@ visualization-name {
   &.resizing {
     z-index: 3;
   }
+
+  // autoHeight animation
+  &.cssTransforms:not(.resizing) {
+    transition-property: transform, height; // added ", height"
+  }
 }

--- a/client/cypress/integration/dashboard/dashboard_spec.js
+++ b/client/cypress/integration/dashboard/dashboard_spec.js
@@ -441,7 +441,7 @@ describe('Dashboard', () => {
       });
     });
 
-    describe.skip('Auto height for table visualization', () => {
+    describe('Auto height for table visualization', () => {
       it('renders correct height for 2 table rows', function () {
         const queryData = {
           query: 'select s.a FROM generate_series(1,2) AS s(a)',
@@ -481,7 +481,7 @@ describe('Dashboard', () => {
               cy.getByTestId('RefreshIndicator').as('refreshButton');
             });
             cy.getByTestId(`ParameterName${paramName}`).within(() => {
-              cy.get('input').as('paramInput');
+              cy.getByTestId('TextParamInput').as('paramInput');
             });
           });
         });
@@ -520,8 +520,10 @@ describe('Dashboard', () => {
           cy.get('@widget').invoke('height').should('eq', 285);
 
           // resize height by 1 grid row
-          resizeBy(cy.get('@widget'), 0, 5);
-          cy.get('@widget').invoke('height').should('eq', 335);
+          resizeBy(cy.get('@widget'), 0, 50)
+            .then(() => cy.get('@widget'))
+            .invoke('height')
+            .should('eq', 335); // resized by 50, , 135 -> 185
 
           // add 4 table rows
           cy.get('@paramInput').clear().type('5');


### PR DESCRIPTION
- [x] Refactor

## Description
Ported the auto height feature

Included:
- [x]  Auto height param taken from widget service info
- [x] Triggered by change to height of widget header / body / footer
- [x] Feature available in single column mode
- [x]  Related tests unskipped and passing

## Mobile & Desktop Screenshots/Recordings

🔔 Red stripe indicator on top is for local testing purposes only. Not in prod. 🔔

#### Auto resizes on update

<img src="https://user-images.githubusercontent.com/486954/56983594-aa674980-6b8c-11e9-8dcb-9d31f2c79ea9.gif" width=400 />

#### Manual resize revokes auto height
<img src="https://user-images.githubusercontent.com/486954/56983417-40e73b00-6b8c-11e9-8dd5-2244ff610e93.gif" width=400 />

