### PR TITLE
Cypress: Specify widgets position on sharing spec

### DIFF
--- a/client/cypress/integration/dashboard/sharing_spec.js
+++ b/client/cypress/integration/dashboard/sharing_spec.js
@@ -47,11 +47,9 @@ describe('Dashboard Sharing', () => {
         query: 'select 1',
       };
 
-      createQueryAndAddWidget(this.dashboardId, queryData).then((elTestId) => {
+      const position = { autoHeight: false, sizeY: 6 };
+      createQueryAndAddWidget(this.dashboardId, queryData, { position }).then(() => {
         cy.visit(this.dashboardUrl);
-        cy.getByTestId(elTestId)
-          .its('0.offsetHeight')
-          .should('eq', 235);
 
         shareDashboard().then((secretAddress) => {
           cy.logout();
@@ -74,11 +72,9 @@ describe('Dashboard Sharing', () => {
         },
       };
 
-      createQueryAndAddWidget(this.dashboardId, queryData).then((elTestId) => {
+      const position = { autoHeight: false, sizeY: 6 };
+      createQueryAndAddWidget(this.dashboardId, queryData, { position }).then(() => {
         cy.visit(this.dashboardUrl);
-        cy.getByTestId(elTestId)
-          .its('0.offsetHeight')
-          .should('eq', 285);
 
         shareDashboard().then((secretAddress) => {
           cy.logout();
@@ -95,12 +91,9 @@ describe('Dashboard Sharing', () => {
       };
 
       // start out by creating a dashboard with no parameters & share it
-      createQueryAndAddWidget(this.dashboardId, queryData).then((elTestId) => {
+      const position = { autoHeight: false, sizeY: 6 };
+      createQueryAndAddWidget(this.dashboardId, queryData, { position }).then(() => {
         cy.visit(this.dashboardUrl);
-        cy.getByTestId(elTestId)
-          .its('0.offsetHeight')
-          .should('eq', 235);
-
         return shareDashboard();
       }).then((secretAddress) => {
         const unsafeQueryData = {
@@ -115,12 +108,9 @@ describe('Dashboard Sharing', () => {
         };
 
         // then, after it is shared, add an unsafe parameterized query to it
-        createQueryAndAddWidget(this.dashboardId, unsafeQueryData, { position: { col: 3 } }).then((elTestId) => {
+        const secondWidgetPos = { autoHeight: false, col: 3, sizeY: 6 };
+        createQueryAndAddWidget(this.dashboardId, unsafeQueryData, { position: secondWidgetPos }).then(() => {
           cy.visit(this.dashboardUrl);
-          cy.getByTestId(elTestId)
-            .its('0.offsetHeight')
-            .should('eq', 285);
-
           cy.logout();
           cy.visit(secretAddress);
           cy.getByTestId('DynamicTable', { timeout: 10000 }).should('exist');

--- a/client/cypress/integration/dashboard/sharing_spec.js
+++ b/client/cypress/integration/dashboard/sharing_spec.js
@@ -115,7 +115,7 @@ describe('Dashboard Sharing', () => {
         };
 
         // then, after it is shared, add an unsafe parameterized query to it
-        createQueryAndAddWidget(this.dashboardId, unsafeQueryData).then((elTestId) => {
+        createQueryAndAddWidget(this.dashboardId, unsafeQueryData, { position: { col: 3 } }).then((elTestId) => {
           cy.visit(this.dashboardUrl);
           cy.getByTestId(elTestId)
             .its('0.offsetHeight')

--- a/client/cypress/integration/dashboard/sharing_spec.js
+++ b/client/cypress/integration/dashboard/sharing_spec.js
@@ -124,6 +124,8 @@ describe('Dashboard Sharing', () => {
           cy.logout();
           cy.visit(secretAddress);
           cy.getByTestId('DynamicTable', { timeout: 10000 }).should('exist');
+          cy.contains('.alert', 'This query contains potentially unsafe parameters' +
+            ' and cannot be executed on a shared dashboard or an embedded visualization.');
           cy.percySnapshot('Successfully Shared Parameterized Dashboard With Some Unsafe Queries');
         });
       });

--- a/client/cypress/support/dashboard/index.js
+++ b/client/cypress/support/dashboard/index.js
@@ -9,12 +9,12 @@ export function getWidgetTestId(widget) {
   return `WidgetId${widget.id}`;
 }
 
-export function createQueryAndAddWidget(dashboardId, queryData = {}) {
+export function createQueryAndAddWidget(dashboardId, queryData = {}, widgetOptions = {}) {
   return createQuery(queryData)
     .then((query) => {
       const visualizationId = get(query, 'visualizations.0.id');
       assert.isDefined(visualizationId, 'Query api call returns at least one visualization with id');
-      return addWidget(dashboardId, visualizationId);
+      return addWidget(dashboardId, visualizationId, widgetOptions);
     })
     .then(getWidgetTestId);
 }

--- a/client/cypress/support/redash-api/index.js
+++ b/client/cypress/support/redash-api/index.js
@@ -51,14 +51,16 @@ export function addTextbox(dashboardId, text = 'text', options = {}) {
     });
 }
 
-export function addWidget(dashboardId, visualizationId) {
+export function addWidget(dashboardId, visualizationId, options = {}) {
+  const defaultOptions = {
+    position: { col: 0, row: 0, sizeX: 3, sizeY: 3 },
+  };
+
   const data = {
     width: 1,
     dashboard_id: dashboardId,
     visualization_id: visualizationId,
-    options: {
-      position: { col: 0, row: 0, sizeX: 3, sizeY: 3 },
-    },
+    options: merge(defaultOptions, options),
   };
 
   return cy.request('POST', 'api/widgets', data)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This specifies the second widget column to avoid widgets [swapping](https://percy.io/Redash/redash/builds/2244669/view/145955649/1280?mode=diff&browser=chrome&snapshot=145955649).

Extra: Make sure widget has error before taking snapshot (noticed this while doing this PR :grin:).
2. Disable `autoHeight`

## Related Tickets & Documents
--
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--