### PR TITLE
Improvements to Query Result serialization code

### DIFF
--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -1,7 +1,8 @@
 import cStringIO
 import csv
 import xlsxwriter
-from dateutil.parser import parse as parse_date
+from funcy import rpartial
+from dateutil.parser import isoparse as parse_date
 from redash.utils import json_loads, UnicodeWriter
 from redash.query_runner import (TYPE_BOOLEAN, TYPE_DATE, TYPE_DATETIME)
 from redash.authentication.org_resolving import current_org
@@ -19,26 +20,13 @@ def _convert_bool(value):
 
     return value
 
-def _convert_date(value):
+
+def _convert_datetime(value, fmt):
     if not value:
         return value
 
     try:
         parsed = parse_date(value)
-        ret = parsed.strftime(_convert_format(current_org.get_setting('date_format')))
-    except Exception:
-        return value
-
-    return ret
-
-
-def _convert_datetime(value):
-    if not value:
-        return value
-
-    try:
-        parsed = parse_date(value)
-        fmt = _convert_format('{} {}'.format(current_org.get_setting('date_format'), current_org.get_setting('time_format')))
         ret = parsed.strftime(fmt)
     except Exception:
         return value
@@ -46,23 +34,25 @@ def _convert_datetime(value):
     return ret
 
 
-SPECIAL_TYPES = {
-    TYPE_BOOLEAN: _convert_bool,
-    TYPE_DATE: _convert_date,
-    TYPE_DATETIME: _convert_datetime
-}
-
-
 def _get_column_lists(columns):
+    date_format = _convert_format(current_org.get_setting('date_format'))
+    datetime_format = _convert_format('{} {}'.format(current_org.get_setting('date_format'), current_org.get_setting('time_format')))
+
+    special_types = {
+        TYPE_BOOLEAN: _convert_bool,
+        TYPE_DATE: rpartial(_convert_datetime, date_format),
+        TYPE_DATETIME: rpartial(_convert_datetime, datetime_format)
+    }
+
     fieldnames = []
     special_columns = dict()
 
     for col in columns:
         fieldnames.append(col['name'])
 
-        for col_type in SPECIAL_TYPES.keys():
+        for col_type in special_types.keys():
             if col['type'] == col_type:
-                special_columns[col['name']] = SPECIAL_TYPES[col_type]
+                special_columns[col['name']] = special_types[col_type]
     
     return fieldnames, special_columns
 

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -23,19 +23,27 @@ def _convert_date(value):
     if not value:
         return value
 
-    parsed = parse_date(value)
+    try:
+        parsed = parse_date(value)
+        ret = parsed.strftime(_convert_format(current_org.get_setting('date_format')))
+    except Exception:
+        return value
 
-    return parsed.strftime(_convert_format(current_org.get_setting('date_format')))
+    return ret
 
 
 def _convert_datetime(value):
     if not value:
         return value
 
-    parsed = parse_date(value)
+    try:
+        parsed = parse_date(value)
+        fmt = _convert_format('{} {}'.format(current_org.get_setting('date_format'), current_org.get_setting('time_format')))
+        ret = parsed.strftime(fmt)
+    except Exception:
+        return value
 
-    fmt = _convert_format('{} {}'.format(current_org.get_setting('date_format'), current_org.get_setting('time_format')))
-    return parsed.strftime(fmt)
+    return ret
 
 
 SPECIAL_TYPES = {

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -14,6 +14,8 @@ data = {
         {"datetime": "2019-05-26T12:39:23.026Z", "bool": True, "date": "2019-05-26"},
         {"datetime": "", "bool": False, "date": ""},
         {"datetime": None, "bool": None, "date": None},
+        {"datetime": 459, "bool": None, "date": 123},
+        {"datetime": "459", "bool": None, "date": "123"},
     ], 
     "columns": [
         {"friendly_name": "bool", "type": "boolean", "name": "bool"}, 
@@ -44,6 +46,15 @@ class CsvSerializationTest(BaseTestCase):
         self.assertEqual(rows[0]['datetime'], '26/05/19 12:39')
         self.assertEqual(rows[1]['datetime'], '')
         self.assertEqual(rows[2]['datetime'], '')
+        self.assertEqual(rows[2]['date'], '')
         self.assertEqual(rows[0]['date'], '26/05/19')
         self.assertEqual(rows[1]['date'], '')
         self.assertEqual(rows[2]['date'], '')
+
+    def test_serializes_datatime_as_is_in_case_of_error(self):
+        with self.app.test_request_context('/'):
+            parsed = csv.DictReader(cStringIO.StringIO(self.get_csv_content()))
+        rows = list(parsed)
+
+        self.assertEqual(rows[3]['datetime'], '459')
+        self.assertEqual(rows[3]['date'], '123')

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -46,7 +46,6 @@ class CsvSerializationTest(BaseTestCase):
         self.assertEqual(rows[0]['datetime'], '26/05/19 12:39')
         self.assertEqual(rows[1]['datetime'], '')
         self.assertEqual(rows[2]['datetime'], '')
-        self.assertEqual(rows[2]['date'], '')
         self.assertEqual(rows[0]['date'], '26/05/19')
         self.assertEqual(rows[1]['date'], '')
         self.assertEqual(rows[2]['date'], '')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix
- [x] Other

## Description

1. Make the CSV serialization of dates safer by handling some edge cases (like invalid or empty values).
2. Improve performance (x10 in my benchmark) of serialization by switching from using [`dateutils.parser.parse`](https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse) to [`dateutils.parser.isoparse`](https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse).

Benchmarking was done with the following script:

```python
from redash import create_app
from redash.models import QueryResult
from redash.utils import json_dumps
from redash.serializers import serialize_query_result_to_csv
import pstats
import cProfile


data = {
    "rows": [
        {"datetime": "2019-05-26T12:39:23.026Z", "date": "2019-05-26"},
    ], 
    "columns": [
        {"friendly_name": "date", "type": "datetime", "name": "datetime"},
        {"friendly_name": "date", "type": "date", "name": "date"}
    ]
}

for i in xrange(5000):
    data['rows'].append({"datetime": "2019-05-26T12:39:23.026Z", "date": "2019-05-26"})


def bench():
    app = create_app()
    app.config['TESTING'] = True
    app.config['SERVER_NAME'] = 'localhost'
    app_ctx = app.app_context()
    app_ctx.push()

    with app.test_request_context('/'):
        query_result = QueryResult(data=json_dumps(data))
        # serialize_query_result_to_csv(query_result)
        cProfile.runctx('serialize_query_result_to_csv(query_result)', globals(), locals(), filename="profile")
        p = pstats.Stats('profile')
        p.sort_stats('cumulative').print_stats(10)


if __name__ == '__main__':
    bench()
```

If I knew the issue would be in `_convert_datetime`, I could make a simpler benchmarking script, but 🤷‍♂ .

The results before the change were:

```
         3782685 function calls (3721728 primitive calls) in 58.708 seconds
```

And after the change:

```
         306441 function calls (305520 primitive calls) in 4.960 seconds
```