### PR TITLE
Migrate Word Cloud visualization to React

### DIFF
--- a/client/app/directives/resize-event.js
+++ b/client/app/directives/resize-event.js
@@ -1,48 +1,13 @@
-import { findIndex } from 'lodash';
-
-const items = new Map();
-
-function checkItems() {
-  items.forEach((item, node) => {
-    const bounds = node.getBoundingClientRect();
-    // convert to int (because these numbers needed for comparisons), but preserve 1 decimal point
-    const width = Math.round(bounds.width * 10);
-    const height = Math.round(bounds.height * 10);
-
-    if (
-      (item.width !== width) ||
-      (item.height !== height)
-    ) {
-      item.width = width;
-      item.height = height;
-      item.callback(node);
-    }
-  });
-
-  setTimeout(checkItems, 100);
-}
-
-checkItems(); // ensure it was called only once!
+import resizeObserver from '@/services/resizeObserver';
 
 function resizeEvent() {
   return {
     restrict: 'A',
     link($scope, $element, attrs) {
-      const node = $element[0];
-      if (!items.has(node)) {
-        items.set(node, {
-          callback: () => {
-            $scope.$evalAsync(attrs.resizeEvent);
-          },
-        });
-
-        $scope.$on('$destroy', () => {
-          const index = findIndex(items, item => item.node === node);
-          if (index >= 0) {
-            items.splice(index, 1); // remove item
-          }
-        });
-      }
+      const unwatch = resizeObserver($element[0], () => {
+        $scope.$evalAsync(attrs.resizeEvent);
+      });
+      $scope.$on('$destroy', unwatch);
     },
   };
 }

--- a/client/app/lib/hooks/useQueryResult.js
+++ b/client/app/lib/hooks/useQueryResult.js
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 
 function getQueryResultData(queryResult) {
   return {
-    columns: queryResult ? queryResult.getColumns() : [],
-    rows: queryResult ? queryResult.getData() : [],
-    filters: queryResult ? queryResult.getFilters() : [],
+    columns: queryResult ? queryResult.getColumns() || [] : [],
+    rows: queryResult ? queryResult.getData() || [] : [],
+    filters: queryResult ? queryResult.getFilters() || [] : [],
   };
 }
 

--- a/client/app/lib/hooks/useQueryResult.js
+++ b/client/app/lib/hooks/useQueryResult.js
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 
 function getQueryResultData(queryResult) {
   return {
-    columns: queryResult ? queryResult.getColumns() || [] : [],
-    rows: queryResult ? queryResult.getData() || [] : [],
-    filters: queryResult ? queryResult.getFilters() || [] : [],
+    columns: (queryResult && queryResult.getColumns()) || [],
+    rows: (queryResult && queryResult.getData()) || [],
+    filters: (queryResult && queryResult.getFilters()) || [],
   };
 }
 

--- a/client/app/pages/dashboards/dashboard.less
+++ b/client/app/pages/dashboards/dashboard.less
@@ -83,6 +83,7 @@
     .sunburst-visualization-container,
     .sankey-visualization-container,
     .map-visualization-container,
