### PR TITLE
Loading indicator till app inits

### DIFF
--- a/client/app/assets/less/main.less
+++ b/client/app/assets/less/main.less
@@ -75,6 +75,7 @@
 @import 'redash/redash-table';
 @import 'redash/query';
 @import 'redash/tags-control';
+@import 'redash/css-logo';
 
 
 

--- a/client/app/assets/less/redash/css-logo.less
+++ b/client/app/assets/less/redash/css-logo.less
@@ -1,8 +1,10 @@
 // based on https://github.com/outbrain/tech-companies-logos-in-css/pull/28
+
+@primary: #ff7964;
+@shadow: #ef6c58;
+@bar: white;
+
 #css-logo {
-  --primary: #ff7964;
-  --shadow: #ef6c58;
-  --bar: white;
   width: 100px;
   height: 100px;
   position: relative;
@@ -10,7 +12,7 @@
   #circle {
     width: 79px;
     height: 79px;
-    background-color: var(--shadow);
+    background-color: @shadow;
     border-radius: 50%;
     margin: auto;
     overflow: hidden;
@@ -19,7 +21,7 @@
     & > div {
       width: 79px;
       height: 73px;
-      background-color: var(--primary);
+      background-color: @primary;
       border-radius: 50%;
       position: absolute;
       top: 0;
@@ -36,8 +38,8 @@
     padding: 0 22px 0;
 
     .bar {
-      background: var(--bar);
-      box-shadow: 0px 2px 0 0 var(--shadow);
+      background: @bar;
+      box-shadow: 0px 2px 0 0 @shadow;
       display: inline-block;
       border-radius: 1px;
       align-self: flex-end;
@@ -68,7 +70,7 @@
     position: absolute;
     width: 0;
     height: 0;
-    border: 17px solid var(--shadow);
+    border: 17px solid @shadow;
     border-right-color: transparent !important;
     border-bottom-color: transparent !important;
     bottom: 0;
@@ -79,7 +81,7 @@
   
   #point > div {
     bottom: -12px;
-    border-color: var(--primary);
+    border-color: @primary;
     transform: scaleX(1.04);
     left: -17px;
   }

--- a/client/app/assets/less/redash/css-logo.less
+++ b/client/app/assets/less/redash/css-logo.less
@@ -1,0 +1,86 @@
+// based on https://github.com/outbrain/tech-companies-logos-in-css/pull/28
+#css-logo {
+  --primary: #ff7964;
+  --shadow: #ef6c58;
+  --bar: white;
+  width: 100px;
+  height: 100px;
+  position: relative;
+  
+  #circle {
+    width: 79px;
+    height: 79px;
+    background-color: var(--shadow);
+    border-radius: 50%;
+    margin: auto;
+    overflow: hidden;
+    position: relative;
+
+    & > div {
+      width: 79px;
+      height: 73px;
+      background-color: var(--primary);
+      border-radius: 50%;
+      position: absolute;
+      top: 0;
+    }
+  }
+  
+  #bars {
+    position: absolute;
+    left: 0;
+    top: 24px;
+    right: 0;
+    height: 33px;
+    display: flex;
+    padding: 0 22px 0;
+
+    .bar {
+      background: var(--bar);
+      box-shadow: 0px 2px 0 0 var(--shadow);
+      display: inline-block;
+      border-radius: 1px;
+      align-self: flex-end;
+      flex: 1;
+      margin: 0 2px;
+      border-radius: 3px;
+
+      &:nth-child(1) {
+        height: 32%;
+      }
+      
+      &:nth-child(2) {
+        height: 71%;
+      }
+      
+      &:nth-child(3) {
+        height: 50%;
+      }
+      
+      &:nth-child(4) {
+        height: 100%;
+      }
+    }
+  }
+  
+  #point,
+  #point > div {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: 17px solid var(--shadow);
+    border-right-color: transparent !important;
+    border-bottom-color: transparent !important;
+    bottom: 0;
+    left: 48px;
+    transform: scaleX(0.87);
+    transform-origin: left;
+  }
+  
+  #point > div {
+    bottom: -12px;
+    border-color: var(--primary);
+    transform: scaleX(1.04);
+    left: -17px;
+  }
+}

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -938,6 +938,57 @@ text.slicetext {
   font-weight: bold;
 }
 
