### PR TITLE
Fix: Avoid sending query identifier to /jobs (when authenticated)

### DIFF
--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -338,9 +338,10 @@ function QueryResultService($resource, $timeout, $q, QueryResultError, Auth) {
       const loadResult = () => (Auth.isAuthenticated()
         ? this.loadResult()
         : this.loadLatestCachedResult(query, parameters));
+      const params = Auth.isAuthenticated() ? { id: this.job.id } : { queryId: query, id: this.job.id };
 
       resource.get(
-        { queryId: query, id: this.job.id },
+        params,
         (jobResponse) => {
           this.update(jobResponse);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
The query identifier is sent over to `/jobs` to correlate with query API keys (for public embeds and dashboards). However, when properly authenticated, there's no need to send that over.

One consequence of sending over the superfluous argument in authenticated sessions is when editing queries, where `query` is the actual query text. When it gets added as a parameter to the `/jobs` endpoint, it could max out the URL size and error for large queries.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
