### PR TITLE
Fix: Top padding for headless embed

### DIFF
--- a/client/app/components/queries/visualization-embed.html
+++ b/client/app/components/queries/visualization-embed.html
@@ -1,5 +1,5 @@
-<div class="tile m-l-10 m-r-10 embed__vis" data-test="VisualizationEmbed">
-  <div class="embed-heading p-t-10 p-b-10 p-r-15 p-l-15" ng-if="!$ctrl.hideHeader">
+<div class="tile m-l-10 m-r-10 p-t-10 embed__vis" data-test="VisualizationEmbed">
+  <div class="embed-heading p-b-10 p-r-15 p-l-15" ng-if="!$ctrl.hideHeader">
     <h3>
       <img ng-src="{{$ctrl.logoUrl}}" style="height: 24px;"/>
       <visualization-name visualization="$ctrl.visualization"/>


### PR DESCRIPTION
- [x] Bug Fix

## Description
If parameters are not displayed, hiding the widget header makes the results
This fixes it.

<img width="356" alt="Screen Shot 2019-07-07 at 13 50 59" src="https://user-images.githubusercontent.com/486954/60767310-05527b00-a0bf-11e9-8f7d-962d0aff6e6d.png">
