### PR TITLE
Visualization rendering getting cut in editor on first load

### DIFF
--- a/client/app/directives/resize-event.js
+++ b/client/app/directives/resize-event.js
@@ -4,20 +4,22 @@ const items = new Map();
 
 function checkItems() {
   items.forEach((item, node) => {
-    const offsetWidth = node.offsetWidth;
-    const offsetHeight = node.offsetHeight;
+    const bounds = node.getBoundingClientRect();
+    // convert to int (because these numbers needed for comparisons), but preserve 1 decimal point
+    const width = Math.round(bounds.width * 10);
+    const height = Math.round(bounds.height * 10);
 
     if (
-      (item.offsetWidth !== offsetWidth) ||
-      (item.offsetHeight !== offsetHeight)
+      (item.width !== width) ||
+      (item.height !== height)
     ) {
-      item.offsetWidth = offsetWidth;
-      item.offsetHeight = offsetHeight;
+      item.width = width;
+      item.height = height;
       item.callback(node);
     }
   });
 
-  setTimeout(checkItems, 50);
+  setTimeout(checkItems, 100);
 }
 
 checkItems(); // ensure it was called only once!


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Ant Modal has open/close animation (Bootstrap modal didn't), which affects `resize-event` directive: it uses `offsetWidth`/`offsetHeight` properties and does not take into account any sort of CSS transformations. Solution: use `getBoundingClientRect` which returns real element dimensions.

## Related Tickets & Documents

Fixes getredash/redash#3753
