### PR TITLE
chore: Add handy make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compose_build up test_db create_database clean down bundle tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
+.PHONY: compose_build up test_db create_database seed_database clean down bundle tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
 
 compose_build:
 	docker-compose build
@@ -15,6 +15,10 @@ test_db:
 
 create_database:
 	docker-compose run server create_db
+
+seed_database:
+	docker-compose exec server \
+		curl -d "name=Example Admin" -d "email=admin@redash.io" -d "password=password" -d "org_name=Redash" http://localhost:5000/setup
 
 clean:
 	docker-compose down && docker-compose rm


### PR DESCRIPTION
Hi there ✋ 

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [x] Other

## Description
This is a handy command to create dev env `$ make seed_database` which can skip creating the admin user step.

My usecase:
```
$ make up
$ make create_database
$ make seed_database
```

## Related Tickets & Documents
https://github.com/getredash/redash/blob/master/client/cypress/cypress.js#L9

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
