### PR TITLE
Provide settings to control multifilter initial selection

### DIFF
--- a/client/app/components/Filters.jsx
+++ b/client/app/components/Filters.jsx
@@ -41,6 +41,31 @@ function createFilterChangeHandler(filters, onChange) {
   };
 }
 
+export function setFilterDefaults(filters, columnOptions) {
+  const multiFilterDefaults = {};
+  columnOptions.forEach((column) => {
+    multiFilterDefaults[column.name] = column.multiFilterDefault;
+  });
+
+  filters.forEach((filter) => {
+    if (filter.current) {
+      return;
+    }
+
+    if (filter.multiple) {
+      if (multiFilterDefaults[filter.name] === 'all') {
+        filter.current = filter.values;
+      } else if (multiFilterDefaults[filter.name] === 'none') {
+        filter.current = [];
+      } else {
+        filter.current = [filter.values[0]];
+      }
+    } else {
+      filter.current = filter.values[0];
+    }
+  });
+}
+
 export function filterData(rows, filters = []) {
   if (!isArray(rows)) {
     return [];

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -248,13 +248,6 @@ function QueryResultService($resource, $timeout, $q, QueryResultError, Auth) {
       this.getRawData().forEach((row) => {
         filters.forEach((filter) => {
           filter.values.push(row[filter.name]);
-          if (filter.values.length === 1) {
-            if (filter.multiple) {
-              filter.current = [row[filter.name]];
-            } else {
-              filter.current = row[filter.name];
-            }
-          }
         });
       });
 

--- a/client/app/visualizations/EditVisualizationDialog.jsx
+++ b/client/app/visualizations/EditVisualizationDialog.jsx
@@ -6,7 +6,7 @@ import Select from 'antd/lib/select';
 import Input from 'antd/lib/input';
 import * as Grid from 'antd/lib/grid';
 import { wrap as wrapDialog, DialogPropType } from '@/components/DialogWrapper';
-import { Filters, filterData } from '@/components/Filters';
+import { Filters, filterData, setFilterDefaults } from '@/components/Filters';
 import notification from '@/services/notification';
 import { Visualization } from '@/services/visualization';
 import recordEvent from '@/services/recordEvent';
@@ -68,11 +68,6 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
   const data = useQueryResult(queryResult);
   const [filters, setFilters] = useState(data.filters);
 
-  const filteredData = useMemo(() => ({
-    columns: data.columns,
-    rows: filterData(data.rows, filters),
-  }), [data, filters]);
-
   const defaultState = useMemo(
     () => {
       const config = visualization ? registeredVisualizations[visualization.type] : getDefaultVisualization();
@@ -91,6 +86,14 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
   const [name, setName] = useState(defaultState.name);
   const [nameChanged, setNameChanged] = useState(false);
   const [options, setOptions] = useState(defaultState.options);
+
+  setFilterDefaults(filters, options.columns);
+
+  const filteredData = useMemo(() => ({
+    columns: data.columns,
+    rows: filterData(data.rows, filters),
+  }), [data, filters]);
+
 
   const [saveInProgress, setSaveInProgress] = useState(false);
 

--- a/client/app/visualizations/VisualizationRenderer.jsx
+++ b/client/app/visualizations/VisualizationRenderer.jsx
@@ -3,7 +3,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import useQueryResult from '@/lib/hooks/useQueryResult';
-import { Filters, FiltersType, filterData } from '@/components/Filters';
+import { Filters, FiltersType, filterData, setFilterDefaults } from '@/components/Filters';
 import { registeredVisualizations, VisualizationType } from './index';
 
 function combineFilters(localFilters, globalFilters) {
@@ -38,14 +38,17 @@ export function VisualizationRenderer(props) {
     setFilters(combineFilters(filters, props.filters));
   }, [props.filters]);
 
-  const filteredData = useMemo(() => ({
-    columns: data.columns,
-    rows: filterData(data.rows, filters),
-  }), [data, filters]);
 
   const { showFilters, visualization } = props;
   const { Renderer, getOptions } = registeredVisualizations[visualization.type];
   const options = getOptions(visualization.options, data);
+
+  setFilterDefaults(filters, options.columns);
+
+  const filteredData = useMemo(() => ({
+    columns: data.columns,
+    rows: filterData(data.rows, filters),
+  }), [data, filters]);
 
   return (
     <React.Fragment>

--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -46,6 +46,7 @@ function getDefaultColumnsOptions(columns) {
     title: getColumnCleanName(col.name),
     allowSearch: false,
     alignContent: getColumnContentAlignment(col.type),
+    multiFilterDefault: 'first',
     // `string` cell options
     allowHTML: true,
     highlightLinks: false,
@@ -171,6 +172,8 @@ const GridEditor = {
     this.setCurrentTab = (tab) => {
       this.currentTab = tab;
     };
+
+    this.isMultiFilter = name => !!name.match(/(::|__)multi(F|-f)ilter$/);
 
     $scope.$watch('$ctrl.options', (options) => {
       this.onOptionsChange(options);

--- a/client/app/visualizations/table/table-editor.html
+++ b/client/app/visualizations/table/table-editor.html
@@ -44,6 +44,15 @@
         <label class="ui-sortable-bypass"><input type="checkbox" ng-model="column.allowSearch"> Use for search</label>
       </div>
 
+      <div class="form-group" ng-if="$ctrl.isMultiFilter(column.name)">
+        <label>Filter default:</label>
+        <select ng-model="column.multiFilterDefault" class="form-control">
+          <option value="all">All</option>
+          <option value="none">None</option>
+          <option value="first">First</option>
+        </select>
+      </div>
+
       <div class="form-group">
         <label>Display as:</label>
         <select ng-options="item.value as item.name for item in $ctrl.displayAsOptions"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description
Back in #608 there was a hidden feature to pre-select all entries in a multi-filter, which got removed when migrating the filters to react. I heavily depend on this and would like to see it come back. I think it would make sense to fix this in a less hacky way, using column metadata.

In below screenshot, the priority and status columns are multi-filters, therefore they have an extra dropdown to select one of "first", "all", or "none". Selecting "first" uses the current behavior to select the first value, "all" and "none" are self-explanatory.

### To-Do

- [ ] Possibly refactor filter current value
- [ ] Find sensible defaults for dashboard-level filters
- [ ] Tests

### Discussion items

I'm not particularly happy about how `setFilterDefaults` runs after the filters are gathered in the query result service and after the options are retrieved. Changing this may require some refactoring, but before I start with that I'd like to get some feedback

The second thing that will require some discussion, how to do dashboard level filters. These don't have access to a specific visualization, so if two visualizations have different defaults for the default state for a multi-filter column then there is a conflict. Also, it doesn't seem like the specific visualizations are available at the time the filters are determined, similar to the first discussion point.

Looking forward to your thoughts.

## Related Tickets & Documents
TBD

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="589" alt="image" src="https://user-images.githubusercontent.com/607198/59569349-84d4c780-9088-11e9-9bd6-19cb031b699c.png">
