### PR TITLE
Fix clickhouse password leak

### DIFF
--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -67,21 +67,25 @@ class ClickHouse(BaseSQLQueryRunner):
         return schema.values()
 
     def _send_query(self, data, stream=False):
-        r = requests.post(
-            self.configuration.get('url', "http://127.0.0.1:8123"),
-            data=data.encode("utf-8"),
-            stream=stream,
-            timeout=self.configuration.get('timeout', 30),
-            params={
-                'user': self.configuration.get('user', "default"),
-                'password':  self.configuration.get('password', ""),
-                'database': self.configuration['dbname']
-            }
-        )
-        if r.status_code != 200:
-            raise Exception(r.text)
-        # logging.warning(r.json())
-        return r.json()
+        url = self.configuration.get('url', "http://127.0.0.1:8123")
+        try:
+            r = requests.post(
+                url,
+                data=data.encode("utf-8"),
+                stream=stream,
+                timeout=self.configuration.get('timeout', 30),
+                params={
+                    'user': self.configuration.get('user', "default"),
+                    'password':  self.configuration.get('password', ""),
+                    'database': self.configuration['dbname']
+                }
+            )
+            if r.status_code != 200:
+                raise Exception(r.text)
+            # logging.warning(r.json())
+            return r.json()
+        except requests.RequestException:
+            raise Exception('Connection error to %s' % url)
 
     @staticmethod
     def _define_column_type(column):

--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -84,8 +84,12 @@ class ClickHouse(BaseSQLQueryRunner):
                 raise Exception(r.text)
             # logging.warning(r.json())
             return r.json()
-        except requests.RequestException:
-            raise Exception('Connection error to %s' % url)
+        except requests.RequestException as e:
+            if e.response:
+                details = "({}, Status Code: {})".format(e.__class__.__name__, e.response.status_code)
+            else:
+                details = "({})".format(e.__class__.__name__)
+            raise Exception("Connection error to: {} {}.".format(url, details))
 
     @staticmethod
     def _define_column_type(column):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Clickhouse credentials appear in web-interface after unsuccessfully http connection while query running:

`Error running query: HTTPConnectionPool(host='10.1.2.3', port=8123): Max retries exceeded with url: /?password=123qweasd&user=redashreadonly&database=default (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff36739bd90>: Failed to establish a new connection: [Errno 111] Connection refused',))
`

So every user with access to redash web-interface can get it. In this PR I catch all requests exceptions and generate new, without private data.

