### PR TITLE
Widget table scroll-x visible

### DIFF
--- a/client/app/assets/less/inc/misc.less
+++ b/client/app/assets/less/inc/misc.less
@@ -234,4 +234,21 @@
     .hide-in-percy, .pace {
         visibility: hidden;
     }
+
+    [data-percy="show-scrollbars"] {
+        overflow: scroll;
+
+        &::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: green;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: red;
+        }
+    }
 }

--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -208,13 +208,6 @@ edit-in-place p.editable:hover {
   }
 }
 
-.visualization-renderer {
-  .pagination,
-  .ant-pagination {
-    margin-top: 10px;
-  }
-}
-
 .embed__vis {
   display: flex;
   flex-flow: column;

--- a/client/app/visualizations/VisualizationRenderer.jsx
+++ b/client/app/visualizations/VisualizationRenderer.jsx
@@ -60,14 +60,13 @@ export function VisualizationRenderer(props) {
   return (
     <React.Fragment>
       {showFilters && <Filters filters={filters} onChange={setFilters} />}
-      <div>
-        <Renderer
-          key={`visualization${visualization.id}`}
-          options={options}
-          data={filteredData}
-          visualizationName={visualization.name}
-        />
-      </div>
+      <Renderer
+        key={`visualization${visualization.id}`}
+        options={options}
+        data={filteredData}
+        visualizationName={visualization.name}
+        context={props.context}
+      />
     </React.Fragment>
   );
 }

--- a/client/app/visualizations/table/Renderer.jsx
+++ b/client/app/visualizations/table/Renderer.jsx
@@ -61,6 +61,7 @@ export default function Renderer({ options, data }) {
   return (
     <div className="table-visualization-container">
       <Table
+        data-percy="show-scrollbars"
         data-test="TableVisualization"
         columns={tableColumns}
         dataSource={preparedRows}

--- a/client/app/visualizations/table/renderer.less
+++ b/client/app/visualizations/table/renderer.less
@@ -8,7 +8,7 @@
     margin-bottom: 0;
   }
 
-  .ant-table-body {
+  .ant-table {
     overflow-x: auto;
   }
 
@@ -100,4 +100,23 @@
       }
     }
   }
+
+  /* START table x scroll */
+  .dashboard-widget-wrapper:not(.widget-auto-height-enabled) & {
+    height: 100%;
+
+    & div {
+      height: inherit;
+    }
+
+    .ant-spin-container {
+      display: flex;
+      flex-direction: column;
+
+      .ant-table {
+        flex-grow: 1;
+      }
+    }
+  }
+  /* END */
 }

--- a/client/app/visualizations/table/renderer.less
+++ b/client/app/visualizations/table/renderer.less
@@ -115,6 +115,24 @@
 
       .ant-table {
         flex-grow: 1;
+
+        // show and color scrollbars
+        @media only percy {
+          overflow-x: scroll;
+
+          &::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+          }
+
+          &::-webkit-scrollbar-track {
+            background: green;
+          }
+
+          &::-webkit-scrollbar-thumb {
+            background: red;
+          }
+        }
       }
     }
   }

--- a/client/app/visualizations/table/renderer.less
+++ b/client/app/visualizations/table/renderer.less
@@ -115,24 +115,6 @@
 
       .ant-table {
         flex-grow: 1;
-
-        // show and color scrollbars
-        @media only percy {
-          overflow-x: scroll;
-
-          &::-webkit-scrollbar {
-            width: 10px;
-            height: 10px;
-          }
-
-          &::-webkit-scrollbar-track {
-            background: green;
-          }
-
-          &::-webkit-scrollbar-thumb {
-            background: red;
-          }
-        }
       }
     }
   }

