### PR TITLE
Fix netlify preview redirect loop in Safari

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 
 [[redirects]]
   from = "/login"
-  to = "http://preview-login.redashapp.com/login"
+  to = "https://preview-login.redashapp.com/login"
   status = 200
 
 [[redirects]]


### PR DESCRIPTION
- [x] Bug Fix

## Description
In Safari, accessing Netlify Preview logged-out results in redirect loop.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img src="https://user-images.githubusercontent.com/486954/63272983-c0b52480-c2a5-11e9-8b1d-149bd160aea4.gif" width="500" />
