### PR TITLE
Fixed boolean filter

### DIFF
--- a/client/app/components/Filters.jsx
+++ b/client/app/components/Filters.jsx
@@ -27,7 +27,8 @@ function createFilterChangeHandler(filters, onChange) {
     if (isArray(values)) {
       values = map(values, value => filter.values[toNumber(value.key)] || value.key);
     } else {
-      values = filter.values[toNumber(values.key)] || values.key;
+      const _values = filter.values[toNumber(values.key)];
+      values = _values !== undefined ? _values : values.key;
     }
 
     if (filter.multiple && includes(values, ALL_VALUES)) {
@@ -73,6 +74,10 @@ export function filterData(rows, filters = []) {
 function formatValue(value) {
   if (moment.isMoment(value)) {
     return formatDateTime(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value.toString();
   }
 
   return value;


### PR DESCRIPTION
- [x] Bug Fix

Fixes #3914.

## Description
### Bug 1
Boolean filter show no label.
Cause: Ant select deficiency.
Fix: Stringify value for booleans.

### Bug 2
Selecting "false" changes value to number.
Cause: Naive code assumes value to be not `Falsy`, falling back to `values.key`.
Fix: Changed condition to be not `undefined`. Now `false` is an acceptable value.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before|After
-------|--------
<img width="466" alt="Screen Shot 2019-06-19 at 10 54 30" src="https://user-images.githubusercontent.com/486954/59746977-a4364500-9280-11e9-876e-bae1811dc710.png"> | <img width="466" alt="Screen Shot 2019-06-19 at 10 50 07" src="https://user-images.githubusercontent.com/486954/59746975-a4364500-9280-11e9-892b-8354f7254129.png">
