### PR TITLE
Unsupported browser redirect script outputted to file

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -5,18 +5,7 @@
     <meta charset="UTF-8">
     <base href="/">
     <title>Redash</title>
-    <script>
-      function onIE() {
-        window.location.href = '/static/unsupported';
-      }
-      if (
-        navigator.userAgent.match('MSIE') || // IE10
-        navigator.appVersion.match('Trident/') // IE11
-      ){
-        onIE();
-      }
-    </script>
-    <!--[if IE]><script>onIE()</script><![endif]-->
+    <script src="/static/unsupportedRedirect.js" async></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/static/images/favicon-96x96.png">

--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -5,18 +5,7 @@
     <meta charset="UTF-8">
     <base href="{{base_href}}">
     <title>Redash</title>
-    <script>
-      function onIE() {
-        window.location.href = '/static/unsupported';
-      }
-      if (
-        navigator.userAgent.match('MSIE') || // IE10
-        navigator.appVersion.match('Trident/') // IE11
-      ){
-        onIE();
-      }
-    </script>
-    <!--[if IE]><script>onIE()</script><![endif]-->
+    <script src="/static/unsupportedRedirect.js" async></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/static/images/favicon-96x96.png">

--- a/client/app/unsupportedRedirect.js
+++ b/client/app/unsupportedRedirect.js
@@ -1,0 +1,6 @@
+if (
+  navigator.appVersion.match('Trident/') || // IE8-11
+  'ActiveXObject' in window // IE<11
+) {
+  window.location.href = '/static/unsupported';
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,7 @@ const config = {
     new CopyWebpackPlugin([
       { from: "client/app/assets/robots.txt" },
       { from: "client/app/unsupported.html" },
+      { from: "client/app/unsupportedRedirect.js" },
       { from: "client/app/assets/css/*.css", to: "styles/", flatten: true },
       { from: "node_modules/jquery/dist/jquery.min.js", to: "js/jquery.min.js" }
     ])


### PR DESCRIPTION
- [x] Refactor
- [x] Bug Fix

## Description
Fixes #3816.

* Moved browser detection/redirect script to file in order to comply with csp directive.
* Made script [async](https://caniuse.com/#feat=script-async) for optimal perf.
* Used alternative method to detect IE<12 to allow above method.

Script now executing asynchronously. Console error gone.