### PR TITLE
Edit parameter mapping: error when trying to change mapping type to Static; cannot change static value

### DIFF
--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -154,6 +154,10 @@ export class ParameterMappingInput extends React.Component {
   updateParamMapping = (update) => {
     const { onChange, mapping } = this.props;
     const newMapping = extend({}, mapping, update);
+    if (newMapping.value !== mapping.value) {
+      newMapping.param = newMapping.param.clone();
+      newMapping.param.setValue(newMapping.value);
+    }
     onChange(newMapping);
   };
 

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -16,8 +16,7 @@ import Form from 'antd/lib/form';
 import Tooltip from 'antd/lib/tooltip';
 import { ParameterValueInput } from '@/components/ParameterValueInput';
 import { ParameterMappingType } from '@/services/widget';
-import { clientConfig } from '@/services/auth';
-import { Query, Parameter } from '@/services/query';
+import { Parameter } from '@/services/query';
 import { HelpTrigger } from '@/components/HelpTrigger';
 
 import './ParameterMappingInput.less';
@@ -120,8 +119,6 @@ export class ParameterMappingInput extends React.Component {
     mapping: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     existingParamNames: PropTypes.arrayOf(PropTypes.string),
     onChange: PropTypes.func,
-    clientConfig: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-    Query: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     inputError: PropTypes.string,
   };
 
@@ -129,8 +126,6 @@ export class ParameterMappingInput extends React.Component {
     mapping: {},
     existingParamNames: [],
     onChange: () => {},
-    clientConfig: null,
-    Query: null,
     inputError: null,
   };
 
@@ -228,9 +223,8 @@ export class ParameterMappingInput extends React.Component {
         value={mapping.param.normalizedValue}
         enumOptions={mapping.param.enumOptions}
         queryId={mapping.param.queryId}
+        parameter={mapping.param}
         onSelect={value => this.updateParamMapping({ value })}
-        clientConfig={this.props.clientConfig}
-        Query={this.props.Query}
       />
     );
   }
@@ -345,8 +339,6 @@ class MappingEditor extends React.Component {
           mapping={mapping}
           existingParamNames={this.props.existingParamNames}
           onChange={this.onChange}
-          clientConfig={clientConfig}
-          Query={Query}
           inputError={inputError}
         />
         <footer>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

1. When editing parameter mapping for query-based parameter, changing it's type to static shows error in console: ![image](https://user-images.githubusercontent.com/12139186/57701829-7cdacf80-7665-11e9-80f3-c1f21bbc7aa4.png) Solution: pass required property to component.
2. Cannot change parameter mapping's static value (bug in data flow between components).
3. Some cleanup (removed unused properties).