### PR TITLE
Remove explicit kombu dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,6 @@ sqlparse==0.2.4
 statsd==2.1.2
 gunicorn==19.7.1
 celery==4.3.0
-kombu==4.5.0
 jsonschema==2.4.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0
@@ -57,11 +56,10 @@ python-geoip-geolite2==2015.303
 chromelogger==0.4.3
 pypd==1.1.0
 disposable-email-domains
-# Uncomment the requirement for ldap3 if using ldap.
-# It is not included by default because of the GPL license conflict.
-# ldap3==2.2.4
 gevent==1.4.0
-
 # Install the dependencies of the bin/bundle-extensions script here.
 # It has its own requirements file to simplify the frontend client build process
 -r requirements_bundles.txt
+# Uncomment the requirement for ldap3 if using ldap.
+# It is not included by default because of the GPL license conflict.
+# ldap3==2.2.4


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

We used an explicit kombu dependency to target the correct Redis version, but current version of Celery supposed to use it by default.