### PR TITLE
Fix failing failure report task

### DIFF
--- a/redash/tasks/failure_report.py
+++ b/redash/tasks/failure_report.py
@@ -24,8 +24,8 @@ def comment_for(failure):
 
 @celery.task(name="redash.tasks.send_aggregated_errors")
 def send_aggregated_errors():
-    for key in redis_connection.scan_iter(key("*")):
-        user_id = re.search(r'\d+', key).group()
+    for k in redis_connection.scan_iter(key("*")):
+        user_id = re.search(r'\d+', k).group()
         send_failure_report(user_id)
 
 

--- a/tests/tasks/test_failure_report.py
+++ b/tests/tasks/test_failure_report.py
@@ -6,7 +6,7 @@ import dateutil
 
 from tests import BaseTestCase
 from redash import redis_connection, models, settings
-from redash.tasks.failure_report import notify_of_failure, send_failure_report, send_aggregated_errors, key
+from redash.tasks.failure_report import notify_of_failure, send_failure_report, key
 from redash.utils import json_loads
 
 class TestSendAggregatedErrorsTask(BaseTestCase):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Following #3797, failures were aggregated, but were not picked up by the `send_aggregated_errors` task due to variable shadowing. This is fixed in this PR.

## Related Tickets & Documents
Related to #3793 