### PR TITLE
Query Results: querying a column with a dictionary or array fails

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -72,6 +72,13 @@ def fix_column_name(name):
     return u'"{}"'.format(re.sub('[:."\s]', '_', name, flags=re.UNICODE))
 
 
+def flatten(value):
+    if isinstance(value, (list, dict)):
+        return json_dumps(value)
+    else:
+        return value
+
+
 def create_table(connection, table_name, query_results):
     try:
         columns = [column['name']
@@ -92,7 +99,7 @@ def create_table(connection, table_name, query_results):
         place_holders=','.join(['?'] * len(columns)))
 
     for row in query_results['rows']:
-        values = [row.get(column) for column in columns]
+        values = [flatten(row.get(column)) for column in columns]
         connection.execute(insert_template, values)
 
 

--- a/tests/query_runner/test_query_results.py
+++ b/tests/query_runner/test_query_results.py
@@ -102,7 +102,7 @@ class TestCreateTable(TestCase):
         self.assertEquals(
             len(list(connection.execute('SELECT * FROM query_123'))), 2)
 
-    def test_loads_array_and_dict_results(self):
+    def test_loads_list_and_dict_results(self):
         connection = sqlite3.connect(':memory:')
         rows = [{'test1': [1,2,3]}, {'test2': {'a': 'b'}}]
         results = {'columns': [{'name': 'test1'},

--- a/tests/query_runner/test_query_results.py
+++ b/tests/query_runner/test_query_results.py
@@ -102,6 +102,16 @@ class TestCreateTable(TestCase):
         self.assertEquals(
             len(list(connection.execute('SELECT * FROM query_123'))), 2)
 
+    def test_loads_array_and_dict_results(self):
+        connection = sqlite3.connect(':memory:')
+        rows = [{'test1': [1,2,3]}, {'test2': {'a': 'b'}}]
+        results = {'columns': [{'name': 'test1'},
+                               {'name': 'test2'}], 'rows': rows}
+        table_name = 'query_123'
+        create_table(connection, table_name, results)
+        self.assertEquals(
+            len(list(connection.execute('SELECT * FROM query_123'))), 2)
+
 
 class TestGetQuery(BaseTestCase):
     # test query from different account


### PR DESCRIPTION
### Issue Summary

When using the Query Results data source to query from a query result that one of the columns if of type dictionary of array, it fails with a cryptic message.

### Steps to Reproduce

Example query: https://redash-preview.netlify.com/queries/154/source. When you execute it you get:

> Error binding parameter 0 - probably unsupported type.

For starters, we should show a friendlier message, explaining which column had this issue. 

As an improved behavior we can convert the value into JSON, so the user can further query it using SQLite's JSON functions.