### PR TITLE
Add direction option in Pie Chart

### DIFF
--- a/client/app/visualizations/chart/chart-editor.html
+++ b/client/app/visualizations/chart/chart-editor.html
@@ -122,6 +122,17 @@
       </ui-select>
     </div>
 
+    <div class="form-group" ng-if="$ctrl.options.globalSeriesType === 'pie'">
+      <label class="control-label">Direction</label>
+
+      <ui-select ng-model="$ctrl.options.direction.type">
+        <ui-select-match placeholder="Choose Direction...">{{$select.selected.label}}</ui-select-match>
+        <ui-select-choices repeat="direction.value as direction in $ctrl.directions">
+          <div ng-bind-html="direction.label | highlight: $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
+    </div>
+
     <div class="checkbox" ng-if="['custom', 'heatmap'].indexOf($ctrl.options.globalSeriesType) == -1">
       <label>
         <input type="checkbox" ng-model="$ctrl.options.legend.enabled">

--- a/client/app/visualizations/chart/index.js
+++ b/client/app/visualizations/chart/index.js
@@ -20,6 +20,7 @@ const DEFAULT_OPTIONS = {
   seriesOptions: {},
   valuesOptions: {},
   columnMapping: {},
+  direction: { type: 'counterclockwise' },
 
   // showDataLabels: false, // depends on chart type
   numberFormat: '0,0[.]00000',
@@ -125,6 +126,11 @@ const ChartEditor = {
     if (clientConfig.allowCustomJSVisualizations) {
       this.chartTypes.custom = { name: 'Custom', icon: 'code' };
     }
+
+    this.directions = [
+      { label: 'Counterclockwise', value: 'counterclockwise' },
+      { label: 'Clockwise', value: 'clockwise' },
+    ];
 
     this.xAxisScales = [
       { label: 'Auto Detect', value: '-' },

--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -262,6 +262,7 @@ function preparePieData(seriesList, options) {
       textposition: 'inside',
       textfont: { color: '#ffffff' },
       name: serie.name,
+      direction: options.direction.type,
       domain: {
         x: [xPosition, xPosition + cellWidth - xPadding],
         y: [yPosition, yPosition + cellHeight - yPadding],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Add direction option in Pie Chart.

Default is `counterclockwise` (same as current).

## Related Tickets & Documents

[plotly\.js chart attribute reference](https://plot.ly/javascript/reference/#pie-direction)

## Mobile & Desktop Screenshots/Recordings (Visualization Editor Page)

Before:
![before_973x840](https://user-images.githubusercontent.com/3317191/57202998-be74d600-6fe6-11e9-8ba2-a67e0f874968.png)

After:
![after_973x840](https://user-images.githubusercontent.com/3317191/57203000-c896d480-6fe6-11e9-934a-657d38023bf2.png)

