### PR TITLE
Update Data Source Lifecycle Events

### DIFF
--- a/client/app/pages/data-sources/DataSourcesList.jsx
+++ b/client/app/pages/data-sources/DataSourcesList.jsx
@@ -12,6 +12,7 @@ import CardsList from '@/components/cards-list/CardsList';
 import LoadingState from '@/components/items-list/components/LoadingState';
 import CreateSourceDialog from '@/components/CreateSourceDialog';
 import helper from '@/components/dynamic-form/dynamicFormHelper';
+import recordEvent from '@/services/recordEvent';
 
 class DataSourcesList extends React.Component {
   state = {
@@ -56,6 +57,7 @@ class DataSourcesList extends React.Component {
   };
 
   showCreateSourceDialog = () => {
+    recordEvent('view', 'page', 'data_sources/new');
     CreateSourceDialog.showModal({
       types: this.state.dataSourceTypes,
       sourceType: 'Data Source',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This updates Data Source Lifecycle Events.

- Add event when someone opens the new data source dialog.
- Add event when someone edits a data source (on the backend) - didn't add the edited keys, but tell me if this adds value.
- Update Test Connection event to include result of test - result added in a `result` key.

Note: Backend-wise the name for the `object_type` is "datasource" and in the frontend it is "data_source", I didn't change this as it could break existing tracking, but lmk if I should.

## Related Tickets & Documents
Closes #3787.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--