### PR TITLE
Fix: MySQL connections without SSL are failing

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -2,7 +2,7 @@ import logging
 import os
 import threading
 
-from redash.query_runner import *
+from redash.query_runner import TYPE_FLOAT, TYPE_INTEGER, TYPE_DATETIME, TYPE_STRING, TYPE_DATE, BaseSQLQueryRunner, InterruptException, register
 from redash.settings import parse_boolean
 from redash.utils import json_dumps, json_loads
 
@@ -11,7 +11,6 @@ try:
     enabled = True
 except ImportError:
     enabled = False
-
 
 logger = logging.getLogger(__name__)
 types_map = {
@@ -44,7 +43,8 @@ class Mysql(BaseSQLQueryRunner):
 
     @classmethod
     def configuration_schema(cls):
-        show_ssl_settings = parse_boolean(os.environ.get('MYSQL_SHOW_SSL_SETTINGS', 'true'))
+        show_ssl_settings = parse_boolean(
+            os.environ.get('MYSQL_SHOW_SSL_SETTINGS', 'true'))
 
         schema = {
             'type': 'object',
@@ -81,8 +81,10 @@ class Mysql(BaseSQLQueryRunner):
                     'title': 'Use SSL'
                 },
                 'ssl_cacert': {
-                    'type': 'string',
-                    'title': 'Path to CA certificate file to verify peer against (SSL)'
+                    'type':
+                    'string',
+                    'title':
+                    'Path to CA certificate file to verify peer against (SSL)'
                 },
                 'ssl_cert': {
                     'type': 'string',
@@ -106,21 +108,21 @@ class Mysql(BaseSQLQueryRunner):
 
     def _connection(self):
         params = dict(host=self.configuration.get('host', ''),
-                                     user=self.configuration.get('user', ''),
-                                     passwd=self.configuration.get('passwd', ''),
-                                     db=self.configuration['db'],
-                                     port=self.configuration.get('port', 3306),
-                                     charset='utf8', 
-                                     use_unicode=True,
-                                     connect_timeout=60)
-        
+                      user=self.configuration.get('user', ''),
+                      passwd=self.configuration.get('passwd', ''),
+                      db=self.configuration['db'],
+                      port=self.configuration.get('port', 3306),
+                      charset='utf8',
+                      use_unicode=True,
+                      connect_timeout=60)
+
         ssl_options = self._get_ssl_parameters()
 
         if ssl_options:
             params['ssl'] = ssl_options
 
         connection = MySQLdb.connect(**params)
-        
+
         return connection
 
     def _get_tables(self, schema):
@@ -141,7 +143,8 @@ class Mysql(BaseSQLQueryRunner):
 
         for row in results['rows']:
             if row['table_schema'] != self.configuration['db']:
-                table_name = u'{}.{}'.format(row['table_schema'], row['table_name'])
+                table_name = u'{}.{}'.format(row['table_schema'],
+                                             row['table_name'])
             else:
                 table_name = row['table_name']
 
@@ -160,7 +163,8 @@ class Mysql(BaseSQLQueryRunner):
         try:
             connection = self._connection()
             thread_id = connection.thread_id()
-            t = threading.Thread(target=self._run_query, args=(query, user, connection, r, ev))
+            t = threading.Thread(target=self._run_query,
+                                 args=(query, user, connection, r, ev))
             t.start()
             while not ev.wait(1):
                 pass
@@ -190,8 +194,12 @@ class Mysql(BaseSQLQueryRunner):
 
             # TODO - very similar to pg.py
             if desc is not None:
-                columns = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in desc])
-                rows = [dict(zip((c['name'] for c in columns), row)) for row in data]
+                columns = self.fetch_columns([(i[0], types_map.get(i[1], None))
+                                              for i in desc])
+                rows = [
+                    dict(zip((c['name'] for c in columns), row))
+                    for row in data
+                ]
 
                 data = {'columns': columns, 'rows': rows}
                 r.json_data = json_dumps(data)
@@ -218,9 +226,7 @@ class Mysql(BaseSQLQueryRunner):
         ssl_params = {}
 
         if self.configuration.get('use_ssl'):
-            config_map = dict(ssl_cacert='ca',
-                              ssl_cert='cert',
-                              ssl_key='key')
+            config_map = dict(ssl_cacert='ca', ssl_cert='cert', ssl_key='key')
             for key, cfg in config_map.items():
                 val = self.configuration.get(key)
                 if val:
@@ -294,7 +300,8 @@ class RDSMySQL(Mysql):
 
     def _get_ssl_parameters(self):
         if self.configuration.get('use_ssl'):
-            ca_path = os.path.join(os.path.dirname(__file__), './files/rds-combined-ca-bundle.pem')
+            ca_path = os.path.join(os.path.dirname(__file__),
+                                   './files/rds-combined-ca-bundle.pem')
             return {'ca': ca_path}
 
         return None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

I don't know if it's a change in `mysqlclient` or the new MariaDB C connector, but now when you pass a value to the `ssl` argument of `MySQLdb.connect` it will try to start an SSL connection (where before it was just ignored).

This PR changes the connect function to not pass `ssl` when not needed and some other cleanup.