### PR TITLE
Restrict markdown image dimensions

### DIFF
--- a/client/app/assets/less/redash/redash-newstyle.less
+++ b/client/app/assets/less/redash/redash-newstyle.less
@@ -937,3 +937,7 @@ text.slicetext {
 .markdown strong {
   font-weight: bold;
 }
+
+.markdown img {
+  max-width: 100%;
+}


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #3300 
Restricting max width to 100%. I don't think this poses any risk.

Before | After
------------ | -------------
<img width="642" alt="Screen Shot 2019-05-12 at 11 07 47" src="https://user-images.githubusercontent.com/486954/57585507-4c006c00-74a6-11e9-871d-c5f5f867fb1c.png"> | <img width="642" alt="Screen Shot 2019-05-12 at 11 07 33" src="https://user-images.githubusercontent.com/486954/57585508-50c52000-74a6-11e9-97f2-d02ee492e1fd.png">
