### PR TITLE
Download links in Embed pages don't include the API key

### DIFF
--- a/client/app/components/queries/visualization-embed.js
+++ b/client/app/components/queries/visualization-embed.js
@@ -31,6 +31,7 @@ const VisualizationEmbed = {
     this.visualization = find(this.query.visualizations, visualization => visualization.id === visualizationId);
     this.showQueryDescription = $routeParams.showDescription;
     this.logoUrl = logoUrl;
+    this.apiKey = $routeParams.api_key;
 
     document.querySelector('body').classList.add('headless');
 


### PR DESCRIPTION
### Issue Summary

Download links in Embed pages don't include the API key, and therefore not working.

### Steps to Reproduce

1. Open this page: https://redash-preview.netlify.com/embed/query/152/visualization/256?api_key=n2fAkycO81m50Q8wogXE2N1QiN44fESdqXwdp9d5 while not logged in.
2. Try to download a CSV or Excel file.

### Technical details:

* Redash Version: master