### PR TITLE
Reduce help drawer close button click area

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -50,6 +50,13 @@
 .@{drawer-prefix-cls} {
   &.help-drawer {
     z-index: 3000; // help drawer should be topmost
+
+    .@{drawer-prefix-cls}-close {
+      top: 15px;
+      right: 15px;
+      width: 26px;
+      height: 26px;
+      line-height: 26px;
   }
 }
 


### PR DESCRIPTION
- [x] Refactor

## Description
Prep work for the [HelpDrawer "Open in New Window" Feature](https://discuss.redash.io/t/should-the-help-drawer-retain-state/3832).
This is so the close button click area doesn't overlap the button aside it.
![close](https://user-images.githubusercontent.com/486954/58979481-67038a80-878b-11e9-9804-966408085f1e.png)

The button stays the same, in the same spot but click area has reduced.

Followup PR is https://github.com/getredash/website/pull/250.

## Mobile & Desktop Screenshots

Before|After
-------|-------
<img width="399" alt="Screen Shot 2019-06-05 at 12 07 03" src="https://user-images.githubusercontent.com/486954/58979351-1855f080-878b-11e9-967a-ef7e2523c454.png"> | <img width="399" alt="Screen Shot 2019-06-05 at 12 07 47" src="https://user-images.githubusercontent.com/486954/58979347-17bd5a00-878b-11e9-8fdc-45321df1c9e5.png">
