### PR TITLE
Visualization: details view

### DIFF
--- a/client/app/visualizations/details/DetailsEditor.jsx
+++ b/client/app/visualizations/details/DetailsEditor.jsx
@@ -1,0 +1,3 @@
+export default function DetailsEditor() {
+  return null;
+}

--- a/client/app/visualizations/details/DetailsRenderer.jsx
+++ b/client/app/visualizations/details/DetailsRenderer.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import map from 'lodash/map';
+import Pagination from 'antd/lib/pagination';
+
+import './details.less';
+
+export default function DetailsRenderer({ data }) {
+  const [page, setPage] = useState(0);
+
+  if (!data || !data.rows) {
+    return null;
+  }
+
+  // We use columsn to maintain order of columns in the view.
+  const columns = data.columns.map(column => column.name);
+  const row = data.rows[page];
+
+  return (
+    <div>
+      <table className="table table-bordered details-viz">
+        <tbody>
+          {map(columns, key => (
+            <tr key={key}>
+              <th>{key}</th>
+              <td>{'' + row[key]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {data.rows.length > 1 && (
+        <div className="paginator-container">
+          <Pagination current={page + 1} defaultPageSize={1} total={data.rows.length} onChange={p => setPage(p - 1)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/app/visualizations/details/DetailsRenderer.jsx
+++ b/client/app/visualizations/details/DetailsRenderer.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import map from 'lodash/map';
+import { RendererPropTypes } from '@/visualizations';
 import Pagination from 'antd/lib/pagination';
 
 import './details.less';
@@ -7,7 +8,7 @@ import './details.less';
 export default function DetailsRenderer({ data }) {
   const [page, setPage] = useState(0);
 
-  if (!data || !data.rows) {
+  if (!data || !data.rows || data.rows.length === 0) {
     return null;
   }
 
@@ -35,3 +36,5 @@ export default function DetailsRenderer({ data }) {
     </div>
   );
 }
+
+DetailsRenderer.propTypes = RendererPropTypes;

--- a/client/app/visualizations/details/details.less
+++ b/client/app/visualizations/details/details.less
@@ -1,0 +1,5 @@
+.details-viz th {
+  width: 1px;
+  white-space: nowrap;
+  background-color: rgba(102, 136, 153, 0.03) !important;
+}

--- a/client/app/visualizations/details/index.js
+++ b/client/app/visualizations/details/index.js
@@ -1,0 +1,20 @@
+import { registerVisualization } from '@/visualizations';
+import DetailsRenderer from './DetailsRenderer';
+import DetailsEditor from './DetailsEditor';
+
+const DEFAULT_OPTIONS = {};
+
+export default function init() {
+  registerVisualization({
+    type: 'DETAILS',
+    name: 'Details View',
+    getOptions: options => ({ ...DEFAULT_OPTIONS, ...options }),
+    Renderer: DetailsRenderer,
+    Editor: DetailsEditor,
+
+    defaultColumns: 2,
+    defaultRows: 2,
+  });
+}
+
+init.init = true;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Details visualization -- shows each row as a table (similar to the expanded view in psql):

![image](https://user-images.githubusercontent.com/71468/57325870-c7af9100-7113-11e9-99fc-f33d81e66538.png)

Paginator only shows if you return more than one row.

Ideally it would use Table's column renderers (or maybe just be a mode of the table visualization), but this can wait until the Table visualization is rewritten with React.

Todo:

- [x] Add PropTypes.
- [x] Fix issue with rendering when there is no column information.
 
## Related Tickets & Documents

https://discuss.redash.io/t/single-row-view/311/6?u=arikfr