### PR TITLE
Add an `extras` field for Presto connection

### DIFF
--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -59,8 +59,12 @@ class Presto(BaseQueryRunner):
                 'password': {
                     'type': 'string'
                 },
+                'extras': {
+                    'type': 'string',
+                    'default': '{"requests_kwargs": null}'
+                }
             },
-            'order': ['host', 'protocol', 'port', 'username', 'password', 'schema', 'catalog'],
+            'order': ['host', 'protocol', 'port', 'username', 'password', 'schema', 'catalog', 'extras'],
             'required': ['host']
         }
 
@@ -105,7 +109,8 @@ class Presto(BaseQueryRunner):
             username=self.configuration.get('username', 'redash'),
             password=(self.configuration.get('password') or None),
             catalog=self.configuration.get('catalog', 'hive'),
-            schema=self.configuration.get('schema', 'default'))
+            schema=self.configuration.get('schema', 'default'),
+            **json_loads(self.configuration.get('extras') or '{}'))
 
         cursor = connection.cursor()
 

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -79,10 +79,11 @@ class Presto(BaseQueryRunner):
     def get_schema(self, get_stats=False):
         schema = {}
         query = """
-        SELECT table_schema, table_name, column_name
-        FROM information_schema.columns
-        WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-        """
+        SELECT
+            table_schem, table_name, column_name
+        FROM system.jdbc.columns
+        WHERE table_cat = '{}'
+        """.format(self.configuration.get('catalog', 'hive'))
 
         results, error = self.run_query(query, None)
 
@@ -92,7 +93,7 @@ class Presto(BaseQueryRunner):
         results = json_loads(results)
 
         for row in results['rows']:
-            table_name = '{}.{}'.format(row['table_schema'], row['table_name'])
+            table_name = '{}.{}'.format(row['table_schem'], row['table_name'])
 
             if table_name not in schema:
                 schema[table_name] = {'name': table_name, 'columns': []}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x ] Feature

## Description

This added a new "Extras" fields for Presto connection,
 mostly for allowing self-assigned SSL certificate.

For example, services like [Qubole](https://docs.qubole.com/en/latest/user-guide/presto/connect-to-presto-when-ssl-enabled.html)
only allows SSL connection via self-assigned CA certificate.

Example usage is to include `requests_kwargs` as JSON string:

```json
{"requests_kwargs":  {"verify": "~/qubole.cert"} }
```


## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)



