### PR TITLE
Update Dockerfile to copy only client side files at the front end stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /frontend
 COPY package.json package-lock.json /frontend/
 RUN npm install
 
-COPY . /frontend
+COPY client /frontend/client
+COPY webpack.config.js /frontend/
 RUN npm run build
 
 FROM redash/base:debian


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Update Dockerfile to copy only client side files at the front end stage
So that changing other files will not trigger the
very expensive npm build process.