### PR TITLE
Fix: Details Visualization: render date/time values as strings and not epoch time

### DIFF
--- a/client/app/visualizations/details/DetailsRenderer.jsx
+++ b/client/app/visualizations/details/DetailsRenderer.jsx
@@ -1,9 +1,26 @@
 import React, { useState } from 'react';
-import map from 'lodash/map';
+import { map, mapValues, keyBy } from 'lodash';
+import moment from 'moment';
 import { RendererPropTypes } from '@/visualizations';
+import { clientConfig } from '@/services/auth';
 import Pagination from 'antd/lib/pagination';
 
 import './details.less';
+
+function renderValue(value, type) {
+  const formats = {
+    date: clientConfig.dateFormat,
+    datetime: clientConfig.dateTimeFormat,
+  };
+
+  if (type === 'date' || type === 'datetime') {
+    if (moment.isMoment(value)) {
+      return value.format(formats[type]);
+    }
+  }
+
+  return '' + value;
+}
 
 export default function DetailsRenderer({ data }) {
   const [page, setPage] = useState(0);
@@ -11,6 +28,8 @@ export default function DetailsRenderer({ data }) {
   if (!data || !data.rows || data.rows.length === 0) {
     return null;
   }
+
+  const types = mapValues(keyBy(data.columns, 'name'), 'type');
 
   // We use columsn to maintain order of columns in the view.
   const columns = data.columns.map(column => column.name);
@@ -23,7 +42,7 @@ export default function DetailsRenderer({ data }) {
           {map(columns, key => (
             <tr key={key}>
               <th>{key}</th>
-              <td>{'' + row[key]}</td>
+              <td>{renderValue(row[key], types[key])}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Because we were just converting values to strings (`'' + value`) date/time values were rendered as epoch times:

![image](https://user-images.githubusercontent.com/71468/60667662-badcbe80-9e72-11e9-9d74-0891f1cea3af.png)

This Pull Request fixes this by properly converting them using the system settings date/time format.

There is some logic duplication here with the Table visualization, which we should remove in the future.