### PR TITLE
Avoid error with duplicate log lines

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -224,7 +224,7 @@
                 <div class="d-flex flex-column p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
                   <div class="p-10" ng-show="showLog">
                     <p>Log Information:</p>
-                    <p class="query-log-line" ng-repeat="l in queryResult.getLog()">{{l}}</p>
+                    <p class="query-log-line" ng-repeat="l in queryResult.getLog() track by $index">{{l}}</p>
                   </div>
                   <ul class="tab-nav" data-test="QueryPageVisualizationTabs">
                     <rd-tab ng-if="!query.visualizations.length" tab-id="table" name="Table" base-path="query.getUrl(sourceMode)"></rd-tab>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Displaying log output from a query runner fails on an error if the output contains duplicate lines and as a result of that error no log output is shown in such cases. This is due to how `ng-repeat` works. Fixed in this PR as shown in the Angular documentation.

https://docs.angularjs.org/error/ngRepeat/dupes

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
