### PR TITLE
Increase celery job timeout

### DIFF
--- a/redash/metrics/celery.py
+++ b/redash/metrics/celery.py
@@ -4,6 +4,9 @@ import logging
 import socket
 import time
 
+from celery.concurrency import asynpool
+asynpool.PROC_ALIVE_TIMEOUT = 10.0
+
 from celery.signals import task_postrun, task_prerun
 from redash import settings, statsd_client
 from redash.utils import json_dumps


### PR DESCRIPTION
- [x] Bug Fix

## Description
With the default 4 sec timeout, I'm experiencing endless repeated job restarts that kill my cpu 🥵
Increased to 10 sec and it doesn't happen no more.