### PR TITLE
Allow users to share aggregated usage information with us

### DIFF
--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { react2angular } from 'react2angular';
+import Card from 'antd/lib/card';
+import Button from 'antd/lib/button';
+import Text from 'antd/lib/typography';
+
+export function BeaconConsent() {
+  //   if (!clientConfig.showBeaconConsentMessage) {
+  //     return;
+  //   }
+
+  return (
+    <div className="m-t-10 tiled">
+      <Card title="Would you like to share aggregated usage information with the Redash team?" bordered={false}>
+        <Text type="secondary">
+          Shared data includes: number of users, queries, dashboards, alerts, widgets and visulizations. Also types of
+          data sources, alert destination and visualizations.
+        </Text>
+        <Text>All the data is aggregated and does not include anything sensitive or private.</Text>
+        <div className="m-t-15">
+          <Button type="primary" className="m-r-5">
+            Yes
+          </Button>
+          <Button type="default">No</Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default function init(ngModule) {
+  console.log('hello world');
+  ngModule.component('beaconConsent', react2angular(BeaconConsent));
+}
+
+init.init = true;

--- a/client/app/pages/home/home.html
+++ b/client/app/pages/home/home.html
@@ -1,9 +1,24 @@
 <div class="container">
-  <div ng-if="$ctrl.messages.includes('using-deprecated-embed-feature')" class="alert alert-warning">
-      You have enabled <code>ALLOW_PARAMETERS_IN_EMBEDS</code>. This setting is now deprecated and should be turned off. Parameters in embeds are supported by default. <a href="https://discuss.redash.io/t/support-for-parameters-in-embedded-visualizations/3337" target="_blank">Read more</a>.
+  <div
+    ng-if="$ctrl.messages.includes('using-deprecated-embed-feature')"
+    class="alert alert-warning"
+  >
+    You have enabled <code>ALLOW_PARAMETERS_IN_EMBEDS</code>. This setting is
+    now deprecated and should be turned off. Parameters in embeds are supported
+    by default.
+    <a
+      href="https://discuss.redash.io/t/support-for-parameters-in-embedded-visualizations/3337"
+      target="_blank"
+      >Read more</a
+    >.
   </div>
-  <div ng-if="$ctrl.messages.includes('email-not-verified')" class="alert alert-warning">
-      We have sent an email with a confirmation link to your email address. Please follow the link to verify your email address. <a ng-click="$ctrl.verifyEmail()">Resend email</a>.
+  <div
+    ng-if="$ctrl.messages.includes('email-not-verified')"
+    class="alert alert-warning"
+  >
+    We have sent an email with a confirmation link to your email address. Please
+    follow the link to verify your email address.
+    <a ng-click="$ctrl.verifyEmail()">Resend email</a>.
   </div>
   <empty-state
     title="'Welcome to Redash 👋'"
@@ -31,13 +46,19 @@
           </p>
 
           <div class="list-group">
-            <a ng-href="dashboard/{{dashboard.slug}}" class="list-group-item" ng-repeat="dashboard in $ctrl.favoriteDashboards"
-              ng-if="dashboard.is_favorite">
+            <a
+              ng-href="dashboard/{{ dashboard.slug }}"
+              class="list-group-item"
+              ng-repeat="dashboard in $ctrl.favoriteDashboards"
+              ng-if="dashboard.is_favorite"
+            >
               <span class="btn-favourite">
                 <i class="fa fa-star" aria-hidden="true"></i>
               </span>
-              {{dashboard.name}}
-              <span class="label label-default" ng-if="dashboard.is_draft">Unpublished</span>
+              {{ dashboard.name }}
+              <span class="label label-default" ng-if="dashboard.is_draft"
+                >Unpublished</span
+              >
             </a>
           </div>
         </div>
@@ -51,17 +72,24 @@
             Favorite <a href="queries">Queries</a> will appear here
           </p>
           <div class="list-group">
-            <a ng-href="queries/{{query.id}}" class="list-group-item" ng-repeat="query in $ctrl.favoriteQueries" ng-if="query.is_favorite">
+            <a
+              ng-href="queries/{{ query.id }}"
+              class="list-group-item"
+              ng-repeat="query in $ctrl.favoriteQueries"
+              ng-if="query.is_favorite"
+            >
               <span class="btn-favourite">
                 <i class="fa fa-star" aria-hidden="true"></i>
               </span>
-              {{query.name}}
-              <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
+              {{ query.name }}
+              <span class="label label-default" ng-if="query.is_draft"
+                >Unpublished</span
+              >
             </a>
           </div>
         </div>
       </div>
-
     </div>
   </div>
+  <beacon-consent></beacon-consent>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

We're very blind towards usage trends from our Open Source users. This feature will enable willing admins to share more information with us:

* Number of queries, visualizations, dashboards, alerts, users created.
* Types of data sources and alert destinations in use.

This is a very early commit just to get help with the consent UI.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/71468/64037610-b1b05b00-cb5e-11e9-9ea8-56dbe74666ee.png)
