### PR TITLE
Drawer menu with recreated close button

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -49,7 +49,7 @@
 
 .@{drawer-prefix-cls} {
   &.help-drawer {
-    z-index: 3000; // help drawer should be topmost
+    z-index: @zindex-tooltip; // help drawer should be topmost
   }
 }
 

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -13,6 +13,7 @@ import './HelpTrigger.less';
 const DOMAIN = 'https://redash.io';
 const HELP_PATH = '/help';
 const IFRAME_TIMEOUT = 20000;
+const IFRAME_URL_UPDATE_MESSAGE = 'iframe_url';
 
 export const TYPES = {
   HOME: [
@@ -90,9 +91,15 @@ export class HelpTrigger extends React.Component {
     visible: false,
     loading: false,
     error: false,
+    currentUrl: null,
   };
 
+  componentDidMount() {
+    window.addEventListener('message', this.onPostMessageReceived, DOMAIN);
+  }
+
   componentWillUnmount() {
+    window.removeEventListener('message', this.onPostMessageReceived);
     clearTimeout(this.iframeLoadingTimeout);
   }
 
@@ -111,6 +118,15 @@ export class HelpTrigger extends React.Component {
     clearTimeout(this.iframeLoadingTimeout);
   };
 
+  onPostMessageReceived = (event) => {
+    const { type, message: currentUrl } = event.data || {};
+    if (type !== IFRAME_URL_UPDATE_MESSAGE) {
+      return;
+    }
+
+    this.setState({ currentUrl });
+  }
+
   openDrawer = () => {
     this.setState({ visible: true });
     const [pagePath] = TYPES[this.props.type];
@@ -125,11 +141,13 @@ export class HelpTrigger extends React.Component {
       event.preventDefault();
     }
     this.setState({ visible: false });
+    this.setState({ visible: false, currentUrl: null });
   };
 
   render() {
     const [, tooltip] = TYPES[this.props.type];
     const className = cx('help-trigger', this.props.className);
+    const url = this.state.currentUrl;
 
     return (
       <React.Fragment>
@@ -149,6 +167,14 @@ export class HelpTrigger extends React.Component {
         >
           <div className="drawer-wrapper">
             <div className="drawer-menu">
+              {url && (
+                <Tooltip title="Open page in a new window" placement="left">
+                  {/* eslint-disable-next-line react/jsx-no-target-blank */}
+                  <a href={url} target="_blank">
+                    <i className="fa fa-external-link" />
+                  </a>
+                </Tooltip>
+              )}
               <Tooltip title="Close" placement="bottom">
                 <a href="#" onClick={this.closeDrawer}>
                   <Icon type="close" />

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Tooltip from 'antd/lib/tooltip';
 import Drawer from 'antd/lib/drawer';
+import Icon from 'antd/lib/icon';
 import { BigMessage } from '@/components/BigMessage';
 import DynamicComponent from '@/components/DynamicComponent';
 
@@ -119,7 +120,10 @@ export class HelpTrigger extends React.Component {
     setTimeout(() => this.loadIframe(url), 300);
   };
 
-  closeDrawer = () => {
+  closeDrawer = (event) => {
+    if (event) {
+      event.preventDefault();
+    }
     this.setState({ visible: false });
   };
 
@@ -136,6 +140,7 @@ export class HelpTrigger extends React.Component {
         </Tooltip>
         <Drawer
           placement="right"
+          closable={false}
           onClose={this.closeDrawer}
           visible={this.state.visible}
           className="help-drawer"
@@ -143,6 +148,14 @@ export class HelpTrigger extends React.Component {
           width={400}
         >
           <div className="drawer-wrapper">
+            <div className="drawer-menu">
+              <Tooltip title="Close" placement="bottom">
+                <a href="#" onClick={this.closeDrawer}>
+                  <Icon type="close" />
+                </a>
+              </Tooltip>
+            </div>
+
             {/* iframe */}
             {!this.state.error && (
               <iframe

--- a/client/app/components/HelpTrigger.less
+++ b/client/app/components/HelpTrigger.less
@@ -1,3 +1,7 @@
+@import '~antd/lib/drawer/style/drawer';
+
+@help-doc-bg: #f7f7f7; // according to https://github.com/getredash/website/blob/13daff2d8b570956565f482236f6245042e8477f/src/scss/_components/_variables.scss#L15
+
 .help-trigger {
   font-size: 15px;
 }
@@ -18,6 +22,37 @@
     align-items: center;
     width: 100%;
     justify-content: center;
+  }
+
+  .drawer-menu {
+    position: fixed;
+    z-index: 1;
+    top: 13px;
+    right: 13px;
+    border-radius: 3px;
+    background: rgba(@help-doc-bg, .75); // makes it dissolve over help doc bg
+    border: 2px solid @help-doc-bg;
+    display: flex;
+
+    a {
+      height: 26px;
+      width: 26px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: @text-color-secondary;
+      transition: color @animation-duration-slow;
+      position: relative;
+
+      &:hover {
+        color: @icon-color-hover;
+        text-decoration: none;
+      }
+
+      .anticon {
+        font-size: 15px;
+      }
+    }
   }
 
   iframe {

--- a/client/app/components/HelpTrigger.less
+++ b/client/app/components/HelpTrigger.less
@@ -52,6 +52,23 @@
       .anticon {
         font-size: 15px;
       }
+
+      .fa-external-link {
+        position: relative;
+        top: 1px;
+        font-size: 14px;
+      }
+
+      // divider
+      &:not(:first-child):before {
+        content: '';
+        position: absolute;
+        width: 1px;
+        height: 9px;
+        left: 0;
+        top: 9px;
+        border-left: 1px dotted rgba(0,0,0,.12);
+      }
     }
   }
 


### PR DESCRIPTION
- [x] Refactor
- [x] Feature

## Description
UX discussion here https://discuss.redash.io/t/should-the-help-drawer-retain-state/3832/8.

This is the first PR to make the drawer menu. The next would introduce the "Open in new window" button alongside the close button.

[This discussion](https://github.com/getredash/website/pull/250#issuecomment-499302532) lead me to implement this and close https://github.com/getredash/redash/pull/3880.

## Mobile & Desktop Screenshots

No regression, looks identical to prev

<img width="400" alt="Screen Shot 2019-06-08 at 0 42 46" src="https://user-images.githubusercontent.com/486954/59135095-5ff49c00-8986-11e9-98a3-5cbf61722790.png">

New features - background, tooltip
<img width="400" alt="Screen Shot 2019-06-08 at 0 42 41" src="https://user-images.githubusercontent.com/486954/59135097-608d3280-8986-11e9-9b48-8f0fc41ec8dc.png">
