### PR TITLE
Remove legacy session identifier support

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -43,15 +43,14 @@ def sign(key, path, expires):
 def load_user(user_id_with_identity):
     org = current_org._get_current_object()
 
-    user_id, _ = user_id_with_identity.split("-")
-
     try:
+        user_id, _ = user_id_with_identity.split("-")
         user = models.User.get_by_id_and_org(user_id, org)
         if user.is_disabled or user.get_id() != user_id_with_identity:
             return None
 
         return user
-    except models.NoResultFound:
+    except (models.NoResultFound, Exception):
         return None
 
 

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -43,30 +43,14 @@ def sign(key, path, expires):
 def load_user(user_id_with_identity):
     org = current_org._get_current_object()
 
-    '''
-    Users who logged in prior to https://github.com/getredash/redash/pull/3174 going live are going
-    to have their (integer) user_id as their session user identifier.
-    These session user identifiers will be updated the first time they visit any page so we add special
-    logic to allow a frictionless transition.
-    This logic will be removed 2-4 weeks after going live, and users who haven't
-    visited any page during that time will simply have to log in again.
-    '''
-
-    is_legacy_session_identifier = str(user_id_with_identity).find('-') < 0
-
-    if is_legacy_session_identifier:
-        user_id = user_id_with_identity
-    else:
-        user_id, _ = user_id_with_identity.split("-")
+    user_id, _ = user_id_with_identity.split("-")
 
     try:
         user = models.User.get_by_id_and_org(user_id, org)
         if user.is_disabled:
             return None
 
-        if is_legacy_session_identifier:
-            login_user(user, remember=True)
-        elif user.get_id() != user_id_with_identity:
+        if user.get_id() != user_id_with_identity:
             return None
 
         return user

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -50,7 +50,7 @@ def load_user(user_id_with_identity):
             return None
 
         return user
-    except (models.NoResultFound, Exception):
+    except (models.NoResultFound, ValueError, AttributeError):
         return None
 
 

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -47,10 +47,7 @@ def load_user(user_id_with_identity):
 
     try:
         user = models.User.get_by_id_and_org(user_id, org)
-        if user.is_disabled:
-            return None
-
-        if user.get_id() != user_id_with_identity:
+        if user.is_disabled or user.get_id() != user_id_with_identity:
             return None
 
         return user

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -30,6 +30,14 @@ class TestAuthentication(BaseTestCase):
     def test_redirects_for_nonsigned_in_user(self):
         rv = self.client.get("/default/")
         self.assertEquals(302, rv.status_code)
+         
+    def test_redirects_for_invalid_session_identifier(self):
+        with self.client as c:
+            with c.session_transaction() as sess:
+                sess['user_id'] = 100
+            rv = self.client.get("/default/")
+
+            self.assertEquals(302, rv.status_code)
 
 
 class PingTest(BaseTestCase):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -27,14 +27,6 @@ class TestAuthentication(BaseTestCase):
 
             self.assertEquals(200, rv.status_code)
 
-    def test_responds_with_success_for_signed_in_user_with_a_legacy_identity_session(self):
-        with self.client as c:
-            with c.session_transaction() as sess:
-                sess['user_id'] = str(self.factory.user.id)
-            rv = self.client.get("/default/")
-
-            self.assertEquals(200, rv.status_code)
-
     def test_redirects_for_nonsigned_in_user(self):
         rv = self.client.get("/default/")
         self.assertEquals(302, rv.status_code)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description
Users who logged in prior to https://github.com/getredash/redash/pull/3174 going live have their (integer) user_id as their session user identifier.
This no longer needs to be supported.

## Related Tickets & Documents
#3174 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
