### PR TITLE
Recycle gunicorn workers

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -31,7 +31,10 @@ dev_worker() {
 }
 
 server() {
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app
+  # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
+  MAX_REQUESTS=${MAX_REQUESTS:-1000}
+  MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER
 }
 
 create_db() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
In order to avoid some issues that pop up on long-standing workers (faulty connections etc), it could be useful to refresh workers every n-th request.