### PR TITLE
Upgrade gspread 3.1.0 for supporting team drive

### DIFF
--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import gspread
+    from gspread.httpsession import HTTPSession
     from oauth2client.service_account import ServiceAccountCredentials
 
     enabled = True
@@ -165,7 +166,11 @@ class GoogleSpreadsheet(BaseQueryRunner):
         key = json_loads(b64decode(self.configuration['jsonKeyFile']))
         creds = ServiceAccountCredentials.from_json_keyfile_dict(key, scope)
 
-        return gspread.authorize(creds)
+        timeout_session = HTTPSession()
+        timeout_session.requests_session = TimeoutSession()
+        spreadsheetservice = gspread.Client(auth=creds, http_session=timeout_session)
+        spreadsheetservice.login()
+        return spreadsheetservice
 
     def test_connection(self):
         self._get_spreadsheet_service()

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 try:
     import gspread
-    from gspread.httpsession import HTTPSession
     from oauth2client.service_account import ServiceAccountCredentials
 
     enabled = True
@@ -166,11 +165,7 @@ class GoogleSpreadsheet(BaseQueryRunner):
         key = json_loads(b64decode(self.configuration['jsonKeyFile']))
         creds = ServiceAccountCredentials.from_json_keyfile_dict(key, scope)
 
-        timeout_session = HTTPSession()
-        timeout_session.requests_session = TimeoutSession()
-        spreadsheetservice = gspread.Client(auth=creds, http_session=timeout_session)
-        spreadsheetservice.login()
-        return spreadsheetservice
+        return gspread.authorize(creds)
 
     def test_connection(self):
         self._get_spreadsheet_service()

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 try:
     import gspread
-    from gspread.httpsession import HTTPSession
     from oauth2client.service_account import ServiceAccountCredentials
 
     enabled = True
@@ -166,9 +165,9 @@ class GoogleSpreadsheet(BaseQueryRunner):
         key = json_loads(b64decode(self.configuration['jsonKeyFile']))
         creds = ServiceAccountCredentials.from_json_keyfile_dict(key, scope)
 
-        timeout_session = HTTPSession()
+        timeout_session = Session()
         timeout_session.requests_session = TimeoutSession()
-        spreadsheetservice = gspread.Client(auth=creds, http_session=timeout_session)
+        spreadsheetservice = gspread.Client(auth=creds, session=timeout_session)
         spreadsheetservice.login()
         return spreadsheetservice
 

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -134,6 +134,10 @@ class GoogleSpreadsheet(BaseQueryRunner):
     @classmethod
     def annotate_query(cls):
         return False
+    
+    @classmethod
+    def name(cls):
+        return "Google Sheets"
 
     @classmethod
     def type(cls):

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,5 +1,5 @@
 google-api-python-client==1.5.1
-gspread==0.6.2
+gspread==3.1.0
 impyla==0.10.0
 influxdb==2.7.1
 MySQL-python==1.2.5

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,5 +1,5 @@
 google-api-python-client==1.5.1
-gspread==3.1.0
+gspread==0.6.2
 impyla==0.10.0
 influxdb==2.7.1
 MySQL-python==1.2.5


### PR DESCRIPTION
Hi there ✋ 

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
google spreadsheet on team drive was not supported by redash due to using old API version of google API.  So, upgrade gspread to the latest version.

## Related Tickets & Documents
- https://discuss.redash.io/t/google-spreadsheet-not-found/3620/
- https://github.com/getredash/redash/pull/2608

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
