### PR TITLE
Fix widget autoHeight related exception

### DIFF
--- a/client/app/components/dashboards/AutoHeightController.js
+++ b/client/app/components/dashboards/AutoHeightController.js
@@ -65,8 +65,15 @@ export default class AutoHeightController {
   };
 
   remove = (id) => {
+    id = id.toString();
+
+    // ignore if not an active autoHeight widget
+    if (!this.widgets[id]) {
+      return;
+    }
+
     // not actually deleting from this.widgets to prevent case of unwanted re-adding
-    this.widgets[id.toString()] = false;
+    this.widgets[id] = false;
 
     if (this.isEmpty()) {
       this.stop();
@@ -78,14 +85,17 @@ export default class AutoHeightController {
   isEmpty = () => !some(this.widgets);
 
   checkHeightChanges = () => {
-    Object.keys(this.widgets).forEach((id) => {
-      const [getHeight, prevHeight] = this.widgets[id];
-      const height = getHeight();
-      if (height && height !== prevHeight) {
-        this.widgets[id][1] = height; // save
-        this.onHeightChange(id, height); // dispatch
-      }
-    });
+    Object
+      .keys(this.widgets)
+      .filter(id => !!this.widgets[id]) // filter already removed items
+      .forEach((id) => {
+        const [getHeight, prevHeight] = this.widgets[id];
+        const height = getHeight();
+        if (height && height !== prevHeight) {
+          this.widgets[id][1] = height; // save
+          this.onHeightChange(id, height); // dispatch
+        }
+      });
   };
 
   start = () => {


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #3857.

The error is due to 2 bugs in the autoHeight code:
1. When resizing a non-autoheight widget, it gets added as a removed widget.
   Fixed by filtering it out:
   ```js
   remove = (id) => {
     if (!this.widgets[id]) {
       return;
     }
   ```
2. When detecting height change, already removed widgets aren't filtered out. Since removed widgets have a value of `false`, the array deconstruction generated the js error:
https://github.com/getredash/redash/blob/b27df216f4cd820843be9d4c68419c2f654895f6/client/app/components/dashboards/AutoHeightController.js#L81-L82
   Fixed by filtering it out:
   ```js
   Object
      .keys(this.widgets)
      .filter(id => !!this.widgets[id])
   ```

## Testing
The feature has e2e coverage so it's safe.