### PR TITLE
Fix: pie chart not rendering when series doesn't exist in options.

### DIFF
--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -527,7 +527,7 @@ export function prepareLayout(element, seriesList, options, data) {
           y: yPosition + cellHeight - 0.015,
           xanchor: 'center',
           yanchor: 'top',
-          text: options.seriesOptions[series.name].name || series.name,
+          text: (options.seriesOptions[series.name] || {}).name || series.name,
           showarrow: false,
         };
       }));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

When new series are created due to new data in the query result, Pie chart won't render as the series isn't available in the options object.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Query reproducing this issue: https://redash-preview.netlify.com/queries/132/source#231
