### PR TITLE
Fix: support for unicode in DynamoDB queries

### DIFF
--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -102,8 +102,10 @@ class DynamoDBSQL(BaseSQLQueryRunner):
         try:
             engine = self._connect()
 
-            result = engine.execute(query if str(
-                query).endswith(';') else str(query) + ';')
+            if not query.endswith(';'):
+                query = query + ';'
+
+            result = engine.execute(query)
 
             columns = []
             rows = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

It was trying to cast query into a string which will fail if it's unicode.