### PR TITLE
Cypress: Fix cy.clock not freezing time

### DIFF
--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -188,8 +188,7 @@ describe('Parameter', () => {
 
       cy.get('.ant-calendar-date-panel')
         .contains('.ant-calendar-date', date)
-        .click()
-        .click(); // workaround for datepicker display bug
+        .click();
     };
 
     beforeEach(() => {
@@ -198,22 +197,18 @@ describe('Parameter', () => {
         query: "SELECT '{{test-parameter}}' AS parameter",
         options: {
           parameters: [
-            { name: 'test-parameter', title: 'Test Parameter', type: 'date' },
+            { name: 'test-parameter', title: 'Test Parameter', type: 'date', value: null },
           ],
         },
       };
 
-      createQuery(queryData, false)
-        .then(({ id }) => cy.visit(`/queries/${id}`));
-
-      // make sure parameter is loaded, otherwise cy.clock won't work
-      cy.getByTestId('ParameterApplyButton')
-        .should('exist');
-
       const now = new Date();
       now.setDate(1);
       cy.wrap(now.getTime()).as('now');
-      cy.clock(now.getTime());
+      cy.clock(now.getTime(), ['Date']);
+
+      createQuery(queryData, false)
+        .then(({ id }) => cy.visit(`/queries/${id}`));
     });
 
     afterEach(() => {
@@ -232,8 +227,7 @@ describe('Parameter', () => {
 
     it('allows picking a dynamic date', function () {
       cy.getByTestId('DynamicButton')
-        .click()
-        .click(); // workaround for datepicker display bug
+        .click();
 
       cy.getByTestId('DynamicButtonMenu')
         .contains('Today/Now')
@@ -258,22 +252,18 @@ describe('Parameter', () => {
         query: "SELECT '{{test-parameter}}' AS parameter",
         options: {
           parameters: [
-            { name: 'test-parameter', title: 'Test Parameter', type: 'datetime-local' },
+            { name: 'test-parameter', title: 'Test Parameter', type: 'datetime-local', value: null },
           ],
         },
       };
 
-      createQuery(queryData, false)
-        .then(({ id }) => cy.visit(`/queries/${id}`));
-
-      // make sure parameter is loaded, otherwise cy.clock won't work
-      cy.getByTestId('ParameterApplyButton')
-        .should('exist');
-
       const now = new Date();
       now.setDate(1);
       cy.wrap(now.getTime()).as('now');
-      cy.clock(now.getTime());
+      cy.clock(now.getTime(), ['Date']);
+
+      createQuery(queryData, false)
+        .then(({ id }) => cy.visit(`/queries/${id}`));
     });
 
     afterEach(() => {
@@ -288,14 +278,10 @@ describe('Parameter', () => {
 
       cy.get('.ant-calendar-date-panel')
         .contains('.ant-calendar-date', '15')
-        .as('SelectedDate')
         .click();
 
       cy.get('.ant-calendar-ok-btn')
         .click();
-
-      // workaround for datepicker display bug
-      cy.get('@SelectedDate').click();
 
       cy.getByTestId('ParameterApplyButton')
         .click();
@@ -312,8 +298,7 @@ describe('Parameter', () => {
 
       cy.get('.ant-calendar-date-panel')
         .contains('Now')
-        .click()
-        .click(); // workaround for datepicker display bug
+        .click();
 
       cy.getByTestId('ParameterApplyButton')
         .click();
@@ -324,8 +309,7 @@ describe('Parameter', () => {
 
     it('allows picking a dynamic date', function () {
       cy.getByTestId('DynamicButton')
-        .click()
-        .click(); // workaround for datepicker display bug
+        .click();
 
       cy.getByTestId('DynamicButtonMenu')
         .contains('Today/Now')
@@ -364,8 +348,7 @@ describe('Parameter', () => {
 
       cy.get('.ant-calendar-date-panel')
         .contains('.ant-calendar-date', endDate)
-        .click()
-        .click(); // workaround for datepicker display bug
+        .click();
     };
 
     beforeEach(() => {
@@ -379,17 +362,13 @@ describe('Parameter', () => {
         },
       };
 
-      createQuery(queryData, false)
-        .then(({ id }) => cy.visit(`/queries/${id}/source`));
-
-      // make sure parameter is loaded, otherwise cy.clock won't work
-      cy.getByTestId('ParameterName-test-parameter')
-        .should('exist');
-
       const now = new Date();
       now.setDate(1);
       cy.wrap(now.getTime()).as('now');
-      cy.clock(now.getTime());
+      cy.clock(now.getTime(), ['Date']);
+
+      createQuery(queryData, false)
+        .then(({ id }) => cy.visit(`/queries/${id}/source`));
     });
 
     afterEach(() => {
@@ -409,7 +388,6 @@ describe('Parameter', () => {
 
     it('allows picking a dynamic date range', function () {
       cy.getByTestId('DynamicButton')
-        .click()
         .click();
 
       cy.getByTestId('DynamicButtonMenu')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
With [this](https://dashboard.cypress.io/#/projects/924cka/runs/1042/failures) I noticed that time wasn't being frozen after using `cy.clock` (it was set, but some second differences were happening). In order to properly set that it must come before `cy.visit`, but this was causing page loading issues. Solved those by using `cy.clock(timestamp, ['Date'])` so the `Date` element is affected and other Timer functions are not.

Note: Could remove all workarounds after that :slightly_smiling_face:

## Related Tickets & Documents
--
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--