+    .word-cloud-visualization-container,
     .plotly-chart-container {
       position: absolute;
       left: 0;

--- a/client/app/services/resizeObserver.js
+++ b/client/app/services/resizeObserver.js
@@ -1,0 +1,31 @@
+const items = new Map();
+
+function checkItems() {
+  items.forEach((item, node) => {
+    const bounds = node.getBoundingClientRect();
+    // convert to int (because these numbers needed for comparisons), but preserve 1 decimal point
+    const width = Math.round(bounds.width * 10);
+    const height = Math.round(bounds.height * 10);
+
+    if (
+      (item.width !== width) ||
+      (item.height !== height)
+    ) {
+      item.width = width;
+      item.height = height;
+      item.callback(node);
+    }
+  });
+
+  setTimeout(checkItems, 100);
+}
+
+checkItems(); // ensure it was called only once!
+
+export default function observe(node, callback) {
+  if (!items.has(node)) {
+    items.set(node, { callback });
+    return () => items.delete(node);
+  }
+  return () => {};
+}

--- a/client/app/services/resizeObserver.js
+++ b/client/app/services/resizeObserver.js
@@ -1,31 +1,50 @@
+/* global ResizeObserver */
+
+function observeNative(node, callback) {
+  if ((typeof ResizeObserver === 'function') && node) {
+    const observer = new ResizeObserver(() => callback()); // eslint-disable-line compat/compat
+    observer.observe(node);
+    return () => observer.disconnect();
+  }
+  return null;
+}
+
 const items = new Map();
 
 function checkItems() {
-  items.forEach((item, node) => {
-    const bounds = node.getBoundingClientRect();
-    // convert to int (because these numbers needed for comparisons), but preserve 1 decimal point
-    const width = Math.round(bounds.width * 10);
-    const height = Math.round(bounds.height * 10);
+  if (items.size > 0) {
+    items.forEach((item, node) => {
+      const bounds = node.getBoundingClientRect();
+      // convert to int (because these numbers needed for comparisons), but preserve 1 decimal point
+      const width = Math.round(bounds.width * 10);
+      const height = Math.round(bounds.height * 10);
 
-    if (
-      (item.width !== width) ||
-      (item.height !== height)
-    ) {
-      item.width = width;
-      item.height = height;
-      item.callback(node);
-    }
-  });
+      if (
+        (item.width !== width) ||
+        (item.height !== height)
+      ) {
+        item.width = width;
+        item.height = height;
+        item.callback(node);
+      }
+    });
 
-  setTimeout(checkItems, 100);
+    setTimeout(checkItems, 100);
+  }
 }
 
-checkItems(); // ensure it was called only once!
-
-export default function observe(node, callback) {
-  if (!items.has(node)) {
+function observeFallback(node, callback) {
+  if (node && !items.has(node)) {
+    const shouldTrigger = items.size === 0;
     items.set(node, { callback });
+    if (shouldTrigger) {
+      checkItems();
+    }
     return () => items.delete(node);
   }
-  return () => {};
+  return null;
+}
+
+export default function observe(node, callback) {
+  return observeNative(node, callback) || observeFallback(node, callback) || (() => {});
 }

--- a/client/app/visualizations/EditVisualizationDialog.jsx
+++ b/client/app/visualizations/EditVisualizationDialog.jsx
@@ -1,4 +1,4 @@
-import { extend, map, findIndex, isEqual } from 'lodash';
+import { extend, map, sortBy, findIndex, isEqual } from 'lodash';
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'antd/lib/modal';
@@ -158,7 +158,7 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
               onChange={onTypeChanged}
             >
               {map(
-                registeredVisualizations,
+                sortBy(registeredVisualizations, ['type']),
                 vis => <Select.Option key={vis.type} data-test={'VisualizationType.' + vis.type}>{vis.name}</Select.Option>,
               )}
             </Select>

--- a/client/app/visualizations/word-cloud/Editor.jsx
+++ b/client/app/visualizations/word-cloud/Editor.jsx
@@ -15,19 +15,21 @@ export default function Editor({ options, data, onOptionsChange }) {
       <div className="form-group">
         <label className="control-label" htmlFor="word-cloud-words-column">Words Column</label>
         <Select
+          data-test="WordCloud.WordsColumn"
           id="word-cloud-words-column"
           className="w-100"
           value={options.column}
           onChange={column => optionsChanged({ column })}
         >
           {map(data.columns, ({ name }) => (
-            <Select.Option key={name}>{name}</Select.Option>
+            <Select.Option key={name} data-test={'WordCloud.WordsColumn.' + name}>{name}</Select.Option>
           ))}
         </Select>
       </div>
       <div className="form-group">
         <label className="control-label" htmlFor="word-cloud-frequencies-column">Frequencies Column</label>
         <Select
+          data-test="WordCloud.FrequenciesColumn"
           id="word-cloud-frequencies-column"
           className="w-100"
           value={options.frequenciesColumn}
@@ -35,7 +37,7 @@ export default function Editor({ options, data, onOptionsChange }) {
         >
           <Select.Option key="none" value=""><i>(count word frequencies automatically)</i></Select.Option>
           {map(data.columns, ({ name }) => (
-            <Select.Option key={'column-' + name} value={name}>{name}</Select.Option>
+            <Select.Option key={'column-' + name} value={name} data-test={'WordCloud.FrequenciesColumn.' + name}>{name}</Select.Option>
           ))}
         </Select>
       </div>
@@ -46,6 +48,7 @@ export default function Editor({ options, data, onOptionsChange }) {
         <Grid.Row gutter={15} type="flex">
           <Grid.Col span={12}>
             <InputNumber
+              data-test="WordCloud.WordLengthLimit.Min"
               className="w-100"
               placeholder="Min"
               min={0}
@@ -55,6 +58,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           </Grid.Col>
           <Grid.Col span={12}>
             <InputNumber
+              data-test="WordCloud.WordLengthLimit.Max"
               className="w-100"
               placeholder="Max"
               min={0}
@@ -71,6 +75,7 @@ export default function Editor({ options, data, onOptionsChange }) {
         <Grid.Row gutter={15} type="flex">
           <Grid.Col span={12}>
             <InputNumber
+              data-test="WordCloud.WordCountLimit.Min"
               className="w-100"
               placeholder="Min"
               min={0}
@@ -80,6 +85,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           </Grid.Col>
           <Grid.Col span={12}>
             <InputNumber
+              data-test="WordCloud.WordCountLimit.Max"
               className="w-100"
               placeholder="Max"
               min={0}

--- a/client/app/visualizations/word-cloud/Editor.jsx
+++ b/client/app/visualizations/word-cloud/Editor.jsx
@@ -1,6 +1,8 @@
 import { map, merge } from 'lodash';
 import React from 'react';
 import Select from 'antd/lib/select';
+import InputNumber from 'antd/lib/input-number';
+import * as Grid from 'antd/lib/grid';
 import { EditorPropTypes } from '@/visualizations';
 
 export default function Editor({ options, data, onOptionsChange }) {
@@ -11,9 +13,9 @@ export default function Editor({ options, data, onOptionsChange }) {
   return (
     <React.Fragment>
       <div className="form-group">
-        <label className="control-label" htmlFor="word-cloud-column">Words Column</label>
+        <label className="control-label" htmlFor="word-cloud-words-column">Words column</label>
         <Select
-          id="word-cloud-column"
+          id="word-cloud-words-column"
           className="w-100"
           value={options.column}
           onChange={column => optionsChanged({ column })}
@@ -24,9 +26,9 @@ export default function Editor({ options, data, onOptionsChange }) {
         </Select>
       </div>
       <div className="form-group">
-        <label className="control-label" htmlFor="word-cloud-column">Frequencies Column</label>
+        <label className="control-label" htmlFor="word-cloud-frequencies-column">Frequencies column</label>
         <Select
-          id="word-cloud-column"
+          id="word-cloud-frequencies-column"
           className="w-100"
           value={options.frequenciesColumn}
           onChange={frequenciesColumn => optionsChanged({ frequenciesColumn })}
@@ -36,6 +38,56 @@ export default function Editor({ options, data, onOptionsChange }) {
             <Select.Option key={'column-' + name} value={name}>{name}</Select.Option>
           ))}
         </Select>
+      </div>
+      <div className="form-group">
+        <label className="control-label" htmlFor="word-cloud-word-length-limit">
+          Show only words with length between
+        </label>
+        <Grid.Row gutter={15} type="flex">
+          <Grid.Col span={12}>
+            <InputNumber
+              className="w-100"
+              placeholder="no limit"
+              min={0}
+              value={options.wordLengthLimit.min}
+              onChange={value => optionsChanged({ wordLengthLimit: { min: value > 0 ? value : null } })}
+            />
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <InputNumber
+              className="w-100"
+              placeholder="no limit"
+              min={0}
+              value={options.wordLengthLimit.max}
+              onChange={value => optionsChanged({ wordLengthLimit: { max: value > 0 ? value : null } })}
+            />
+          </Grid.Col>
+        </Grid.Row>
+      </div>
+      <div className="form-group">
+        <label className="control-label" htmlFor="word-cloud-word-length-limit">
+          Show only words with count between
+        </label>
+        <Grid.Row gutter={15} type="flex">
+          <Grid.Col span={12}>
+            <InputNumber
+              className="w-100"
+              placeholder="no limit"
+              min={0}
+              value={options.wordCountLimit.min}
+              onChange={value => optionsChanged({ wordCountLimit: { min: value > 0 ? value : null } })}
+            />
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <InputNumber
+              className="w-100"
+              placeholder="no limit"
+              min={0}
+              value={options.wordCountLimit.max}
+              onChange={value => optionsChanged({ wordCountLimit: { max: value > 0 ? value : null } })}
+            />
+          </Grid.Col>
+        </Grid.Row>
       </div>
     </React.Fragment>
   );

--- a/client/app/visualizations/word-cloud/Editor.jsx
+++ b/client/app/visualizations/word-cloud/Editor.jsx
@@ -47,7 +47,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="No Limit"
+              placeholder="Min"
               min={0}
               value={options.wordLengthLimit.min}
               onChange={value => optionsChanged({ wordLengthLimit: { min: value > 0 ? value : null } })}
@@ -56,7 +56,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="No Limit"
+              placeholder="Max"
               min={0}
               value={options.wordLengthLimit.max}
               onChange={value => optionsChanged({ wordLengthLimit: { max: value > 0 ? value : null } })}
@@ -72,7 +72,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="No Limit"
+              placeholder="Min"
               min={0}
               value={options.wordCountLimit.min}
               onChange={value => optionsChanged({ wordCountLimit: { min: value > 0 ? value : null } })}
@@ -81,7 +81,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="No Limit"
+              placeholder="Max"
               min={0}
               value={options.wordCountLimit.max}
               onChange={value => optionsChanged({ wordCountLimit: { max: value > 0 ? value : null } })}

--- a/client/app/visualizations/word-cloud/Editor.jsx
+++ b/client/app/visualizations/word-cloud/Editor.jsx
@@ -13,7 +13,7 @@ export default function Editor({ options, data, onOptionsChange }) {
   return (
     <React.Fragment>
       <div className="form-group">
-        <label className="control-label" htmlFor="word-cloud-words-column">Words column</label>
+        <label className="control-label" htmlFor="word-cloud-words-column">Words Column</label>
         <Select
           id="word-cloud-words-column"
           className="w-100"
@@ -26,7 +26,7 @@ export default function Editor({ options, data, onOptionsChange }) {
         </Select>
       </div>
       <div className="form-group">
-        <label className="control-label" htmlFor="word-cloud-frequencies-column">Frequencies column</label>
+        <label className="control-label" htmlFor="word-cloud-frequencies-column">Frequencies Column</label>
         <Select
           id="word-cloud-frequencies-column"
           className="w-100"
@@ -41,13 +41,13 @@ export default function Editor({ options, data, onOptionsChange }) {
       </div>
       <div className="form-group">
         <label className="control-label" htmlFor="word-cloud-word-length-limit">
-          Show only words with length between
+          Words Length Limit
         </label>
         <Grid.Row gutter={15} type="flex">
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="no limit"
+              placeholder="No Limit"
               min={0}
               value={options.wordLengthLimit.min}
               onChange={value => optionsChanged({ wordLengthLimit: { min: value > 0 ? value : null } })}
@@ -56,7 +56,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="no limit"
+              placeholder="No Limit"
               min={0}
               value={options.wordLengthLimit.max}
               onChange={value => optionsChanged({ wordLengthLimit: { max: value > 0 ? value : null } })}
@@ -66,13 +66,13 @@ export default function Editor({ options, data, onOptionsChange }) {
       </div>
       <div className="form-group">
         <label className="control-label" htmlFor="word-cloud-word-length-limit">
-          Show only words with count between
+          Frequencies Limit
         </label>
         <Grid.Row gutter={15} type="flex">
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="no limit"
+              placeholder="No Limit"
               min={0}
               value={options.wordCountLimit.min}
               onChange={value => optionsChanged({ wordCountLimit: { min: value > 0 ? value : null } })}
@@ -81,7 +81,7 @@ export default function Editor({ options, data, onOptionsChange }) {
           <Grid.Col span={12}>
             <InputNumber
               className="w-100"
-              placeholder="no limit"
+              placeholder="No Limit"
               min={0}
               value={options.wordCountLimit.max}
               onChange={value => optionsChanged({ wordCountLimit: { max: value > 0 ? value : null } })}

--- a/client/app/visualizations/word-cloud/Editor.jsx
+++ b/client/app/visualizations/word-cloud/Editor.jsx
@@ -1,30 +1,43 @@
-import { map } from 'lodash';
+import { map, merge } from 'lodash';
 import React from 'react';
 import Select from 'antd/lib/select';
 import { EditorPropTypes } from '@/visualizations';
 
-const { Option } = Select;
-
 export default function Editor({ options, data, onOptionsChange }) {
-  const onColumnChanged = (column) => {
-    const newOptions = { ...options, column };
-    onOptionsChange(newOptions);
+  const optionsChanged = (newOptions) => {
+    onOptionsChange(merge({}, options, newOptions));
   };
 
   return (
-    <div className="form-group">
-      <label className="control-label" htmlFor="word-cloud-column">Word Cloud Column Name</label>
-      <Select
-        id="word-cloud-column"
-        className="w-100"
-        value={options.column}
-        onChange={onColumnChanged}
-      >
-        {map(data.columns, ({ name }) => (
-          <Option key={name}>{name}</Option>
-        ))}
-      </Select>
-    </div>
+    <React.Fragment>
+      <div className="form-group">
+        <label className="control-label" htmlFor="word-cloud-column">Words Column</label>
+        <Select
+          id="word-cloud-column"
+          className="w-100"
+          value={options.column}
+          onChange={column => optionsChanged({ column })}
+        >
+          {map(data.columns, ({ name }) => (
+            <Select.Option key={name}>{name}</Select.Option>
+          ))}
+        </Select>
+      </div>
+      <div className="form-group">
+        <label className="control-label" htmlFor="word-cloud-column">Frequencies Column</label>
+        <Select
+          id="word-cloud-column"
+          className="w-100"
+          value={options.frequenciesColumn}
+          onChange={frequenciesColumn => optionsChanged({ frequenciesColumn })}
+        >
+          <Select.Option key="none" value=""><i>(count word frequencies automatically)</i></Select.Option>
+          {map(data.columns, ({ name }) => (
+            <Select.Option key={'column-' + name} value={name}>{name}</Select.Option>
+          ))}
+        </Select>
+      </div>
+    </React.Fragment>
   );
 }
 

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -2,6 +2,7 @@ import d3 from 'd3';
 import cloud from 'd3-cloud';
 import { each, map, min, max, values, sortBy } from 'lodash';
 import React, { useMemo, useState, useEffect } from 'react';
+import resizeObserver from '@/services/resizeObserver';
 import { RendererPropTypes } from '@/visualizations';
 
 import './renderer.less';
@@ -172,6 +173,13 @@ export default function Renderer({ data, options }) {
       render(container, words);
     }
   }, [container, words]);
+
+  useEffect(() => resizeObserver(container, () => {
+    const svg = container.querySelector('svg');
+    if (svg) {
+      scaleElement(svg, container);
+    }
+  }), [container]);
 
   return (<div className="word-cloud-visualization-container" ref={setContainer} />);
 }

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -81,8 +81,9 @@ function scaleElement(node, container) {
 
 function createLayout() {
   return cloud()
-  // make the area large enough to contain even very long words; word cloud will be placed in the center of the area
-    .size([10000, 10000])
+    // make the area large enough to contain even very long words; word cloud will be placed in the center of the area
+    // TODO: dimensions probably should be larger, but `d3-cloud` has some performance issues related to these values
+    .size([5000, 5000])
     .padding(3)
     .font('Impact')
     .rotate(d => d.angle)
@@ -107,13 +108,11 @@ function render(container, words) {
     .attr('transform', d => `translate(${[d.x, d.y]}) rotate(${d.rotate})`)
     .text(d => d.text);
 
-  // get real bounds of words and add some padding to ensure that everything is visible
-  const bounds = g.node().getBoundingClientRect();
-  const width = bounds.width + 10;
-  const height = bounds.height + 10;
+  const svgBounds = svg.node().getBoundingClientRect();
+  const gBounds = g.node().getBoundingClientRect();
 
-  svg.attr('width', width).attr('height', height);
-  g.attr('transform', `translate(${width / 2},${height / 2})`);
+  svg.attr('width', Math.ceil(gBounds.width)).attr('height', Math.ceil(gBounds.height));
+  g.attr('transform', `translate(${svgBounds.left - gBounds.left},${svgBounds.top - gBounds.top})`);
 
   scaleElement(svg.node(), container.node());
 }

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -1,6 +1,6 @@
 import d3 from 'd3';
 import cloud from 'd3-cloud';
-import { each, map, min, max, values, sortBy } from 'lodash';
+import { each, map, min, max, values, sortBy, toString } from 'lodash';
 import React, { useMemo, useState, useEffect } from 'react';
 import resizeObserver from '@/services/resizeObserver';
 import { RendererPropTypes } from '@/visualizations';
@@ -11,7 +11,7 @@ function computeWordFrequencies(rows, column) {
   const result = {};
 
   each(rows, (row) => {
-    const wordsList = row[column].toString().split(/\s/g);
+    const wordsList = toString(row[column]).split(/\s/g);
     each(wordsList, (d) => {
       result[d] = (result[d] || 0) + 1;
     });

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -100,12 +100,14 @@ function scaleElement(node, container) {
 }
 
 function createLayout() {
+  const fontFamily = window.getComputedStyle(document.body).fontFamily;
+
   return cloud()
     // make the area large enough to contain even very long words; word cloud will be placed in the center of the area
     // TODO: dimensions probably should be larger, but `d3-cloud` has some performance issues related to these values
     .size([5000, 5000])
     .padding(3)
-    .font('"Roboto Regular", sans-serif')
+    .font(fontFamily)
     .rotate(d => d.angle)
     .fontSize(d => d.size)
     .random(() => 0.5); // do not place words randomly - use compact layout

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -1,0 +1,121 @@
+import d3 from 'd3';
+import cloud from 'd3-cloud';
+import { map, min, max, values } from 'lodash';
+import React from 'react';
+import { RendererPropTypes } from '@/visualizations';
+
+function findWordFrequencies(data, columnName) {
+  const wordsHash = {};
+
+  data.forEach((row) => {
+    const wordsList = row[columnName].toString().split(' ');
+    wordsList.forEach((d) => {
+      if (d in wordsHash) {
+        wordsHash[d] += 1;
+      } else {
+        wordsHash[d] = 1;
+      }
+    });
+  });
+
+  return wordsHash;
+}
+
+// target domain: [t1, t2]
+const MIN_WORD_SIZE = 10;
+const MAX_WORD_SIZE = 100;
+
+function createScale(wordCounts) {
+  wordCounts = values(wordCounts);
+
+  // source domain: [s1, s2]
+  const minCount = min(wordCounts);
+  const maxCount = max(wordCounts);
+
+  // Edge case - if all words have the same count; just set middle size for all
+  if (minCount === maxCount) {
+    return () => (MAX_WORD_SIZE + MIN_WORD_SIZE) / 2;
+  }
+
+  // v is value from source domain:
+  //    s1 <= v <= s2.
+  // We need to fit it target domain:
+  //    t1 <= v" <= t2
+  // 1. offset source value to zero point:
+  //    v' = v - s1
+  // 2. offset source and target domains to zero point:
+  //    s' = s2 - s1
+  //    t' = t2 - t1
+  // 3. compute fraction:
+  //    f = v' / s';
+  //    0 <= f <= 1
+  // 4. map f to target domain:
+  //    v" = f * t' + t1;
+  //    t1 <= v" <= t' + t1;
+  //    t1 <= v" <= t2 (because t' = t2 - t1, so t2 = t' + t1)
+
+  const sourceScale = maxCount - minCount;
+  const targetScale = MAX_WORD_SIZE - MIN_WORD_SIZE;
+
+  return value => ((value - minCount) / sourceScale) * targetScale + MIN_WORD_SIZE;
+}
+
+function render(container, data, options) {
+  let wordsHash = {};
+  if (options.column) {
+    wordsHash = findWordFrequencies(data.rows, options.column);
+  }
+
+  const scaleValue = createScale(wordsHash);
+
+  const wordList = map(wordsHash, (count, key) => ({
+    text: key,
+    size: scaleValue(count),
+  }));
+
+  const fill = d3.scale.category20();
+  const layout = cloud()
+    .size([500, 500])
+    .words(wordList)
+    .padding(5)
+    .rotate(() => Math.floor(Math.random() * 2) * 90)
+    .font('Impact')
+    .fontSize(d => d.size);
+
+  function draw(words) {
+    d3.select(container).selectAll('*').remove();
+
+    d3.select(container)
+      .append('svg')
+      .attr('width', layout.size()[0])
+      .attr('height', layout.size()[1])
+      .append('g')
+      .attr('transform', `translate(${layout.size()[0] / 2},${layout.size()[1] / 2})`)
+      .selectAll('text')
+      .data(words)
+      .enter()
+      .append('text')
+      .style('font-size', d => `${d.size}px`)
+      .style('font-family', 'Impact')
+      .style('fill', (d, i) => fill(i))
+      .attr('text-anchor', 'middle')
+      .attr('transform', d => `translate(${[d.x, d.y]})rotate(${d.rotate})`)
+      .text(d => d.text);
+  }
+
+  layout.on('end', draw);
+
+  layout.start();
+}
+
+export default function Renderer({ data, options }) {
+  const containerRef = (container) => {
+    if (container) {
+      render(container, data, options);
+    }
+  };
+
+  return (<div ref={containerRef} />);
+}
+
+Renderer.propTypes = RendererPropTypes;

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -105,7 +105,7 @@ function createLayout() {
     // TODO: dimensions probably should be larger, but `d3-cloud` has some performance issues related to these values
     .size([5000, 5000])
     .padding(3)
-    .font('Impact')
+    .font('"Roboto Regular", sans-serif')
     .rotate(d => d.angle)
     .fontSize(d => d.size)
     .random(() => 0.5); // do not place words randomly - use compact layout

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -37,15 +37,9 @@ function getWordsWithFrequencies(rows, wordColumn, frequencyColumn) {
 function applyLimitsToWords(words, { wordLength, wordCount }) {
   wordLength.min = Number.isFinite(wordLength.min) ? wordLength.min : null;
   wordLength.max = Number.isFinite(wordLength.max) ? wordLength.max : null;
-  if (wordLength.min && wordLength.max && (wordLength.min > wordLength.max)) {
-    wordLength = { min: wordLength.max, max: wordLength.min }; // swap
-  }
 
   wordCount.min = Number.isFinite(wordCount.min) ? wordCount.min : null;
   wordCount.max = Number.isFinite(wordCount.max) ? wordCount.max : null;
-  if (wordCount.min && wordCount.max && (wordCount.min > wordCount.max)) {
-    wordCount = { min: wordCount.max, max: wordCount.min }; // swap
-  }
 
   return filter(words, ({ text, count }) => {
     const wordLengthFits = (
@@ -159,12 +153,16 @@ export default function Renderer({ data, options }) {
     }
   }, [container, words]);
 
-  useEffect(() => resizeObserver(container, () => {
-    const svg = container.querySelector('svg');
-    if (svg) {
-      scaleElement(svg, container);
+  useEffect(() => {
+    if (container) {
+      return resizeObserver(container, () => {
+        const svg = container.querySelector('svg');
+        if (svg) {
+          scaleElement(svg, container);
+        }
+      });
     }
-  }), [container]);
+  }, [container]);
 
   return (<div className="word-cloud-visualization-container" ref={setContainer} />);
 }

--- a/client/app/visualizations/word-cloud/Renderer.jsx
+++ b/client/app/visualizations/word-cloud/Renderer.jsx
@@ -1,31 +1,45 @@
 import d3 from 'd3';
 import cloud from 'd3-cloud';
-import { map, min, max, values, sortBy } from 'lodash';
+import { each, map, min, max, values, sortBy } from 'lodash';
 import React, { useMemo, useState, useEffect } from 'react';
 import { RendererPropTypes } from '@/visualizations';
 
 function computeWordFrequencies(rows, column) {
-  const wordsHash = {};
+  const result = {};
 
-  rows.forEach((row) => {
-    const wordsList = row[column].toString().split(' ');
-    wordsList.forEach((d) => {
-      if (d in wordsHash) {
-        wordsHash[d] += 1;
-      } else {
-        wordsHash[d] = 1;
-      }
+  each(rows, (row) => {
+    const wordsList = row[column].toString().split(/\s/g);
+    each(wordsList, (d) => {
+      result[d] = (result[d] || 0) + 1;
     });
   });
 
-  return wordsHash;
+  return result;
+}
+
+function getWordsWithFrequencies(rows, wordColumn, frequencyColumn) {
+  const result = {};
+
+  each(rows, (row) => {
+    const count = parseFloat(row[frequencyColumn]);
+    if (Number.isFinite(count) && (count > 0)) {
+      const word = row[wordColumn];
+      result[word] = count;
+    }
+  });
+
+  return result;
 }
 
 function prepareWords(rows, options) {
   let result = [];
 
   if (options.column) {
-    result = computeWordFrequencies(rows, options.column);
+    if (options.frequenciesColumn) {
+      result = getWordsWithFrequencies(rows, options.column, options.frequenciesColumn);
+    } else {
+      result = computeWordFrequencies(rows, options.column);
+    }
   }
 
   const counts = values(result);

--- a/client/app/visualizations/word-cloud/index.js
+++ b/client/app/visualizations/word-cloud/index.js
@@ -3,11 +3,16 @@ import { registerVisualization } from '@/visualizations';
 import Renderer from './Renderer';
 import Editor from './Editor';
 
+const DEFAULT_OPTIONS = {
+  column: '',
+  frequenciesColumn: '',
+};
+
 export default function init() {
   registerVisualization({
     type: 'WORD_CLOUD',
     name: 'Word Cloud',
-    getOptions: options => ({ ...options }),
+    getOptions: options => ({ ...DEFAULT_OPTIONS, ...options }),
     Renderer,
     Editor,
 

--- a/client/app/visualizations/word-cloud/index.js
+++ b/client/app/visualizations/word-cloud/index.js
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import { registerVisualization } from '@/visualizations';
 
 import Renderer from './Renderer';
@@ -6,13 +7,15 @@ import Editor from './Editor';
 const DEFAULT_OPTIONS = {
   column: '',
   frequenciesColumn: '',
+  wordLengthLimit: { min: null, max: null },
+  wordCountLimit: { min: null, max: null },
 };
 
 export default function init() {
   registerVisualization({
     type: 'WORD_CLOUD',
     name: 'Word Cloud',
-    getOptions: options => ({ ...DEFAULT_OPTIONS, ...options }),
+    getOptions: options => merge({}, DEFAULT_OPTIONS, options),
     Renderer,
     Editor,
 

--- a/client/app/visualizations/word-cloud/index.js
+++ b/client/app/visualizations/word-cloud/index.js
@@ -1,145 +1,17 @@
-import d3 from 'd3';
-import cloud from 'd3-cloud';
-import { map, min, max, values } from 'lodash';
-import { angular2react } from 'angular2react';
 import { registerVisualization } from '@/visualizations';
 
+import Renderer from './Renderer';
 import Editor from './Editor';
 
-function findWordFrequencies(data, columnName) {
-  const wordsHash = {};
+export default function init() {
+  registerVisualization({
+    type: 'WORD_CLOUD',
+    name: 'Word Cloud',
+    getOptions: options => ({ ...options }),
+    Renderer,
+    Editor,
 
-  data.forEach((row) => {
-    const wordsList = row[columnName].toString().split(' ');
-    wordsList.forEach((d) => {
-      if (d in wordsHash) {
-        wordsHash[d] += 1;
-      } else {
-        wordsHash[d] = 1;
-      }
-    });
-  });
-
-  return wordsHash;
-}
-
-// target domain: [t1, t2]
-const MIN_WORD_SIZE = 10;
-const MAX_WORD_SIZE = 100;
-
-function createScale(wordCounts) {
-  wordCounts = values(wordCounts);
-
-  // source domain: [s1, s2]
-  const minCount = min(wordCounts);
-  const maxCount = max(wordCounts);
-
-  // Edge case - if all words have the same count; just set middle size for all
-  if (minCount === maxCount) {
-    return () => (MAX_WORD_SIZE + MIN_WORD_SIZE) / 2;
-  }
-
-  // v is value from source domain:
-  //    s1 <= v <= s2.
-  // We need to fit it target domain:
-  //    t1 <= v" <= t2
-  // 1. offset source value to zero point:
-  //    v' = v - s1
-  // 2. offset source and target domains to zero point:
-  //    s' = s2 - s1
-  //    t' = t2 - t1
-  // 3. compute fraction:
-  //    f = v' / s';
-  //    0 <= f <= 1
-  // 4. map f to target domain:
-  //    v" = f * t' + t1;
-  //    t1 <= v" <= t' + t1;
-  //    t1 <= v" <= t2 (because t' = t2 - t1, so t2 = t' + t1)
-
-  const sourceScale = maxCount - minCount;
-  const targetScale = MAX_WORD_SIZE - MIN_WORD_SIZE;
-
-  return value => ((value - minCount) / sourceScale) * targetScale + MIN_WORD_SIZE;
-}
-
-const WordCloudRenderer = {
-  restrict: 'E',
-  bindings: {
-    data: '<',
-    options: '<',
-  },
-  controller($scope, $element) {
-    $element[0].style.display = 'block';
-
-    const update = () => {
-      const data = this.data.rows;
-      const options = this.options;
-
-      let wordsHash = {};
-      if (options.column) {
-        wordsHash = findWordFrequencies(data, options.column);
-      }
-
-      const scaleValue = createScale(wordsHash);
-
-      const wordList = map(wordsHash, (count, key) => ({
-        text: key,
-        size: scaleValue(count),
-      }));
-
-      const fill = d3.scale.category20();
-      const layout = cloud()
-        .size([500, 500])
-        .words(wordList)
-        .padding(5)
-        .rotate(() => Math.floor(Math.random() * 2) * 90)
-        .font('Impact')
-        .fontSize(d => d.size);
-
-      function draw(words) {
-        d3.select($element[0]).selectAll('*').remove();
-
-        d3.select($element[0])
-          .append('svg')
-          .attr('width', layout.size()[0])
-          .attr('height', layout.size()[1])
-          .append('g')
-          .attr('transform', `translate(${layout.size()[0] / 2},${layout.size()[1] / 2})`)
-          .selectAll('text')
-          .data(words)
-          .enter()
-          .append('text')
-          .style('font-size', d => `${d.size}px`)
-          .style('font-family', 'Impact')
-          .style('fill', (d, i) => fill(i))
-          .attr('text-anchor', 'middle')
-          .attr('transform', d => `translate(${[d.x, d.y]})rotate(${d.rotate})`)
-          .text(d => d.text);
-      }
-
-      layout.on('end', draw);
-
-      layout.start();
-    };
-
-    $scope.$watch('$ctrl.data', update);
-    $scope.$watch('$ctrl.options', update, true);
-  },
-};
-
-export default function init(ngModule) {
-  ngModule.component('wordCloudRenderer', WordCloudRenderer);
-
-  ngModule.run(($injector) => {
-    registerVisualization({
-      type: 'WORD_CLOUD',
-      name: 'Word Cloud',
-      getOptions: options => ({ ...options }),
-      Renderer: angular2react('wordCloudRenderer', WordCloudRenderer, $injector),
-      Editor,
-
-      defaultRows: 8,
-    });
+    defaultRows: 8,
   });
 }
 

--- a/client/app/visualizations/word-cloud/renderer.less
+++ b/client/app/visualizations/word-cloud/renderer.less
@@ -1,7 +1,12 @@
 .word-cloud-visualization-container {
   overflow: hidden;
+  height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   svg {
-    transform-origin: left top;
+    transform-origin: center center;
+    flex: 0 0 auto;
   }
 }

--- a/client/app/visualizations/word-cloud/renderer.less
+++ b/client/app/visualizations/word-cloud/renderer.less
@@ -1,3 +1,12 @@
+@font-face {
+  font-family: "Roboto Regular";
+  src: url("../../assets/fonts/roboto/Roboto-Regular-webfont.eot");
+  src: url("../../assets/fonts/roboto/Roboto-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("../../assets/fonts/roboto/Roboto-Regular-webfont.woff") format("woff"),
+       url("../../assets/fonts/roboto/Roboto-Regular-webfont.ttf") format("truetype"),
+       url("../../assets/fonts/roboto/Roboto-Regular-webfont.svg") format("svg");
+}
+
 .word-cloud-visualization-container {
   overflow: hidden;
   height: 400px;

--- a/client/app/visualizations/word-cloud/renderer.less
+++ b/client/app/visualizations/word-cloud/renderer.less
@@ -1,12 +1,3 @@
-@font-face {
-  font-family: "Roboto Regular";
-  src: url("../../assets/fonts/roboto/Roboto-Regular-webfont.eot");
-  src: url("../../assets/fonts/roboto/Roboto-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("../../assets/fonts/roboto/Roboto-Regular-webfont.woff") format("woff"),
-       url("../../assets/fonts/roboto/Roboto-Regular-webfont.ttf") format("truetype"),
-       url("../../assets/fonts/roboto/Roboto-Regular-webfont.svg") format("svg");
-}
-
 .word-cloud-visualization-container {
   overflow: hidden;
   height: 400px;

--- a/client/app/visualizations/word-cloud/renderer.less
+++ b/client/app/visualizations/word-cloud/renderer.less
@@ -1,0 +1,7 @@
+.word-cloud-visualization-container {
+  overflow: hidden;
+
+  svg {
+    transform-origin: left top;
+  }
+}

--- a/client/cypress/integration/visualizations/edit_visualization_dialog_spec.js
+++ b/client/cypress/integration/visualizations/edit_visualization_dialog_spec.js
@@ -22,8 +22,23 @@ describe('Edit visualization dialog', () => {
   it('opens Edit Visualization dialog', () => {
     cy.getByTestId('EditVisualization').click();
     cy.getByTestId('EditVisualizationDialog').should('exist');
-    // Default visualization should be selected
+    // Default `Table` visualization should be selected
     cy.getByTestId('VisualizationType').should('exist').should('contain', 'Table');
     cy.getByTestId('VisualizationName').should('exist').should('have.value', 'Table');
+  });
+
+  it('creates visualization with custom name', () => {
+    const visualizationName = 'Custom name';
+
+    cy.clickThrough(`
+      NewVisualization
+      VisualizationType
+      VisualizationType.TABLE
+    `);
+
+    cy.getByTestId('VisualizationName').clear().type(visualizationName);
+
+    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
+    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
   });
 });

--- a/client/cypress/integration/visualizations/word_cloud_spec.js
+++ b/client/cypress/integration/visualizations/word_cloud_spec.js
@@ -1,0 +1,83 @@
+/* global cy */
+
+import { createQuery } from '../../support/redash-api';
+
+const SQL = `
+  SELECT 'Lorem ipsum dolor'     AS a, 'ipsum'  AS b, 2 AS c UNION ALL
+  SELECT 'Lorem sit amet'        AS a, 'amet'   AS b, 2 AS c UNION ALL
+  SELECT 'dolor adipiscing elit' AS a, 'elit'   AS b, 4 AS c UNION ALL
+  SELECT 'sed do sed'            AS a, 'sed'    AS b, 5 AS c UNION ALL
+  SELECT 'sed eiusmod tempor'    AS a, 'tempor' AS b, 7 AS c
+`;
+
+describe('Word Cloud', () => {
+  beforeEach(() => {
+    cy.login();
+    createQuery({ query: SQL }).then(({ id }) => {
+      cy.visit(`queries/${id}/source`);
+      cy.getByTestId('ExecuteButton').click();
+    });
+  });
+
+  it('creates visualization with automatic word frequencies', () => {
+    const visualizationName = 'Word Cloud (auto)';
+
+    cy.getByTestId('NewVisualization').click();
+    cy.getByTestId('VisualizationType').click();
+    cy.getByTestId('VisualizationType.WORD_CLOUD').click();
+    cy.getByTestId('VisualizationName').clear().type(visualizationName);
+
+    cy.getByTestId('WordCloud.WordsColumn').click();
+    cy.getByTestId('WordCloud.WordsColumn.a').click();
+
+    cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 11);
+
+    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
+    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
+  });
+
+  it('creates visualization with word frequencies from another column', () => {
+    const visualizationName = 'Word Cloud (frequencies)';
+
+    cy.getByTestId('NewVisualization').click();
+    cy.getByTestId('VisualizationType').click();
+    cy.getByTestId('VisualizationType.WORD_CLOUD').click();
+    cy.getByTestId('VisualizationName').clear().type(visualizationName);
+
+    cy.getByTestId('WordCloud.WordsColumn').click();
+    cy.getByTestId('WordCloud.WordsColumn.b').click();
+
+    cy.getByTestId('WordCloud.FrequenciesColumn').click();
+    cy.getByTestId('WordCloud.FrequenciesColumn.c').click();
+
+    cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 5);
+
+    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
+    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
+  });
+
+  it('creates visualization with word length and frequencies limits', () => {
+    const visualizationName = 'Word Cloud (filters)';
+
+    cy.getByTestId('NewVisualization').click();
+    cy.getByTestId('VisualizationType').click();
+    cy.getByTestId('VisualizationType.WORD_CLOUD').click();
+    cy.getByTestId('VisualizationName').clear().type(visualizationName);
+
+    cy.getByTestId('WordCloud.WordsColumn').click();
+    cy.getByTestId('WordCloud.WordsColumn.b').click();
+
+    cy.getByTestId('WordCloud.FrequenciesColumn').click();
+    cy.getByTestId('WordCloud.FrequenciesColumn.c').click();
+
+    cy.getByTestId('WordCloud.WordLengthLimit.Min').clear().type('4');
+    cy.getByTestId('WordCloud.WordLengthLimit.Max').clear().type('5');
+    cy.getByTestId('WordCloud.WordCountLimit.Min').clear().type('1');
+    cy.getByTestId('WordCloud.WordCountLimit.Max').clear().type('3');
+
+    cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 2);
+
+    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
+    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
+  });
+});

--- a/client/cypress/integration/visualizations/word_cloud_spec.js
+++ b/client/cypress/integration/visualizations/word_cloud_spec.js
@@ -29,9 +29,12 @@ describe('Word Cloud', () => {
       WordCloud.WordsColumn.a
     `);
 
+    // Wait for proper initialization of visualization
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 11);
 
-    cy.percySnapshot('Visualizations - Word Cloud (Automatic word frequencies)');
+    cy.percySnapshot('Visualizations - Word Cloud (Automatic word frequencies)', { widths: [1280] });
   });
 
   it('creates visualization with word frequencies from another column', () => {
@@ -46,6 +49,9 @@ describe('Word Cloud', () => {
       WordCloud.FrequenciesColumn
       WordCloud.FrequenciesColumn.c
     `);
+
+    // Wait for proper initialization of visualization
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 5);
 
@@ -71,6 +77,9 @@ describe('Word Cloud', () => {
       'WordCloud.WordCountLimit.Min': '1',
       'WordCloud.WordCountLimit.Max': '3',
     });
+
+    // Wait for proper initialization of visualization
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 2);
 

--- a/client/cypress/integration/visualizations/word_cloud_spec.js
+++ b/client/cypress/integration/visualizations/word_cloud_spec.js
@@ -30,11 +30,11 @@ describe('Word Cloud', () => {
     `);
 
     // Wait for proper initialization of visualization
-    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 11);
 
-    cy.percySnapshot('Visualizations - Word Cloud (Automatic word frequencies)', { widths: [1280] });
+    cy.percySnapshot('Visualizations - Word Cloud (Automatic word frequencies)');
   });
 
   it('creates visualization with word frequencies from another column', () => {
@@ -51,7 +51,7 @@ describe('Word Cloud', () => {
     `);
 
     // Wait for proper initialization of visualization
-    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 5);
 
@@ -79,7 +79,7 @@ describe('Word Cloud', () => {
     });
 
     // Wait for proper initialization of visualization
-    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 2);
 

--- a/client/cypress/integration/visualizations/word_cloud_spec.js
+++ b/client/cypress/integration/visualizations/word_cloud_spec.js
@@ -20,64 +20,60 @@ describe('Word Cloud', () => {
   });
 
   it('creates visualization with automatic word frequencies', () => {
-    const visualizationName = 'Word Cloud (auto)';
+    cy.clickThrough(`
+      NewVisualization
+      VisualizationType
+      VisualizationType.WORD_CLOUD
 
-    cy.getByTestId('NewVisualization').click();
-    cy.getByTestId('VisualizationType').click();
-    cy.getByTestId('VisualizationType.WORD_CLOUD').click();
-    cy.getByTestId('VisualizationName').clear().type(visualizationName);
-
-    cy.getByTestId('WordCloud.WordsColumn').click();
-    cy.getByTestId('WordCloud.WordsColumn.a').click();
+      WordCloud.WordsColumn
+      WordCloud.WordsColumn.a
+    `);
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 11);
 
-    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
-    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
+    cy.percySnapshot('Visualizations - Word Cloud (Automatic word frequencies)');
   });
 
   it('creates visualization with word frequencies from another column', () => {
-    const visualizationName = 'Word Cloud (frequencies)';
+    cy.clickThrough(`
+      NewVisualization
+      VisualizationType
+      VisualizationType.WORD_CLOUD
 
-    cy.getByTestId('NewVisualization').click();
-    cy.getByTestId('VisualizationType').click();
-    cy.getByTestId('VisualizationType.WORD_CLOUD').click();
-    cy.getByTestId('VisualizationName').clear().type(visualizationName);
+      WordCloud.WordsColumn
+      WordCloud.WordsColumn.b
 
-    cy.getByTestId('WordCloud.WordsColumn').click();
-    cy.getByTestId('WordCloud.WordsColumn.b').click();
-
-    cy.getByTestId('WordCloud.FrequenciesColumn').click();
-    cy.getByTestId('WordCloud.FrequenciesColumn.c').click();
+      WordCloud.FrequenciesColumn
+      WordCloud.FrequenciesColumn.c
+    `);
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 5);
 
-    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
-    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
+    cy.percySnapshot('Visualizations - Word Cloud (Frequencies from another column)');
   });
 
   it('creates visualization with word length and frequencies limits', () => {
-    const visualizationName = 'Word Cloud (filters)';
+    cy.clickThrough(`
+      NewVisualization
+      VisualizationType
+      VisualizationType.WORD_CLOUD
 
-    cy.getByTestId('NewVisualization').click();
-    cy.getByTestId('VisualizationType').click();
-    cy.getByTestId('VisualizationType.WORD_CLOUD').click();
-    cy.getByTestId('VisualizationName').clear().type(visualizationName);
+      WordCloud.WordsColumn
+      WordCloud.WordsColumn.b
 
-    cy.getByTestId('WordCloud.WordsColumn').click();
-    cy.getByTestId('WordCloud.WordsColumn.b').click();
+      WordCloud.FrequenciesColumn
+      WordCloud.FrequenciesColumn.c
+    `);
 
-    cy.getByTestId('WordCloud.FrequenciesColumn').click();
-    cy.getByTestId('WordCloud.FrequenciesColumn.c').click();
-
-    cy.getByTestId('WordCloud.WordLengthLimit.Min').clear().type('4');
-    cy.getByTestId('WordCloud.WordLengthLimit.Max').clear().type('5');
-    cy.getByTestId('WordCloud.WordCountLimit.Min').clear().type('1');
-    cy.getByTestId('WordCloud.WordCountLimit.Max').clear().type('3');
+    cy.fillInputs({
+      'WordCloud.WordLengthLimit.Min': '4',
+      'WordCloud.WordLengthLimit.Max': '5',
+      'WordCloud.WordCountLimit.Min': '1',
+      'WordCloud.WordCountLimit.Max': '3',
+    });
 
     cy.getByTestId('VisualizationPreview').find('svg text').should('have.length', 2);
 
-    cy.getByTestId('EditVisualizationDialog').contains('button', 'Save').click();
-    cy.getByTestId('QueryPageVisualizationTabs').contains('li', visualizationName).should('exist');
+    cy.percySnapshot('Visualizations - Word Cloud (With filters)');
   });
 });

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -1,5 +1,7 @@
 import '@percy/cypress'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
+const { each } = Cypress._;
+
 Cypress.Commands.add('login', (email = 'admin@redash.io', password = 'password') => cy.request({
   url: '/login',
   method: 'POST',
@@ -19,4 +21,10 @@ Cypress.Commands.add('clickThrough', (elements) => {
     .filter(Boolean)
     .forEach(element => cy.getByTestId(element).click());
   return undefined;
+});
+
+Cypress.Commands.add('fillInputs', (elements) => {
+  each(elements, (value, testId) => {
+    cy.getByTestId(testId).clear().type(value);
+  });
 });

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -1,3 +1,5 @@
+/* global Cypress */
+
 import '@percy/cypress'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 const { each } = Cypress._;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,8 @@ const config = {
       { from: "client/app/unsupported.html" },
       { from: "client/app/unsupportedRedirect.js" },
       { from: "client/app/assets/css/*.css", to: "styles/", flatten: true },
-      { from: "node_modules/jquery/dist/jquery.min.js", to: "js/jquery.min.js" }
+      { from: "node_modules/jquery/dist/jquery.min.js", to: "js/jquery.min.js" },
+      { from: "client/app/assets/fonts", to: "fonts/" },
     ])
   ],
   optimization: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix

## Description

- [x] Convert component to React
- [x] Make visualization responsive (scale contents to fit container) - this should also fix getredash/redash#3730:
  - [x] fit visualization to its container;
  - [x] watch container size changes and update visualization;
  - [x] handle very long words (with high frequencies).
- [x] Implement getredash/redash#1414 (replace getredash/redash#3668):
  - [x] pass word frequencies in another column;
  - [x] limits on min/max word frequency and min/max word length.
- [x] Tests

## Related Tickets & Documents

getredash/redash#3301 (Migrate Visualizations to React -> Word Cloud)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Query page:
![image](https://user-images.githubusercontent.com/12139186/60362619-1548cb80-99ea-11e9-8087-65dfdf01d6b0.png)

New editor options:
![image](https://user-images.githubusercontent.com/12139186/60362638-272a6e80-99ea-11e9-92ef-9cc71726b208.png)
![image](https://user-images.githubusercontent.com/12139186/60362656-30b3d680-99ea-11e9-9a78-802e94147adc.png)

Dashboard:
![image](https://user-images.githubusercontent.com/12139186/60362788-77a1cc00-99ea-11e9-9ddc-0987e25f988e.png)
