### PR TITLE
Switch to mysqlclient from Python-MySQL

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -2,7 +2,7 @@ google-api-python-client==1.5.1
 gspread==3.1.0
 impyla==0.10.0
 influxdb==2.7.1
-MySQL-python==1.2.5
+mysqlclient==1.4.4
 oauth2client==3.0.0
 pyhive==0.5.1
 pymongo[tls,srv]==3.6.1
@@ -17,7 +17,7 @@ sasl>=0.1.3
 thrift>=0.8.0
 thrift_sasl>=0.1.0
 cassandra-driver==3.11.0
-memsql==2.16.0
+memsql==3.0.0
 atsd_client==2.0.12
 simple_salesforce==0.72.2
 PyAthena>=1.5.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

* Newer versions of Debian use MariaDB clients by default, which aren't compatible with Python-MySQL (it's unclear to me how the CI build passes - maybe it uses a cached redash/base:debian image?).
* Python-MySQL isn't compatible with Python 3 and unmaintained, so needs to be replaced anyway.
* As older version of `memsql` were using Python-MySQL I had to upgrade it as well. This version of memsql might not support Python 2, but as memsql isn't very popular in Redash, it seemed like a reasonable trade off.