### PR TITLE
Support regenerating Query API Key

### DIFF
--- a/client/app/components/queries/api-key-dialog.js
+++ b/client/app/components/queries/api-key-dialog.js
@@ -5,7 +5,7 @@ const ApiKeyDialog = {
 <div class="modal-body">
     <h5>API Key</h5>
     <div class="form-group">
-        <pre>{{$ctrl.api_key}}</pre>
+        <pre>{{$ctrl.query.api_key}}</pre>
         <div ng-if="$ctrl.canEdit">
             <button class="btn btn-default" ng-click="$ctrl.regenerateQueryApiKey()" ng-disabled="$ctrl.disableRegenerateApiKeyButton">Regenerate</button>
         </div>
@@ -16,11 +16,11 @@ const ApiKeyDialog = {
     <div>
         Results in CSV format:
 
-        <pre>{{$ctrl.csvUrlBase + $ctrl.api_key}}</pre>
+        <pre>{{$ctrl.csvUrlBase + $ctrl.query.api_key}}</pre>
 
         Results in JSON format:
 
-        <pre>{{$ctrl.jsonUrlBase + $ctrl.api_key}}</pre>
+        <pre>{{$ctrl.jsonUrlBase + $ctrl.query.api_key}}</pre>
     </div>
 </div>`,
   controller($http, clientConfig, currentUser) {
@@ -28,7 +28,7 @@ const ApiKeyDialog = {
 
     this.canEdit = currentUser.id === this.resolve.query.user.id || currentUser.hasPermission('admin');
     this.disableRegenerateApiKeyButton = false;
-    this.api_key = this.resolve.query.api_key;
+    this.query = this.resolve.query;
     this.csvUrlBase = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.csv?api_key=`;
     this.jsonUrlBase = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.json?api_key=`;
 
@@ -37,7 +37,7 @@ const ApiKeyDialog = {
       $http
         .post(`api/queries/${this.resolve.query.id}/regenerate_api_key`)
         .success((data) => {
-          this.api_key = data.api_key;
+          this.query.api_key = data.api_key;
           this.disableRegenerateApiKeyButton = false;
         })
         .error(() => {

--- a/client/app/components/queries/api-key-dialog.js
+++ b/client/app/components/queries/api-key-dialog.js
@@ -5,7 +5,7 @@ const ApiKeyDialog = {
 <div class="modal-body">
     <h5>API Key</h5>
     <div class="form-group">
-        <pre>{{$ctrl.query.api_key}}</pre>
+        <pre>{{$ctrl.api_key}}</pre>
         <div ng-if="$ctrl.canEdit">
             <button class="btn btn-default" ng-click="$ctrl.regenerateQueryApiKey()" ng-disabled="$ctrl.disableRegenerateApiKeyButton">Regenerate</button>
         </div>
@@ -16,11 +16,11 @@ const ApiKeyDialog = {
     <div>
         Results in CSV format:
 
-        <pre>{{$ctrl.csvUrlBase + query.api_key}}</pre>
+        <pre>{{$ctrl.csvUrlBase + $ctrl.api_key}}</pre>
 
         Results in JSON format:
 
-        <pre>{{$ctrl.jsonUrlBase + query.api_key}}</pre>
+        <pre>{{$ctrl.jsonUrlBase + $ctrl.api_key}}</pre>
     </div>
 </div>`,
   controller($http, clientConfig, currentUser) {
@@ -28,7 +28,7 @@ const ApiKeyDialog = {
 
     this.canEdit = currentUser.id === this.resolve.query.user.id || currentUser.hasPermission('admin');
     this.disableRegenerateApiKeyButton = false;
-    this.query = this.resolve.query;
+    this.api_key = this.resolve.query.api_key;
     this.csvUrlBase = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.csv?api_key=`;
     this.jsonUrlBase = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.json?api_key=`;
 
@@ -37,7 +37,7 @@ const ApiKeyDialog = {
       $http
         .post(`api/queries/${this.resolve.query.id}/regenerate_api_key`)
         .success((data) => {
-          this.query = data;
+          this.api_key = data.api_key;
           this.disableRegenerateApiKeyButton = false;
         })
         .error(() => {

--- a/client/app/components/queries/api-key-dialog.js
+++ b/client/app/components/queries/api-key-dialog.js
@@ -5,9 +5,9 @@ const ApiKeyDialog = {
 <div class="modal-body">
     <h5>API Key</h5>
     <div class="form-group">
-        <pre>{{query.api_key}}</pre>
-        <div ng-if="canEdit">
-            <button class="btn btn-default" ng-click="$ctrl.regenerateQueryApiKey()" ng-disabled="disableRegenerateApiKeyButton">Regenerate</button>
+        <pre>{{$ctrl.query.api_key}}</pre>
+        <div ng-if="$ctrl.canEdit">
+            <button class="btn btn-default" ng-click="$ctrl.regenerateQueryApiKey()" ng-disabled="$ctrl.disableRegenerateApiKeyButton">Regenerate</button>
         </div>
     </div>
 
@@ -23,25 +23,25 @@ const ApiKeyDialog = {
         <pre>{{$ctrl.jsonUrlBase + query.api_key}}</pre>
     </div>
 </div>`,
-  controller($scope, $http, clientConfig, currentUser) {
+  controller($http, clientConfig, currentUser) {
     'ngInject';
 
-    $scope.canEdit = currentUser.id === this.resolve.query.user.id || currentUser.hasPermission('admin');
-    $scope.disableRegenerateApiKeyButton = false;
-    $scope.query = this.resolve.query;
+    this.canEdit = currentUser.id === this.resolve.query.user.id || currentUser.hasPermission('admin');
+    this.disableRegenerateApiKeyButton = false;
+    this.query = this.resolve.query;
     this.csvUrlBase = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.csv?api_key=`;
     this.jsonUrlBase = `${clientConfig.basePath}api/queries/${this.resolve.query.id}/results.json?api_key=`;
 
     this.regenerateQueryApiKey = () => {
-      $scope.disableRegenerateApiKeyButton = true;
+      this.disableRegenerateApiKeyButton = true;
       $http
         .post(`api/queries/${this.resolve.query.id}/regenerate_api_key`)
         .success((data) => {
-          $scope.query = data;
-          $scope.disableRegenerateApiKeyButton = false;
+          this.query = data;
+          this.disableRegenerateApiKeyButton = false;
         })
         .error(() => {
-          $scope.disableRegenerateApiKeyButton = false;
+          this.disableRegenerateApiKeyButton = false;
         });
     };
   },

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -35,7 +35,8 @@ from redash.handlers.queries import (MyQueriesResource, QueryArchiveResource,
                                      QueryForkResource, QueryListResource,
                                      QueryRecentResource, QueryRefreshResource,
                                      QueryResource, QuerySearchResource,
-                                     QueryTagsResource)
+                                     QueryTagsResource,
+                                     QueryRegenerateApiKeyResource)
 from redash.handlers.query_results import (JobResource,
                                            QueryResultDropdownResource,
                                            QueryDropdownsResource,
@@ -115,6 +116,7 @@ api.add_org_resource(MyQueriesResource, '/api/queries/my', endpoint='my_queries'
 api.add_org_resource(QueryRefreshResource, '/api/queries/<query_id>/refresh', endpoint='query_refresh')
 api.add_org_resource(QueryResource, '/api/queries/<query_id>', endpoint='query')
 api.add_org_resource(QueryForkResource, '/api/queries/<query_id>/fork', endpoint='query_fork')
+api.add_org_resource(QueryRegenerateApiKeyResource, '/api/queries/<query_id>/regenerate_api_key', endpoint='query_regenerate_api_key')
 
 api.add_org_resource(ObjectPermissionsListResource, '/api/<object_type>/<object_id>/acl', endpoint='object_permissions')
 api.add_org_resource(CheckPermissionResource, '/api/<object_type>/<object_id>/acl/<access_type>', endpoint='check_permissions')

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -116,7 +116,9 @@ api.add_org_resource(MyQueriesResource, '/api/queries/my', endpoint='my_queries'
 api.add_org_resource(QueryRefreshResource, '/api/queries/<query_id>/refresh', endpoint='query_refresh')
 api.add_org_resource(QueryResource, '/api/queries/<query_id>', endpoint='query')
 api.add_org_resource(QueryForkResource, '/api/queries/<query_id>/fork', endpoint='query_fork')
-api.add_org_resource(QueryRegenerateApiKeyResource, '/api/queries/<query_id>/regenerate_api_key', endpoint='query_regenerate_api_key')
+api.add_org_resource(QueryRegenerateApiKeyResource,
+                     '/api/queries/<query_id>/regenerate_api_key',
+                     endpoint='query_regenerate_api_key')
 
 api.add_org_resource(ObjectPermissionsListResource, '/api/<object_type>/<object_id>/acl', endpoint='object_permissions')
 api.add_org_resource(CheckPermissionResource, '/api/<object_type>/<object_id>/acl/<access_type>', endpoint='check_permissions')

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -387,6 +387,24 @@ class QueryResource(BaseResource):
         models.db.session.commit()
 
 
+class QueryRegenerateApiKeyResource(BaseResource):
+    @require_permission('edit_query')
+    def post(self, query_id):
+        query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
+        require_admin_or_owner(query.user_id)
+        query.regenerate_api_key()
+        models.db.session.commit()
+
+        self.record_event({
+            'action': 'regnerate_api_key',
+            'object_id': query_id,
+            'object_type': 'query',
+        })
+
+        result = QuerySerializer(query, with_visualizations=True).serialize()
+        return result
+
+
 class QueryForkResource(BaseResource):
     @require_permission('edit_query')
     def post(self, query_id):

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -401,7 +401,7 @@ class QueryRegenerateApiKeyResource(BaseResource):
             'object_type': 'query',
         })
 
-        result = QuerySerializer(query, with_visualizations=True).serialize()
+        result = QuerySerializer(query).serialize()
         return result
 
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -453,6 +453,9 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         if user:
             self.record_changes(user)
 
+    def regenerate_api_key(self):
+        self.api_key = generate_token(40)
+
     @classmethod
     def create(cls, **kwargs):
         query = cls(**kwargs)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Support regenerating Query API Key.

Add API endpoint to regenerate.

```
POST /api/queries/{id}/regenerate_api_key
```

Also its button (ref: the screenshot below at the bottom of this page).

## Related Tickets & Documents

- [Regenerate API KEY \- Feature Requests \- Redash Discourse](https://discuss.redash.io/t/regenerate-api-key/2134/2)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Query API Key dialog:
![after_567x335](https://user-images.githubusercontent.com/3317191/57215401-bab57380-7027-11e9-8eba-b8e7d3c6a0e5.png)

