### PR TITLE
Cannot edit dashboard after adding widget

### DIFF
--- a/redash/handlers/widgets.py
+++ b/redash/handlers/widgets.py
@@ -24,12 +24,11 @@ class WidgetListResource(BaseResource):
         :>json object widget: The created widget
         """
         widget_properties = request.get_json(force=True)
-        dashboard = models.Dashboard.get_by_id_and_org(widget_properties.pop('dashboard_id'), self.current_org)
+        dashboard = models.Dashboard.get_by_id_and_org(widget_properties.get('dashboard_id'), self.current_org)
         require_object_modify_permission(dashboard, self.current_user)
 
         widget_properties['options'] = json_dumps(widget_properties['options'])
         widget_properties.pop('id', None)
-        widget_properties['dashboard'] = dashboard
 
         visualization_id = widget_properties.pop('visualization_id')
         if visualization_id:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

After adding a new widget user cannot edit dashboard properties: name, tags, enable dashboard-level filters. It happens because after adding a new widget dashboard version is increased but not sent to frontend which continues using old version number.