### PR TITLE
Allow dynamic values dropdown to scroll with the page

### DIFF
--- a/client/app/components/dynamic-parameters/DynamicButton.jsx
+++ b/client/app/components/dynamic-parameters/DynamicButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { isFunction, get, findIndex } from 'lodash';
 import Dropdown from 'antd/lib/dropdown';
@@ -35,23 +35,28 @@ function DynamicButton({ options, selectedDynamicValue, onSelect, enabled }) {
     </Menu>
   );
 
+  const containerRef = useRef(null);
+
   return (
-    <a onClick={e => e.stopPropagation()}>
-      <Dropdown.Button
-        overlay={menu}
-        className="dynamic-button"
-        placement="bottomRight"
-        trigger={['click']}
-        icon={(
-          <Icon
-            type="thunderbolt"
-            theme={enabled ? 'twoTone' : 'outlined'}
-            className="dynamic-icon"
-          />
-        )}
-        data-test="DynamicButton"
-      />
-    </a>
+    <div ref={containerRef}>
+      <a onClick={e => e.stopPropagation()}>
+        <Dropdown.Button
+          overlay={menu}
+          className="dynamic-button"
+          placement="bottomRight"
+          trigger={['click']}
+          icon={(
+            <Icon
+              type="thunderbolt"
+              theme={enabled ? 'twoTone' : 'outlined'}
+              className="dynamic-icon"
+            />
+            )}
+          getPopupContainer={() => containerRef.current}
+          data-test="DynamicButton"
+        />
+      </a>
+    </div>
   );
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
This was annoying me a bit so I searched and found [this](https://ant.design/docs/react/faq#Select-Dropdown-DatePicker-TimePicker-Popover-Popconfirm-scrolls-with-the-page?). The issue is easily noticed on mobile (showed in the gif below :slightly_smiling_face:), then it should improve the usage for dynamic values in this context.

## Related Tickets & Documents
--
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**
![dynamic-values-scroll-before](https://user-images.githubusercontent.com/3356951/62499377-d5c78900-b7b8-11e9-8d2b-c0246c8e8f2b.gif)

**After**
![dynamic-values-scroll-after](https://user-images.githubusercontent.com/3356951/62499393-df50f100-b7b8-11e9-94ab-33b01b2c06b1.gif)

