### PR TITLE
Allow users to share aggregated usage information with us

### DIFF
--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -23,13 +23,17 @@ export function BeaconConsent() {
           </Button>
           <Button type="default">No</Button>
         </div>
+        <div className="m-t-15">
+          <Text type="secondary">
+            You can always change your descision from the <a href="">Organization Settings</a> screen.
+          </Text>
+        </div>
       </Card>
     </div>
   );
 }
 
 export default function init(ngModule) {
-  console.log('hello world');
   ngModule.component('beaconConsent', react2angular(BeaconConsent));
 }
 

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { react2angular } from 'react2angular';
 import Card from 'antd/lib/card';
 import Button from 'antd/lib/button';
-import Text from 'antd/lib/typography';
+import Typography from 'antd/lib/typography';
+
+const Text = Typography.Text;
 
 export function BeaconConsent() {
   //   if (!clientConfig.showBeaconConsentMessage) {
@@ -12,7 +14,7 @@ export function BeaconConsent() {
   return (
     <div className="m-t-10 tiled">
       <Card title="Would you like to share aggregated usage information with the Redash team?" bordered={false}>
-        <Text type="secondary">
+        <Text>
           Shared data includes: number of users, queries, dashboards, alerts, widgets and visulizations. Also types of
           data sources, alert destination and visualizations.
         </Text>
@@ -25,7 +27,8 @@ export function BeaconConsent() {
         </div>
         <div className="m-t-15">
           <Text type="secondary">
-            You can always change your descision from the <a href="">Organization Settings</a> screen.
+            You can always change your descision from the <a href="settings/organization">Organization Settings</a>{' '}
+            screen.
           </Text>
         </div>
       </Card>

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -1,24 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { react2angular } from 'react2angular';
 import Card from 'antd/lib/card';
 import Button from 'antd/lib/button';
 import Typography from 'antd/lib/typography';
 import { clientConfig } from '@/services/auth';
+import OrgSettings from '@/services/organizationSettings';
 
 const Text = Typography.Text;
 
 export function BeaconConsent() {
-  if (!clientConfig.showBeaconConsentMessage) {
-    return;
+  const [hide, setHide] = useState(false);
+
+  if (!clientConfig.showBeaconConsentMessage || hide) {
+    return null;
   }
 
-  // import OrgSettings from '@/services/organizationSettings';
-  // OrgSettings.save(this.state.formValues)
-  //   .then((response) => {
-  //     const settings = get(response, 'settings');
-  //     this.setState({ settings, formValues: { ...settings } });
-  //   })
-  //   .finally(() => this.setState({ submitting: false }));
+  const hideConsentCard = () => {
+    clientConfig.showBeaconConsentMessage = false;
+    setHide(true);
+  };
+
+  const confirmConsent = (confirm) => {
+    let message = '🙏 Thank you.';
+
+    if (!confirm) {
+      message = 'Settings Saved.';
+    }
+
+    OrgSettings.save({ beacon_consent: confirm }, message)
+      // .then(() => {
+      //   // const settings = get(response, 'settings');
+      //   // this.setState({ settings, formValues: { ...settings } });
+      // })
+      .finally(hideConsentCard);
+  };
 
   return (
     <div className="m-t-10 tiled">
@@ -32,10 +47,12 @@ export function BeaconConsent() {
         </div>
         <Text>All data is aggregated and will never include any sensitive or private data.</Text>
         <div className="m-t-5">
-          <Button type="primary" className="m-r-5">
+          <Button type="primary" className="m-r-5" onClick={() => confirmConsent(true)}>
             Yes
           </Button>
-          <Button type="default">No</Button>
+          <Button type="default" onClick={() => confirmConsent(false)}>
+            No
+          </Button>
         </div>
         <div className="m-t-15">
           <Text type="secondary">

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -13,12 +13,15 @@ export function BeaconConsent() {
 
   return (
     <div className="m-t-10 tiled">
-      <Card title="Would you like to share aggregated usage information with the Redash team?" bordered={false}>
-        <Text>
-          Shared data includes: number of users, queries, dashboards, alerts, widgets and visulizations. Also types of
-          data sources, alert destination and visualizations.
-        </Text>
-        <Text>All the data is aggregated and does not include anything sensitive or private.</Text>
+      <Card title="Would you be ok with sharing anonymous usage data with the Redash team?" bordered={false}>
+        <Text>Help Redash improve by automatically sending anonymous usage data:</Text>
+        <div className="m-t-5">
+          <ul>
+            <li> Number of users, queries, dashboards, alerts, widgets and visualizations.</li>
+            <li> Types of data sources, alert destinations and visualizations.</li>
+          </ul>
+        </div>
+        <Text>All data is aggregated and will never include any sensitive or private data.</Text>
         <div className="m-t-15">
           <Button type="primary" className="m-r-5">
             Yes
@@ -27,8 +30,7 @@ export function BeaconConsent() {
         </div>
         <div className="m-t-15">
           <Text type="secondary">
-            You can always change your descision from the <a href="settings/organization">Organization Settings</a>{' '}
-            screen.
+            You can change this setting anytime from the <a href="settings/organization">Organization Settings</a> page.
           </Text>
         </div>
       </Card>

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -3,13 +3,22 @@ import { react2angular } from 'react2angular';
 import Card from 'antd/lib/card';
 import Button from 'antd/lib/button';
 import Typography from 'antd/lib/typography';
+import { clientConfig } from '@/services/auth';
 
 const Text = Typography.Text;
 
 export function BeaconConsent() {
-  //   if (!clientConfig.showBeaconConsentMessage) {
-  //     return;
-  //   }
+  if (!clientConfig.showBeaconConsentMessage) {
+    return;
+  }
+
+  // import OrgSettings from '@/services/organizationSettings';
+  // OrgSettings.save(this.state.formValues)
+  //   .then((response) => {
+  //     const settings = get(response, 'settings');
+  //     this.setState({ settings, formValues: { ...settings } });
+  //   })
+  //   .finally(() => this.setState({ submitting: false }));
 
   return (
     <div className="m-t-10 tiled">
@@ -22,7 +31,7 @@ export function BeaconConsent() {
           </ul>
         </div>
         <Text>All data is aggregated and will never include any sensitive or private data.</Text>
-        <div className="m-t-15">
+        <div className="m-t-5">
           <Button type="primary" className="m-r-5">
             Yes
           </Button>

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -4,6 +4,7 @@ import Card from 'antd/lib/card';
 import Button from 'antd/lib/button';
 import Typography from 'antd/lib/typography';
 import { clientConfig } from '@/services/auth';
+import { HelpTrigger } from '@/components/HelpTrigger';
 import OrgSettings from '@/services/organizationSettings';
 
 const Text = Typography.Text;
@@ -37,7 +38,15 @@ export function BeaconConsent() {
 
   return (
     <div className="m-t-10 tiled">
-      <Card title="Would you be ok with sharing anonymous usage data with the Redash team?" bordered={false}>
+      <Card
+        title={(
+          <>
+            Would you be ok with sharing anonymous usage data with the Redash team?{' '}
+            <HelpTrigger type="USAGE_DATA_SHARING" />
+          </>
+        )}
+        bordered={false}
+      >
         <Text>Help Redash improve by automatically sending anonymous usage data:</Text>
         <div className="m-t-5">
           <ul>

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -5,6 +5,7 @@ import Button from 'antd/lib/button';
 import Typography from 'antd/lib/typography';
 import { clientConfig } from '@/services/auth';
 import { HelpTrigger } from '@/components/HelpTrigger';
+import DynamicComponent from '@/components/DynamicComponent';
 import OrgSettings from '@/services/organizationSettings';
 
 const Text = Typography.Text;
@@ -37,39 +38,41 @@ export function BeaconConsent() {
   };
 
   return (
-    <div className="m-t-10 tiled">
-      <Card
-        title={(
-          <>
-            Would you be ok with sharing anonymous usage data with the Redash team?{' '}
-            <HelpTrigger type="USAGE_DATA_SHARING" />
-          </>
-        )}
-        bordered={false}
-      >
-        <Text>Help Redash improve by automatically sending anonymous usage data:</Text>
-        <div className="m-t-5">
-          <ul>
-            <li> Number of users, queries, dashboards, alerts, widgets and visualizations.</li>
-            <li> Types of data sources, alert destinations and visualizations.</li>
-          </ul>
-        </div>
-        <Text>All data is aggregated and will never include any sensitive or private data.</Text>
-        <div className="m-t-5">
-          <Button type="primary" className="m-r-5" onClick={() => confirmConsent(true)}>
-            Yes
-          </Button>
-          <Button type="default" onClick={() => confirmConsent(false)}>
-            No
-          </Button>
-        </div>
-        <div className="m-t-15">
-          <Text type="secondary">
-            You can change this setting anytime from the <a href="settings/organization">Organization Settings</a> page.
-          </Text>
-        </div>
-      </Card>
-    </div>
+    <DynamicComponent name="BeaconConsent">
+      <div className="m-t-10 tiled">
+        <Card
+          title={(
+            <>
+              Would you be ok with sharing anonymous usage data with the Redash team?{' '}
+              <HelpTrigger type="USAGE_DATA_SHARING" />
+            </>
+          )}
+          bordered={false}
+        >
+          <Text>Help Redash improve by automatically sending anonymous usage data:</Text>
+          <div className="m-t-5">
+            <ul>
+              <li> Number of users, queries, dashboards, alerts, widgets and visualizations.</li>
+              <li> Types of data sources, alert destinations and visualizations.</li>
+            </ul>
+          </div>
+          <Text>All data is aggregated and will never include any sensitive or private data.</Text>
+          <div className="m-t-5">
+            <Button type="primary" className="m-r-5" onClick={() => confirmConsent(true)}>
+              Yes
+            </Button>
+            <Button type="default" onClick={() => confirmConsent(false)}>
+              No
+            </Button>
+          </div>
+          <div className="m-t-15">
+            <Text type="secondary">
+              You can change this setting anytime from the <a href="settings/organization">Organization Settings</a> page.
+            </Text>
+          </div>
+        </Card>
+      </div>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { react2angular } from 'react2angular';
+import Card from 'antd/lib/card';
+import Button from 'antd/lib/button';
+import Text from 'antd/lib/typography';
+
+export function BeaconConsent() {
+  //   if (!clientConfig.showBeaconConsentMessage) {
+  //     return;
+  //   }
+
+  return (
+    <div className="m-t-10 tiled">
+      <Card title="Would you like to share aggregated usage information with the Redash team?" bordered={false}>
+        <Text type="secondary">
+          Shared data includes: number of users, queries, dashboards, alerts, widgets and visulizations. Also types of
+          data sources, alert destination and visualizations.
+        </Text>
+        <Text>All the data is aggregated and does not include anything sensitive or private.</Text>
+        <div className="m-t-15">
+          <Button type="primary" className="m-r-5">
+            Yes
+          </Button>
+          <Button type="default">No</Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default function init(ngModule) {
+  console.log('hello world');
+  ngModule.component('beaconConsent', react2angular(BeaconConsent));
+}
+
+init.init = true;

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -32,6 +32,10 @@ export const TYPES = {
     '/user-guide/users/authentication-options',
     'Guide: Authentication Options',
   ],
+  USAGE_DATA_SHARING: [
+    '/open-source/admin-guide/usage-data',
+    'Help: Anonymous Usage Data Sharing',
+  ],
   DS_ATHENA: [
     '/data-sources/amazon-athena-setup',
     'Guide: Help Setting up Amazon Athena',

--- a/client/app/pages/home/home.html
+++ b/client/app/pages/home/home.html
@@ -1,9 +1,24 @@
 <div class="container">
-  <div ng-if="$ctrl.messages.includes('using-deprecated-embed-feature')" class="alert alert-warning">
-      You have enabled <code>ALLOW_PARAMETERS_IN_EMBEDS</code>. This setting is now deprecated and should be turned off. Parameters in embeds are supported by default. <a href="https://discuss.redash.io/t/support-for-parameters-in-embedded-visualizations/3337" target="_blank">Read more</a>.
+  <div
+    ng-if="$ctrl.messages.includes('using-deprecated-embed-feature')"
+    class="alert alert-warning"
+  >
+    You have enabled <code>ALLOW_PARAMETERS_IN_EMBEDS</code>. This setting is
+    now deprecated and should be turned off. Parameters in embeds are supported
+    by default.
+    <a
+      href="https://discuss.redash.io/t/support-for-parameters-in-embedded-visualizations/3337"
+      target="_blank"
+      >Read more</a
+    >.
   </div>
-  <div ng-if="$ctrl.messages.includes('email-not-verified')" class="alert alert-warning">
-      We have sent an email with a confirmation link to your email address. Please follow the link to verify your email address. <a ng-click="$ctrl.verifyEmail()">Resend email</a>.
+  <div
+    ng-if="$ctrl.messages.includes('email-not-verified')"
+    class="alert alert-warning"
+  >
+    We have sent an email with a confirmation link to your email address. Please
+    follow the link to verify your email address.
+    <a ng-click="$ctrl.verifyEmail()">Resend email</a>.
   </div>
   <empty-state
     title="'Welcome to Redash 👋'"
@@ -31,13 +46,19 @@
           </p>
 
           <div class="list-group">
-            <a ng-href="dashboard/{{dashboard.slug}}" class="list-group-item" ng-repeat="dashboard in $ctrl.favoriteDashboards"
-              ng-if="dashboard.is_favorite">
+            <a
+              ng-href="dashboard/{{ dashboard.slug }}"
+              class="list-group-item"
+              ng-repeat="dashboard in $ctrl.favoriteDashboards"
+              ng-if="dashboard.is_favorite"
+            >
               <span class="btn-favourite">
                 <i class="fa fa-star" aria-hidden="true"></i>
               </span>
-              {{dashboard.name}}
-              <span class="label label-default" ng-if="dashboard.is_draft">Unpublished</span>
+              {{ dashboard.name }}
+              <span class="label label-default" ng-if="dashboard.is_draft"
+                >Unpublished</span
+              >
             </a>
           </div>
         </div>
@@ -51,17 +72,24 @@
             Favorite <a href="queries">Queries</a> will appear here
           </p>
           <div class="list-group">
-            <a ng-href="queries/{{query.id}}" class="list-group-item" ng-repeat="query in $ctrl.favoriteQueries" ng-if="query.is_favorite">
+            <a
+              ng-href="queries/{{ query.id }}"
+              class="list-group-item"
+              ng-repeat="query in $ctrl.favoriteQueries"
+              ng-if="query.is_favorite"
+            >
               <span class="btn-favourite">
                 <i class="fa fa-star" aria-hidden="true"></i>
               </span>
-              {{query.name}}
-              <span class="label label-default" ng-if="query.is_draft">Unpublished</span>
+              {{ query.name }}
+              <span class="label label-default" ng-if="query.is_draft"
+                >Unpublished</span
+              >
             </a>
           </div>
         </div>
       </div>
-
     </div>
   </div>
+  <beacon-consent></beacon-consent>
 </div>

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -181,7 +181,7 @@ class OrganizationSettings extends React.Component {
           Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
           </Checkbox>
         </Form.Item>
-        <Form.Item label="Anonymous Usage Data Sharing">
+        <Form.Item label={<>Anonymous Usage Data Sharing <HelpTrigger type="USAGE_DATA_SHARING" /></>}>
           <Checkbox
             name="beacon_consent"
             checked={formValues.beacon_consent}

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -155,7 +155,24 @@ class OrganizationSettings extends React.Component {
             ))}
           </Select>
         </Form.Item>
-        <Form.Item label="Multi-byte Search">
+        <Form.Item label="Feature Flags">
+          <Checkbox
+            name="feature_show_permissions_control"
+            checked={formValues.feature_show_permissions_control}
+            onChange={e => this.handleChange('feature_show_permissions_control', e.target.checked)}
+          >
+            Enable experimental multiple owners support
+          </Checkbox>
+        </Form.Item>
+        <Form.Item>
+          <Checkbox
+            name="send_email_on_failed_scheduled_queries"
+            checked={formValues.send_email_on_failed_scheduled_queries}
+            onChange={e => this.handleChange('send_email_on_failed_scheduled_queries', e.target.checked)}
+          >Email query owners when scheduled queries fail
+          </Checkbox>
+        </Form.Item>
+        <Form.Item>
           <Checkbox
             name="multi_byte_search_enabled"
             checked={formValues.multi_byte_search_enabled}
@@ -164,21 +181,13 @@ class OrganizationSettings extends React.Component {
           Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
           </Checkbox>
         </Form.Item>
-        <Form.Item label="Email Reports">
+        <Form.Item label="Anonymous Usage Data Sharing">
           <Checkbox
-            name="send_email_on_failed_scheduled_queries"
-            checked={formValues.send_email_on_failed_scheduled_queries}
-            onChange={e => this.handleChange('send_email_on_failed_scheduled_queries', e.target.checked)}
-          >Email query owners when scheduled queries fail
-          </Checkbox>
-        </Form.Item>
-        <Form.Item label="Feature Flags">
-          <Checkbox
-            name="feature_show_permissions_control"
-            checked={formValues.feature_show_permissions_control}
-            onChange={e => this.handleChange('feature_show_permissions_control', e.target.checked)}
+            name="beacon_consent"
+            checked={formValues.beacon_consent}
+            onChange={e => this.handleChange('beacon_consent', e.target.checked)}
           >
-            Enable experimental multiple owners support
+            Help Redash improve by automatically sending anonymous usage data
           </Checkbox>
         </Form.Item>
       </React.Fragment>

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -10,13 +10,14 @@ import Select from 'antd/lib/select';
 import Checkbox from 'antd/lib/checkbox';
 import Tooltip from 'antd/lib/tooltip';
 import LoadingState from '@/components/items-list/components/LoadingState';
-import { HelpTrigger } from '@/components/HelpTrigger';
 
 import { routesToAngularRoutes } from '@/lib/utils';
 import { clientConfig } from '@/services/auth';
 import settingsMenu from '@/services/settingsMenu';
 import recordEvent from '@/services/recordEvent';
 import OrgSettings from '@/services/organizationSettings';
+import { HelpTrigger } from '@/components/HelpTrigger';
+import DynamicComponent from '@/components/DynamicComponent';
 
 const Option = Select.Option;
 
@@ -181,15 +182,17 @@ class OrganizationSettings extends React.Component {
           Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
           </Checkbox>
         </Form.Item>
-        <Form.Item label={<>Anonymous Usage Data Sharing <HelpTrigger type="USAGE_DATA_SHARING" /></>}>
-          <Checkbox
-            name="beacon_consent"
-            checked={formValues.beacon_consent}
-            onChange={e => this.handleChange('beacon_consent', e.target.checked)}
-          >
-            Help Redash improve by automatically sending anonymous usage data
-          </Checkbox>
-        </Form.Item>
+        <DynamicComponent name="BeaconConsentSetting">
+          <Form.Item label={<>Anonymous Usage Data Sharing <HelpTrigger type="USAGE_DATA_SHARING" /></>}>
+            <Checkbox
+              name="beacon_consent"
+              checked={formValues.beacon_consent}
+              onChange={e => this.handleChange('beacon_consent', e.target.checked)}
+            >
+              Help Redash improve by automatically sending anonymous usage data
+            </Checkbox>
+          </Form.Item>
+        </DynamicComponent>
       </React.Fragment>
     );
   }

--- a/client/app/services/organizationSettings.js
+++ b/client/app/services/organizationSettings.js
@@ -3,10 +3,13 @@ import notification from '@/services/notification';
 
 export default {
   get: () => $http.get('api/settings/organization').then(response => response.data),
-  save: data => $http.post('api/settings/organization', data).then((response) => {
-    notification.success('Settings changes saved.');
-    return response.data;
-  }).catch(() => {
-    notification.error('Failed saving changes.');
-  }),
+  save: (data, message = 'Settings changes saved.') => $http
+    .post('api/settings/organization', data)
+    .then((response) => {
+      notification.success(message);
+      return response.data;
+    })
+    .catch(() => {
+      notification.error('Failed saving changes.');
+    }),
 };

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -225,7 +225,7 @@ def client_config():
         }
     else:
         client_config = {}
-    
+ 
     if current_user.has_permission('admin') and current_org.get_setting('beacon_consent') is None:
         client_config['showBeaconConsentMessage'] = True
 

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -225,6 +225,9 @@ def client_config():
         }
     else:
         client_config = {}
+    
+    if current_user.has_permission('admin') and current_org.get_setting('beacon_consent') is None:
+        client_config['showBeaconConsentMessage'] = True
 
     defaults = {
         'allowScriptsInUserInput': settings.ALLOW_SCRIPTS_IN_USER_INPUT,

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -35,6 +35,7 @@ SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES = parse_boolean(
     os.environ.get('REDASH_SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES', 'false'))
 
 settings = {
+    "beacon_consent": None,
     "auth_password_login_enabled": PASSWORD_LOGIN_ENABLED,
     "auth_saml_enabled": SAML_LOGIN_ENABLED,
     "auth_saml_entity_id": SAML_ENTITY_ID,

--- a/redash/version_check.py
+++ b/redash/version_check.py
@@ -4,23 +4,74 @@ import semver
 
 from redash import __version__ as current_version
 from redash import redis_connection
+from redash.models import db, Organization
 from redash.utils import json_dumps
 
 REDIS_KEY = "new_version_available"
+
+
+def usage_data():
+    counts_query = """
+    SELECT 'users_count' as name, count(0) as value
+    FROM users
+    WHERE disabled_at is null
+
+    UNION ALL
+
+    SELECT 'queries_count' as name, count(0) as value
+    FROM queries
+    WHERE is_archived is false
+
+    UNION ALL
+
+    SELECT 'alerts_count' as name, count(0) as value
+    FROM alerts
+
+    UNION ALL
+
+    SELECT 'dashboards_count' as name, count(0) as value
+    FROM dashboards
+    WHERE is_archived is false
+
+    UNION ALL
+
+    SELECT 'widgets_count' as name, count(0) as value
+    FROM widgets
+    WHERE visualization_id is not null
+
+    UNION ALL
+
+    SELECT 'textbox_count' as name, count(0) as value 
+    FROM widgets
+    WHERE visualization_id is null
+    """
+
+    data_sources_query = "SELECT type, count(0) FROM data_sources GROUP by 1"
+    visualizations_query = "SELECT type, count(0) FROM visualizations GROUP by 1"
+    destinations_query = "SELECT type, count(0) FROM notification_destinations GROUP by 1"
+
+    data = {name: value for (name, value) in db.session.execute(counts_query)}
+    data['data_sources'] = {name: value for (name, value) in db.session.execute(data_sources_query)}
+    data['visualization_types'] = {name: value for (name, value) in db.session.execute(visualizations_query)}
+    data['destination_types'] = {name: value for (name, value) in db.session.execute(destinations_query)}
+
+    return data
 
 
 def run_version_check():
     logging.info("Performing version check.")
     logging.info("Current version: %s", current_version)
 
-    data = json_dumps({
+    data = {
         'current_version': current_version
-    })
-    headers = {'content-type': 'application/json'}
+    }
+
+    if Organization.query.first().get_setting('beacon_consent'):
+        data['usage'] = usage_data()
 
     try:
         response = requests.post('https://version.redash.io/api/report?channel=stable',
-                                 data=data, headers=headers, timeout=3.0)
+                                 json=data, timeout=3.0)
         latest_version = response.json()['release']['version']
 
         _compare_and_update(latest_version)

--- a/redash/version_check.py
+++ b/redash/version_check.py
@@ -41,7 +41,7 @@ def usage_data():
 
     UNION ALL
 
-    SELECT 'textbox_count' as name, count(0) as value 
+    SELECT 'textbox_count' as name, count(0) as value
     FROM widgets
     WHERE visualization_id is null
     """


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

We're very blind towards usage trends from our Open Source users. This feature will enable willing admins to share more information with us:

* Number of queries, visualizations, dashboards, alerts, users created.
* Types of data sources and alert destinations in use.

This is a very early commit just to get help with the consent UI.

- [x] Backend
  - [x] Add consent setting toggle to clientConfig
  - [x] Add consent setting to organization settings
  - [x] Data collection method
  - [x] Update beacon ping with extra information (if allowed)
- [x] Frontend
  - [x] Make initial consent look nice
  - [x] Add consent toggle to organization settings
- [x] Create help page about this (with example data)
- [x] Add Help Trigger where relevant

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/71468/64037610-b1b05b00-cb5e-11e9-9ea8-56dbe74666ee.png)
