### PR TITLE
Align content vertically in restricted widget type

### DIFF
--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -83,8 +83,8 @@
     </div>
   </div>
 
-  <div class="tile body-container widget-restricted" ng-if="$ctrl.type=='restricted'" ng-class="$ctrl.type">
-    <div class="t-body body-row-auto scrollbox">
+  <div class="tile body-container d-flex justify-content-center align-items-center widget-restricted" ng-if="$ctrl.type=='restricted'" ng-class="$ctrl.type">
+    <div class="t-body scrollbox">
       <div class="text-center">
         <h1><span class="zmdi zmdi-lock"></span></h1>
         <p class="text-muted">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
This displays content in restricted widget type vertically centered.
It sets the flex property for the scrollbox back to default initial value
by removing `body-row-auto` class.

## Related Tickets & Documents
#3949

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Mobile
<img width="499" alt="image" src="https://user-images.githubusercontent.com/13223818/62831873-d3848500-bc25-11e9-99dd-5ecd62fb7036.png">

Desktop
<img width="704" alt="image" src="https://user-images.githubusercontent.com/13223818/62831867-b780e380-bc25-11e9-95b3-8dc182d5b4c8.png">
