### PR TITLE
Add an `extras` field for Presto connector

### DIFF
--- a/client/app/components/dynamic-form/DynamicForm.jsx
+++ b/client/app/components/dynamic-form/DynamicForm.jsx
@@ -28,7 +28,7 @@ const fieldRules = ({ type, required, minLength }) => {
     jsonRule && {
       type: 'object',
       transform(x) {
-        if (x.trim()) {
+        if (x && x.trim()) {
           try {
             JSON.parse(x);
           } catch {
@@ -93,7 +93,12 @@ class DynamicForm extends React.Component {
   parseValues = (values) => {
     this.props.fields.forEach((field) => {
       if (field.type === 'json' && field.name in values) {
-        values[field.name] = JSON.parse(values[field.name]);
+        try {
+          values[field.name] = JSON.parse(values[field.name]);
+        } catch {
+          // Invalid JSON must be discarded
+          values[field.name] = null;
+        }
       }
     });
     return values;

--- a/client/app/components/dynamic-form/DynamicForm.jsx
+++ b/client/app/components/dynamic-form/DynamicForm.jsx
@@ -7,22 +7,37 @@ import Checkbox from 'antd/lib/checkbox';
 import Button from 'antd/lib/button';
 import Upload from 'antd/lib/upload';
 import Icon from 'antd/lib/icon';
-import { includes, isFunction } from 'lodash';
+import { includes, isFunction, isPlainObject, isArray } from 'lodash';
 import Select from 'antd/lib/select';
 import notification from '@/services/notification';
 import AceEditorInput from '@/components/AceEditorInput';
 import { Field, Action, AntdForm } from '../proptypes';
 import helper from './dynamicFormHelper';
 
+const { TextArea } = Input;
+
 const fieldRules = ({ type, required, minLength }) => {
   const requiredRule = required;
   const minLengthRule = minLength && includes(['text', 'email', 'password'], type);
   const emailTypeRule = type === 'email';
+  const jsonRule = type === 'json';
 
   return [
     requiredRule && { required, message: 'This field is required.' },
-    minLengthRule && { min: minLength, message: 'This field is too short.' },
-    emailTypeRule && { type: 'email', message: 'This field must be a valid email.' },
+    minLengthRule && { min: minLength, message: 'This field is too short.' }, emailTypeRule && { type: 'email', message: 'This field must be a valid email.' },
+    jsonRule && {
+      type: 'object',
+      transform(x) {
+        if (x.trim()) {
+          try {
+            JSON.parse(x);
+          } catch {
+            return '';
+          }
+        }
+      },
+      message: 'This field must be a JSON string.',
+    },
   ].filter(rule => rule);
 };
 
@@ -75,13 +90,22 @@ class DynamicForm extends React.Component {
     }));
   };
 
+  parseValues = (values) => {
+    this.props.fields.forEach((field) => {
+      if (field.type === 'json' && field.name in values) {
+        values[field.name] = JSON.parse(values[field.name]);
+      }
+    });
+    return values;
+  };
+
   handleSubmit = (e) => {
     this.setState({ isSubmitting: true });
     e.preventDefault();
     this.props.form.validateFieldsAndScroll((err, values) => {
       if (!err) {
         this.props.onSubmit(
-          values,
+          this.parseValues(values),
           (msg) => {
             const { setFieldsValue, getFieldsValue } = this.props.form;
             this.setState({ isSubmitting: false });
@@ -156,8 +180,13 @@ class DynamicForm extends React.Component {
 
   renderField(field, props) {
     const { getFieldDecorator } = this.props.form;
-    const { name, type, initialValue } = field;
+    const { name, type } = field;
     const fieldLabel = field.title || helper.toHuman(name);
+    let initialValue = field.initialValue;
+
+    if (isPlainObject(initialValue) || isArray(initialValue)) {
+      initialValue = JSON.stringify(field.initialValue);
+    }
 
     const options = {
       rules: fieldRules(field),
@@ -176,9 +205,11 @@ class DynamicForm extends React.Component {
     } else if (type === 'number') {
       return getFieldDecorator(name, options)(<InputNumber {...props} />);
     } else if (type === 'textarea') {
-      return getFieldDecorator(name, options)(<Input.TextArea {...props} />);
+      return getFieldDecorator(name, options)(<TextArea {...props} />);
     } else if (type === 'ace') {
       return getFieldDecorator(name, options)(<AceEditorInput {...props} />);
+    } else if (type === 'json') {
+      return getFieldDecorator(name, options)(<TextArea {...props} />);
     }
     return getFieldDecorator(name, options)(<Input {...props} />);
   }
@@ -190,12 +221,6 @@ class DynamicForm extends React.Component {
       const fieldLabel = title || helper.toHuman(name);
       const { feedbackIcons, form } = this.props;
 
-      const formItemProps = {
-        className: 'm-b-10',
-        hasFeedback: type !== 'checkbox' && type !== 'file' && feedbackIcons,
-        label: type === 'checkbox' ? '' : fieldLabel,
-      };
-
       const fieldProps = {
         ...field.props,
         className: 'w-100',
@@ -205,6 +230,12 @@ class DynamicForm extends React.Component {
         autoFocus,
         placeholder: field.placeholder,
         'data-test': fieldLabel,
+      };
+      const formItemProps = {
+        className: 'm-b-10',
+        hasFeedback: type !== 'checkbox' && type !== 'file' && feedbackIcons,
+        label: type === 'checkbox' ? '' : fieldLabel,
+        extra: fieldProps.extra,
       };
 
       return (

--- a/client/app/components/dynamic-form/dynamicFormHelper.js
+++ b/client/app/components/dynamic-form/dynamicFormHelper.js
@@ -5,13 +5,15 @@ function orderedInputs(properties, order, targetOptions) {
   const inputs = new Array(order.length);
   Object.keys(properties).forEach((key) => {
     const position = order.indexOf(key);
+    const field = properties[key];
     const input = {
       name: key,
-      title: properties[key].title,
-      type: properties[key].type,
-      placeholder: properties[key].default && properties[key].default.toString(),
-      required: properties[key].required,
+      title: field.title,
+      type: field.type,
+      placeholder: field.default && field.default.toString(),
+      required: field.required,
       initialValue: targetOptions[key],
+      props: field.props,
     };
 
     if (position > -1) {
@@ -39,6 +41,10 @@ function normalizeSchema(configurationSchema) {
 
     if (prop.type === 'string') {
       prop.type = 'text';
+    }
+
+    if (prop.type === 'object') {
+      prop.type = 'json';
     }
 
     prop.required = includes(configurationSchema.required, name);

--- a/client/app/components/proptypes.js
+++ b/client/app/components/proptypes.js
@@ -45,11 +45,13 @@ export const Field = PropTypes.shape({
     'file',
     'select',
     'content',
+    'json',
   ]).isRequired,
   initialValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
     PropTypes.bool,
+    PropTypes.object,
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.arrayOf(PropTypes.number),
   ]),

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -46,7 +46,7 @@ class DataSourceResource(BaseResource):
         try:
             data_source.options.set_schema(schema)
             data_source.options.update(filter_none(req['options']))
-        except ValidationError:
+        except ValidationError, e:
             abort(400)
 
         data_source.type = req['type']

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -70,9 +70,17 @@ class Presto(BaseQueryRunner):
                 'password': {
                     'type': 'string'
                 },
+                'extras': {
+                    'type': 'object',
+                    'default': '{ "requests_kwargs": null }',
+                    'props': {
+                        'rows': 2,
+                        'extra': 'Extra kwargs passed to presto.connect(...)',
+                    }
+                }
             },
-            'order': ['host', 'protocol', 'port', 'username', 'password',
-                      'default_schema', 'schema_filter', 'table_filter', 'catalog'],
+            'order': ['host', 'protocol', 'port', 'username', 'password', 'default_schema',
+                      'schema_filter', 'table_filter', 'catalog', 'extras'],
             'required': ['host']
         }
 
@@ -129,7 +137,8 @@ class Presto(BaseQueryRunner):
             username=self.configuration.get('username', 'redash'),
             password=(self.configuration.get('password') or None),
             catalog=self.configuration.get('catalog', 'hive'),
-            schema=self.configuration.get('schema', 'default'))
+            schema=self.configuration.get('schema', 'default'),
+            **self.configuration.get('extras', {}))
 
         cursor = connection.cursor()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This adds a new "Extras" field for Presto connection, which is simply a JSON string and will be parsed as a dictionary and passed to [PyHive's `presto.connect` API](https://github.com/dropbox/PyHive/blob/6925cd74721cc474a02a6759490b2b4c8bef3831/pyhive/presto.py#L83).

The most useful utilization of this feature is to allow self-assigned SSL certificate. For example, services like [Qubole](https://docs.qubole.com/en/latest/user-guide/presto/connect-to-presto-when-ssl-enabled.html) only allows SSL connection via self-assigned CA certificate. In which case we can then add `requests_kwargs` in the extras:

```json
{"requests_kwargs":  {"verify": "~/qubole.cert"} }
```

We prefer this approach instead of the Qubole connector because Qubole charges you for every API call and the roundtrip from local EMR cluster to Qubole servers is not ideal.

This change also solves the need of adding extra fields for other connection arguments such as `Connection Source` implemented in #3938 .

One can simply set the "Extras" field to:
```json
{"source": "redash"}
```

## Related Tickets & Documents

This is an iteration of #3909. I've added type validation and help text.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Snip20190620_6](https://user-images.githubusercontent.com/335541/59878190-85a57c00-935c-11e9-81e0-e720851a5db1.png)

![Snip20190707_6](https://user-images.githubusercontent.com/335541/60783330-fa1f3f80-a0fe-11e9-80b7-37505bf0d003.png)