### PR TITLE
DynamoDB: safe implementation of schema loading

### DIFF
--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 try:
     from dql import Engine, FragmentEngine
+    from dynamo3 import DynamoDBError
     from pyparsing import ParseException
     enabled = True
 except ImportError as e:
@@ -101,7 +102,8 @@ class DynamoDBSQL(BaseSQLQueryRunner):
         try:
             engine = self._connect()
 
-            result = engine.execute(query if str(query).endswith(';') else str(query)+';')
+            result = engine.execute(query if str(
+                query).endswith(';') else str(query) + ';')
 
             columns = []
             rows = []
@@ -129,7 +131,8 @@ class DynamoDBSQL(BaseSQLQueryRunner):
             json_data = json_dumps(data)
             error = None
         except ParseException as e:
-            error = u"Error parsing query at line {} (column {}):\n{}".format(e.lineno, e.column, e.line)
+            error = u"Error parsing query at line {} (column {}):\n{}".format(
+                e.lineno, e.column, e.line)
             json_data = None
         except (SyntaxError, RuntimeError) as e:
             error = e.message
@@ -141,5 +144,6 @@ class DynamoDBSQL(BaseSQLQueryRunner):
             json_data = None
 
         return json_data, error
+
 
 register(DynamoDBSQL)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Instead of using DQL's `describe_all` method, we implement it in place and catch exceptions. This makes sure that if we happen to have ability to list tables we don't have describe permission for, the schema load won't fail.