### PR TITLE
Upgrading from 3.0.0 to 5.0.0 or upper is failed

### DIFF
--- a/migrations/versions/969126bd800f_.py
+++ b/migrations/versions/969126bd800f_.py
@@ -24,15 +24,20 @@ def upgrade():
     # Update widgets position data:
     column_size = 3
     print("Updating dashboards position data:")
-    for dashboard in Dashboard.query:
-        print("  Updating dashboard: {}".format(dashboard.id))
-        layout = simplejson.loads(dashboard.layout)
+    dashboard_result = db.session.execute("SELECT id, layout FROM dashboards")
+    for dashboard in dashboard_result:
+        print("  Updating dashboard: {}".format(dashboard['id']))
+        layout = simplejson.loads(dashboard['layout'])
 
         print("    Building widgets map:")
         widgets = {}
-        for w in dashboard.widgets:
-            print("    Widget: {}".format(w.id))
-            widgets[w.id] = w
+        widget_result = db.session.execute(
+                "SELECT id, options, width FROM widgets WHERE dashboard_id=:dashboard_id",
+                {"dashboard_id" : dashboard['id']})
+        for w in widget_result:
+            print("    Widget: {}".format(w['id']))
+            widgets[w['id']] = w
+        widget_result.close()
 
         print("    Iterating over layout:")
         for row_index, row in enumerate(layout):
@@ -47,17 +52,18 @@ def upgrade():
                 if widget is None:
                     continue
 
-                options = simplejson.loads(widget.options) or {}
+                options = simplejson.loads(widget['options']) or {}
                 options['position'] = {
                     "row": row_index,
                     "col": column_index * column_size,
                     "sizeX": column_size * widget.width
                 }
 
-                widget.options = simplejson.dumps(options)
+                db.session.execute(
+                    "UPDATE widgets SET options=:options WHERE id=:id",
+                    {"options" : simplejson.dumps(options), "id" : widget_id})
 
-                db.session.add(widget)
-
+    dashboard_result.close()
     db.session.commit()
 
     # Remove legacy columns no longer in use.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

`tags` field is added to `models.Dashboard` from 5.0.0.
As a result, `upgrade` from 3.0.0 or lower fails now.

I fixed this by using [session.execute](https://docs.sqlalchemy.org/en/12/orm/session_api.html#sqlalchemy.orm.session.Session.execute) method.

## Related Tickets & Documents

https://discuss.redash.io/t/upgrade-from-3-0-0-b3134-to-v5/2384