### PR TITLE
Move query runners/destinations import from redash.app to redash.

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -73,5 +73,5 @@ migrate = Migrate()
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)
 limiter = Limiter(key_func=get_ipaddr, storage_uri=settings.LIMITER_STORAGE)
 
-import_query_runners()
+import_query_runners(settings.QUERY_RUNNERS)
 import_destinations(settings.DESTINATIONS)

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -13,6 +13,8 @@ from statsd import StatsClient
 
 from . import settings
 from .app import create_app  # noqa
+from .query_runner import import_query_runners
+from .destinations import import_destinations
 
 __version__ = '8.0.0-beta'
 
@@ -66,11 +68,10 @@ def create_redis_connection():
 setup_logging()
 
 redis_connection = create_redis_connection()
-
 mail = Mail()
-
 migrate = Migrate()
-
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)
-
 limiter = Limiter(key_func=get_ipaddr, storage_uri=settings.LIMITER_STORAGE)
+
+import_query_runners()
+import_destinations(settings.DESTINATIONS)

--- a/redash/app.py
+++ b/redash/app.py
@@ -21,12 +21,10 @@ class Redash(Flask):
 
 def create_app():
     from . import authentication, extensions, handlers, limiter, mail, migrate, security
-    from .destinations import import_destinations
     from .handlers import chrome_logger
     from .handlers.webpack import configure_webpack
     from .metrics import request as request_metrics
     from .models import db, users
-    from .query_runner import import_query_runners
     from .utils import sentry
     from .version_check import reset_new_version_status
 
@@ -35,10 +33,6 @@ def create_app():
 
     # Check and update the cached version for use by the client
     app.before_first_request(reset_new_version_status)
-
-    # Load query runners and destinations
-    import_query_runners(settings.QUERY_RUNNERS)
-    import_destinations(settings.DESTINATIONS)
 
     security.init_app(app)
     request_metrics.init_app(app)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

While it was nice to delay the loading of query runners to the Flask app creation, it was creating issues on systems with less resources. Specifically when Celery was creating multiple workers at the same time, it was stressing the system.

Considering that due to how Flask works you need the app object anyway for everything, we were not gaining much by this delay.

I moved the alert destinations import to the same location for consistency.