### PR TITLE
Add support for int/float values in guess_type

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -271,7 +271,18 @@ def import_query_runners(query_runner_imports):
         __import__(runner_import)
 
 
-def guess_type(string_value):
+def guess_type(value):
+    if isinstance(value, bool):
+        return TYPE_BOOLEAN
+    elif isinstance(value, int):
+        return TYPE_INTEGER
+    elif isinstance(value, float):
+        return TYPE_FLOAT
+
+    return guess_type_from_string(value)
+
+
+def guess_type_from_string(string_value):
     if string_value == '' or string_value is None:
         return TYPE_STRING
 

--- a/tests/query_runner/test_utils.py
+++ b/tests/query_runner/test_utils.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
 
-from redash.query_runner import TYPE_DATETIME, TYPE_FLOAT, TYPE_INTEGER, TYPE_BOOLEAN, TYPE_STRING
-from redash.query_runner.drill import guess_type
+from redash.query_runner import TYPE_DATETIME, TYPE_FLOAT, TYPE_INTEGER, TYPE_BOOLEAN, TYPE_STRING, guess_type
 
 
 class TestGuessType(TestCase):
@@ -16,6 +15,7 @@ class TestGuessType(TestCase):
         self.assertEqual(guess_type('false'), TYPE_BOOLEAN)
         self.assertEqual(guess_type('False'), TYPE_BOOLEAN)
         self.assertEqual(guess_type('FALSE'), TYPE_BOOLEAN)
+        self.assertEqual(guess_type(False), TYPE_BOOLEAN)
 
     def test_detects_strings(self):
         self.assertEqual(guess_type(None), TYPE_STRING)
@@ -24,9 +24,11 @@ class TestGuessType(TestCase):
 
     def test_detects_integer(self):
         self.assertEqual(guess_type('42'), TYPE_INTEGER)
+        self.assertEqual(guess_type(42), TYPE_INTEGER)
 
     def test_detects_float(self):
         self.assertEqual(guess_type('3.14'), TYPE_FLOAT)
+        self.assertEqual(guess_type(3.14), TYPE_FLOAT)
 
     def test_detects_date(self):
         self.assertEqual(guess_type('2018-10-31'), TYPE_DATETIME)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor
- [x] Bug Fix

## Description

Some data sources, like Query Results, use the `guess_type` function to set the column type. But `guess_type` wasn't working properly with non strings:

```python
int(3.5) #  3
int("3.5") #  raises Exception
```

This changes the `guess_type` function to first handle non string values and only after switch to string based detection.

## Related Tickets & Documents

#3820