### PR TITLE
PagerDuty destination multi-byte error

### DIFF
--- a/redash/destinations/pagerduty.py
+++ b/redash/destinations/pagerduty.py
@@ -12,7 +12,7 @@ except ImportError:
 class PagerDuty(BaseDestination):
 
     KEY_STRING = '{alert_id}_{query_id}'
-    DESCRIPTION_STR = 'Alert - Redash Query #{query_id}: {query_name}'
+    DESCRIPTION_STR = u'Alert - Redash Query #{query_id}: {query_name}'
 
     @classmethod
     def enabled(cls):
@@ -41,12 +41,12 @@ class PagerDuty(BaseDestination):
 
     def notify(self, alert, query, user, new_state, app, host, options):
 
-        default_desc = self.DESCRIPTION_STR.format(query_id=query.id, query_name=query.name)
-
         if alert.custom_subject:
             default_desc = alert.custom_subject
         elif options.get('description'):
             default_desc = options.get('description')
+        else:
+            default_desc = self.DESCRIPTION_STR.format(query_id=query.id, query_name=query.name)
 
         incident_key = self.KEY_STRING.format(alert_id=alert.id, query_id=query.id)
         data = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

PagerDuty alert destination ends in error when query name contains multibyte characters.

```
[2019-07-22 09:21:52,077][PID:132][ERROR][ForkPoolWorker-29] task_name=redash.tasks.check_alerts_for_query task_id=c806feed-ea79-4251-bb95-a80712cda707 Error with processing destination
Traceback (most recent call last):
File "/app/redash/tasks/alerts.py", line 23, in notify_subscriptions
subscription.notify(alert, alert.query_rel, subscription.user, new_state, current_app, host)
File "/app/redash/models/__init__.py", line 1125, in notify
app, host)
File "/app/redash/models/__init__.py", line 1083, in notify
app, host, self.options)
File "/app/redash/destinations/pagerduty.py", line 44, in notify
default_desc = self.DESCRIPTION_STR.format(query_id=query.id, query_name=query.name)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 8-20: ordinal not in range(128)
```

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes