### PR TITLE
Fix for Mac browser’s scrollbar obscuring content

### DIFF
--- a/client/app/components/app-view/index.js
+++ b/client/app/components/app-view/index.js
@@ -37,6 +37,10 @@ class AppViewComponent {
     this.layout = layouts.defaultSignedOut;
     this.handler = handler;
 
+    // remove when fix lands
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=914844#c36
+    $rootScope.platform = navigator.platform;
+
     $rootScope.$on('$routeChangeStart', (event, route) => {
       this.handler.reset();
 

--- a/client/app/components/dynamic-table/dynamic-table.less
+++ b/client/app/components/dynamic-table/dynamic-table.less
@@ -1,6 +1,13 @@
 .dynamic-table-container {
   overflow-x: auto;
 
+  // remove when fix lands
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=914844#c36
+  body[data-platform^="Mac"] & {
+    padding-bottom: 10px; // workaround for Mac browser's scrollbar obscuring content
+    margin-bottom: -10px; // compensation for above
+  }
+
   th {
     white-space: nowrap;
     span {

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -23,7 +23,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
   </head>
 
-  <body ng-class="bodyClass">
+  <body ng-class="bodyClass" ng-attr-data-platform="{{platform}}">
     <section>
       <app-view></app-view>
       <div class="loading-indicator">

--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -23,7 +23,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
   </head>
 
-  <body ng-class="bodyClass">
+  <body ng-class="bodyClass" ng-attr-data-platform="{{platform}}">
     <section>
       <app-view></app-view>
       <div class="loading-indicator">


### PR DESCRIPTION
- [x] Bug Fix

## Description
In table visualizations two visual bugs occur on Mac browsers (FF, SF, CH):
1. Scrollbar obscures table content. Solved in this PR.
2. After scroll the bar doesn't disappear in CH, SF. There's an [open bug for it](https://bugs.chromium.org/p/chromium/issues/detail?id=914844#c36) and very recent discussions.

## Mobile & Desktop Screenshots

Before:

<img width="826" alt="Screen Shot 2019-05-24 at 18 48 52" src="https://user-images.githubusercontent.com/486954/58362606-28e69c80-7e56-11e9-9cc9-dda684032600.png">

After:

<img width="823" alt="Screen Shot 2019-05-24 at 18 48 35" src="https://user-images.githubusercontent.com/486954/58362610-2dab5080-7e56-11e9-86c8-5be34a0a22d0.png">