### PR TITLE
Toggling Use Dashboard Level Filter cause widgets to show reload spinner forever

### DIFF
--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -303,27 +303,9 @@ function DashboardCtrl(
 
   this.updateDashboardFiltersState = () => {
     collectFilters(this.dashboard, false);
-    Dashboard.save(
-      {
-        slug: this.dashboard.id,
-        version: this.dashboard.version,
-        dashboard_filters_enabled: this.dashboard.dashboard_filters_enabled,
-      },
-      (dashboard) => {
-        this.dashboard = dashboard;
-      },
-      (error) => {
-        if (error.status === 403) {
-          notification.error('Name update failed', 'Permission denied.');
-        } else if (error.status === 409) {
-          notification.error(
-            'It seems like the dashboard has been modified by another user. ',
-            'Please copy/backup your changes and reload this page.',
-            { duration: null },
-          );
-        }
-      },
-    );
+    updateDashboard({
+      dashboard_filters_enabled: this.dashboard.dashboard_filters_enabled,
+    });
   };
 
   this.showAddTextboxDialog = () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

We previously had similar issue when updating dashboard name and other fields (getredash/redash#3142): after updating fields, dashboard object was replaced by value returned from server, so some internal state was lost. Fixed in the same way as previous time

## Related Tickets & Documents

Fixes getredash/redash#3937
