### PR TITLE
Support multi-byte search for query names and descriptions

### DIFF
--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -161,7 +161,7 @@ class OrganizationSettings extends React.Component {
             checked={formValues.multi_byte_search_enabled}
             onChange={e => this.handleChange('multi_byte_search_enabled', e.target.checked)}
           >
-          Enable multi-byte search for query names and descriptions (slower)
+          Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
           </Checkbox>
         </Form.Item>
         <Form.Item label="Feature Flags">

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -155,6 +155,15 @@ class OrganizationSettings extends React.Component {
             ))}
           </Select>
         </Form.Item>
+        <Form.Item label="Multi-byte Search">
+          <Checkbox
+            name="multi_byte_search_enabled"
+            checked={formValues.multi_byte_search_enabled}
+            onChange={e => this.handleChange('multi_byte_search_enabled', e.target.checked)}
+          >
+          Enable multi-byte search for query names and descriptions (slower)
+          </Checkbox>
+        </Form.Item>
         <Form.Item label="Feature Flags">
           <Checkbox
             name="feature_show_permissions_control"

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -112,6 +112,7 @@ class BaseQueryListResource(BaseResource):
                 self.current_user.group_ids,
                 self.current_user.id,
                 include_drafts=True,
+                multi_byte_search=current_org.get_setting('multi_byte_search_enabled'),
             )
         else:
             results = models.Query.all_queries(
@@ -256,6 +257,7 @@ class QueryArchiveResource(BaseQueryListResource):
                 self.current_user.id,
                 include_drafts=False,
                 include_archived=True,
+                multi_byte_search=current_org.get_setting('multi_byte_search_enabled'),
             )
         else:
             return models.Query.all_queries(

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -578,8 +578,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def search(cls, term, group_ids, user_id=None, include_drafts=False,
-               limit=None, include_archived=False):
-        from redash.authentication.org_resolving import current_org
+               limit=None, include_archived=False, multi_byte_search=False):
         all_queries = cls.all_queries(
             group_ids,
             user_id=user_id,
@@ -587,7 +586,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
             include_archived=include_archived,
         )
 
-        if current_org.get_setting("multi_byte_search_enabled"):
+        if multi_byte_search:
             # Since tsvector doesn't work well with CJK languages, use `ilike` too
             pattern = u'%{}%'.format(term)
             return all_queries.filter(

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -592,7 +592,6 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
             pattern = u'%{}%'.format(term)
             return all_queries.filter(
                 or_(
-                    cls.search_vector.match(term),
                     cls.name.ilike(pattern),
                     cls.description.ilike(pattern)
                 )

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -20,6 +20,7 @@ DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
 TIME_FORMAT = os.environ.get("REDASH_TIME_FORMAT", "HH:mm")
 INTEGER_FORMAT = os.environ.get("REDASH_INTEGER_FORMAT", "0,0")
 FLOAT_FORMAT = os.environ.get("REDASH_FLOAT_FORMAT", "0,0.00")
+MULTI_BYTE_SEARCH_ENABLED = parse_boolean(os.environ.get("MULTI_BYTE_SEARCH_ENABLED", "false"))
 
 JWT_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_JWT_LOGIN_ENABLED", "false"))
 JWT_AUTH_ISSUER = os.environ.get("REDASH_JWT_AUTH_ISSUER", "")
@@ -41,6 +42,7 @@ settings = {
     "time_format": TIME_FORMAT,
     "integer_format": INTEGER_FORMAT,
     "float_format": FLOAT_FORMAT,
+    "multi_byte_search_enabled": MULTI_BYTE_SEARCH_ENABLED,
     "auth_jwt_login_enabled": JWT_LOGIN_ENABLED,
     "auth_jwt_auth_issuer": JWT_AUTH_ISSUER,
     "auth_jwt_auth_public_certs_url": JWT_AUTH_PUBLIC_CERTS_URL,

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -52,6 +52,17 @@ class QueryTest(BaseTestCase):
         self.assertIn(q2, queries)
         self.assertNotIn(q3, queries)
 
+    def test_search_finds_in_multi_byte_name_and_description(self):
+        q1 = self.factory.create_query(name="日本語の名前テスト")
+        q2 = self.factory.create_query(description=u"日本語の説明文テスト")
+        q3 = self.factory.create_query(description=u"Testing search")
+
+        queries = Query.search(u"テスト", [self.factory.default_group.id], multi_byte_search=True)
+
+        self.assertIn(q1, queries)
+        self.assertIn(q2, queries)
+        self.assertNotIn(q3, queries)
+
     def test_search_by_id_returns_query(self):
         q1 = self.factory.create_query(description=u"Testing search")
         q2 = self.factory.create_query(description=u"Testing searching")


### PR DESCRIPTION
* add multi_byte_support_enabled option to organization settings
* add `ilike %...%` to query search conditions when the option is enabled

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Since postgres tsvector does not work well with multi-byte characters in CJK- (and some others) launguages , currently queries named in multi-byte characters are often fails to be searched as described #2622.

This fixes the issue by adding an option to enable multi-byte compliant search into organization settings, and if it is enabled, search for queries using `<name or description> ilike %<search_term>%` pattern in addition to tsvector.
This search method is slower than tsvector search, so it is recommended only when multi-byte search is more important than speed.

## Related Tickets & Documents

This closes #2622.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

* New organization settings for multi-byte search

<img width="800" alt="スクリーンショット 2019-06-18 16 16 13" src="https://user-images.githubusercontent.com/26372128/59660943-bf537700-91e4-11e9-994f-e4c80161ccaa.png">
<img width="362" alt="スクリーンショット 2019-06-18 16 17 03" src="https://user-images.githubusercontent.com/26372128/59660954-c4b0c180-91e4-11e9-9305-52bfdcdc32da.png">

* The result of search result when multi-byte search is enabled

<img width="1139" alt="スクリーンショット 2019-06-18 16 18 06" src="https://user-images.githubusercontent.com/26372128/59660999-d2664700-91e4-11e9-9e32-e720d20fb9a1.png">

(If the option is disabled, nothing is hit in `ユーザー` search results.)