+.loading-indicator {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  margin: -50px 0 0 -50px; // center
+  width: 100px;
+  height: 100px;
+  transition-duration: 150ms;
+  transition-timing-function: linear;
+  transition-property: opacity, transform;
+
+  #css-logo {
+    animation: hover 2s infinite;
+  }
+
+  shadow {
+    width: 33px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: black;
+    opacity: 0.25;
+    display: block;
+    position: absolute;
+    left: 34px;
+    top: 115px;
+    animation: shadow 2s infinite;
+  }
+
+  @keyframes hover {
+    50% {
+      transform: translateY(-5px);
+    }
+  }
+  @keyframes shadow {
+    50% {
+      transform: scaleX(0.9);
+      opacity: 0.2;
+    }
+  }
+}
+
+// hide indicator when app-view has content
+app-view:not(:empty) ~ .loading-indicator {
+  opacity: 0;
+  transform: scale(0.9);
+  pointer-events: none;
+
+  * {
+    animation: none !important;
+  }
+}
 .markdown img {
   max-width: 100%;
 }

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -938,6 +938,10 @@ text.slicetext {
   font-weight: bold;
 }
 
+.markdown img {
+  max-width: 100%;
+}
+
 .loading-indicator {
   position: fixed;
   top: 50%;
@@ -988,7 +992,4 @@ app-view:not(:empty) ~ .loading-indicator {
   * {
     animation: none !important;
   }
-}
-.markdown img {
-  max-width: 100%;
 }

--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -957,7 +957,7 @@ text.slicetext {
     animation: hover 2s infinite;
   }
 
-  shadow {
+  #shadow {
     width: 33px;
     height: 12px;
     border-radius: 50%;

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -41,7 +41,7 @@
             <div class="bar"></div>
           </div>
         </div>
-        <shadow></shadow>
+        <div id="shadow"></div>
       </div>
     </section>
   </body>

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -26,6 +26,23 @@
   <body ng-class="bodyClass">
     <section>
       <app-view></app-view>
+      <div class="loading-indicator">
+        <div id="css-logo">
+          <div id="circle">
+            <div></div>
+          </div>
+          <div id="point">
+            <div></div>
+          </div>
+          <div id="bars">
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+          </div>
+        </div>
+        <shadow></shadow>
+      </div>
     </section>
   </body>
 </html>

--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -41,7 +41,7 @@
             <div class="bar"></div>
           </div>
         </div>
-        <shadow></shadow>
+        <div id="shadow"></div>
       </div>
     </section>
   </body>

--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -26,6 +26,23 @@
   <body ng-class="bodyClass">
     <section>
       <app-view></app-view>
+      <div class="loading-indicator">
+        <div id="css-logo">
+          <div id="circle">
+            <div></div>
+          </div>
+          <div id="point">
+            <div></div>
+          </div>
+          <div id="bars">
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+          </div>
+        </div>
+        <shadow></shadow>
+      </div>
     </section>
   </body>
 </html>


### PR DESCRIPTION
- [x] Feature

## Description
Before app loads there might be a substantial wait for `<app-view>` to populate. Instead of looking at a blank screen, here's a nice hovering logo.

This is a css+html only change 😛
Even determining indicator hide/show is done with css, according to `<app-view>` being empty/full.

### Some notes
I created a new beautiful sleek animation with the bars but for some reason it's animation got stuck on the main thread. Don't know how since I used only gpu accelerated transition props. Anywho, this is good enough.

I only wish I didn't have to stick the entire html elements into `index.html` and it's twin brother.
Lmk if there's a way around that (independent of Angular/React).

## Mobile & Desktop Screenshots/Recordings

Before:

<img src="https://user-images.githubusercontent.com/486954/57583429-c7095880-748d-11e9-9fd8-7541318a06ee.gif" width=400 />

After:

<img src="https://user-images.githubusercontent.com/486954/57583430-ca044900-748d-11e9-8d7b-105f5d5d2bd4.gif" width=400 />


