### PR TITLE
refresh_queries requires Request Context

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -451,7 +451,7 @@ class QueryRefreshResource(BaseResource):
         require_access(query, self.current_user, not_view_only)
 
         parameter_values = collect_parameters_from_request(request.args)
-        parameterized_query = ParameterizedQuery(query.query_text)
+        parameterized_query = ParameterizedQuery(query.query_text, org=self.current_org)
 
         return run_query(parameterized_query, parameter_values, query.data_source, query.id)
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -12,7 +12,7 @@ from redash.tasks import QueryTask
 from redash.tasks.queries import enqueue_query
 from redash.utils import (collect_parameters_from_request, gen_query_hash, json_dumps, utcnow, to_filename)
 from redash.models.parameterized_query import (ParameterizedQuery, InvalidParameterError,
-                                              QueryDetachedFromDataSourceError, dropdown_values)
+                                               QueryDetachedFromDataSourceError, dropdown_values)
 from redash.serializers import serialize_query_result, serialize_query_result_to_csv, serialize_query_result_to_xlsx
 
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -125,7 +125,7 @@ class QueryResultDropdownResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_access(query.data_source, current_user, view_only)
         try:
-            return dropdown_values(query_id)
+            return dropdown_values(query_id, self.current_org)
         except QueryDetachedFromDataSourceError as e:
             abort(400, message=e.message)
 
@@ -140,7 +140,7 @@ class QueryDropdownsResource(BaseResource):
             dropdown_query = get_object_or_404(models.Query.get_by_id_and_org, dropdown_query_id, self.current_org)
             require_access(dropdown_query.data_source, current_user, view_only)
 
-        return dropdown_values(dropdown_query_id)
+        return dropdown_values(dropdown_query_id, self.current_org)
 
 
 class QueryResultResource(BaseResource):

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -11,7 +11,8 @@ from redash.permissions import (has_access, not_view_only, require_access,
 from redash.tasks import QueryTask
 from redash.tasks.queries import enqueue_query
 from redash.utils import (collect_parameters_from_request, gen_query_hash, json_dumps, utcnow, to_filename)
-from redash.models.parameterized_query import ParameterizedQuery, InvalidParameterError, QueryDetachedFromDataSourceError, dropdown_values
+from redash.models.parameterized_query import (ParameterizedQuery, InvalidParameterError,
+                                              QueryDetachedFromDataSourceError, dropdown_values)
 from redash.serializers import serialize_query_result, serialize_query_result_to_csv, serialize_query_result_to_xlsx
 
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -95,7 +95,7 @@ class QueryResultListResource(BaseResource):
         query_id = params.get('query_id', 'adhoc')
         parameters = params.get('parameters', collect_parameters_from_request(request.args))
 
-        parameterized_query = ParameterizedQuery(query)
+        parameterized_query = ParameterizedQuery(query, org=self.current_org)
 
         data_source_id = params.get('data_source_id')
         if data_source_id:

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -263,10 +263,6 @@ class QueryResult(db.Model, BelongsToOrgMixin):
         }
 
     @classmethod
-    def get_by_id(cls, _id):
-        return cls.query.filter(cls.id == _id).one()
-
-    @classmethod
     def unused(cls, days=7):
         age_threshold = datetime.datetime.now() - datetime.timedelta(days=days)
         return (
@@ -692,7 +688,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @property
     def parameterized(self):
-        return ParameterizedQuery(self.query_text, self.parameters)
+        return ParameterizedQuery(self.query_text, self.parameters, self.org)
 
     @property
     def dashboard_api_keys(self):

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -263,6 +263,10 @@ class QueryResult(db.Model, BelongsToOrgMixin):
         }
 
     @classmethod
