### PR TITLE
Pin kombu version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ sqlparse==0.2.4
 statsd==2.1.2
 gunicorn==19.7.1
 celery==4.3.0
+kombu==4.6.3
 jsonschema==2.4.0
 RestrictedPython==3.6.0
 pysaml2==4.5.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

kombu is a dependency of Celery and usually we let them declare the version, but their version is pinned and the most recent release (4.6.4) has a severe regression where workers stop responding to inspect commands.