### PR TITLE
Cypress: Force readonly inputs click

### DIFF
--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -155,7 +155,7 @@ describe('Parameter', () => {
     const selectCalendarDate = (date) => {
       cy.getByTestId('ParameterName-test-parameter')
         .find('input')
-        .click();
+        .click({ force: true });
 
       cy.get('.ant-calendar-date-panel')
         .contains('.ant-calendar-date', date)
@@ -255,7 +255,7 @@ describe('Parameter', () => {
       cy.getByTestId('ParameterName-test-parameter')
         .find('input')
         .as('Input')
-        .click();
+        .click({ force: true });
 
       cy.get('.ant-calendar-date-panel')
         .contains('.ant-calendar-date', '15')
@@ -279,7 +279,7 @@ describe('Parameter', () => {
       cy.getByTestId('ParameterName-test-parameter')
         .find('input')
         .as('Input')
-        .click();
+        .click({ force: true });
 
       cy.get('.ant-calendar-date-panel')
         .contains('Now')
@@ -313,7 +313,7 @@ describe('Parameter', () => {
       expectDirtyStateChange(() => {
         cy.getByTestId('ParameterName-test-parameter')
           .find('input')
-          .click();
+          .click({ force: true });
 
         cy.get('.ant-calendar-date-panel')
           .contains('Now')
@@ -327,7 +327,7 @@ describe('Parameter', () => {
       cy.getByTestId('ParameterName-test-parameter')
         .find('input')
         .first()
-        .click();
+        .click({ force: true });
 
       cy.get('.ant-calendar-date-panel')
         .contains('.ant-calendar-date', startDate)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
After cypress update to v3.4.1 readonly inputs are not reachable by default, so I added `{ force: true }` where needed to make existing CI tests pass again.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--