--- a/client/cypress/integration/dashboard/widget_spec.js
+++ b/client/cypress/integration/dashboard/widget_spec.js
@@ -147,9 +147,9 @@ describe('Widget', () => {
 
     const widgetOptions = { position: { col: 0, row: 0, sizeX: 3, sizeY: 10, autoHeight: false } };
 
-    createQueryAndAddWidget(this.dashboardId, queryData, widgetOptions).then((elTestId) => {
+    createQueryAndAddWidget(this.dashboardId, queryData, widgetOptions).then(() => {
       cy.visit(this.dashboardUrl);
-      cy.getByTestId(elTestId).should('exist');
+      cy.getByTestId('TableVisualization').should('exist');
       cy.percySnapshot('Shows horizontal scrollbar for overflowing tabular content');
     });
   });
@@ -161,9 +161,9 @@ describe('Widget', () => {
 
     const widgetOptions = { position: { col: 0, row: 0, sizeX: 3, sizeY: 10, autoHeight: false } };
 
-    createQueryAndAddWidget(this.dashboardId, queryData, widgetOptions).then((elTestId) => {
+    createQueryAndAddWidget(this.dashboardId, queryData, widgetOptions).then(() => {
       cy.visit(this.dashboardUrl);
-      cy.getByTestId(elTestId).should('exist');
+      cy.getByTestId('TableVisualization').should('exist');
       cy.percySnapshot('Shows fixed pagination for overflowing tabular content');
     });
   });

--- a/client/cypress/integration/dashboard/widget_spec.js
+++ b/client/cypress/integration/dashboard/widget_spec.js
@@ -139,4 +139,32 @@ describe('Widget', () => {
       });
     });
   });
+
+  it('shows horizontal scrollbar for overflowing tabular content', function () {
+    const queryData = {
+      query: `select '${'loremipsum'.repeat(15)}' FROM generate_series(1,15)`,
+    };
+
+    const widgetOptions = { position: { col: 0, row: 0, sizeX: 3, sizeY: 10, autoHeight: false } };
+
+    createQueryAndAddWidget(this.dashboardId, queryData, widgetOptions).then((elTestId) => {
+      cy.visit(this.dashboardUrl);
+      cy.getByTestId(elTestId).should('exist');
+      cy.percySnapshot('Shows horizontal scrollbar for overflowing tabular content');
+    });
+  });
+
+  it('shows fixed pagination for overflowing tabular content ', function () {
+    const queryData = {
+      query: 'select \'lorem ipsum\' FROM generate_series(1,50)',
+    };
+
+    const widgetOptions = { position: { col: 0, row: 0, sizeX: 3, sizeY: 10, autoHeight: false } };
+
+    createQueryAndAddWidget(this.dashboardId, queryData, widgetOptions).then((elTestId) => {
+      cy.visit(this.dashboardUrl);
+      cy.getByTestId(elTestId).should('exist');
+      cy.percySnapshot('Shows fixed pagination for overflowing tabular content');
+    });
+  });
 });


### PR DESCRIPTION
- [x] Feature

## Description
In wide table visualizations, the horizontal scrollbar doesn't appear unless scrolled to bottom and is therefore inconvenient for those using a mouse pointer. 

This PR introduces two changes:
1. Horizontal scrollbar is always accessible.
2. Pagination as well. (it's possible to keep it at the bottom, but that would cause a double scrollbar)

## About the implementation

There are two reason I'm not a fan of this implementation.
1. It relies on `height: 100%` which means all of the elements between `.table-visualization-container` and `.ant-spin-container` must all inherit this property or else the chain is broken.
2. It relies on ant elements `.ant-spin-container` and `.ant-table` which might change over time and the feature would break.

So I made tests with Percy shots in which any breakage in the two conditions above would either push the pagination out of sight (cause height won't be 100%) or h-scrollbar won't appear 😉

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="726" alt="Screen Shot 2019-08-29 at 21 59 23" src="https://user-images.githubusercontent.com/486954/63968409-4c019780-caa8-11e9-80a4-c7d9aed09d32.png">
