### PR TITLE
Fix initialization of dashboard-level parameters

### DIFF
--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -210,7 +210,8 @@ function DashboardService($resource, $http, $location, currentUser, Widget) {
       }
     });
     return _.values(_.each(globalParams, (param) => {
-      param.fromUrlParams(queryParams);
+      param.setValue(param.getValue()); // apply global param value to all locals
+      param.fromUrlParams(queryParams); // try to initialize from url (may do nothing)
     }));
   };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

When creating dashboard-level parameter object, propagate its value to all underlying parameters, and only then try to init from URL.

## Related Tickets & Documents

Fixes getredash/redash#3849