### PR TITLE
Cancel previous execution on parameters value update

### DIFF
--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -38,7 +38,7 @@
         </div>
       </div>
       <div class="m-b-10" ng-if="$ctrl.localParametersDefs().length > 0">
-        <parameters parameters="$ctrl.localParametersDefs()" on-values-change="$ctrl.refresh"></parameters>
+        <parameters parameters="$ctrl.localParametersDefs()" on-values-change="$ctrl.cancelPreviousAndRefresh"></parameters>
       </div>
     </div>
 

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -96,6 +96,13 @@ function DashboardWidgetCtrl($scope, $location, $uibModal, $window, $rootScope, 
     this.load(true);
   };
 
+  this.cancelPreviousAndRefresh = () => {
+    if (this.widget.queryResults && this.widget.queryResults.cancelExecution) {
+      this.widget.queryResults.cancelExecution();
+    }
+    this.refresh();
+  };
+
   if (this.widget.visualization) {
     Events.record('view', 'query', this.widget.visualization.query.id, { dashboard: true });
     Events.record('view', 'visualization', this.widget.visualization.id, { dashboard: true });

--- a/client/app/components/queries/visualization-embed.html
+++ b/client/app/components/queries/visualization-embed.html
@@ -13,7 +13,7 @@
 
   <div class="col-md-12 query__vis">
     <div class="p-t-15 p-b-5" ng-if="$ctrl.query.hasParameters()">
-      <parameters parameters="$ctrl.query.getParametersDefs()" on-values-change="$ctrl.refreshQueryResults"></parameters>
+      <parameters parameters="$ctrl.query.getParametersDefs()" on-values-change="$ctrl.cancelPreviousAndRefresh"></parameters>
     </div>
 
     <div ng-if="$ctrl.error">

--- a/client/app/components/queries/visualization-embed.js
+++ b/client/app/components/queries/visualization-embed.js
@@ -27,6 +27,13 @@ const VisualizationEmbed = {
         });
     };
 
+    this.cancelPreviousAndRefresh = () => {
+      if (this.query.queryResults && this.query.queryResults.cancelExecution) {
+        this.query.queryResults.cancelExecution();
+      }
+      this.refreshQueryResults();
+    };
+
     const visualizationId = parseInt($routeParams.visualizationId, 10);
     this.visualization = find(this.query.visualizations, visualization => visualization.id === visualizationId);
     this.showQueryDescription = $routeParams.showDescription;

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -94,7 +94,7 @@
   </div>
 
   <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0">
-    <parameters parameters="$ctrl.globalParameters" on-values-change="$ctrl.refreshDashboard"></parameters>
+    <parameters parameters="$ctrl.globalParameters" on-values-change="$ctrl.cancelPreviousAndRefresh"></parameters>
   </div>
 
   <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.filters | notEmpty">

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -207,6 +207,15 @@ function DashboardCtrl(
     renderDashboard(this.dashboard, true);
   };
 
+  this.cancelPreviousAndRefresh = () => {
+    this.dashboard.widgets.forEach((widget) => {
+      if (widget.queryResults && widget.queryResults.cancelExecution) {
+        widget.queryResults.cancelExecution();
+      }
+    });
+    this.refreshDashboard();
+  };
+
   this.autoRefresh = () => {
     $timeout(() => {
       this.refreshDashboard();

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -192,7 +192,7 @@
             <div class="d-flex flex-column p-b-15 p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
               <div class="p-t-15 p-b-5" ng-if="query.hasParameters()">
                 <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"
-                  on-updated="onParametersUpdated" on-values-change="executeQuery"></parameters>
+                  on-updated="onParametersUpdated" on-values-change="cancelPreviousAndExecuteQuery"></parameters>
               </div>
               <!-- Query Execution Status -->
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -136,6 +136,13 @@ function QueryViewCtrl(
     Notifications.getPermissions();
   };
 
+  $scope.cancelPreviousAndExecuteQuery = () => {
+    if ($scope.queryResult && $scope.queryResult.cancelExecution) {
+      $scope.queryResult.cancelExecution();
+    }
+    $scope.executeQuery();
+  };
+
   $scope.selectedVisualization = DEFAULT_VISUALIZATION;
   $scope.currentUser = currentUser;
   $scope.dataSource = {};

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -147,7 +147,9 @@ function QueryResultService($resource, $timeout, $q, QueryResultError, Auth) {
     }
 
     cancelExecution() {
-      Job.delete({ id: this.job.id });
+      if (this.job.id) {
+        Job.delete({ id: this.job.id });
+      }
     }
 
     getStatus() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
Hi :slightly_smiling_face: 

I was a bit concerned about slow queries after #3737 (when updating many parameters at once). One thing that can improve this a lot (@ranbena mentioned in the PR) is to cancel the previous execution before running the new one. This idea was simple enough to open a PR directly for discussion from it. The concerns I have regarding it:
- It's necessary that the cancel operation works properly. If it doesn't, the behavior will be no different than it is now. I remember there were issues with MySQL cancelling (afaik a recent PR fixed that), but for PostgreSQL it works nicely.
- Can there be any performance issues with it, like, is it a function that is not supposed to be used that often?
- Are there datasources without cancel operation?

I guess this can be also done backend-wise, but I opted to update it as is to change it only where it could be needed (on parameters value update).

## Related Tickets & Documents
--
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--