### PR TITLE
Add support ssl connections to redis

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -48,7 +48,7 @@ def create_redis_connection():
 
         client = redis.StrictRedis(unix_socket_path=redis_url.path, db=db)
     else:
-        use_ssl = False
+        use_ssl = redis_url.scheme == 'rediss'
 
         if redis_url.scheme == 'rediss':
             use_ssl = True

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -50,9 +50,6 @@ def create_redis_connection():
     else:
         use_ssl = redis_url.scheme == 'rediss'
 
-        if redis_url.scheme == 'rediss':
-            use_ssl = True
-
         if redis_url.path:
             redis_db = redis_url.path[1]
         else:

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -48,13 +48,18 @@ def create_redis_connection():
 
         client = redis.StrictRedis(unix_socket_path=redis_url.path, db=db)
     else:
+        use_ssl = False
+
+        if redis_url.scheme == 'rediss':
+            use_ssl = True
+
         if redis_url.path:
             redis_db = redis_url.path[1]
         else:
             redis_db = 0
         # Redis passwords might be quoted with special characters
         redis_password = redis_url.password and urllib.unquote(redis_url.password)
-        client = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_password)
+        client = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_password, ssl=use_ssl)
 
     return client
 

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -59,7 +59,9 @@ def create_redis_connection():
             redis_db = 0
         # Redis passwords might be quoted with special characters
         redis_password = redis_url.password and urllib.unquote(redis_url.password)
-        client = redis.StrictRedis(host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_password, ssl=use_ssl)
+        client = redis.StrictRedis(
+            host=redis_url.hostname, port=redis_url.port, db=redis_db, password=redis_password,
+            ssl=use_ssl)
 
     return client
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -36,7 +36,7 @@ CELERY_SSL_CONFIG = {
     'ssl_cert_reqs': int(os.environ.get("REDASH_CELERY_BROKER_SSL_CERT_REQS",  ssl.CERT_OPTIONAL)),
     'ssl_ca_certs': os.environ.get("REDASH_CELERY_BROKER_SSL_CA_CERTS"),
     'ssl_certfile': os.environ.get("REDASH_CELERY_BROKER_SSL_CERTFILE"),
-    'ssl_keyfilefile': os.environ.get("REDASH_CELERY_BROKER_SSL_KEYFILE"),
+    'ssl_keyfile': os.environ.get("REDASH_CELERY_BROKER_SSL_KEYFILE"),
 } if CELERY_BROKER_USE_SSL else None
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -31,12 +31,13 @@ CELERY_RESULT_BACKEND = os.environ.get(
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))
+CELERY_BROKER_USE_SSL = CELERY_BROKER.startswith('rediss')
 CELERY_SSL_CONFIG = {
-    'ssl_cert_reqs': int(os.environ.get("REDASH_CELERY_BROKER_SSL_CERT_REQS",  ssl.CERT_OPTIONAL if CELERY_BROKER.startswith('rediss') else ssl.CERT_NONE)),
+    'ssl_cert_reqs': int(os.environ.get("REDASH_CELERY_BROKER_SSL_CERT_REQS",  ssl.CERT_OPTIONAL)),
     'ssl_ca_certs': os.environ.get("REDASH_CELERY_BROKER_SSL_CA_CERTS"),
     'ssl_certfile': os.environ.get("REDASH_CELERY_BROKER_SSL_CERTFILE"),
     'ssl_keyfilefile': os.environ.get("REDASH_CELERY_BROKER_SSL_KEYFILE"),
-}
+} if CELERY_BROKER_USE_SSL else None
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+import ssl
 from funcy import distinct, remove
 from flask_talisman import talisman
 
@@ -30,6 +31,12 @@ CELERY_RESULT_BACKEND = os.environ.get(
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))
+CELERY_SSL_CONFIG = {
+    'ssl_cert_reqs': int(os.environ.get("REDASH_CELERY_BROKER_SSL_CERT_REQS",  ssl.CERT_OPTIONAL if CELERY_BROKER.startswith('rediss') else ssl.CERT_NONE)),
+    'ssl_ca_certs': os.environ.get("REDASH_CELERY_BROKER_SSL_CA_CERTS"),
+    'ssl_certfile': os.environ.get("REDASH_CELERY_BROKER_SSL_CERTFILE"),
+    'ssl_keyfilefile': os.environ.get("REDASH_CELERY_BROKER_SSL_KEYFILE"),
+}
 
 # The following enables periodic job (every 5 minutes) of removing unused query results.
 QUERY_RESULTS_CLEANUP_ENABLED = parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP_ENABLED", "true"))

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -12,25 +12,13 @@ from celery.utils.log import get_logger
 from redash import create_app, extensions, settings
 from redash.metrics import celery as celery_metrics  # noqa
 
-import ssl
-
-redis_ssl_config = None
-if settings.CELERY_BROKER.startswith('rediss'):
-    # TODO make these values configurable
-    redis_ssl_config = {
-        'ssl_cert_reqs': ssl.CERT_REQUIRED,
-        # 'ssl_ca_certs': '/path/to/ca.crt',
-        # 'ssl_certfile': '/path/to/client.crt',
-        # 'ssl_keyfile': '/path/to/client.key'
-    }
-
 logger = get_logger(__name__)
 
 
 celery = Celery('redash',
                 broker=settings.CELERY_BROKER,
-                broker_use_ssl=redis_ssl_config,
-                redis_backend_use_ssl=redis_ssl_config,
+                broker_use_ssl=settings.CELERY_SSL_CONFIG,
+                redis_backend_use_ssl=settings.CELERY_SSL_CONFIG,
                 include='redash.tasks')
 
 # The internal periodic Celery tasks to automatically schedule.

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -12,12 +12,25 @@ from celery.utils.log import get_logger
 from redash import create_app, extensions, settings
 from redash.metrics import celery as celery_metrics  # noqa
 
+import ssl
+
+redis_ssl_config = None
+if settings.CELERY_BROKER.startswith('rediss'):
+    # TODO make these values configurable
+    redis_ssl_config = {
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
+        # 'ssl_ca_certs': '/path/to/ca.crt',
+        # 'ssl_certfile': '/path/to/client.crt',
+        # 'ssl_keyfile': '/path/to/client.key'
+    }
 
 logger = get_logger(__name__)
 
 
 celery = Celery('redash',
                 broker=settings.CELERY_BROKER,
+                broker_use_ssl=redis_ssl_config,
+                redis_backend_use_ssl=redis_ssl_config,
                 include='redash.tasks')
 
 # The internal periodic Celery tasks to automatically schedule.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ psycopg2==2.7.3.2
 python-dateutil==2.7.5
 pytz==2016.7
 PyYAML==3.12
-redis==3.0.1
+redis==3.2.1
 requests==2.21.0
 six==1.11.0
 SQLAlchemy==1.2.12
@@ -36,8 +36,8 @@ SQLAlchemy-Utils==0.33.11
 sqlparse==0.2.4
 statsd==2.1.2
 gunicorn==19.7.1
-celery==4.2.1
-kombu==4.2.2.post1
+celery==4.3.0
+kombu==4.5.0
 jsonschema==2.4.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

Allows TLS connection to Redis via `rediss` scheme https://www.iana.org/assignments/uri-schemes/prov/rediss

This is achieved mostly via dependency upgrades, and some config tweaks. I've been running this on our self-hosted for a few weeks and its been working great.

## Related Tickets & Documents

This follows #2357

I'd appreciate any thoughts or pointers on:
 - how can `ssl_config` be passed in?
 - testing this
 - docs