### PR TITLE
Add parameter dialog doesn't work when query has selected text

### DIFF
--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -1,4 +1,4 @@
-import { map, defer } from 'lodash';
+import { map, debounce, defer } from 'lodash';
 import template from './query.html';
 import EditParameterSettingsDialog from '@/components/EditParameterSettingsDialog';
 
@@ -52,7 +52,9 @@ function QuerySourceCtrl(
 
   $scope.canForkQuery = () => currentUser.hasPermission('edit_query') && !$scope.dataSource.view_only;
 
-  $scope.updateQuery = newQueryText => defer(() => $scope.$apply(() => { $scope.query.query = newQueryText; }));
+  $scope.updateQuery = debounce(
+    newQueryText => defer(() => $scope.$apply(() => { $scope.query.query = newQueryText; })),
+  );
 
   // @override
   $scope.saveQuery = (options, data) => {

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -1,4 +1,4 @@
-import { map, debounce, defer } from 'lodash';
+import { map, debounce } from 'lodash';
 import template from './query.html';
 import EditParameterSettingsDialog from '@/components/EditParameterSettingsDialog';
 
@@ -53,7 +53,9 @@ function QuerySourceCtrl(
   $scope.canForkQuery = () => currentUser.hasPermission('edit_query') && !$scope.dataSource.view_only;
 
   $scope.updateQuery = debounce(
-    newQueryText => defer(() => $scope.$apply(() => { $scope.query.query = newQueryText; })),
+    newQueryText => $scope.$apply(() => {
+      $scope.query.query = newQueryText;
+    }),
   );
 
   // @override


### PR DESCRIPTION
<!--

We use GitHub only for bug reports 🐛

Anything else should be posted to https://discuss.redash.io 👫

🚨For support, help & questions use https://discuss.redash.io/c/support
💡For feature requests & ideas use https://discuss.redash.io/c/feature-requests

**Found a security vulnerability?** Please email security@redash.io to report any security vulnerabilities. We will acknowledge receipt of your vulnerability and strive to send you regular updates about our progress. If you're curious about the status of your disclosure please feel free to email us again. If you want to encrypt your disclosure email, you can use this PGP key.

-->

### Issue Summary
Adding a parameter through the Parameter settings dialog won't work when you have a selected text in the query (parameter is added without any settings): 

![add-param](https://user-images.githubusercontent.com/3356951/62323789-71d25700-b47e-11e9-9ab8-01aae801bbb0.gif)

This is definitively not critical, but I thought it was worth to report in any case.

### Steps to Reproduce

1. Open a query or create one
2. Select part of the text
3. Add a Parameter using `Ctrl/Cmd+P`
4. Notice that the parameter will be created without any settings

### Technical details:

* Redash Version: Latest
* Browser/OS: --
* How did you install Redash: 
