### PR TITLE
Dashboard: when updating parameters, run only relevant queries

### DIFF
--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -111,8 +111,9 @@ export class Parameters extends React.Component {
   applyChanges = () => {
     const { onValuesChange, disableUrlUpdate } = this.props;
     this.setState(({ parameters }) => {
+      const parametersWithPendingValues = parameters.filter(p => p.hasPendingValue);
       forEach(parameters, p => p.applyPendingValue());
-      onValuesChange();
+      onValuesChange(parametersWithPendingValues);
       if (!disableUrlUpdate) {
         updateUrl(parameters);
       }

--- a/client/app/components/dashboards/widget.html
+++ b/client/app/components/dashboards/widget.html
@@ -44,7 +44,7 @@
         </div>
       </div>
       <div class="m-b-10" ng-if="$ctrl.localParametersDefs().length > 0">
-        <parameters parameters="$ctrl.localParametersDefs()" on-values-change="$ctrl.refresh"></parameters>
+        <parameters parameters="$ctrl.localParametersDefs()" on-values-change="$ctrl.forceRefresh"></parameters>
       </div>
     </div>
 

--- a/client/app/components/dashboards/widget.js
+++ b/client/app/components/dashboards/widget.js
@@ -92,6 +92,8 @@ function DashboardWidgetCtrl($scope, $location, $uibModal, $window, $rootScope, 
     return this.widget.load(refresh, maxAge);
   };
 
+  this.forceRefresh = () => this.load(true);
+
   this.refresh = (buttonId) => {
     this.refreshClickButtonId = buttonId;
     this.load(true).finally(() => {

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -142,7 +142,7 @@ function DashboardCtrl(
       widget => Object.values(widget.getParameterMappings()).filter(
         ({ type }) => type === 'dashboard-level',
       ).some(
-        ({ mapTo }) => updatedParameters.map(p => p.name).includes(mapTo),
+        ({ mapTo }) => _.includes(updatedParameters.map(p => p.name), mapTo),
       ),
     ) : this.dashboard.widgets;
 

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -139,8 +139,10 @@ function DashboardCtrl(
 
   const collectFilters = (dashboard, forceRefresh, updatedParameters = []) => {
     const affectedWidgets = updatedParameters.length > 0 ? this.dashboard.widgets.filter(
-      widget => widget.getQuery() && widget.getQuery().getParametersDefs().some(
-        ({ name }) => updatedParameters.map(p => p.name).includes(name),
+      widget => Object.values(widget.getParameterMappings()).filter(
+        ({ type }) => type === 'dashboard-level',
+      ).some(
+        ({ mapTo }) => updatedParameters.map(p => p.name).includes(mapTo),
       ),
     ) : this.dashboard.widgets;
 

--- a/client/app/pages/dashboards/dashboard.js
+++ b/client/app/pages/dashboards/dashboard.js
@@ -137,10 +137,10 @@ function DashboardCtrl(
     this.extractGlobalParameters();
   });
 
-  const collectFilters = (dashboard, forceRefresh, pendingParameters = []) => {
-    const affectedWidgets = pendingParameters.length > 0 ? this.dashboard.widgets.filter(
+  const collectFilters = (dashboard, forceRefresh, updatedParameters = []) => {
+    const affectedWidgets = updatedParameters.length > 0 ? this.dashboard.widgets.filter(
       widget => widget.getQuery() && widget.getQuery().getParametersDefs().some(
-        ({ name }) => pendingParameters.map(p => p.name).includes(name),
+        ({ name }) => updatedParameters.map(p => p.name).includes(name),
       ),
     ) : this.dashboard.widgets;
 


### PR DESCRIPTION
When dashboard-level parameters are updated, all widgets in that dashboard are updated, even if they are unaffected by the new parameter values.

For example - in this dashboard, the bottom widget is completely unrelated to `param1`, yet updating its value refreshes the widget.

![dashboard](https://user-images.githubusercontent.com/289488/63799589-0e203a00-c915-11e9-8a43-32ee55832d88.gif)

This PR changes this behavior by only refreshing the widgets that have at least parameter which maps to one of the dashboard-level parameter which were updated.