### PR TITLE
Fix OverflowError on Celery worker

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -354,7 +354,10 @@ def should_schedule_next(previous_iteration, now, interval, time=None, day_of_we
         next_iteration = (previous_iteration + datetime.timedelta(days=days_delay) +
                           datetime.timedelta(days=days_to_add)).replace(hour=hour, minute=minute)
     if failures:
-        next_iteration += datetime.timedelta(minutes=2**failures)
+        try:
+            next_iteration += datetime.timedelta(minutes=2**failures)
+        except OverflowError:
+            return False
     return now > next_iteration
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -131,6 +131,11 @@ class ShouldScheduleNextTest(TestCase):
         self.assertFalse(models.should_schedule_next(two_hours_ago, now,
                                                      "3600", failures=10))
 
+    def test_next_iteration_overflow(self):
+        now = utcnow()
+        two_hours_ago = now - datetime.timedelta(hours=2)
+        self.assertFalse(models.should_schedule_next(two_hours_ago, now, "3600", failures=32))
+
 
 class QueryOutdatedQueriesTest(BaseTestCase):
     # TODO: this test can be refactored to use mock version of should_schedule_next to simplify it.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
`next_iteration += datetime.timedelta(minutes=2**failures)` start failing when number of failures is larger then 31 and celery worker stops refreshing queries
