### PR TITLE
Update query to bring only name to make sure screenshots are consistent.

### DIFF
--- a/client/cypress/integration/embed/share_embed_spec.js
+++ b/client/cypress/integration/embed/share_embed_spec.js
@@ -6,7 +6,7 @@ describe('Embedded Queries', () => {
   });
 
   it('are shared without parameters', () => {
-    createQuery({ query: 'select * from users' })
+    createQuery({ query: 'select name from users' })
       .then((query) => {
         cy.visit(`/queries/${query.id}/source`);
         cy.getByTestId('ExecuteButton').click();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Otherwise the Percy snapshot will render different data everytime.