### PR TITLE
Expose celery job timeout setting to env var

### DIFF
--- a/redash/metrics/celery.py
+++ b/redash/metrics/celery.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import logging
 import socket
 import time
+from redash import settings
 
 from celery.concurrency import asynpool
-asynpool.PROC_ALIVE_TIMEOUT = 10.0
+asynpool.PROC_ALIVE_TIMEOUT = settings.CELERY_JOB_TIMEOUT
 
 from celery.signals import task_postrun, task_prerun
 from redash import settings, statsd_client

--- a/redash/metrics/celery.py
+++ b/redash/metrics/celery.py
@@ -6,7 +6,7 @@ import time
 from redash import settings
 
 from celery.concurrency import asynpool
-asynpool.PROC_ALIVE_TIMEOUT = settings.CELERY_JOB_TIMEOUT
+asynpool.PROC_ALIVE_TIMEOUT = settings.CELERY_INIT_TIMEOUT
 
 from celery.signals import task_postrun, task_prerun
 from redash import settings, statsd_client

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -31,8 +31,8 @@ CELERY_RESULT_BACKEND = os.environ.get(
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))
-CELERY_JOB_TIMEOUT = int(os.environ.get(
-    "REDASH_CELERY_JOB_TIMEOUT", 10))
+CELERY_INIT_TIMEOUT = int(os.environ.get(
+    "REDASH_CELERY_INIT_TIMEOUT", 10))
 CELERY_BROKER_USE_SSL = CELERY_BROKER.startswith('rediss')
 CELERY_SSL_CONFIG = {
     'ssl_cert_reqs': int(os.environ.get("REDASH_CELERY_BROKER_SSL_CERT_REQS",  ssl.CERT_OPTIONAL)),

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -31,6 +31,8 @@ CELERY_RESULT_BACKEND = os.environ.get(
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))
+CELERY_JOB_TIMEOUT = int(os.environ.get(
+    "REDASH_CELERY_JOB_TIMEOUT", 10))
 CELERY_BROKER_USE_SSL = CELERY_BROKER.startswith('rediss')
 CELERY_SSL_CONFIG = {
     'ssl_cert_reqs': int(os.environ.get("REDASH_CELERY_BROKER_SSL_CERT_REQS",  ssl.CERT_OPTIONAL)),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
This PR allows users to define celery job timeout from environment variable. Environment variable is `REDASH_CELERY_INIT_TIMEOUT` and the default value is 10 seconds.

It should help people with limited computing resource seeing `[ERROR][MainProcess] Process 'ForkPoolWorker-19' pid:63 exited with 'signal 9 (SIGKILL)'` in their logs.

## Related Tickets & Documents
This PR is an follow up of #3903.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
