### PR TITLE
Added “Open in new window” drawer menu button

### DIFF
--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -124,7 +124,7 @@ export class HelpTrigger extends React.Component {
       return;
     }
 
-    this.setState({ currentUrl: url });
+    this.setState({ currentUrl });
   }
 
   openDrawer = () => {

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -13,6 +13,7 @@ import './HelpTrigger.less';
 const DOMAIN = 'https://redash.io';
 const HELP_PATH = '/help';
 const IFRAME_TIMEOUT = 20000;
+const IFRAME_URL_UPDATE_MESSAGE = 'iframe_url';
 
 export const TYPES = {
   HOME: [
@@ -90,9 +91,15 @@ export class HelpTrigger extends React.Component {
     visible: false,
     loading: false,
     error: false,
+    currentUrl: null,
   };
 
+  componentDidMount() {
+    window.addEventListener('message', this.onPostMessageReceived, DOMAIN);
+  }
+
   componentWillUnmount() {
+    window.removeEventListener('message', this.onPostMessageReceived);
     clearTimeout(this.iframeLoadingTimeout);
   }
 
@@ -111,6 +118,15 @@ export class HelpTrigger extends React.Component {
     clearTimeout(this.iframeLoadingTimeout);
   };
 
+  onPostMessageReceived = (event) => {
+    const { type, message: url } = event.data || {};
+    if (type !== IFRAME_URL_UPDATE_MESSAGE) {
+      return;
+    }
+
+    this.setState({ currentUrl: url });
+  }
+
   openDrawer = () => {
     this.setState({ visible: true });
     const [pagePath] = TYPES[this.props.type];
@@ -125,11 +141,13 @@ export class HelpTrigger extends React.Component {
       event.preventDefault();
     }
     this.setState({ visible: false });
+    this.setState({ visible: false, currentUrl: null });
   };
 
   render() {
     const [, tooltip] = TYPES[this.props.type];
     const className = cx('help-trigger', this.props.className);
+    const url = this.state.currentUrl;
 
     return (
       <React.Fragment>
@@ -149,6 +167,14 @@ export class HelpTrigger extends React.Component {
         >
           <div className="drawer-wrapper">
             <div className="drawer-menu">
+              {url && (
+                <Tooltip title="Open page in a new window" placement="left">
+                  {/* eslint-disable-next-line react/jsx-no-target-blank */}
+                  <a href={url} target="_blank">
+                    <i className="fa fa-external-link" />
+                  </a>
+                </Tooltip>
+              )}
               <Tooltip title="Close" placement="bottom">
                 <a href="#" onClick={this.closeDrawer}>
                   <Icon type="close" />

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -119,7 +119,7 @@ export class HelpTrigger extends React.Component {
   };
 
   onPostMessageReceived = (event) => {
-    const { type, message: url } = event.data || {};
+    const { type, message: currentUrl } = event.data || {};
     if (type !== IFRAME_URL_UPDATE_MESSAGE) {
       return;
     }

--- a/client/app/components/HelpTrigger.less
+++ b/client/app/components/HelpTrigger.less
@@ -52,6 +52,23 @@
       .anticon {
         font-size: 15px;
       }
+
+      .fa-external-link {
+        position: relative;
+        top: 1px;
+        font-size: 14px;
+      }
+
+      // divider
+      &:not(:first-child):before {
+        content: '';
+        position: absolute;
+        width: 1px;
+        height: 9px;
+        left: 0;
+        top: 9px;
+        border-left: 1px dotted rgba(0,0,0,.12);
+      }
     }
   }
 


### PR DESCRIPTION
- [x] Feature

## Description
Added a window open button to drawer menu.
Depends on #3889.
Not dependent on, but requires https://github.com/getredash/website/pull/252 to work.

<img width="62" alt="Screen Shot 2019-06-08 at 10 40 21" src="https://user-images.githubusercontent.com/486954/59144006-e71f2f80-89d9-11e9-8f8c-a4a9fdb949f1.png">

UX discussion here https://discuss.redash.io/t/should-the-help-drawer-retain-state/3832/8.

Defaults to no button.
Listens to iframe for postMessage with current url in it and then button appears.

## Mobile & Desktop Screenshots

<img src="https://user-images.githubusercontent.com/486954/59145420-6cabdb00-89ec-11e9-8d52-b596029b8246.gif" width=400 />
