### PR TITLE
Require a more up-to-date version of importlib-metadata.

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,6 +4,6 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata==0.9  # remove when on 3.8
+importlib-metadata>=0.19  # remove when on 3.8
 importlib_resources==1.0.2  # remove when on 3.7
 pathlib2==2.3.3  # remove when on 3.x


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This is needed since kombu 4.6.4 just switched to importlib-metadata (which we use for the extension system to load entrypoints as well) and requires a newer version of it (https://github.com/celery/kombu/commit/5b44bf94fa20532082507d6825aef2cb7b8d1883).

I think it's fair to keep the version unpinned since its API is pretty stable since it's being synced with the ongoing Python 3.8 stdlib importlib.

The original PR changing it in kombu was https://github.com/celery/kombu/pull/1071.