### PR TITLE
Fixed filter style issue

### DIFF
--- a/client/app/components/Filters.jsx
+++ b/client/app/components/Filters.jsx
@@ -95,7 +95,7 @@ export function Filters({ filters, onChange }) {
 
   return (
     <div className="filters-wrapper">
-      <div className="parameter-container container bg-white">
+      <div className="container bg-white">
         <div className="row">
           {map(filters, (filter) => {
             const options = map(filter.values, (value, index) => (


### PR DESCRIPTION
- [x] Bug Fix

## Description
After #3907 landed, filters are misaligned and causing widget width overflow.

<img width="256" alt="Screen Shot 2019-07-18 at 13 19 25" src="https://user-images.githubusercontent.com/486954/61450477-dd390680-a95f-11e9-96dd-457c40baf812.png">

## The fix
Removed the classname `parameter-container` from filters.
Tested on dashboard page, query page and viz editor.

<img width="239" alt="Screen Shot 2019-07-18 at 13 25 53" src="https://user-images.githubusercontent.com/486954/61450574-0bb6e180-a960-11e9-8745-49ab8158a2f9.png">
