### PR TITLE
Adding widget from query page is broken

### DIFF
--- a/client/app/pages/queries/add-to-dashboard.js
+++ b/client/app/pages/queries/add-to-dashboard.js
@@ -2,7 +2,7 @@ import template from './add-to-dashboard.html';
 import notification from '@/services/notification';
 
 const AddToDashboardForm = {
-  controller($sce, Dashboard, currentUser, Widget) {
+  controller($sce, Dashboard) {
     'ngInject';
 
     this.vis = this.resolve.vis;
@@ -13,25 +13,7 @@ const AddToDashboardForm = {
       this.selected_query = this.resolve.query.id;
       // Load dashboard with all widgets
       Dashboard.get({ slug }).$promise
-        .then((dashboard) => {
-          const widget = new Widget({
-            visualization_id: this.vis && this.vis.id,
-            dashboard_id: dashboard.id,
-            options: {
-              isHidden: false,
-              position: {},
-            },
-            width: 1,
-            type: 'visualization',
-            visualization: this.vis, // `Widget` constructor uses it to compute default dimensions based on viz config
-          });
-
-          const position = dashboard.calculateNewWidgetPosition(widget);
-          widget.options.position.col = position.col;
-          widget.options.position.row = position.row;
-
-          return widget.save();
-        })
+        .then(dashboard => dashboard.addWidget(this.vis))
         .then(() => {
           this.close();
           notification.success('Widget added to dashboard.');

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import dashboardGridOptions from '@/config/dashboard-grid-options';
+import { Widget } from './widget';
 
 export let Dashboard = null; // eslint-disable-line import/no-mutable-exports
 
@@ -76,7 +77,53 @@ function prepareWidgetsForDashboard(widgets) {
   return widgets;
 }
 
-function DashboardService($resource, $http, $location, currentUser, Widget) {
+function calculateNewWidgetPosition(existingWidgets, newWidget) {
+  const width = _.extend({ sizeX: dashboardGridOptions.defaultSizeX }, _.extend({}, newWidget.options).position).sizeX;
+
+  // Find first free row for each column
+  const bottomLine = _
+    .chain(existingWidgets)
+    .map((w) => {
+      const options = _.extend({}, w.options);
+      const position = _.extend({ row: 0, sizeY: 0 }, options.position);
+      return {
+        left: position.col,
+        top: position.row,
+        right: position.col + position.sizeX,
+        bottom: position.row + position.sizeY,
+        width: position.sizeX,
+        height: position.sizeY,
+      };
+    })
+    .reduce((result, item) => {
+      const from = Math.max(item.left, 0);
+      const to = Math.min(item.right, result.length + 1);
+      for (let i = from; i < to; i += 1) {
+        result[i] = Math.max(result[i], item.bottom);
+      }
+      return result;
+    }, _.map(new Array(dashboardGridOptions.columns), _.constant(0)))
+    .value();
+
+  // Go through columns, pick them by count necessary to hold new block,
+  // and calculate bottom-most free row per group.
+  // Choose group with the top-most free row (comparing to other groups)
+  return _
+    .chain(_.range(0, dashboardGridOptions.columns - width + 1))
+    .map(col => ({
+      col,
+      row: _
+        .chain(bottomLine)
+        .slice(col, col + width)
+        .max()
+        .value(),
+    }))
+    .sortBy('row')
+    .first()
+    .value();
+}
+
+function DashboardService($resource, $http, $location, currentUser) {
   function prepareDashboardWidgets(widgets) {
     return prepareWidgetsForDashboard(_.map(widgets, widget => new Widget(widget)));
   }
@@ -134,52 +181,6 @@ function DashboardService($resource, $http, $location, currentUser, Widget) {
     return currentUser.canEdit(this) || this.can_edit;
   };
 
-  resource.prototype.calculateNewWidgetPosition = function calculateNewWidgetPosition(widget) {
-    const width = _.extend({ sizeX: dashboardGridOptions.defaultSizeX }, _.extend({}, widget.options).position).sizeX;
-
-    // Find first free row for each column
-    const bottomLine = _
-      .chain(this.widgets)
-      .map((w) => {
-        const options = _.extend({}, w.options);
-        const position = _.extend({ row: 0, sizeY: 0 }, options.position);
-        return {
-          left: position.col,
-          top: position.row,
-          right: position.col + position.sizeX,
-          bottom: position.row + position.sizeY,
-          width: position.sizeX,
-          height: position.sizeY,
-        };
-      })
-      .reduce((result, item) => {
-        const from = Math.max(item.left, 0);
-        const to = Math.min(item.right, result.length + 1);
-        for (let i = from; i < to; i += 1) {
-          result[i] = Math.max(result[i], item.bottom);
-        }
-        return result;
-      }, _.map(new Array(dashboardGridOptions.columns), _.constant(0)))
-      .value();
-
-    // Go through columns, pick them by count necessary to hold new block,
-    // and calculate bottom-most free row per group.
-    // Choose group with the top-most free row (comparing to other groups)
-    return _
-      .chain(_.range(0, dashboardGridOptions.columns - width + 1))
-      .map(col => ({
-        col,
-        row: _
-          .chain(bottomLine)
-          .slice(col, col + width)
-          .max()
-          .value(),
-      }))
-      .sortBy('row')
-      .first()
-      .value();
-  };
-
   resource.prepareDashboardWidgets = prepareDashboardWidgets;
   resource.prepareWidgetsForDashboard = prepareWidgetsForDashboard;
 
@@ -213,6 +214,40 @@ function DashboardService($resource, $http, $location, currentUser, Widget) {
       param.setValue(param.getValue()); // apply global param value to all locals
       param.fromUrlParams(queryParams); // try to initialize from url (may do nothing)
     }));
+  };
+
+  resource.prototype.addWidget = function addWidget(textOrVisualization, options = {}) {
+    const props = {
+      dashboard_id: this.id,
+      options: {
+        ...options,
+        isHidden: false,
+        position: {},
+      },
+      text: '',
+      visualization_id: null,
+      visualization: null,
+    };
+
+    if (_.isString(textOrVisualization)) {
+      props.text = textOrVisualization;
+    } else if (_.isObject(textOrVisualization)) {
+      props.visualization_id = textOrVisualization.id;
+      props.visualization = textOrVisualization;
+    } else {
+      // TODO: Throw an error?
+    }
+
+    const widget = new Widget(props);
+
+    const position = calculateNewWidgetPosition(this.widgets, widget);
+    widget.options.position.col = position.col;
+    widget.options.position.row = position.row;
+
+    return widget.save().then(() => {
+      this.widgets = [...this.widgets, widget]; // ANGULAR_REMOVE_ME
+      return widget;
+    });
   };
 
   return resource;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Refactor

## Description

Newly added widgets have no initialized size and position which causes errors on dashboard page.

Refactor: `addTexbox` and `addWidget` functions merged and moved to `Dashboard` service. Newly added function is now used both on dashboard and query pages (which also fixes a bug).

## Related Tickets & Documents

Fixes getredash/redash#3917
