### PR TITLE
Google Sheets: friendlier error message in case of an API error and more reliable test connection

### DIFF
--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -216,4 +216,5 @@ class GoogleSpreadsheet(BaseQueryRunner):
         except APIError as e:
             return None, parse_api_error(e)
 
+
 register(GoogleSpreadsheet)

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import gspread
+    from gspread.exceptions import APIError
     from oauth2client.service_account import ServiceAccountCredentials
 
     enabled = True
@@ -120,6 +121,17 @@ def is_url_key(key):
     return key.startswith('https://')
 
 
+def parse_api_error(error):
+    error_data = error.response.json()
+
+    if 'error' in error_data and 'message' in error_data['error']:
+        message = error_data['error']['message']
+    else:
+        message = error.message
+
+    return message
+
+
 class TimeoutSession(Session):
     def request(self, *args, **kwargs):
         kwargs.setdefault('timeout', 300)
@@ -176,7 +188,13 @@ class GoogleSpreadsheet(BaseQueryRunner):
         return spreadsheetservice
 
     def test_connection(self):
-        self._get_spreadsheet_service()
+        service = self._get_spreadsheet_service()
+        test_spreadsheet_key = '1S0mld7LMbUad8LYlo13Os9f7eNjw57MqVC0YiCd1Jis'
+        try:
+            service.open_by_key(test_spreadsheet_key).worksheets()
+        except APIError as e:
+            message = parse_api_error(e)
+            raise Exception(message)
 
     def run_query(self, query, user):
         logger.debug("Spreadsheet is about to execute query: %s", query)
@@ -195,6 +213,7 @@ class GoogleSpreadsheet(BaseQueryRunner):
             return json_dumps(data), None
         except gspread.SpreadsheetNotFound:
             return None, "Spreadsheet ({}) not found. Make sure you used correct id.".format(key)
-
+        except APIError as e:
+            return None, parse_api_error(e)
 
 register(GoogleSpreadsheet)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

1. Changed Test Connection to try and open a spreadsheet to verify that credentials actually work.
2. Show friendlier message when receiving an API error:

Before|After
-------|-------
![image](https://user-images.githubusercontent.com/71468/59025380-b6fe5200-885c-11e9-939b-1ca32cda0234.png) |  ![image](https://user-images.githubusercontent.com/71468/59025413-c5e50480-885c-11e9-8f85-d2e3e42eb5ef.png)