+    def get_by_id(cls, _id):
+        return cls.query.filter(cls.id == _id).one()
+
+    @classmethod
     def unused(cls, days=7):
         age_threshold = datetime.datetime.now() - datetime.timedelta(days=days)
         return (

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -16,13 +16,12 @@ def _pluck_name_and_value(default_column, row):
 
 
 def _load_result(query_id):
-    from redash.authentication.org_resolving import current_org
     from redash import models
 
-    query = models.Query.get_by_id_and_org(query_id, current_org)
+    query = models.Query.get_by_id(query_id)
 
     if query.data_source:
-        query_result = models.QueryResult.get_by_id_and_org(query.latest_query_data_id, current_org)
+        query_result = models.QueryResult.get_by_id(query.latest_query_data_id)
         return json_loads(query_result.data)
     else:
         raise QueryDetachedFromDataSourceError(query_id)

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -190,4 +190,5 @@ class InvalidParameterError(Exception):
 class QueryDetachedFromDataSourceError(Exception):
     def __init__(self, query_id):
         self.query_id = query_id
-        super(QueryDetachedFromDataSourceError, self).__init__("This query is detached from any data source. Please select a different query.")
+        super(QueryDetachedFromDataSourceError, self).__init__(
+            "This query is detached from any data source. Please select a different query.")

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -1,6 +1,5 @@
 import pystache
 from functools import partial
-from flask_restful import abort
 from numbers import Number
 from redash.utils import mustache_render, json_loads
 from redash.permissions import require_access, view_only
@@ -26,7 +25,7 @@ def _load_result(query_id):
         query_result = models.QueryResult.get_by_id_and_org(query.latest_query_data_id, current_org)
         return json_loads(query_result.data)
     else:
-        abort(400, message="This query is detached from any data source. Please select a different query.")
+        raise QueryDetachedFromDataSourceError
 
 
 def dropdown_values(query_id):
@@ -187,3 +186,8 @@ class InvalidParameterError(Exception):
         parameter_names = u", ".join(parameters)
         message = u"The following parameter values are incompatible with their definitions: {}".format(parameter_names)
         super(InvalidParameterError, self).__init__(message)
+
+
+class QueryDetachedFromDataSourceError(Exception):
+    def __init__(self):
+        super(QueryDetachedFromDataSourceError, self).__init__("This query is detached from any data source. Please select a different query.")

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -25,7 +25,7 @@ def _load_result(query_id):
         query_result = models.QueryResult.get_by_id_and_org(query.latest_query_data_id, current_org)
         return json_loads(query_result.data)
     else:
-        raise QueryDetachedFromDataSourceError
+        raise QueryDetachedFromDataSourceError(query_id)
 
 
 def dropdown_values(query_id):
@@ -189,5 +189,6 @@ class InvalidParameterError(Exception):
 
 
 class QueryDetachedFromDataSourceError(Exception):
-    def __init__(self):
+    def __init__(self, query_id):
+        self.query_id = query_id
         super(QueryDetachedFromDataSourceError, self).__init__("This query is detached from any data source. Please select a different query.")

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -183,13 +183,13 @@ def refresh_queries():
     with statsd_client.timer('manager.outdated_queries_lookup'):
         for query in models.Query.outdated_queries():
             if settings.FEATURE_DISABLE_REFRESH_QUERIES:
-                logging.info("Disabled refresh queries.")
+                logging.debug("Disabled refresh queries.")
             elif query.org.is_disabled:
                 logging.debug("Skipping refresh of %s because org is disabled.", query.id)
             elif query.data_source is None:
-                logging.info("Skipping refresh of %s because the datasource is none.", query.id)
+                logging.debug("Skipping refresh of %s because the datasource is none.", query.id)
             elif query.data_source.paused:
-                logging.info("Skipping refresh of %s because datasource - %s is paused (%s).", query.id, query.data_source.name, query.data_source.pause_reason)
+                logging.debug("Skipping refresh of %s because datasource - %s is paused (%s).", query.id, query.data_source.name, query.data_source.pause_reason)
             else:
                 query_text = query.query_text
 
@@ -198,10 +198,10 @@ def refresh_queries():
                     try:
                         query_text = query.parameterized.apply(parameters).query
                     except InvalidParameterError as e:
-                        logging.info("Skipping refresh of %s because of invalid parameters: %s", query.id, e.message)
+                        logging.debug("Skipping refresh of %s because of invalid parameters: %s", query.id, e.message)
                         continue
                     except QueryDetachedFromDataSourceError as e:
-                        logging.info(
+                        logging.debug(
                             "Skipping refresh of %s because a related dropdown query (%s) is unattached to any datasource.",
                             query.id, e.query_id)
                         continue

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -193,7 +193,7 @@ def refresh_queries():
             else:
                 query_text = query.query_text
 
-                parameters = {p['name']: p.get('value') for p in query.options.get('parameters', [])}
+                parameters = {p['name']: p.get('value') for p in query.parameters}
                 if any(parameters):
                     try:
                         query_text = query.parameterized.apply(parameters).query

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -189,7 +189,8 @@ def refresh_queries():
             elif query.data_source is None:
                 logging.debug("Skipping refresh of %s because the datasource is none.", query.id)
             elif query.data_source.paused:
-                logging.debug("Skipping refresh of %s because datasource - %s is paused (%s).", query.id, query.data_source.name, query.data_source.pause_reason)
+                logging.debug("Skipping refresh of %s because datasource - %s is paused (%s).",
+                              query.id, query.data_source.name, query.data_source.pause_reason)
             else:
                 query_text = query.query_text
 
@@ -202,7 +203,8 @@ def refresh_queries():
                         track_failure(query, error)
                         continue
                     except QueryDetachedFromDataSourceError as e:
-                        error = "Skipping refresh of {} because a related dropdown query ({}) is unattached to any datasource.".format(query.id, e.query_id)
+                        error = ("Skipping refresh of {} because a related dropdown "
+                                 "query ({}) is unattached to any datasource.").format(query.id, e.query_id)
                         track_failure(query, error)
                         continue
 
@@ -314,6 +316,7 @@ def _resolve_user(user_id, is_api_key, query_id):
     else:
         return None
 
+
 def track_failure(query, error):
     logging.debug(error)
 
@@ -322,6 +325,7 @@ def track_failure(query, error):
     models.db.session.commit()
 
     notify_of_failure(error, query)
+
 
 # We could have created this as a celery.Task derived class, and act as the task itself. But this might result in weird
 # issues as the task class created once per process, so decided to have a plain object instead.

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -201,7 +201,9 @@ def refresh_queries():
                         logging.info("Skipping refresh of %s because of invalid parameters: %s", query.id, e.message)
                         continue
                     except QueryDetachedFromDataSourceError as e:
-                        logging.info("Skipping refresh of %s because a related dropdown query (%s) is unattached to any datasource.", query.id, e.query_id)
+                        logging.info(
+                            "Skipping refresh of %s because a related dropdown query (%s) is unattached to any datasource.",
+                            query.id, e.query_id)
                         continue
 
                 enqueue_query(query_text, query.data_source, query.user_id,

--- a/tests/models/test_parameterized_query.py
+++ b/tests/models/test_parameterized_query.py
@@ -3,7 +3,7 @@ from mock import patch
 from collections import namedtuple
 import pytest
 
-from redash.models.parameterized_query import ParameterizedQuery, InvalidParameterError, dropdown_values
+from redash.models.parameterized_query import ParameterizedQuery, InvalidParameterError, QueryDetachedFromDataSourceError, dropdown_values
 
 
 class TestParameterizedQuery(TestCase):
@@ -246,3 +246,8 @@ class TestParameterizedQuery(TestCase):
     def test_dropdown_supports_upper_cased_columns(self, _):
         values = dropdown_values(1)
         self.assertEquals(values, [{"name": 5, "value": "5"}])
+
+    @patch('redash.models.Query.get_by_id_and_org', return_value=namedtuple('Query', 'data_source')(None))
+    def test_dropdown_values_raises_when_query_is_detached_from_data_source(self, _):
+        with pytest.raises(QueryDetachedFromDataSourceError):
+            dropdown_values(1)

--- a/tests/models/test_parameterized_query.py
+++ b/tests/models/test_parameterized_query.py
@@ -230,24 +230,24 @@ class TestParameterizedQuery(TestCase):
         "columns": [{"name": "id"}, {"name": "Name"}, {"name": "Value"}],
         "rows": [{"id": 5, "Name": "John", "Value": "John Doe"}]})
     def test_dropdown_values_prefers_name_and_value_columns(self, _):
-        values = dropdown_values(1)
+        values = dropdown_values(1, None)
         self.assertEquals(values, [{"name": "John", "value": "John Doe"}])
 
     @patch('redash.models.parameterized_query._load_result', return_value={
         "columns": [{"name": "id"}, {"name": "fish"}, {"name": "poultry"}],
         "rows": [{"fish": "Clown", "id": 5, "poultry": "Hen"}]})
     def test_dropdown_values_compromises_for_first_column(self, _):
-        values = dropdown_values(1)
+        values = dropdown_values(1, None)
         self.assertEquals(values, [{"name": 5, "value": "5"}])
 
     @patch('redash.models.parameterized_query._load_result', return_value={
         "columns": [{"name": "ID"}, {"name": "fish"}, {"name": "poultry"}],
         "rows": [{"fish": "Clown", "ID": 5, "poultry": "Hen"}]})
     def test_dropdown_supports_upper_cased_columns(self, _):
-        values = dropdown_values(1)
+        values = dropdown_values(1, None)
         self.assertEquals(values, [{"name": 5, "value": "5"}])
 
-    @patch('redash.models.Query.get_by_id', return_value=namedtuple('Query', 'data_source')(None))
+    @patch('redash.models.Query.get_by_id_and_org', return_value=namedtuple('Query', 'data_source')(None))
     def test_dropdown_values_raises_when_query_is_detached_from_data_source(self, _):
         with pytest.raises(QueryDetachedFromDataSourceError):
-            dropdown_values(1)
+            dropdown_values(1, None)

--- a/tests/models/test_parameterized_query.py
+++ b/tests/models/test_parameterized_query.py
@@ -247,7 +247,7 @@ class TestParameterizedQuery(TestCase):
         values = dropdown_values(1)
         self.assertEquals(values, [{"name": 5, "value": "5"}])
 
-    @patch('redash.models.Query.get_by_id_and_org', return_value=namedtuple('Query', 'data_source')(None))
+    @patch('redash.models.Query.get_by_id', return_value=namedtuple('Query', 'data_source')(None))
     def test_dropdown_values_raises_when_query_is_detached_from_data_source(self, _):
         with pytest.raises(QueryDetachedFromDataSourceError):
             dropdown_values(1)

--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -83,3 +83,24 @@ class TestRefreshQuery(BaseTestCase):
                 patch.object(Query, 'outdated_queries', oq):
             refresh_queries()
             add_job_mock.assert_not_called()
+
+    def test_doesnt_enqueue_parameterized_queries_with_dropdown_queries_that_are_detached_from_data_source(self):
+        """
+        Scheduled queries with a dropdown parameter which points to a query that is detached from its data source are skipped.
+        """
+        query = self.factory.create_query(
+            query_text="select {{n}}",
+            options={"parameters": [{
+                "global": False,
+                "type": "query",
+                "name": "n",
+                "queryId": 100,
+                "title": "n"}]})
+
+        dropdown_query = self.factory.create_query(id=100, data_source=None)
+
+        oq = staticmethod(lambda: [query])
+        with patch('redash.tasks.queries.enqueue_query') as add_job_mock, \
+                patch.object(Query, 'outdated_queries', oq):
+            refresh_queries()
+            add_job_mock.assert_not_called()


### PR DESCRIPTION
[Now that `refresh_queries` uses `query.parameterized.apply`](https://github.com/getredash/redash/commit/f0576a362352bd63ae3f96d70bd2d0da1d0646da#diff-5ca0dc869c9c3218d8a95ba7f99f5f4cR196), it requires Flask's Request Context to work.

As this code is used from a background job, it should work without a Request Context. In general we should avoid using Request Context code in models.