### PR TITLE
Updated timeago strings

### DIFF
--- a/client/app/components/TimeAgo.jsx
+++ b/client/app/components/TimeAgo.jsx
@@ -6,6 +6,25 @@ import PropTypes from 'prop-types';
 import { Moment } from '@/components/proptypes';
 import { clientConfig } from '@/services/auth';
 import useForceUpdate from '@/lib/hooks/useForceUpdate';
+import Tooltip from 'antd/lib/tooltip';
+
+moment.updateLocale('en', {
+  relativeTime: {
+    future: '%s',
+    past: '%s',
+    s: 'just now',
+    m: 'a minute ago',
+    mm: '%d minutes ago',
+    h: 'an hour ago',
+    hh: '%d hours ago',
+    d: 'a day ago',
+    dd: '%d days ago',
+    M: 'a month ago',
+    MM: '%d months ago',
+    y: 'a year ago',
+    yy: '%d years ago',
+  },
+});
 
 function toMoment(value) {
   value = !isNil(value) ? moment(value) : null;
@@ -27,7 +46,11 @@ export function TimeAgo({ date, placeholder, autoUpdate }) {
     }
   }, [autoUpdate]);
 
-  return <span title={title} data-test="TimeAgo">{value}</span>;
+  return (
+    <Tooltip title={title}>
+      <span data-test="TimeAgo">{value}</span>
+    </Tooltip>
+  );
 }
 
 TimeAgo.propTypes = {

--- a/client/app/components/TimeAgo.jsx
+++ b/client/app/components/TimeAgo.jsx
@@ -8,24 +8,6 @@ import { clientConfig } from '@/services/auth';
 import useForceUpdate from '@/lib/hooks/useForceUpdate';
 import Tooltip from 'antd/lib/tooltip';
 
-moment.updateLocale('en', {
-  relativeTime: {
-    future: '%s',
-    past: '%s',
-    s: 'just now',
-    m: 'a minute ago',
-    mm: '%d minutes ago',
-    h: 'an hour ago',
-    hh: '%d hours ago',
-    d: 'a day ago',
-    dd: '%d days ago',
-    M: 'a month ago',
-    MM: '%d months ago',
-    y: 'a year ago',
-    yy: '%d years ago',
-  },
-});
-
 function toMoment(value) {
   value = !isNil(value) ? moment(value) : null;
   return value && value.isValid() ? value : null;

--- a/client/app/config/index.js
+++ b/client/app/config/index.js
@@ -30,6 +30,7 @@ import registerDirectives from '@/directives';
 import markdownFilter from '@/filters/markdown';
 import dateTimeFilter from '@/filters/datetime';
 import './antd-spinner';
+import moment from 'moment';
 
 const logger = debug('redash:config');
 
@@ -40,6 +41,24 @@ Pace.options.shouldHandlePushState = (prevUrl, newUrl) => {
   const [newPrefix] = newUrl.split('?');
   return prevPrefix !== newPrefix;
 };
+
+moment.updateLocale('en', {
+  relativeTime: {
+    future: '%s',
+    past: '%s',
+    s: 'just now',
+    m: 'a minute ago',
+    mm: '%d minutes ago',
+    h: 'an hour ago',
+    hh: '%d hours ago',
+    d: 'a day ago',
+    dd: '%d days ago',
+    M: 'a month ago',
+    MM: '%d months ago',
+    y: 'a year ago',
+    yy: '%d years ago',
+  },
+});
 
 const requirements = [
   ngRoute,


### PR DESCRIPTION
- [x] Refactor

## Description
1. "a few seconds ago" is too common to be so long. "just now" is better.
2. Sometimes differences in server/client clocks cause the confusing "**in** a few seconds". Now will simply say "just now".
3. Updated the tooltip to ant design.

This also manifests to "Outdated Queries", "Users" list and "Alerts" list.

## Mobile & Desktop Screenshots

Before|After
-------|-------
<img width="243" alt="Screen Shot 2019-07-27 at 16 42 27" src="https://user-images.githubusercontent.com/486954/61995242-50442a80-b08e-11e9-8084-2c015952228f.png"> | <img width="243" alt="Screen Shot 2019-07-27 at 16 40 41" src="https://user-images.githubusercontent.com/486954/61995241-50442a80-b08e-11e9-86e9-e26bd2545475.png">
