### PR TITLE
 Disable execute when params are dirty

### DIFF
--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -54,7 +54,7 @@ class QueryEditor extends React.Component {
     isDirty: PropTypes.bool.isRequired,
     isQueryOwner: PropTypes.bool.isRequired,
     updateDataSource: PropTypes.func.isRequired,
-    canExecuteQuery: PropTypes.func.isRequired,
+    canExecuteQuery: PropTypes.bool.isRequired,
     executeQuery: PropTypes.func.isRequired,
     queryExecuting: PropTypes.bool.isRequired,
     saveQuery: PropTypes.func.isRequired,
@@ -227,7 +227,7 @@ class QueryEditor extends React.Component {
   render() {
     const modKey = KeyboardShortcuts.modKey;
 
-    const isExecuteDisabled = this.props.queryExecuting || !this.props.canExecuteQuery();
+    const isExecuteDisabled = this.props.queryExecuting || !this.props.canExecuteQuery;
 
     return (
       <section style={{ height: '100%' }} data-test="QueryEditor">

--- a/client/app/components/parameters.js
+++ b/client/app/components/parameters.js
@@ -17,25 +17,23 @@ function ParametersDirective($location, KeyboardShortcuts) {
     },
     template,
     link(scope, $element) {
-      if (scope.applyOnKeyboardShortcut !== false) {
-        const el = $element.get(0);
-        const shortcuts = {
-          'mod+enter': () => scope.onApply(),
-          'alt+enter': () => scope.onApply(),
-        };
+      const el = $element.get(0);
+      const shortcuts = {
+        'mod+enter': () => scope.onApply(),
+        'alt+enter': () => scope.onApply(),
+      };
 
-        const onFocus = () => { KeyboardShortcuts.bind(shortcuts); };
-        const onBlur = () => { KeyboardShortcuts.unbind(shortcuts); };
+      const onFocus = () => { KeyboardShortcuts.bind(shortcuts); };
+      const onBlur = () => { KeyboardShortcuts.unbind(shortcuts); };
 
-        el.addEventListener('focus', onFocus, true);
-        el.addEventListener('blur', onBlur, true);
+      el.addEventListener('focus', onFocus, true);
+      el.addEventListener('blur', onBlur, true);
 
-        scope.$on('$destroy', () => {
-          KeyboardShortcuts.unbind(shortcuts);
-          el.removeEventListener('focus', onFocus);
-          el.removeEventListener('blur', onBlur);
-        });
-      }
+      scope.$on('$destroy', () => {
+        KeyboardShortcuts.unbind(shortcuts);
+        el.removeEventListener('focus', onFocus);
+        el.removeEventListener('blur', onBlur);
+      });
 
       // is this the correct location for this logic?
       if (scope.syncValues !== false) {

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -158,7 +158,7 @@
               update-data-source="updateDataSource"
               execute-query="executeQuery"
               query-executing="queryExecuting"
-              can-execute-query="canExecuteQuery"
+              can-execute-query="canExecuteQuery()"
               listen-for-resize="listenForResize"
               listen-for-editor-command="listenForEditorCommand"
               save-query="saveQuery"

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -192,7 +192,7 @@
             <div class="d-flex flex-column p-b-15 p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
               <div class="p-t-15 p-b-5" ng-if="query.hasParameters()">
                 <parameters parameters="query.getParametersDefs()" sync-values="!query.isNew()" editable="sourceMode && canEdit"
-                  on-updated="onParametersUpdated" on-values-change="executeQuery" apply-on-keyboard-shortcut="false"></parameters>
+                  on-updated="onParametersUpdated" on-values-change="executeQuery"></parameters>
               </div>
               <!-- Query Execution Status -->
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -166,7 +166,7 @@ function QueryViewCtrl(
   $scope.canEdit = currentUser.canEdit($scope.query) || $scope.query.can_edit;
   $scope.canViewSource = currentUser.hasPermission('view_source');
 
-  $scope.canExecuteQuery = () => $scope.query.is_safe || (currentUser.hasPermission('execute_query') && !$scope.dataSource.view_only);
+  $scope.canExecuteQuery = () => !$scope.query.$parameters.hasPendingValues() && ($scope.query.is_safe || (currentUser.hasPermission('execute_query') && !$scope.dataSource.view_only));
 
   $scope.canForkQuery = () => currentUser.hasPermission('edit_query') && !$scope.dataSource.view_only;
 

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -514,7 +514,6 @@ function QueryResource(
 
   QueryService.prototype.prepareQueryResultExecution = function prepareQueryResultExecution(execute, maxAge) {
     const parameters = this.getParameters();
-    parameters.applyPendingValues();
     const missingParams = parameters.getMissing();
 
     if (missingParams.length > 0) {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -3,7 +3,7 @@ import debug from 'debug';
 import Mustache from 'mustache';
 import {
   zipObject, isEmpty, map, filter, includes, union, uniq, has,
-  isNull, isUndefined, isArray, isObject, identity, extend, each,
+  isNull, isUndefined, isArray, isObject, identity, extend, each, some,
 } from 'lodash';
 
 Mustache.escape = identity; // do not html-escape values
@@ -320,6 +320,10 @@ class Parameters {
   getValues() {
     const params = this.get();
     return zipObject(map(params, i => i.name), map(params, i => i.getValue()));
+  }
+
+  hasPendingValues() {
+    return some(this.get(), p => p.hasPendingValue);
   }
 
   applyPendingValues() {

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -387,16 +387,21 @@ describe('Parameter', () => {
       });
     });
 
-    it('applies changes from "Execute" button', () => {
-      expectAppliedChanges(() => {
-        cy.getByTestId('ExecuteButton').click();
-      });
-    });
-
     it('applies changes from "alt+enter" keyboard shortcut', () => {
       expectAppliedChanges((input) => {
         input.type('{alt}{enter}');
       });
+    });
+
+    it('disables "Execute" button', () => {
+      cy.getByTestId('ParameterName-test-parameter-1')
+        .find('input')
+        .as('Input')
+        .type('Redash');
+      cy.getByTestId('ExecuteButton').should('be.disabled');
+
+      cy.get('@Input').clear();
+      cy.getByTestId('ExecuteButton').should('not.be.disabled');
     });
   });
 });


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #3997.

### The bug
There are a few execution paths in `query.js` and not all apply "pending param changes" before execution. In this scenario changes have not been applied, executing the parameter's initial value instead of the pending value.

### The fix
Instead of coding `applyPendingChanges()` into every which way, made it so execution by button and shortcut are disabled when params are dirty.

- [x] Disable button (also bottom one) and kb shortcut when params dirty
- [x] Allow execution upon applying param changes from button and kb shortcut
- [x] Add relevant tests

#### What is commit a02a2dc for?
Since the query page already listens to ctrl+enter, I previously had to disable the params listener to prevent multiple listeners from executing. But now that param dirty state disables the query shortcut, there's no risk of that happening, so the whole mechanism can be removed.

----------------

<img src="https://user-images.githubusercontent.com/486954/61591434-95201b00-abcf-11e9-8373-71d76be91311.gif" width=400 />
