### PR TITLE
Restrict dynamic-table internal scroll only when pagination appears

### DIFF
--- a/client/app/components/app-view/index.js
+++ b/client/app/components/app-view/index.js
@@ -37,10 +37,6 @@ class AppViewComponent {
     this.layout = layouts.defaultSignedOut;
     this.handler = handler;
 
-    // remove when fix lands
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=914844#c36
-    $rootScope.platform = navigator.platform;
-
     $rootScope.$on('$routeChangeStart', (event, route) => {
       this.handler.reset();
 

--- a/client/app/components/dynamic-table/dynamic-table.html
+++ b/client/app/components/dynamic-table/dynamic-table.html
@@ -1,4 +1,4 @@
-<div class="dynamic-table-container">
+<div class="dynamic-table-container" ng-attr-data-has-pagination="{{ $ctrl.paginatorAdapter.hasPagination }}">
   <table class="table table-condensed table-hover" data-test="DynamicTable">
     <thead>
       <tr>

--- a/client/app/components/dynamic-table/dynamic-table.less
+++ b/client/app/components/dynamic-table/dynamic-table.less
@@ -1,11 +1,6 @@
 .dynamic-table-container {
   overflow-x: auto;
 
-  // remove when fix lands
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=914844#c36
-  body[data-platform^="Mac"] & {
-    padding-bottom: 10px; // workaround for Mac browser's scrollbar obscuring content
-    margin-bottom: -10px; // compensation for above
   }
 
   th {

--- a/client/app/components/dynamic-table/dynamic-table.less
+++ b/client/app/components/dynamic-table/dynamic-table.less
@@ -1,6 +1,6 @@
 .dynamic-table-container {
-  overflow-x: auto;
-
+  &[data-has-pagination="true"] {
+    overflow-x: auto; // enable internal scroll so pagination stays put
   }
 
   th {

--- a/client/app/components/dynamic-table/index.js
+++ b/client/app/components/dynamic-table/index.js
@@ -99,6 +99,10 @@ class DynamicTablePaginatorAdapter {
     return this.$ctrl.preparedRows.length;
   }
 
+  get hasPagination() {
+    return this.totalCount > this.itemsPerPage; // same condition as in Paginator.jsx
+  }
+
   setPage(page) {
     this.$ctrl.onPageChanged(page);
   }

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
   </head>
 
-  <body ng-class="bodyClass" ng-attr-data-platform="{{platform}}">
+  <body ng-class="bodyClass">
     <section>
       <app-view></app-view>
       <div class="loading-indicator">

--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -12,7 +12,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
   </head>
 
-  <body ng-class="bodyClass" ng-attr-data-platform="{{platform}}">
+  <body ng-class="bodyClass">
     <section>
       <app-view></app-view>
       <div class="loading-indicator">


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #3859.
1. Reverted #3830 - no more autoheight miscalculation.
2. Restricted internal scrolling only when pagination is available - so the Mac browser scroll bug won't manifest in this case

## Mobile & Desktop Screenshots

Before|After
-------|--------
<img width="644" alt="Screen Shot 2019-06-03 at 16 33 57" src="https://user-images.githubusercontent.com/486954/58839101-f12de080-861d-11e9-92be-ba71bf05bf80.png"> | <img width="644" alt="Screen Shot 2019-06-03 at 16 34 00" src="https://user-images.githubusercontent.com/486954/58839102-f12de080-861d-11e9-8000-681ca349aa3f.png">