### PR TITLE
Force a Choose account step for Google OAuth

### DIFF
--- a/redash/authentication/google_oauth.py
+++ b/redash/authentication/google_oauth.py
@@ -17,7 +17,7 @@ def google_remote_app():
     if 'google' not in oauth.remote_apps:
         oauth.remote_app('google',
                          base_url='https://www.google.com/accounts/',
-                         authorize_url='https://accounts.google.com/o/oauth2/auth',
+                         authorize_url='https://accounts.google.com/o/oauth2/auth?prompt=select_account+consent',
                          request_token_url=None,
                          request_token_params={
                              'scope': 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Force show a Choose account step for Google OAuth (previously this feature didn't work for me - I have two accounts, and it was using only active (default? most recently used?) one). Small side-effect: with this fix it will show Choose account step even if there is the only account available (probably not a big deal - at least, users will be 100% sure which account will be used).