### PR TITLE
enable view_source permission

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -372,11 +372,12 @@ class QueryResource(BaseResource):
             'object_type': 'query',
         })
 
-        if not self.current_user.has_permissions('view_source'):
-            result['query'] = '\n'.join(
-                ['-- Query Source requires \'view_source\' permission.'] \
-                + list(map(lambda p: '-- {{{{{}}}}}'.format(p['name']), result['options']['parameters']))
-            )
+        if not self.current_user.has_permission('view_source'):
+            result['query'] = '-- Query Source requires \'view_source\' permission.'
+            if 'parameters' in result['options']:
+                result['query'] += '\n' + '\n'.join(
+                    [] + list(map(lambda p: '-- {{{{{}}}}}'.format(p['name']), result['options']['parameters']))
+                )
         return result
 
     # TODO: move to resource of its own? (POST /queries/{id}/archive)

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -351,7 +351,7 @@ class QueryResource(BaseResource):
 
         return QuerySerializer(query, with_visualizations=True).serialize()
 
-    @require_permissions(('view_query', 'view_source'))
+    @require_permission('view_query')
     def get(self, query_id):
         """
         Retrieve a query.
@@ -372,6 +372,11 @@ class QueryResource(BaseResource):
             'object_type': 'query',
         })
 
+        if not self.current_user.has_permissions('view_source'):
+            result['query'] = '\n'.join(
+                ['-- Query Source requires \'view_source\' permission.'] \
+                + list(map(lambda p: '-- {{{{{}}}}}'.format(p['name']), result['options']['parameters']))
+            )
         return result
 
     # TODO: move to resource of its own? (POST /queries/{id}/archive)

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -13,7 +13,7 @@ from redash.handlers.query_results import run_query
 from redash.permissions import (can_modify, not_view_only, require_access,
                                 require_admin_or_owner,
                                 require_object_modify_permission,
-                                require_permission, view_only)
+                                require_permission, require_permissions, view_only)
 from redash.utils import collect_parameters_from_request
 from redash.serializers import QuerySerializer
 from redash.models.parameterized_query import ParameterizedQuery
@@ -351,7 +351,7 @@ class QueryResource(BaseResource):
 
         return QuerySerializer(query, with_visualizations=True).serialize()
 
-    @require_permission('view_query')
+    @require_permissions(('view_query', 'view_source'))
     def get(self, query_id):
         """
         Retrieve a query.

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -175,7 +175,9 @@ class QueryResultResource(BaseResource):
 
         if has_access(query, self.current_user, allow_executing_with_view_only_permissions):
             query_result = run_query(query.parameterized, parameter_values, query.data_source, query_id, max_age)
-            if not self.current_user.has_permissions('view_source'):
+            if isinstance(query_result, tuple) and query_result[1] != 200:
+                return query_result
+            if not self.current_user.has_permission('view_source'):
                 query_result['query'] = 'Query Source requires \'view_source\' permission.'
             return query_result
         else:

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -171,11 +171,13 @@ class QueryResultResource(BaseResource):
         max_age = int(max_age)
 
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
-
         allow_executing_with_view_only_permissions = query.parameterized.is_safe
 
         if has_access(query, self.current_user, allow_executing_with_view_only_permissions):
-            return run_query(query.parameterized, parameter_values, query.data_source, query_id, max_age)
+            query_result = run_query(query.parameterized, parameter_values, query.data_source, query_id, max_age)
+            if not self.current_user.has_permissions('view_source'):
+                query_result['query'] = 'Query Source requires \'view_source\' permission.'
+            return query_result
         else:
             return {'job': {'status': 4, 'error': 'You do not have permission to run queries with this data source.'}}, 403
 


### PR DESCRIPTION
## Permission for viewing query source 
- [x] Feature

## Description
Now users who do not have `view_source` permission can view query source, so this permission does not work for the intent that is.
In this commit, the users are not able to view query sources.

## Related Tickets & Documents
#3212

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/10035/57453601-c57b3d00-72a1-11e9-8e1e-a80fd3aaed90.png)
![image](https://user-images.githubusercontent.com/10035/57453623-d3c95900-72a1-11e9-9b25-e59e3783d5c4.png)
