### PR TITLE
Plotly legend overlaps plot on small screens

### DIFF
--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -747,14 +747,6 @@ export function updateLayout(plotlyElement, layout, updatePlot) {
   layout.width = Math.floor(plotlyElement.offsetWidth);
   layout.height = Math.floor(plotlyElement.offsetHeight);
 
-  const transformName = find([
-    'transform',
-    'webkitTransform',
-    'mozTransform',
-    'msTransform',
-    'oTransform',
-  ], prop => has(plotlyElement.style, prop));
-
   if (layout.width <= 600) {
     // change legend orientation to horizontal; plotly has a bug with this
     // legend alignment - it does not preserve enough space under the plot;
@@ -802,9 +794,9 @@ export function updateLayout(plotlyElement, layout, updatePlot) {
           layout.height / 2,
           layout.height - (bounds.bottom - bounds.top),
         ));
-        // offset the legend
-        legend.style[transformName] = 'translate(0, ' + layout.height + 'px)';
         updatePlot(plotlyElement, pick(layout, ['height']));
+        // offset the legend
+        legend.setAttribute('transform', 'translate(0, ' + layout.height + ')');
       }
     });
   } else {
@@ -817,12 +809,6 @@ export function updateLayout(plotlyElement, layout, updatePlot) {
       xanchor: 'left',
       yanchor: 'top',
     };
-
-    const legend = plotlyElement.querySelector('.legend');
-    if (legend) {
-      legend.style[transformName] = null;
-    }
-
     updatePlot(plotlyElement, pick(layout, ['width', 'height', 'legend']));
   }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

For some reason, Firefox didn't apply CSS `transform: translate(x, y)` to legend element. Replaced it with attribute which works fine.

## Related Tickets & Documents

Fixes getredash/redash#3879

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Firefox (was and became):

![image](https://user-images.githubusercontent.com/12139186/59018921-ae534f00-884f-11e9-95c6-6834cc132832.png)
![image](https://user-images.githubusercontent.com/12139186/59018945-bc08d480-884f-11e9-99fe-ad99dcace710.png)

Chrome/Chromium: no visual changes
