### PR TITLE
CSV: correctly serialize booleans and dates.

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -12,6 +12,7 @@ from redash.tasks import QueryTask
 from redash.tasks.queries import enqueue_query
 from redash.utils import (collect_parameters_from_request, gen_query_hash, json_dumps, utcnow, to_filename)
 from redash.models.parameterized_query import ParameterizedQuery, InvalidParameterError, dropdown_values
+from redash.serializers import serialize_query_result_to_csv, serialize_query_result_to_xlsx
 
 
 def error_response(message):
@@ -279,12 +280,12 @@ class QueryResultResource(BaseResource):
     @staticmethod
     def make_csv_response(query_result):
         headers = {'Content-Type': "text/csv; charset=UTF-8"}
-        return make_response(query_result.make_csv_content(), 200, headers)
+        return make_response(serialize_query_result_to_csv(query_result), 200, headers)
 
     @staticmethod
     def make_excel_response(query_result):
         headers = {'Content-Type': "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}
-        return make_response(query_result.make_excel_content(), 200, headers)
+        return make_response(serialize_query_result_to_xlsx(query_result), 200, headers)
 
 
 class JobResource(BaseResource):

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -12,6 +12,8 @@ from redash.permissions import has_access, view_only
 from redash.utils import json_loads
 from redash.models.parameterized_query import ParameterizedQuery
 
+from .query_result import serialize_query_result_to_csv, serialize_query_result_to_xlsx
+
 
 def public_widget(widget):
     res = {

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -21,11 +21,9 @@ def _get_column_lists(columns):
         fieldnames.append(col['name'])
         if col['type'] == TYPE_BOOLEAN:
             bool_columns.append(col['name'])
-     
-        if col['type'] == TYPE_DATE:
+        elif col['type'] == TYPE_DATE:
             date_columns.append(col['name'])
-
-        if col['type'] == TYPE_DATETIME:
+        elif col['type'] == TYPE_DATETIME:
             datetime_columns.append(col['name'])
     
     return fieldnames, bool_columns, date_columns, datetime_columns

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -11,17 +11,13 @@ def convert_format(fmt):
     return fmt.replace('DD', '%d').replace('MM', '%m').replace('YYYY', '%Y').replace('YY', '%y').replace('HH', '%H').replace('mm', '%M').replace('ss', '%s')
 
 
-def serialize_query_result_to_csv(query_result):
-    s = cStringIO.StringIO()
-
-    query_data = json_loads(query_result.data)
-
+def _get_column_lists(columns):
     fieldnames = []
     bool_columns = []
     date_columns = []
     datetime_columns = []
 
-    for col in query_data['columns']:
+    for col in columns:
         fieldnames.append(col['name'])
         if col['type'] == TYPE_BOOLEAN:
             bool_columns.append(col['name'])
@@ -31,8 +27,18 @@ def serialize_query_result_to_csv(query_result):
 
         if col['type'] == TYPE_DATETIME:
             datetime_columns.append(col['name'])
+    
+    return fieldnames, bool_columns, date_columns, datetime_columns
 
-    writer = csv.DictWriter(s, extrasaction="ignore", fieldnames=[col['name'] for col in query_data['columns']])
+
+def serialize_query_result_to_csv(query_result):
+    s = cStringIO.StringIO()
+
+    query_data = json_loads(query_result.data)
+
+    fieldnames, bool_columns, date_columns, datetime_columns = _get_column_lists(query_data['columns'])
+
+    writer = csv.DictWriter(s, extrasaction="ignore", fieldnames=fieldnames)
     writer.writer = UnicodeWriter(s)
     writer.writeheader()
 

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -10,6 +10,7 @@ from redash.authentication.org_resolving import current_org
 def convert_format(fmt):
     return fmt.replace('DD', '%d').replace('MM', '%m').replace('YYYY', '%Y').replace('YY', '%y').replace('HH', '%H').replace('mm', '%M').replace('ss', '%s')
 
+
 def serialize_query_result_to_csv(query_result):
     s = cStringIO.StringIO()
 
@@ -24,7 +25,7 @@ def serialize_query_result_to_csv(query_result):
         fieldnames.append(col['name'])
         if col['type'] == TYPE_BOOLEAN:
             bool_columns.append(col['name'])
-        
+     
         if col['type'] == TYPE_DATE:
             date_columns.append(col['name'])
 
@@ -34,13 +35,13 @@ def serialize_query_result_to_csv(query_result):
     writer = csv.DictWriter(s, extrasaction="ignore", fieldnames=[col['name'] for col in query_data['columns']])
     writer.writer = UnicodeWriter(s)
     writer.writeheader()
-    for row in query_data['rows']:
 
+    for row in query_data['rows']:
         for col in bool_columns:
             if col in row:
-                if row[col] == True:
+                if row[col] is True:
                     row[col] = "true"
-                elif row[col] == False:
+                elif row[col] is False:
                     row[col] = "false"
         
         for col in date_columns:
@@ -61,7 +62,6 @@ def serialize_query_result_to_csv(query_result):
 
                 fmt = convert_format('{} {}'.format(current_org.get_setting('date_format'), current_org.get_setting('time_format')))
                 row[col] = parsed.strftime(fmt)
-
 
         writer.writerow(row)
 

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -1,0 +1,92 @@
+import cStringIO
+import csv
+import xlsxwriter
+from dateutil.parser import parse as parse_date
+from redash.utils import json_loads, UnicodeWriter
+from redash.query_runner import (TYPE_BOOLEAN, TYPE_DATE, TYPE_DATETIME)
+from redash.authentication.org_resolving import current_org
+
+
+def convert_format(fmt):
+    return fmt.replace('DD', '%d').replace('MM', '%m').replace('YYYY', '%Y').replace('YY', '%y').replace('HH', '%H').replace('mm', '%M').replace('ss', '%s')
+
+def serialize_query_result_to_csv(query_result):
+    s = cStringIO.StringIO()
+
+    query_data = json_loads(query_result.data)
+
+    fieldnames = []
+    bool_columns = []
+    date_columns = []
+    datetime_columns = []
+
+    for col in query_data['columns']:
+        fieldnames.append(col['name'])
+        if col['type'] == TYPE_BOOLEAN:
+            bool_columns.append(col['name'])
+        
+        if col['type'] == TYPE_DATE:
+            date_columns.append(col['name'])
+
+        if col['type'] == TYPE_DATETIME:
+            datetime_columns.append(col['name'])
+
+    writer = csv.DictWriter(s, extrasaction="ignore", fieldnames=[col['name'] for col in query_data['columns']])
+    writer.writer = UnicodeWriter(s)
+    writer.writeheader()
+    for row in query_data['rows']:
+
+        for col in bool_columns:
+            if col in row:
+                if row[col] == True:
+                    row[col] = "true"
+                elif row[col] == False:
+                    row[col] = "false"
+        
+        for col in date_columns:
+            if not row[col]:
+                continue
+
+            if col in row:
+                parsed = parse_date(row[col])
+
+                row[col] = parsed.strftime(convert_format(current_org.get_setting('date_format')))
+
+        for col in datetime_columns:
+            if not row[col]:
+                continue
+
+            if col in row:
+                parsed = parse_date(row[col])
+
+                fmt = convert_format('{} {}'.format(current_org.get_setting('date_format'), current_org.get_setting('time_format')))
+                row[col] = parsed.strftime(fmt)
+
+
+        writer.writerow(row)
+
+    return s.getvalue()
+
+
+def serialize_query_result_to_xlsx(query_result):
+    s = cStringIO.StringIO()
+
+    query_data = json_loads(query_result.data)
+    book = xlsxwriter.Workbook(s, {'constant_memory': True})
+    sheet = book.add_worksheet("result")
+
+    column_names = []
+    for (c, col) in enumerate(query_data['columns']):
+        sheet.write(0, c, col['name'])
+        column_names.append(col['name'])
+
+    for (r, row) in enumerate(query_data['rows']):
+        for (c, name) in enumerate(column_names):
+            v = row.get(name)
+            if isinstance(v, list) or isinstance(v, dict):
+                v = str(v).encode('utf-8')
+            sheet.write(r + 1, c, v)
+
+    book.close()
+
+    return s.getvalue()

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -4,7 +4,7 @@ import datetime
 from tests import BaseTestCase
 
 from redash import models
-from redash.utils import utcnow
+from redash.utils import utcnow, json_dumps
 
 
 class QueryResultTest(BaseTestCase):

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -22,15 +22,14 @@ data = {
     ]
 }
 
-def get_csv_content(factory):
-    query_result = factory.create_query_result(data=json_dumps(data))
-    return serialize_query_result_to_csv(query_result)
-
-
 class CsvSerializationTest(BaseTestCase):
+    def get_csv_content(self):
+        query_result = self.factory.create_query_result(data=json_dumps(data))
+        return serialize_query_result_to_csv(query_result)
+
     def test_serializes_booleans_correctly(self):
         with self.app.test_request_context('/'):
-            parsed = csv.DictReader(cStringIO.StringIO(get_csv_content(self.factory)))
+            parsed = csv.DictReader(cStringIO.StringIO(self.get_csv_content()))
         rows = list(parsed)
 
         self.assertEqual(rows[0]['bool'], 'true')
@@ -39,7 +38,7 @@ class CsvSerializationTest(BaseTestCase):
 
     def test_serializes_datatime_with_correct_format(self):
         with self.app.test_request_context('/'):
-            parsed = csv.DictReader(cStringIO.StringIO(get_csv_content(self.factory)))
+            parsed = csv.DictReader(cStringIO.StringIO(self.get_csv_content()))
         rows = list(parsed)
 
         self.assertEqual(rows[0]['datetime'], '26/05/19 12:39')

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -1,0 +1,54 @@
+import datetime
+import csv
+import cStringIO
+
+from tests import BaseTestCase
+
+from redash import models
+from redash.utils import utcnow, json_dumps
+from redash.serializers import serialize_query_result_to_csv
+
+
+data = {
+    "rows": [
+        {"datetime": "2019-05-26T12:39:23.026Z", "bool": True, "date": "2019-05-26"},
+        {"datetime": "", "bool": False, "date": ""},
+        {"datetime": None, "bool": None, "date": None},
+    ], 
+    "columns": [
+        {"friendly_name": "bool", "type": "boolean", "name": "bool"}, 
+        {"friendly_name": "date", "type": "datetime", "name": "datetime"},
+        {"friendly_name": "date", "type": "date", "name": "date"}
+    ]
+}
+
+def get_csv_content(factory):
+    query_result = factory.create_query_result(data=json_dumps(data))
+    return serialize_query_result_to_csv(query_result)
+
+
+class CsvSerializationTest(BaseTestCase):
+    def test_serializes_booleans_correctly(self):
+        with self.app.test_request_context('/'):
+            parsed = csv.DictReader(cStringIO.StringIO(get_csv_content(self.factory)))
+        rows = list(parsed)
+
+        self.assertEqual(rows[0]['bool'], 'true')
+        self.assertEqual(rows[1]['bool'], 'false')
+        self.assertEqual(rows[2]['bool'], '')
+
+    def test_serializes_datatime_with_correct_format(self):
+        with self.app.test_request_context('/'):
+            parsed = csv.DictReader(cStringIO.StringIO(get_csv_content(self.factory)))
+        rows = list(parsed)
+
+        self.assertEqual(rows[0]['datetime'], '26/05/19 12:39')
+        self.assertEqual(rows[1]['datetime'], '')
+        self.assertEqual(rows[2]['datetime'], '')
+        self.assertEqual(rows[0]['date'], '26/05/19')
+        self.assertEqual(rows[1]['date'], '')
+        self.assertEqual(rows[2]['date'], '')
+
+
+
+

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -48,7 +48,3 @@ class CsvSerializationTest(BaseTestCase):
         self.assertEqual(rows[0]['date'], '26/05/19')
         self.assertEqual(rows[1]['date'], '')
         self.assertEqual(rows[2]['date'], '')
-
-
-
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

When downloading CSV version of a query result, it will:

1. Serialize booleans as `true`/`false` (instead of `True`/`False`).
2. Serialize date/time using the organization format for date/time.

## Related Tickets & Documents

Closes #3736, closes #2751.
