### PR TITLE
Added apply on keyboard shortcut to all parameters

### DIFF
--- a/client/app/components/ParameterApplyButton.jsx
+++ b/client/app/components/ParameterApplyButton.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
 import Button from 'antd/lib/button';
 import Badge from 'antd/lib/badge';
+import Tooltip from 'antd/lib/tooltip';
+import { KeyboardShortcuts } from '@/services/keyboard-shortcuts';
 
 function ParameterApplyButton({ paramCount, onClick, isApplying }) {
   // show spinner when applying (also when count is empty so the fade out is consistent)
@@ -11,9 +13,13 @@ function ParameterApplyButton({ paramCount, onClick, isApplying }) {
   return (
     <div className="parameter-apply-button" data-show={!!paramCount} data-test="ParameterApplyButton">
       <Badge count={paramCount}>
-        <Button onClick={onClick}>
-          <i className={`fa fa-${icon}`} /> Apply Changes
-        </Button>
+        <Tooltip title={`${KeyboardShortcuts.modKey} + Enter`}>
+          <span>
+            <Button onClick={onClick}>
+              <i className={`fa fa-${icon}`} /> Apply Changes
+            </Button>
+          </span>
+        </Tooltip>
       </Badge>
     </div>
   );

--- a/client/app/components/ParameterValueInput.less
+++ b/client/app/components/ParameterValueInput.less
@@ -39,11 +39,13 @@
       padding-left: 16px;
       opacity: 0;
       display: block;
+      pointer-events: none; // so tooltip doesn't remain after button hides
     }
   
     &[data-show="true"] {
       opacity: 1;
       display: block;
+      pointer-events: auto;
     }
 
     button {

--- a/client/app/components/parameters.js
+++ b/client/app/components/parameters.js
@@ -2,7 +2,7 @@ import { extend, filter, forEach, size } from 'lodash';
 import template from './parameters.html';
 import EditParameterSettingsDialog from './EditParameterSettingsDialog';
 
-function ParametersDirective($location) {
+function ParametersDirective($location, KeyboardShortcuts) {
   return {
     restrict: 'E',
     transclude: true,
@@ -13,9 +13,30 @@ function ParametersDirective($location) {
       changed: '&onChange',
       onUpdated: '=',
       onValuesChange: '=',
+      applyOnKeyboardShortcut: '<?',
     },
     template,
-    link(scope) {
+    link(scope, $element) {
+      if (scope.applyOnKeyboardShortcut !== false) {
+        const el = $element.get(0);
+        const shortcuts = {
+          'mod+enter': () => scope.onApply(),
+          'alt+enter': () => scope.onApply(),
+        };
+
+        const onFocus = () => { KeyboardShortcuts.bind(shortcuts); };
+        const onBlur = () => { KeyboardShortcuts.unbind(shortcuts); };
+
+        el.addEventListener('focus', onFocus, true);
+        el.addEventListener('blur', onBlur, true);
+
+        scope.$on('$destroy', () => {
+          KeyboardShortcuts.unbind(shortcuts);
+          el.removeEventListener('focus', onFocus);
+          el.removeEventListener('blur', onBlur);
+        });
+      }
+
       // is this the correct location for this logic?
       if (scope.syncValues !== false) {
         scope.$watch(
@@ -60,6 +81,10 @@ function ParametersDirective($location) {
       };
 
       scope.onApply = () => {
+        if (scope.dirtyParamCount) {
+          return false; // so keyboard shortcut doesn't run needlessly
+        }
+
         scope.$apply(scope.applyChanges);
         scope.onValuesChange();
       };

--- a/client/app/components/parameters.js
+++ b/client/app/components/parameters.js
@@ -81,7 +81,7 @@ function ParametersDirective($location, KeyboardShortcuts) {
       };
 
       scope.onApply = () => {
-        if (scope.dirtyParamCount) {
+        if (!scope.dirtyParamCount) {
           return false; // so keyboard shortcut doesn't run needlessly
         }
 

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -192,7 +192,7 @@
             <div class="d-flex flex-column p-b-15 p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
               <div class="p-t-15 p-b-5" ng-if="query.hasParameters()">
                 <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"
-                  on-updated="onParametersUpdated" on-values-change="executeQuery"></parameters>
+                  on-updated="onParametersUpdated" on-values-change="executeQuery" apply-on-keyboard-shortcut="false"></parameters>
               </div>
               <!-- Query Execution Status -->
 


### PR DESCRIPTION
- [x] Feature

## Description
Added meta+enter (and alt+enter) key bindings to `parameters`.
Activated when focusing on input elements when there are changes to be applied.

#### How
Put focus/blur listeners on the `<parameters>` element which adds/removes the key bindings accordingly.

#### Caveat
Since the query page already has these key bindings, it would result in double execution ☠
I tried a few approaches but eventually I went for disabling it for the query page with an attribute.
I don't like this solution cause it's coupled (the tooltip promises an ability that's fulfilled by another component) but it's the simplest 😣