### PR TITLE
Add an `extras` field for Presto #3909

### DIFF
--- a/client/app/components/dynamic-form/dynamicFormHelper.js
+++ b/client/app/components/dynamic-form/dynamicFormHelper.js
@@ -5,13 +5,15 @@ function orderedInputs(properties, order, targetOptions) {
   const inputs = new Array(order.length);
   Object.keys(properties).forEach((key) => {
     const position = order.indexOf(key);
+    const field = properties[key];
     const input = {
       name: key,
-      title: properties[key].title,
-      type: properties[key].type,
-      placeholder: properties[key].default && properties[key].default.toString(),
-      required: properties[key].required,
+      title: field.title,
+      type: field.type,
+      placeholder: field.default && field.default.toString(),
+      required: field.required,
       initialValue: targetOptions[key],
+      props: field.props,
     };
 
     if (position > -1) {
@@ -39,6 +41,10 @@ function normalizeSchema(configurationSchema) {
 
     if (prop.type === 'string') {
       prop.type = 'text';
+    }
+
+    if (prop.type === 'object') {
+      prop.type = 'json';
     }
 
     prop.required = includes(configurationSchema.required, name);

--- a/client/app/components/proptypes.js
+++ b/client/app/components/proptypes.js
@@ -43,11 +43,13 @@ export const Field = PropTypes.shape({
     'file',
     'select',
     'content',
+    'json',
   ]).isRequired,
   initialValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
     PropTypes.bool,
+    PropTypes.object,
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.arrayOf(PropTypes.number),
   ]),

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -45,7 +45,7 @@ class DataSourceResource(BaseResource):
         try:
             data_source.options.set_schema(schema)
             data_source.options.update(filter_none(req['options']))
-        except ValidationError:
+        except ValidationError, e:
             abort(400)
 
         data_source.type = req['type']

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -59,8 +59,17 @@ class Presto(BaseQueryRunner):
                 'password': {
                     'type': 'string'
                 },
+                'extras': {
+                    'type': 'object',
+                    'default': '{ "requests_kwargs": null }',
+                    'props': {
+                        'rows': 2,
+                        'extra': 'Extra kwargs passed to presto.connect(...)',
+                    }
+                }
             },
-            'order': ['host', 'protocol', 'port', 'username', 'password', 'schema', 'catalog'],
+            'order': ['host', 'protocol', 'port', 'username', 'password',
+                      'schema', 'catalog', 'extras'],
             'required': ['host']
         }
 
@@ -105,7 +114,8 @@ class Presto(BaseQueryRunner):
             username=self.configuration.get('username', 'redash'),
             password=(self.configuration.get('password') or None),
             catalog=self.configuration.get('catalog', 'hive'),
-            schema=self.configuration.get('schema', 'default'))
+            schema=self.configuration.get('schema', 'default'),
+            **self.configuration.get('extras', {}))
 
         cursor = connection.cursor()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x ] Feature

## Description

This added a new "Extras" fields for Presto connection,
 mostly for allowing self-assigned SSL certificate.

For example, services like [Qubole](https://docs.qubole.com/en/latest/user-guide/presto/connect-to-presto-when-ssl-enabled.html) only allows SSL connection via self-assigned CA certificate.

Example usage is to add `requests_kwargs` in the extras:
```json
{"requests_kwargs":  {"verify": "~/qubole.cert"} }
```

We prefer this instead of the Qubole connector because Qubole charges you for every API call and the roundtrip from local EMR cluster to Qubole servers is not ideal.

## Related Tickets & Documents

This is a refile of #3909, with type validation and help text added.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Snip20190620_6](https://user-images.githubusercontent.com/335541/59878190-85a57c00-935c-11e9-81e0-e720851a5db1.png)



