### PR TITLE
Fix "Now" in DateTime parameter not working

### DIFF
--- a/client/app/components/DateTimeInput.jsx
+++ b/client/app/components/DateTimeInput.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import DatePicker from 'antd/lib/date-picker';
@@ -13,20 +13,21 @@ export function DateTimeInput({
 }) {
   const format = (clientConfig.dateFormat || 'YYYY-MM-DD') +
     (withSeconds ? ' HH:mm:ss' : ' HH:mm');
-  let defaultValue;
+  const additionalAttributes = {};
   if (value && value.isValid()) {
-    defaultValue = value;
+    additionalAttributes.defaultValue = value;
   }
-  const [currentValue, setCurrentValue] = useState(defaultValue);
+  const currentValueRef = useRef(additionalAttributes.defaultValue);
   return (
     <DatePicker
       className={className}
       showTime
-      value={currentValue}
+      {...additionalAttributes}
       format={format}
       placeholder="Select Date and Time"
-      onChange={newValue => setCurrentValue(newValue)}
+      onChange={(newValue) => { currentValueRef.current = newValue; }}
       onOpenChange={(status) => {
+        const currentValue = currentValueRef.current;
         if (!status) { // on close picker
           if (currentValue && currentValue.isValid()) {
             onSelect(currentValue);

--- a/client/app/components/DateTimeInput.jsx
+++ b/client/app/components/DateTimeInput.jsx
@@ -1,58 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import DatePicker from 'antd/lib/date-picker';
 import { clientConfig } from '@/services/auth';
 import { Moment } from '@/components/proptypes';
 
-export class DateTimeInput extends React.Component {
-  static propTypes = {
-    value: Moment,
-    withSeconds: PropTypes.bool,
-    onSelect: PropTypes.func,
-    className: PropTypes.string,
-  };
-
-  static defaultProps = {
-    value: null,
-    withSeconds: false,
-    onSelect: () => {},
-    className: '',
-  };
-
-  constructor(props) {
-    super(props);
-    const { value } = props;
-    this.state = { currentValue: value && value.isValid() ? value : null, open: false };
+export function DateTimeInput({
+  value,
+  withSeconds,
+  onSelect,
+  className,
+}) {
+  const format = (clientConfig.dateFormat || 'YYYY-MM-DD') +
+    (withSeconds ? ' HH:mm:ss' : ' HH:mm');
+  let defaultValue;
+  if (value && value.isValid()) {
+    defaultValue = value;
   }
-
-  render() {
-    const { withSeconds, onSelect, className } = this.props;
-    const format = (clientConfig.dateFormat || 'YYYY-MM-DD') +
-      (withSeconds ? ' HH:mm:ss' : ' HH:mm');
-
-    return (
-      <DatePicker
-        className={className}
-        showTime
-        value={this.state.currentValue}
-        format={format}
-        placeholder="Select Date and Time"
-        onChange={newValue => this.setState({ currentValue: newValue })}
-        onOpenChange={(status) => {
-          this.setState({ open: status }, () => {
-            const { open, currentValue } = this.state;
-            if (!open) { // on close picker
-              if (currentValue && currentValue.isValid()) {
-                onSelect(currentValue);
-              }
-            }
-          });
-        }}
-      />
-    );
-  }
+  const [currentValue, setCurrentValue] = useState(defaultValue);
+  return (
+    <DatePicker
+      className={className}
+      showTime
+      value={currentValue}
+      format={format}
+      placeholder="Select Date and Time"
+      onChange={newValue => setCurrentValue(newValue)}
+      onOpenChange={(status) => {
+        if (!status) { // on close picker
+          if (currentValue && currentValue.isValid()) {
+            onSelect(currentValue);
+          }
+        }
+      }}
+    />
+  );
 }
+
+DateTimeInput.propTypes = {
+  value: Moment,
+  withSeconds: PropTypes.bool,
+  onSelect: PropTypes.func,
+  className: PropTypes.string,
+};
+
+DateTimeInput.defaultProps = {
+  value: null,
+  withSeconds: false,
+  onSelect: () => {},
+  className: '',
+};
 
 export default function init(ngModule) {
   ngModule.component('dateTimeInput', react2angular(DateTimeInput));

--- a/client/app/components/DateTimeInput.jsx
+++ b/client/app/components/DateTimeInput.jsx
@@ -1,55 +1,58 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import DatePicker from 'antd/lib/date-picker';
 import { clientConfig } from '@/services/auth';
 import { Moment } from '@/components/proptypes';
 
-export function DateTimeInput({
-  value,
-  withSeconds,
-  onSelect,
-  className,
-}) {
-  const format = (clientConfig.dateFormat || 'YYYY-MM-DD') +
-    (withSeconds ? ' HH:mm:ss' : ' HH:mm');
-  let defaultValue;
-  if (value && value.isValid()) {
-    defaultValue = value;
+export class DateTimeInput extends React.Component {
+  static propTypes = {
+    value: Moment,
+    withSeconds: PropTypes.bool,
+    onSelect: PropTypes.func,
+    className: PropTypes.string,
+  };
+
+  static defaultProps = {
+    value: null,
+    withSeconds: false,
+    onSelect: () => {},
+    className: '',
+  };
+
+  constructor(props) {
+    super(props);
+    const { value } = props;
+    this.state = { currentValue: value && value.isValid() ? value : null, open: false };
   }
-  const [currentValue, setCurrentValue] = useState(defaultValue);
-  return (
-    <DatePicker
-      className={className}
-      showTime
-      value={currentValue}
-      format={format}
-      placeholder="Select Date and Time"
-      onChange={newValue => setCurrentValue(newValue)}
-      onOpenChange={(status) => {
-        if (!status) { // on close picker
-          if (currentValue && currentValue.isValid()) {
-            onSelect(currentValue);
-          }
-        }
-      }}
-    />
-  );
+
+  render() {
+    const { withSeconds, onSelect, className } = this.props;
+    const format = (clientConfig.dateFormat || 'YYYY-MM-DD') +
+      (withSeconds ? ' HH:mm:ss' : ' HH:mm');
+
+    return (
+      <DatePicker
+        className={className}
+        showTime
+        value={this.state.currentValue}
+        format={format}
+        placeholder="Select Date and Time"
+        onChange={newValue => this.setState({ currentValue: newValue })}
+        onOpenChange={(status) => {
+          this.setState({ open: status }, () => {
+            const { open, currentValue } = this.state;
+            if (!open) { // on close picker
+              if (currentValue && currentValue.isValid()) {
+                onSelect(currentValue);
+              }
+            }
+          });
+        }}
+      />
+    );
+  }
 }
-
-DateTimeInput.propTypes = {
-  value: Moment,
-  withSeconds: PropTypes.bool,
-  onSelect: PropTypes.func,
-  className: PropTypes.string,
-};
-
-DateTimeInput.defaultProps = {
-  value: null,
-  withSeconds: false,
-  onSelect: () => {},
-  className: '',
-};
 
 export default function init(ngModule) {
   ngModule.component('dateTimeInput', react2angular(DateTimeInput));

--- a/client/app/components/DateTimeRangeInput.jsx
+++ b/client/app/components/DateTimeRangeInput.jsx
@@ -1,5 +1,5 @@
 import { isArray } from 'lodash';
-import React, { useState } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import DatePicker from 'antd/lib/date-picker';
@@ -16,19 +16,20 @@ export function DateTimeRangeInput({
 }) {
   const format = (clientConfig.dateFormat || 'YYYY-MM-DD') +
     (withSeconds ? ' HH:mm:ss' : ' HH:mm');
-  let defaultValue;
+  const additionalAttributes = {};
   if (isArray(value) && value[0].isValid() && value[1].isValid()) {
-    defaultValue = value;
+    additionalAttributes.defaultValue = value;
   }
-  const [currentValue, setCurrentValue] = useState(defaultValue);
+  const currentValueRef = useRef(additionalAttributes.defaultValue);
   return (
     <RangePicker
       className={className}
       showTime
-      value={currentValue}
+      {...additionalAttributes}
       format={format}
-      onChange={newValue => setCurrentValue(newValue)}
+      onChange={(newValue) => { currentValueRef.current = newValue; }}
       onOpenChange={(status) => {
+        const currentValue = currentValueRef.current;
         if (!status) { // on close picker
           if (isArray(currentValue) && currentValue[0].isValid() && currentValue[1].isValid()) {
             onSelect(currentValue);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
I did find the cause for this bug, but with DatePicker methods and our current needs the only way I could think as a fix was to create an "unnecessary" state. Leaving this as WIP so @ranbena and @kravets-levko can join here (also I have to extend the fix to `DateTimeRangeInput` as a guarantee).

Antd's DatePicker provides the following callbacks:
- `onChange`: Triggered whenever you change the value on the dialog
- `onOk`: Triggered only when you click "ok"
- `onOpenChange`: Triggered when you open/close the dialog

`onOpenChange` seemed to be the most reliable event to trigger the update for the Query, so I used it by adding a state to track the value.

The cause for the issue: when you click "Now" it invokes `onChange` -> `onOpenChange` fast enough that the component doesn't update.
The workaround in this PR: Considering that React guarantees the order for `setState` I added a new state to use its callback to make sure `currentValue` would be updated.

BTW, `onOk` may seem a good solution, but it's not triggered when you click on "Now".

An alternative is to add the "Apply" button for this too, so the update event could be `onChange` with no problems. The con is that it's not the best to have both "Ok" and "Apply" to set the parameter.

Edit:
- Updated to use `useRef` instead.
## Related Tickets & Documents
Closes #3803
 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Dashboard**
![now-dashboard](https://user-images.githubusercontent.com/3356951/57851562-41501a80-77b7-11e9-848c-ed1e457f3d4f.gif)

**Query**
![now-query](https://user-images.githubusercontent.com/3356951/57851694-98ee8600-77b7-11e9-982f-f2b5584f6718.gif)
