### PR TITLE
Add explicit route for dashboards to allow embedding in iframes.

### DIFF
--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -5,7 +5,7 @@ from redash import settings
 from redash.handlers import routes
 from redash.handlers.authentication import base_href
 from redash.handlers.base import org_scoped_rule
-
+from redash.security import csp_allows_embeding
 
 def render_index():
     if settings.MULTI_ORG:
@@ -15,6 +15,12 @@ def render_index():
         response = send_file(full_path, **dict(cache_timeout=0, conditional=True))
 
     return response
+
+@routes.route(org_scoped_rule('/dashboard/<slug>'), methods=['GET'])
+@login_required
+@csp_allows_embeding
+def dashboard(slug, org_slug=None):
+    return render_index()
 
 
 @routes.route(org_scoped_rule('/<path:path>'))

--- a/redash/handlers/static.py
+++ b/redash/handlers/static.py
@@ -7,6 +7,7 @@ from redash.handlers.authentication import base_href
 from redash.handlers.base import org_scoped_rule
 from redash.security import csp_allows_embeding
 
+
 def render_index():
     if settings.MULTI_ORG:
         response = render_template("multi_org.html", base_href=base_href())
@@ -15,6 +16,7 @@ def render_index():
         response = send_file(full_path, **dict(cache_timeout=0, conditional=True))
 
     return response
+
 
 @routes.route(org_scoped_rule('/dashboard/<slug>'), methods=['GET'])
 @login_required


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

Now that we have a CSP that prevents embedding Redash pages in iframes, we need to add a few exceptions. Dashboard pages are some times embedded in iframes, and therefore need an exception.

## Related Tickets & Documents

#3404 