### PR TITLE
check float if scale > 0 in snowflake query result

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -60,6 +60,13 @@ class Snowflake(BaseQueryRunner):
     def enabled(cls):
         return enabled
 
+    @classmethod
+    def determine_type(cls, data_type, scale):
+        t = TYPES_MAP.get(data_type, None)
+        if t == TYPE_INTEGER and scale > 0:
+            return TYPE_FLOAT
+        return t
+
     def run_query(self, query, user):
         region = self.configuration.get('region')
 
@@ -84,7 +91,7 @@ class Snowflake(BaseQueryRunner):
             cursor.execute(query)
 
             columns = self.fetch_columns(
-                [(i[0], TYPES_MAP.get(i[1], None)) for i in cursor.description])
+                    [(i[0], self.determine_type(i[1], i[5])) for i in cursor.description])
             rows = [dict(zip((c['name'] for c in columns), row))
                     for row in cursor]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Bug Fix

## Description
The simple `select 2.5` will return result 3 when the datasourc is snowflake. Redahs directly use the inferred datatype given by datasource, but it's not totally accurate. However, snowflake also provide precision and scale of query result. If the data is numerical, we check whether scale is greater than 0 to determine Float or Integer. 

## Related Tickets & Documents
https://github.com/getredash/redash/issues/3820
This rounding issues appeared in snowflake data source as well. 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
