### PR TITLE
fix: SparkSQL query refresh in the hive datasource

### DIFF
--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -120,7 +120,7 @@ class Hive(BaseSQLQueryRunner):
 
         if isinstance(query, str):
             query_result = self._run_query_internal(query)
-        elif isinstance():
+        elif isinstance(query, list):
             query_result = query
 
         return filter(

--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -95,7 +95,7 @@ class Hive(BaseSQLQueryRunner):
         for schema_name in self._extract_column(schemas_query_result, database_name_col):
             for table_name in self._extract_column(tables_query % schema_name, database_tablename_col):
                 columns_query_templated = columns_query % (schema_name, table_name)
-                columns = self._extract_column(columns_query_templated, database_tablename_col)
+                columns = self._extract_column(columns_query_templated, column_name_col)
 
                 if schema_name != 'default':
                     table_name = '{}.{}'.format(schema_name, table_name)

--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -92,7 +92,7 @@ class Hive(BaseSQLQueryRunner):
             database_tablename_col = 'tableName'
             column_name_col = 'col_name'
 
-        for schema_name in self._extract_column(schemas_query, database_name_col):
+        for schema_name in self._extract_column(schemas_query_result, database_name_col):
             for table_name in self._extract_column(tables_query % schema_name, database_tablename_col):
                 columns_query_templated = columns_query % (schema_name, table_name)
                 columns = self._extract_column(columns_query_templated, database_tablename_col)
@@ -116,11 +116,18 @@ class Hive(BaseSQLQueryRunner):
         return connection
     
     def _extract_column(self, query, column_name):
-        filter(
+        query_result = []
+
+        if isinstance(query, str):
+            query_result = self._run_query_internal(query)
+        elif isinstance():
+            query_result = query
+
+        return filter(
             lambda a: len(a) > 0,
             map(
                 lambda a: str(a[column_name]), 
-                self._run_query_internal(query)
+                query_result
             )
         )
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

When using SparkSQL and the Hive Datasource Redash fails to refresh the query because SparkSQL has different column names than Hive. Here is the map below.

Hive has,
Database Name => 'database_name'
Tablename => 'tab_name'
Column Name => 'field',

While SparkSQL has,
Database Name => 'databaseName'
Tablename => 'tableName'
Column Name => 'col_name',

In this PR I detect which one the user is connecting to and then change the names dynamically.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/3784748/60372491-9df74580-99b1-11e9-8243-c50146af6d73.png)
