### PR TITLE
Move annotation logic into Query Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-redash.io/help-brightgreen.svg)](https://redash.io/help/)
 [![Datree](https://s3.amazonaws.com/catalog.static.datree.io/datree-badge-20px.svg)](https://datree.io/?src=badge)
-![Build Status](https://circleci.com/gh/getredash/redash.png?circle-token=8a695aa5ec2cbfa89b48c275aea298318016f040)
+[![Build Status](https://circleci.com/gh/getredash/redash.png?style=shield&circle-token=8a695aa5ec2cbfa89b48c275aea298318016f040)](https://circleci.com/gh/getredash/redash/tree/master)
 
 **_Redash_** is our take on freeing the data within our company in a way that will better fit our culture and usage patterns.
 

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     'BaseQueryRunner',
-    'NoAnnotationMixin',
     'BaseHTTPQueryRunner',
     'InterruptException',
     'BaseSQLQueryRunner',
@@ -55,14 +54,9 @@ class NotSupported(Exception):
     pass
 
 
-class NoAnnotationMixin(object):
-    """Simple Mixin to disable query annotation."""
-    def annotate_query(self, query, metadata):
-        return query
-
-
 class BaseQueryRunner(object):
     deprecated = False
+    should_annotate_query = True
     noop_query = None
 
     def __init__(self, configuration):
@@ -86,6 +80,9 @@ class BaseQueryRunner(object):
         return {}
 
     def annotate_query(self, query, metadata):
+        if not self.should_annotate_query:
+            return query
+
         annotation = u", ".join([u"{}: {}".format(k, v) for k, v in metadata.iteritems()])
         annotated_query = u"/* {} */ {}".format(annotation, query)
         return annotated_query
@@ -158,6 +155,7 @@ class BaseSQLQueryRunner(BaseQueryRunner):
 
 
 class BaseHTTPQueryRunner(BaseQueryRunner):
+    should_annotate_query = False
     response_error = "Endpoint returned unexpected status code"
     requires_authentication = False
     requires_url = True

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     'BaseQueryRunner',
+    'NoAnnotationMixin',
     'BaseHTTPQueryRunner',
     'InterruptException',
     'BaseSQLQueryRunner',

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -54,6 +54,12 @@ class NotSupported(Exception):
     pass
 
 
+class NoAnnotationMixin(object):
+    """Simple Mixin to disable query annotation."""
+    def annotate_query(self, query, metadata):
+        return query
+
+
 class BaseQueryRunner(object):
     deprecated = False
     noop_query = None
@@ -75,12 +81,13 @@ class BaseQueryRunner(object):
         return True
 
     @classmethod
-    def annotate_query(cls):
-        return True
-
-    @classmethod
     def configuration_schema(cls):
         return {}
+
+    def annotate_query(self, query, metadata):
+        annotation = u", ".join([u"{}: {}".format(k, v) for k, v in metadata.iteritems()])
+        annotated_query = u"/* {} */ {}".format(annotation, query)
+        return annotated_query
 
     def test_connection(self):
         if self.noop_query is None:

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -132,9 +132,10 @@ class Athena(BaseQueryRunner):
     def enabled(cls):
         return enabled
 
-    @classmethod
-    def annotate_query(cls):
-        return ANNOTATE_QUERY
+    def annotate_query(self, query, metadata):
+        if ANNOTATE_QUERY:
+            return super(Athena, self).annotate_query(query, metadata)
+        return query
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/azure_kusto.py
+++ b/redash/query_runner/azure_kusto.py
@@ -1,5 +1,5 @@
 from redash.query_runner import BaseQueryRunner, register
-from redash.query_runner import TYPE_STRING, TYPE_DATE, TYPE_DATETIME, TYPE_INTEGER, TYPE_FLOAT, TYPE_BOOLEAN
+from redash.query_runner import TYPE_STRING, TYPE_DATE, TYPE_DATETIME, TYPE_INTEGER, TYPE_FLOAT, TYPE_BOOLEAN, NoAnnotationMixin
 from redash.utils import json_dumps, json_loads
 
 
@@ -25,7 +25,7 @@ TYPES_MAP = {
 }
 
 
-class AzureKusto(BaseQueryRunner):
+class AzureKusto(BaseQueryRunner, NoAnnotationMixin):
     noop_query = "let noop = datatable (Noop:string)[1]; noop"
 
     def __init__(self, configuration):
@@ -70,10 +70,6 @@ class AzureKusto(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return enabled
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/azure_kusto.py
+++ b/redash/query_runner/azure_kusto.py
@@ -1,5 +1,5 @@
 from redash.query_runner import BaseQueryRunner, register
-from redash.query_runner import TYPE_STRING, TYPE_DATE, TYPE_DATETIME, TYPE_INTEGER, TYPE_FLOAT, TYPE_BOOLEAN, NoAnnotationMixin
+from redash.query_runner import TYPE_STRING, TYPE_DATE, TYPE_DATETIME, TYPE_INTEGER, TYPE_FLOAT, TYPE_BOOLEAN
 from redash.utils import json_dumps, json_loads
 
 
@@ -25,7 +25,8 @@ TYPES_MAP = {
 }
 
 
-class AzureKusto(BaseQueryRunner, NoAnnotationMixin):
+class AzureKusto(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = "let noop = datatable (Noop:string)[1]; noop"
 
     def __init__(self, configuration):

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -82,7 +82,7 @@ def _get_query_results(jobs, project_id, location, job_id, start_index):
     return query_reply
 
 
-class BigQuery(BaseQueryRunner):
+class BigQuery(BaseQueryRunner, NoAnnotationMixin):
     noop_query = "SELECT 1"
 
     @classmethod
@@ -132,10 +132,6 @@ class BigQuery(BaseQueryRunner):
             "order": ['projectId', 'jsonKeyFile', 'loadSchema', 'useStandardSql', 'location', 'totalMBytesProcessedLimit', 'maximumBillingTier', 'userDefinedFunctionResourceUri'],
             'secret': ['jsonKeyFile']
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def _get_bigquery_service(self):
         scope = [

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -82,7 +82,8 @@ def _get_query_results(jobs, project_id, location, job_id, start_index):
     return query_reply
 
 
-class BigQuery(BaseQueryRunner, NoAnnotationMixin):
+class BigQuery(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1"
 
     @classmethod

--- a/redash/query_runner/couchbase.py
+++ b/redash/query_runner/couchbase.py
@@ -69,8 +69,8 @@ def parse_results(results):
     return rows, columns
 
 
-class Couchbase(BaseQueryRunner, NoAnnotationMixin):
-
+class Couchbase(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = 'Select 1'
 
     @classmethod

--- a/redash/query_runner/couchbase.py
+++ b/redash/query_runner/couchbase.py
@@ -69,7 +69,7 @@ def parse_results(results):
     return rows, columns
 
 
-class Couchbase(BaseQueryRunner):
+class Couchbase(BaseQueryRunner, NoAnnotationMixin):
 
     noop_query = 'Select 1'
 
@@ -108,10 +108,6 @@ class Couchbase(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return True
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def test_connection(self):
         result = self.call_service(self.noop_query, '')

--- a/redash/query_runner/dgraph.py
+++ b/redash/query_runner/dgraph.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     enabled = False
 
-from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, register
+from redash.query_runner import BaseQueryRunner, register
 from redash.utils import json_dumps
 
 
@@ -28,7 +28,8 @@ def reduce_item(reduced_item, key, value):
         reduced_item[key] = value
 
 
-class Dgraph(BaseQueryRunner, NoAnnotationMixin):
+class Dgraph(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = """
     {
       test() {

--- a/redash/query_runner/dgraph.py
+++ b/redash/query_runner/dgraph.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     enabled = False
 
-from redash.query_runner import BaseQueryRunner, register
+from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, register
 from redash.utils import json_dumps
 
 
@@ -28,7 +28,7 @@ def reduce_item(reduced_item, key, value):
         reduced_item[key] = value
 
 
-class Dgraph(BaseQueryRunner):
+class Dgraph(BaseQueryRunner, NoAnnotationMixin):
     noop_query = """
     {
       test() {
@@ -64,13 +64,7 @@ class Dgraph(BaseQueryRunner):
     def enabled(cls):
         return enabled
 
-    @classmethod
-    def annotate_query(cls):
-        """Dgraph uses '#' as a comment delimiter, not '/* */'"""
-        return False
-
     def run_dgraph_query_raw(self, query):
-
         servers = self.configuration.get('servers')
 
         client_stub = pydgraph.DgraphClientStub(servers)

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -32,7 +32,7 @@ types_map = {
 }
 
 
-class DynamoDBSQL(BaseSQLQueryRunner):
+class DynamoDBSQL(BaseSQLQueryRunner, NoAnnotationMixin):
     @classmethod
     def configuration_schema(cls):
         return {
@@ -56,10 +56,6 @@ class DynamoDBSQL(BaseSQLQueryRunner):
     def test_connection(self):
         engine = self._connect()
         list(engine.connection.list_tables())
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -32,7 +32,9 @@ types_map = {
 }
 
 
-class DynamoDBSQL(BaseSQLQueryRunner, NoAnnotationMixin):
+class DynamoDBSQL(BaseSQLQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def configuration_schema(cls):
         return {

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -45,7 +45,7 @@ PYTHON_TYPES_MAPPING = {
 }
 
 
-class BaseElasticSearch(BaseQueryRunner):
+class BaseElasticSearch(BaseQueryRunner, NoAnnotationMixin):
     DEBUG_ENABLED = False
 
     @classmethod
@@ -288,14 +288,9 @@ class BaseElasticSearch(BaseQueryRunner):
 
 
 class Kibana(BaseElasticSearch):
-
     @classmethod
     def enabled(cls):
         return True
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def _execute_simple_query(self, url, auth, _from, mappings, result_fields, result_columns, result_rows):
         url += "&from={0}".format(_from)
@@ -379,14 +374,9 @@ class Kibana(BaseElasticSearch):
 
 
 class ElasticSearch(BaseElasticSearch):
-
     @classmethod
     def enabled(cls):
         return True
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -45,7 +45,8 @@ PYTHON_TYPES_MAPPING = {
 }
 
 
-class BaseElasticSearch(BaseQueryRunner, NoAnnotationMixin):
+class BaseElasticSearch(BaseQueryRunner):
+    should_annotate_query = False
     DEBUG_ENABLED = False
 
     @classmethod

--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -77,7 +77,9 @@ def parse_ga_response(response):
     return {'columns': columns, 'rows': rows}
 
 
-class GoogleAnalytics(BaseSQLQueryRunner, NoAnnotationMixin):
+class GoogleAnalytics(BaseSQLQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def type(cls):
         return "google_analytics"

--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -77,11 +77,7 @@ def parse_ga_response(response):
     return {'columns': columns, 'rows': rows}
 
 
-class GoogleAnalytics(BaseSQLQueryRunner):
-    @classmethod
-    def annotate_query(cls):
-        return False
-
+class GoogleAnalytics(BaseSQLQueryRunner, NoAnnotationMixin):
     @classmethod
     def type(cls):
         return "google_analytics"

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -138,7 +138,9 @@ class TimeoutSession(Session):
         return super(TimeoutSession, self).request(*args, **kwargs)
 
 
-class GoogleSpreadsheet(BaseQueryRunner, NoAnnotationMixin):
+class GoogleSpreadsheet(BaseQueryRunner):
+    should_annotate_query = False
+
     def __init__(self, configuration):
         super(GoogleSpreadsheet, self).__init__(configuration)
         self.syntax = 'custom'

--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -138,14 +138,10 @@ class TimeoutSession(Session):
         return super(TimeoutSession, self).request(*args, **kwargs)
 
 
-class GoogleSpreadsheet(BaseQueryRunner):
+class GoogleSpreadsheet(BaseQueryRunner, NoAnnotationMixin):
     def __init__(self, configuration):
         super(GoogleSpreadsheet, self).__init__(configuration)
         self.syntax = 'custom'
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/graphite.py
+++ b/redash/query_runner/graphite.py
@@ -25,7 +25,7 @@ def _transform_result(response):
     return json_dumps(data)
 
 
-class Graphite(BaseQueryRunner):
+class Graphite(BaseQueryRunner, NoAnnotationMixin):
     @classmethod
     def configuration_schema(cls):
         return {
@@ -48,10 +48,6 @@ class Graphite(BaseQueryRunner):
             'required': ['url'],
             'secret': ['password']
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def __init__(self, configuration):
         super(Graphite, self).__init__(configuration)

--- a/redash/query_runner/graphite.py
+++ b/redash/query_runner/graphite.py
@@ -25,7 +25,9 @@ def _transform_result(response):
     return json_dumps(data)
 
 
-class Graphite(BaseQueryRunner, NoAnnotationMixin):
+class Graphite(BaseQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def configuration_schema(cls):
         return {

--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -35,7 +35,7 @@ types_map = {
 }
 
 
-class Hive(BaseSQLQueryRunner):
+class Hive(BaseSQLQueryRunner, NoAnnotationMixin):
     noop_query = "SELECT 1"
 
     @classmethod
@@ -59,10 +59,6 @@ class Hive(BaseSQLQueryRunner):
             "order": ["host", "port", "database", "username"],
             "required": ["host"]
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -35,7 +35,8 @@ types_map = {
 }
 
 
-class Hive(BaseSQLQueryRunner, NoAnnotationMixin):
+class Hive(BaseSQLQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1"
 
     @classmethod

--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -47,7 +47,7 @@ def _transform_result(results):
     })
 
 
-class InfluxDB(BaseQueryRunner):
+class InfluxDB(BaseQueryRunner, NoAnnotationMixin):
     noop_query = "show measurements limit 1"
 
     @classmethod
@@ -65,10 +65,6 @@ class InfluxDB(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return enabled
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -47,7 +47,8 @@ def _transform_result(results):
     })
 
 
-class InfluxDB(BaseQueryRunner, NoAnnotationMixin):
+class InfluxDB(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = "show measurements limit 1"
 
     @classmethod

--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -138,7 +138,7 @@ class FieldMapping:
         return None
 
 
-class JiraJQL(BaseHTTPQueryRunner):
+class JiraJQL(BaseHTTPQueryRunner, NoAnnotationMixin):
     noop_query = '{"queryType": "count"}'
     response_error = "JIRA returned unexpected status code"
     requires_authentication = True
@@ -149,10 +149,6 @@ class JiraJQL(BaseHTTPQueryRunner):
     @classmethod
     def name(cls):
         return "JIRA (JQL)"
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def __init__(self, configuration):
         super(JiraJQL, self).__init__(configuration)

--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -138,7 +138,7 @@ class FieldMapping:
         return None
 
 
-class JiraJQL(BaseHTTPQueryRunner, NoAnnotationMixin):
+class JiraJQL(BaseHTTPQueryRunner):
     noop_query = '{"queryType": "count"}'
     response_error = "JIRA returned unexpected status code"
     requires_authentication = True

--- a/redash/query_runner/json_ds.py
+++ b/redash/query_runner/json_ds.py
@@ -10,7 +10,7 @@ from redash.utils import json_dumps
 from redash.utils.compat import long
 from redash.query_runner import (BaseHTTPQueryRunner, register,
                                  TYPE_BOOLEAN, TYPE_DATETIME, TYPE_FLOAT,
-                                 TYPE_INTEGER, TYPE_STRING, NoAnnotationMixin)
+                                 TYPE_INTEGER, TYPE_STRING)
 
 
 class QueryParseError(Exception):
@@ -138,7 +138,7 @@ def parse_json(data, path, fields):
     return {'rows': rows, 'columns': columns}
 
 
-class JSON(BaseHTTPQueryRunner, NoAnnotationMixin):
+class JSON(BaseHTTPQueryRunner):
     requires_url = False
 
     @classmethod

--- a/redash/query_runner/json_ds.py
+++ b/redash/query_runner/json_ds.py
@@ -10,7 +10,7 @@ from redash.utils import json_dumps
 from redash.utils.compat import long
 from redash.query_runner import (BaseHTTPQueryRunner, register,
                                  TYPE_BOOLEAN, TYPE_DATETIME, TYPE_FLOAT,
-                                 TYPE_INTEGER, TYPE_STRING)
+                                 TYPE_INTEGER, TYPE_STRING, NoAnnotationMixin)
 
 
 class QueryParseError(Exception):
@@ -138,7 +138,7 @@ def parse_json(data, path, fields):
     return {'rows': rows, 'columns': columns}
 
 
-class JSON(BaseHTTPQueryRunner):
+class JSON(BaseHTTPQueryRunner, NoAnnotationMixin):
     requires_url = False
 
     @classmethod
@@ -158,10 +158,6 @@ class JSON(BaseHTTPQueryRunner):
             'secret': ['password'],
             'order': ['username', 'password']
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def __init__(self, configuration):
         super(JSON, self).__init__(configuration)

--- a/redash/query_runner/memsql_ds.py
+++ b/redash/query_runner/memsql_ds.py
@@ -36,7 +36,7 @@ types_map = {
 }
 
 
-class MemSQL(BaseSQLQueryRunner):
+class MemSQL(BaseSQLQueryRunner, NoAnnotationMixin):
     noop_query = 'SELECT 1'
 
     @classmethod
@@ -61,10 +61,6 @@ class MemSQL(BaseSQLQueryRunner):
             "required": ["host", "port"],
             "secret": ["password"]
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/memsql_ds.py
+++ b/redash/query_runner/memsql_ds.py
@@ -36,7 +36,8 @@ types_map = {
 }
 
 
-class MemSQL(BaseSQLQueryRunner, NoAnnotationMixin):
+class MemSQL(BaseSQLQueryRunner):
+    should_annotate_query = False
     noop_query = 'SELECT 1'
 
     @classmethod

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -120,7 +120,9 @@ def parse_results(results):
     return rows, columns
 
 
-class MongoDB(BaseQueryRunner, NoAnnotationMixin):
+class MongoDB(BaseQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def configuration_schema(cls):
         return {

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -120,7 +120,7 @@ def parse_results(results):
     return rows, columns
 
 
-class MongoDB(BaseQueryRunner):
+class MongoDB(BaseQueryRunner, NoAnnotationMixin):
     @classmethod
     def configuration_schema(cls):
         return {
@@ -145,10 +145,6 @@ class MongoDB(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return enabled
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def __init__(self, configuration):
         super(MongoDB, self).__init__(configuration)

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -25,7 +25,7 @@ types_map = {
 }
 
 
-class SqlServer(BaseSQLQueryRunner):
+class SqlServer(BaseSQLQueryRunner, NoAnnotationMixin):
     noop_query = "SELECT 1"
 
     @classmethod
@@ -77,10 +77,6 @@ class SqlServer(BaseSQLQueryRunner):
     @classmethod
     def type(cls):
         return "mssql"
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def _get_tables(self, schema):
         query = """

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -25,7 +25,8 @@ types_map = {
 }
 
 
-class SqlServer(BaseSQLQueryRunner, NoAnnotationMixin):
+class SqlServer(BaseSQLQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1"
 
     @classmethod

--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -15,7 +15,8 @@ except ImportError:
     enabled = False
 
 
-class SQLServerODBC(BaseSQLQueryRunner, NoAnnotationMixin):
+class SQLServerODBC(BaseSQLQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1"
 
     @classmethod

--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -15,7 +15,7 @@ except ImportError:
     enabled = False
 
 
-class SQLServerODBC(BaseSQLQueryRunner):
+class SQLServerODBC(BaseSQLQueryRunner, NoAnnotationMixin):
     noop_query = "SELECT 1"
 
     @classmethod
@@ -67,10 +67,6 @@ class SQLServerODBC(BaseSQLQueryRunner):
     @classmethod
     def type(cls):
         return "mssql_odbc"
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def _get_tables(self, schema):
         query = """

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -38,10 +38,8 @@ class PostgreSQLJSONEncoder(JSONEncoder):
 
             items = [
                 o._bounds[0],
-                str(o._lower),
-                ', ',
-                str(o._upper),
-                o._bounds[1]
+                str(o._lower), ', ',
+                str(o._upper), o._bounds[1]
             ]
 
             return ''.join(items)
@@ -92,9 +90,9 @@ class PostgreSQL(BaseSQLQueryRunner):
                     "title": "Database Name"
                 },
                 "sslmode": {
-                   "type": "string",
-                   "title": "SSL Mode",
-                   "default": "prefer"
+                    "type": "string",
+                    "title": "SSL Mode",
+                    "default": "prefer"
                 }
             },
             "order": ['host', 'port', 'user', 'password'],
@@ -116,7 +114,8 @@ class PostgreSQL(BaseSQLQueryRunner):
 
         for row in results['rows']:
             if row['table_schema'] != 'public':
-                table_name = u'{}.{}'.format(row['table_schema'], row['table_name'])
+                table_name = u'{}.{}'.format(row['table_schema'],
+                                             row['table_name'])
             else:
                 table_name = row['table_name']
 
@@ -168,13 +167,14 @@ class PostgreSQL(BaseSQLQueryRunner):
         return schema.values()
 
     def _get_connection(self):
-        connection = psycopg2.connect(user=self.configuration.get('user'),
-                                      password=self.configuration.get('password'),
-                                      host=self.configuration.get('host'),
-                                      port=self.configuration.get('port'),
-                                      dbname=self.configuration.get('dbname'),
-                                      sslmode=self.configuration.get('sslmode'),
-                                      async_=True)
+        connection = psycopg2.connect(
+            user=self.configuration.get('user'),
+            password=self.configuration.get('password'),
+            host=self.configuration.get('host'),
+            port=self.configuration.get('port'),
+            dbname=self.configuration.get('dbname'),
+            sslmode=self.configuration.get('sslmode'),
+            async_=True)
 
         return connection
 
@@ -189,12 +189,18 @@ class PostgreSQL(BaseSQLQueryRunner):
             _wait(connection)
 
             if cursor.description is not None:
-                columns = self.fetch_columns([(i[0], types_map.get(i[1], None)) for i in cursor.description])
-                rows = [dict(zip((c['name'] for c in columns), row)) for row in cursor]
+                columns = self.fetch_columns([(i[0], types_map.get(i[1], None))
+                                              for i in cursor.description])
+                rows = [
+                    dict(zip((c['name'] for c in columns), row))
+                    for row in cursor
+                ]
 
                 data = {'columns': columns, 'rows': rows}
                 error = None
-                json_data = json_dumps(data, ignore_nan=True, cls=PostgreSQLJSONEncoder)
+                json_data = json_dumps(data,
+                                       ignore_nan=True,
+                                       cls=PostgreSQLJSONEncoder)
             else:
                 error = 'Query completed but it returned no data.'
                 json_data = None
@@ -220,22 +226,23 @@ class Redshift(PostgreSQL):
         return "redshift"
 
     def _get_connection(self):
-        sslrootcert_path = os.path.join(os.path.dirname(__file__), './files/redshift-ca-bundle.crt')
+        sslrootcert_path = os.path.join(os.path.dirname(__file__),
+                                        './files/redshift-ca-bundle.crt')
 
-        connection = psycopg2.connect(user=self.configuration.get('user'),
-                                      password=self.configuration.get('password'),
-                                      host=self.configuration.get('host'),
-                                      port=self.configuration.get('port'),
-                                      dbname=self.configuration.get('dbname'),
-                                      sslmode=self.configuration.get('sslmode', 'prefer'),
-                                      sslrootcert=sslrootcert_path,
-                                      async_=True)
+        connection = psycopg2.connect(
+            user=self.configuration.get('user'),
+            password=self.configuration.get('password'),
+            host=self.configuration.get('host'),
+            port=self.configuration.get('port'),
+            dbname=self.configuration.get('dbname'),
+            sslmode=self.configuration.get('sslmode', 'prefer'),
+            sslrootcert=sslrootcert_path,
+            async_=True)
 
         return connection
 
     @classmethod
     def configuration_schema(cls):
-
         return {
             "type": "object",
             "properties": {
@@ -256,9 +263,9 @@ class Redshift(PostgreSQL):
                     "title": "Database Name"
                 },
                 "sslmode": {
-                   "type": "string",
-                   "title": "SSL Mode",
-                   "default": "prefer"
+                    "type": "string",
+                    "title": "SSL Mode",
+                    "default": "prefer"
                 }
             },
             "order": ['host', 'port', 'user', 'password'],
@@ -300,7 +307,6 @@ class Redshift(PostgreSQL):
 
 
 class CockroachDB(PostgreSQL):
-
     @classmethod
     def type(cls):
         return "cockroach"

--- a/redash/query_runner/prometheus.py
+++ b/redash/query_runner/prometheus.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from dateutil import parser
 from urlparse import parse_qs
-from redash.query_runner import BaseQueryRunner, register, TYPE_DATETIME, TYPE_STRING, NoAnnotationMixin
+from redash.query_runner import BaseQueryRunner, register, TYPE_DATETIME, TYPE_STRING
 from redash.utils import json_dumps
 
 
@@ -63,7 +63,9 @@ def convert_query_range(payload):
     payload.update(query_range)
 
 
-class Prometheus(BaseQueryRunner, NoAnnotationMixin):
+class Prometheus(BaseQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def configuration_schema(cls):
         return {

--- a/redash/query_runner/prometheus.py
+++ b/redash/query_runner/prometheus.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from dateutil import parser
 from urlparse import parse_qs
-from redash.query_runner import BaseQueryRunner, register, TYPE_DATETIME, TYPE_STRING
+from redash.query_runner import BaseQueryRunner, register, TYPE_DATETIME, TYPE_STRING, NoAnnotationMixin
 from redash.utils import json_dumps
 
 
@@ -63,8 +63,7 @@ def convert_query_range(payload):
     payload.update(query_range)
 
 
-class Prometheus(BaseQueryRunner):
-
+class Prometheus(BaseQueryRunner, NoAnnotationMixin):
     @classmethod
     def configuration_schema(cls):
         return {
@@ -77,10 +76,6 @@ class Prometheus(BaseQueryRunner):
             },
             "required": ["url"]
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def test_connection(self):
         resp = requests.get(self.configuration.get("url", None))

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -35,7 +35,9 @@ class CustomPrint(object):
         return self
 
 
-class Python(BaseQueryRunner, NoAnnotationMixin):
+class Python(BaseQueryRunner):
+    should_annotate_query = False
+
     safe_builtins = (
         'sorted', 'reversed', 'map', 'reduce', 'any', 'all',
         'slice', 'filter', 'len', 'next', 'enumerate',

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -35,7 +35,7 @@ class CustomPrint(object):
         return self
 
 
-class Python(BaseQueryRunner):
+class Python(BaseQueryRunner, NoAnnotationMixin):
     safe_builtins = (
         'sorted', 'reversed', 'map', 'reduce', 'any', 'all',
         'slice', 'filter', 'len', 'next', 'enumerate',
@@ -62,10 +62,6 @@ class Python(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return True
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def __init__(self, configuration):
         super(Python, self).__init__(configuration)

--- a/redash/query_runner/qubole.py
+++ b/redash/query_runner/qubole.py
@@ -4,7 +4,7 @@ import requests
 import logging
 from cStringIO import StringIO
 
-from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, register
+from redash.query_runner import BaseQueryRunner, register
 from redash.query_runner import TYPE_STRING
 from redash.utils import json_dumps
 
@@ -18,7 +18,9 @@ except ImportError:
     enabled = False
 
 
-class Qubole(BaseQueryRunner, NoAnnotationMixin):
+class Qubole(BaseQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def configuration_schema(cls):
         return {

--- a/redash/query_runner/qubole.py
+++ b/redash/query_runner/qubole.py
@@ -4,7 +4,7 @@ import requests
 import logging
 from cStringIO import StringIO
 
-from redash.query_runner import BaseQueryRunner, register
+from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, register
 from redash.query_runner import TYPE_STRING
 from redash.utils import json_dumps
 
@@ -18,8 +18,7 @@ except ImportError:
     enabled = False
 
 
-class Qubole(BaseQueryRunner):
-
+class Qubole(BaseQueryRunner, NoAnnotationMixin):
     @classmethod
     def configuration_schema(cls):
         return {
@@ -61,10 +60,6 @@ class Qubole(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return enabled
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def test_connection(self):
         headers = self._get_header()

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -4,7 +4,7 @@ import sqlite3
 
 from redash import models
 from redash.permissions import has_access, not_view_only
-from redash.query_runner import BaseQueryRunner, TYPE_STRING, guess_type, register
+from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, TYPE_STRING, guess_type, register
 from redash.utils import json_dumps, json_loads
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ def create_table(connection, table_name, query_results):
         connection.execute(insert_template, values)
 
 
-class Results(BaseQueryRunner):
+class Results(BaseQueryRunner, NoAnnotationMixin):
     noop_query = 'SELECT 1'
 
     @classmethod
@@ -113,10 +113,6 @@ class Results(BaseQueryRunner):
             "properties": {
             }
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -4,7 +4,7 @@ import sqlite3
 
 from redash import models
 from redash.permissions import has_access, not_view_only
-from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, TYPE_STRING, guess_type, register
+from redash.query_runner import BaseQueryRunner, TYPE_STRING, guess_type, register
 from redash.utils import json_dumps, json_loads
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,8 @@ def create_table(connection, table_name, query_results):
         connection.execute(insert_template, values)
 
 
-class Results(BaseQueryRunner, NoAnnotationMixin):
+class Results(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = 'SELECT 1'
 
     @classmethod

--- a/redash/query_runner/salesforce.py
+++ b/redash/query_runner/salesforce.py
@@ -3,7 +3,7 @@
 import re
 import logging
 from collections import OrderedDict
-from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, register
+from redash.query_runner import BaseQueryRunner, register
 from redash.query_runner import TYPE_STRING, TYPE_DATE, TYPE_DATETIME, TYPE_INTEGER, TYPE_FLOAT, TYPE_BOOLEAN
 from redash.utils import json_dumps
 logger = logging.getLogger(__name__)
@@ -49,7 +49,9 @@ TYPES_MAP = dict(
 # https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_examples.htm
 
 
-class Salesforce(BaseQueryRunner, NoAnnotationMixin):
+class Salesforce(BaseQueryRunner):
+    should_annotate_query = False
+    
     @classmethod
     def enabled(cls):
         return enabled

--- a/redash/query_runner/salesforce.py
+++ b/redash/query_runner/salesforce.py
@@ -3,7 +3,7 @@
 import re
 import logging
 from collections import OrderedDict
-from redash.query_runner import BaseQueryRunner, register
+from redash.query_runner import BaseQueryRunner, NoAnnotationMixin, register
 from redash.query_runner import TYPE_STRING, TYPE_DATE, TYPE_DATETIME, TYPE_INTEGER, TYPE_FLOAT, TYPE_BOOLEAN
 from redash.utils import json_dumps
 logger = logging.getLogger(__name__)
@@ -49,15 +49,10 @@ TYPES_MAP = dict(
 # https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_examples.htm
 
 
-class Salesforce(BaseQueryRunner):
-
+class Salesforce(BaseQueryRunner, NoAnnotationMixin):
     @classmethod
     def enabled(cls):
         return enabled
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def configuration_schema(cls):

--- a/redash/query_runner/script.py
+++ b/redash/query_runner/script.py
@@ -28,7 +28,9 @@ def run_script(script, shell):
     return output, None
 
 
-class Script(BaseQueryRunner, NoAnnotationMixin):
+class Script(BaseQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def enabled(cls):
         return "check_output" in subprocess.__dict__

--- a/redash/query_runner/script.py
+++ b/redash/query_runner/script.py
@@ -28,11 +28,7 @@ def run_script(script, shell):
     return output, None
 
 
-class Script(BaseQueryRunner):
-    @classmethod
-    def annotate_query(cls):
-        return False
-
+class Script(BaseQueryRunner, NoAnnotationMixin):
     @classmethod
     def enabled(cls):
         return "check_output" in subprocess.__dict__

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -33,7 +33,8 @@ TD_TYPES_MAPPING = {
 }
 
 
-class TreasureData(BaseQueryRunner, NoAnnotationMixin):
+class TreasureData(BaseQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1"
 
     @classmethod

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -33,7 +33,7 @@ TD_TYPES_MAPPING = {
 }
 
 
-class TreasureData(BaseQueryRunner):
+class TreasureData(BaseQueryRunner, NoAnnotationMixin):
     noop_query = "SELECT 1"
 
     @classmethod
@@ -66,10 +66,6 @@ class TreasureData(BaseQueryRunner):
     @classmethod
     def enabled(cls):
         return enabled
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     @classmethod
     def type(cls):

--- a/redash/query_runner/uptycs.py
+++ b/redash/query_runner/uptycs.py
@@ -9,7 +9,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Uptycs(BaseSQLQueryRunner, NoAnnotationMixin):
+class Uptycs(BaseSQLQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1"
 
     @classmethod

--- a/redash/query_runner/uptycs.py
+++ b/redash/query_runner/uptycs.py
@@ -9,7 +9,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Uptycs(BaseSQLQueryRunner):
+class Uptycs(BaseSQLQueryRunner, NoAnnotationMixin):
     noop_query = "SELECT 1"
 
     @classmethod
@@ -39,10 +39,6 @@ class Uptycs(BaseSQLQueryRunner):
             "required": ["url", "customer_id", "key", "secret"],
             "secret": ["secret", "key"]
         }
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def generate_header(self, key, secret):
         header = {}

--- a/redash/query_runner/url.py
+++ b/redash/query_runner/url.py
@@ -1,9 +1,9 @@
-from redash.query_runner import BaseHTTPQueryRunner, NoAnnotationMixin, register
+from redash.query_runner import BaseHTTPQueryRunner, register
 from redash.utils import deprecated
 
 
 @deprecated()
-class Url(BaseHTTPQueryRunner, NoAnnotationMixin):
+class Url(BaseHTTPQueryRunner):
     requires_url = False
 
     def test_connection(self):

--- a/redash/query_runner/url.py
+++ b/redash/query_runner/url.py
@@ -1,14 +1,10 @@
-from redash.query_runner import BaseHTTPQueryRunner, register
+from redash.query_runner import BaseHTTPQueryRunner, NoAnnotationMixin, register
 from redash.utils import deprecated
 
 
 @deprecated()
-class Url(BaseHTTPQueryRunner):
+class Url(BaseHTTPQueryRunner, NoAnnotationMixin):
     requires_url = False
-
-    @classmethod
-    def annotate_query(cls):
-        return False
 
     def test_connection(self):
         pass

--- a/redash/query_runner/yandex_metrica.py
+++ b/redash/query_runner/yandex_metrica.py
@@ -61,7 +61,9 @@ def parse_ym_response(response):
     return {'columns': columns, 'rows': rows}
 
 
-class YandexMetrica(BaseSQLQueryRunner, NoAnnotationMixin):
+class YandexMetrica(BaseSQLQueryRunner):
+    should_annotate_query = False
+
     @classmethod
     def type(cls):
         # This is written with a "k" for backward-compatibility. See #2874.

--- a/redash/query_runner/yandex_metrica.py
+++ b/redash/query_runner/yandex_metrica.py
@@ -61,11 +61,7 @@ def parse_ym_response(response):
     return {'columns': columns, 'rows': rows}
 
 
-class YandexMetrica(BaseSQLQueryRunner):
-    @classmethod
-    def annotate_query(cls):
-        return False
-
+class YandexMetrica(BaseSQLQueryRunner, NoAnnotationMixin):
     @classmethod
     def type(cls):
         # This is written with a "k" for backward-compatibility. See #2874.

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -400,16 +400,10 @@ class QueryExecutor(object):
             return result
 
     def _annotate_query(self, query_runner):
-        if query_runner.annotate_query():
-            self.metadata['Task ID'] = self.task.request.id
-            self.metadata['Query Hash'] = self.query_hash
-            self.metadata['Queue'] = self.task.request.delivery_info['routing_key']
-
-            annotation = u", ".join([u"{}: {}".format(k, v) for k, v in self.metadata.iteritems()])
-            annotated_query = u"/* {} */ {}".format(annotation, self.query)
-        else:
-            annotated_query = self.query
-        return annotated_query
+        self.metadata['Task ID'] = self.task.request.id
+        self.metadata['Query Hash'] = self.query_hash
+        self.metadata['Queue'] = self.task.request.delivery_info['routing_key']
+        return query_runner.annotate_query(self.query, self.metadata)
 
     def _log_progress(self, state):
         logger.info(

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -403,6 +403,8 @@ class QueryExecutor(object):
         self.metadata['Task ID'] = self.task.request.id
         self.metadata['Query Hash'] = self.query_hash
         self.metadata['Queue'] = self.task.request.delivery_info['routing_key']
+        self.metadata['Scheduled'] = self.scheduled_query is not None
+            
         return query_runner.annotate_query(self.query, self.metadata)
 
     def _log_progress(self, state):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

This is a small refactor towards allowing controlling the query annotation in the query runner (a relevant use case is coming up in a follow up PR). 

In this pull request, we move the annotation logic into the query runner (with a default implementation in `BaseQueryRunner`).