### PR TITLE
Fix Apply Changes is lost when query is edited

### DIFF
--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -39,7 +39,7 @@ export class ParameterValueInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: props.parameter.pendingValue || props.value,
+      value: props.parameter.hasPendingValue ? props.parameter.pendingValue : props.value,
       isDirty: props.parameter.hasPendingValue,
     };
   }

--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -49,7 +49,7 @@ export class ParameterValueInput extends React.Component {
     // if value prop updated, reset dirty state
     if (prevProps.value !== value || prevProps.parameter !== parameter) {
       this.setState({
-        value: parameter.pendingValue || value,
+        value: parameter.hasPendingValue ? parameter.pendingValue : value,
         isDirty: parameter.hasPendingValue,
       });
     }

--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -39,16 +39,19 @@ export class ParameterValueInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: props.value,
-      isDirty: false,
+      value: props.parameter.pendingValue || props.value,
+      isDirty: props.parameter.hasPendingValue,
     };
   }
 
   componentDidUpdate = (prevProps) => {
-    const { value } = this.props;
+    const { value, parameter } = this.props;
     // if value prop updated, reset dirty state
-    if (prevProps.value !== value) {
-      this.setState({ value, isDirty: false });
+    if (prevProps.value !== value || prevProps.parameter !== parameter) {
+      this.setState({
+        value: parameter.pendingValue || value,
+        isDirty: parameter.hasPendingValue,
+      });
     }
   }
 

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -254,10 +254,12 @@ function QueryViewCtrl(
     }
 
     // omit pendingValue before saving
-    request.options = {
-      ...request.options,
-      parameters: map(request.options.parameters, p => omit(p, 'pendingValue')),
-    };
+    if (request.options && request.options.parameters) {
+      request.options = {
+        ...request.options,
+        parameters: map(request.options.parameters, p => omit(p, 'pendingValue')),
+      };
+    }
 
     function overwrite() {
       options.force = true;

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -1,4 +1,4 @@
-import { pick, some, find, minBy, map, intersection, isArray } from 'lodash';
+import { pick, some, find, minBy, map, intersection, isArray, omit } from 'lodash';
 import { SCHEMA_NOT_SUPPORTED, SCHEMA_LOAD_ERROR } from '@/services/data-source';
 import getTags from '@/services/getTags';
 import { policy } from '@/services/policy';
@@ -252,6 +252,12 @@ function QueryViewCtrl(
     if (options.force) {
       delete request.version;
     }
+
+    // omit pendingValue before saving
+    request.options = {
+      ...request.options,
+      parameters: map(request.options.parameters, p => omit(p, 'pendingValue')),
+    };
 
     function overwrite() {
       options.force = true;

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -290,7 +290,8 @@ class Parameters {
 
     const parameterExists = p => includes(parameterNames, p.name);
     const parameters = this.query.options.parameters;
-    this.query.options.parameters = parameters.filter(parameterExists).map(p => new Parameter(p, this.query.id));
+    this.query.options.parameters = parameters.filter(parameterExists)
+      .map(p => (p instanceof Parameter ? p : new Parameter(p, this.query.id)));
   }
 
   initFromQueryString(query) {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -66,6 +66,9 @@ export class Parameter {
     // validate value and init internal state
     this.setValue(parameter.value);
 
+    // initialize pendingValue
+    this.pendingValue = parameter.pendingValue;
+
     // Used for URL serialization
     Object.defineProperty(this, 'urlPrefix', {
       configurable: true,

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -66,9 +66,6 @@ export class Parameter {
     // validate value and init internal state
     this.setValue(parameter.value);
 
-    // initialize pendingValue
-    this.pendingValue = parameter.pendingValue;
-
     // Used for URL serialization
     Object.defineProperty(this, 'urlPrefix', {
       configurable: true,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
When editing a query the "Apply Changes" state was lost:
![state-lost](https://user-images.githubusercontent.com/3356951/61918542-1c4ef500-af28-11e9-83f6-612646a576aa.gif)



## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![apply-all-edit-query](https://user-images.githubusercontent.com/3356951/61919675-0c85df80-af2d-11e9-848a-10919b8b392f.gif)
