### PR TITLE
Format Counter target value as a number with reasonable default

### DIFF
--- a/client/app/visualizations/counter/index.js
+++ b/client/app/visualizations/counter/index.js
@@ -145,8 +145,13 @@ const CounterRenderer = {
         $scope.targetValueTooltip = formatTooltip($scope.targetValue, options.tooltipFormat);
 
         $scope.counterValue = formatValue($scope.counterValue, options);
+
         if (options.formatTargetValue) {
           $scope.targetValue = formatValue($scope.targetValue, options);
+        } else {
+          if (Number.isFinite($scope.targetValue)) {
+            $scope.targetValue = numeral($scope.targetValue).format('0[.]00[0]');
+          }
         }
       }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

When we restored the default behavior of not formatting the target value we didn't restore formatting the target value as a number. This PR does it but with a fallback to not formatting in case it's not a number.