### PR TITLE
Show non relative timestamp when printing an embed

### DIFF
--- a/client/app/components/parameters.html
+++ b/client/app/components/parameters.html
@@ -1,16 +1,31 @@
-<div class="parameter-container form-inline bg-white"
+<div
+  class="parameter-container form-inline bg-white"
   ng-if="parameters | notEmpty"
   ui-sortable="{ 'ui-floating': true, 'disabled': !editable }"
   ng-model="parameters"
 >
-  <div class="form-group m-r-10" ng-repeat="param in parameters" data-test="ParameterName{{ param.name }}">
-    <label class="parameter-label">{{param.title}}</label>
-    <button class="btn btn-default btn-xs" ng-if="editable" ng-click="showParameterSettings(param, $index)" data-test="ParameterSettings-{{ param.name }}">
+  <div
+    class="form-group m-r-10"
+    ng-repeat="param in parameters"
+    data-test="ParameterName{{ param.name }}"
+  >
+    <label class="parameter-label">{{ param.title }}</label>
+    <button
+      class="btn btn-default btn-xs"
+      ng-if="editable"
+      ng-click="showParameterSettings(param, $index)"
+      data-test="ParameterSettings-{{ param.name }}"
+    >
       <i class="zmdi zmdi-settings"></i>
     </button>
     <parameter-value-input param="param"></parameter-value-input>
   </div>
-  <button class="m-t-20 btn btn-primary" ng-if="onRefresh" ng-click="onRefresh()" title="Refresh Dataset">
+  <button
+    class="m-t-20 btn btn-primary hidden-print"
+    ng-if="onRefresh"
+    ng-click="onRefresh()"
+    title="Refresh Dataset"
+  >
     <span class="zmdi zmdi-play"></span>
   </button>
 </div>

--- a/client/app/components/queries/visualization-embed.html
+++ b/client/app/components/queries/visualization-embed.html
@@ -33,6 +33,7 @@
           <rd-timer from="$ctrl.refreshStartedAt" ng-if="$ctrl.loading"></rd-timer>
         </a>
       </div>
+      <span class="small visible-print"><i class="zmdi zmdi-time-restore"></i> {{$ctrl.queryResult.getUpdatedAt() | dateTime}} UTC</span>
       <div class="col-xs-6 text-right hidden-print">
         <a class="btn btn-default btn-sm" ng-href="{{$ctrl.query.getUrl()}}" target="_blank" tooltip="Open in Redash">
           <span class="zmdi zmdi-link"></span>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Show non relative timestamp when printing an embed. (Also used for the Slack snapshots)

This brings back a functionality accidentally removed in #3752.