### PR TITLE
Fix: dashboard filters collects all options too

### DIFF
--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -19,13 +19,12 @@ export function collectDashboardFilters(dashboard, queryResults, urlParams) {
         queryFilter.current = urlParams[queryFilter.name];
       }
 
+      const filter = { ...queryFilter };
       if (!_.has(filters, queryFilter.name)) {
-        const filter = { ...queryFilter };
         filters[filter.name] = filter;
+      } else {
+        filters[filter.name].values = _.union(filters[filter.name].values, filter.values);
       }
-
-      // TODO: merge values. -- maybe - intersect??
-      // filters[queryFilter.name].originFilters.push(queryFilter);
     });
   });
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
Fix for a bug in the global filter, The global filter collects the first filter that's it
finds in some name and ignores additional options from filters with the same name.

## Related Tickets & Documents
Describes in this issue: #2327 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/5693018/57170067-fdeac900-6e12-11e9-87a8-b98948e25fc7.png)

You can see working example in netlify previews.
[before](https://5cc8467c0eead4000961827b--redash-preview.netlify.com/dashboard/filters)
[after](https://5ccccc952a4b30000833d92b--redash-preview.netlify.com/dashboard/filters)