### PR TITLE
Dropdown endpoint is called on every keystroke

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -569,11 +569,13 @@ function QueryResource(
       asDropdown: {
         method: 'get',
         isArray: true,
+        cache: true,
         url: 'api/queries/:id/dropdown',
       },
       associatedDropdown: {
         method: 'get',
         isArray: true,
+        cache: true,
         url: 'api/queries/:queryId/dropdowns/:dropdownQueryId',
       },
       favorites: {


### PR DESCRIPTION
<!--

We use GitHub only for bug reports 🐛

Anything else should be posted to https://discuss.redash.io 👫

🚨For support, help & questions use https://discuss.redash.io/c/support
💡For feature requests & ideas use https://discuss.redash.io/c/feature-requests

**Found a security vulnerability?** Please email security@redash.io to report any security vulnerabilities. We will acknowledge receipt of your vulnerability and strive to send you regular updates about our progress. If you're curious about the status of your disclosure please feel free to email us again. If you want to encrypt your disclosure email, you can use this PGP key.

-->

### Issue Summary

When editing the source of a query with a dropdown parameter, the `/api/queries/<query_id>/dropdown` endpoint is hit on every keystroke.

### Steps to Reproduce

1. Create a query with a dropdown parameter
2. Type in something in the source editor
3. Watch the Network tab for requests

### Technical details:

* Redash Version: master
* Browser/OS: Chrome
