### PR TITLE
Turned off max asset size warning

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -225,6 +225,9 @@ const config = {
       modules: false,
       chunkModules: false
     }
+  },
+  performance: {
+    hints: false
   }
 };
 


### PR DESCRIPTION
- [x] Other

## Description
Warning shows on build, not a necessity, much annoying, turned off.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="382" alt="Screen Shot 2019-07-31 at 9 30 48" src="https://user-images.githubusercontent.com/486954/62194401-7580b380-b382-11e9-815e-b13ff2bda46e.png">
