### PR TITLE
Cypress: Fix date parameters false positive

### DIFF
--- a/client/app/components/EditParameterSettingsDialog.jsx
+++ b/client/app/components/EditParameterSettingsDialog.jsx
@@ -177,6 +177,7 @@ function EditParameterSettingsDialog(props) {
             <Checkbox
               defaultChecked={param.useCurrentDateTime}
               onChange={e => setParam({ ...param, useCurrentDateTime: e.target.checked })}
+              data-test="UseCurrentDateTimeCheckbox"
             >
               Default to Today/Now if no other value is set
             </Checkbox>

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -120,6 +120,7 @@ describe('Parameter', () => {
         ParameterSettings-test-parameter
         ParameterTypeSelect
         DateParameterTypeOption
+        UseCurrentDateTimeCheckbox
         SaveParameterSettings 
       `);
 
@@ -159,6 +160,7 @@ describe('Parameter', () => {
         ParameterSettings-test-parameter
         ParameterTypeSelect
         DateTimeParameterTypeOption
+        UseCurrentDateTimeCheckbox
         SaveParameterSettings
       `);
 

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -120,14 +120,12 @@ describe('Parameter', () => {
         ParameterSettings-test-parameter
         ParameterTypeSelect
         DateParameterTypeOption
+        UseCurrentDateTimeCheckbox
         SaveParameterSettings 
       `);
 
       const now = new Date(2019, 0, 1).getTime(); // January 1, 2019 timestamp
       cy.clock(now);
-
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(1000);
     });
 
     afterEach(() => {

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -120,12 +120,14 @@ describe('Parameter', () => {
         ParameterSettings-test-parameter
         ParameterTypeSelect
         DateParameterTypeOption
-        UseCurrentDateTimeCheckbox
         SaveParameterSettings 
       `);
 
       const now = new Date(2019, 0, 1).getTime(); // January 1, 2019 timestamp
       cy.clock(now);
+
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(1000);
     });
 
     afterEach(() => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
[Example test results with this issue](https://dashboard.cypress.io/#/projects/924cka/runs/444/specs)

I did run this fix a few times and got no fail on tests, but I guess I'll just know it really works after merge. 

My guess is that the Save action to close the dialog didn't occur due to a sudden change in the dialog (the checkbox rendering). The solution I could think: click on the checkbox as well, this way it will wait for it to be rendered.

@ranbena I tried the `cy.wait` to see if the false positive would happen, didn't get it in my tests as well. In any case, if the fix without `cy.wait` works, I prefer it.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--