### PR TITLE
Fix: waiting tasks are not shown in admin view

### DIFF
--- a/client/app/pages/admin/Tasks.jsx
+++ b/client/app/pages/admin/Tasks.jsx
@@ -13,6 +13,8 @@ import { $http } from '@/services/ng';
 import recordEvent from '@/services/recordEvent';
 import { routesToAngularRoutes } from '@/lib/utils';
 
+// Converting name coming from API to the one the UI expects.
+// TODO: update the UI components to use `waiting_in_queue` instead of `waiting`.
 function stateName(state) {
   if (state === 'waiting_in_queue') {
     return 'waiting';

--- a/client/app/pages/admin/Tasks.jsx
+++ b/client/app/pages/admin/Tasks.jsx
@@ -13,6 +13,13 @@ import { $http } from '@/services/ng';
 import recordEvent from '@/services/recordEvent';
 import { routesToAngularRoutes } from '@/lib/utils';
 
+function stateName(state) {
+  if (state === 'waiting_in_queue') {
+    return 'waiting';
+  }
+  return state;
+}
+
 class Tasks extends React.Component {
   state = {
     isLoading: true,
@@ -46,6 +53,7 @@ class Tasks extends React.Component {
     const counters = { active: 0, reserved: 0, waiting: 0 };
 
     each(tasks, (task) => {
+      task.state = stateName(task.state);
       queues[task.queue] = queues[task.queue] || { name: task.queue, active: 0, reserved: 0, waiting: 0 };
       queues[task.queue][task.state] += 1;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Waiting tasks were not showing in admin view, because it was expecting them to have a different name for the state. To avoid breaking existing users of this API, we're just translating the state name in the UI.