### PR TITLE
Fix number param value normlization

### DIFF
--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -140,7 +140,7 @@ class ParameterValueInput extends React.Component {
     const { className } = this.props;
     const { value } = this.state;
 
-    const normalize = val => !isNaN(val) && val || 0;
+    const normalize = val => (isNaN(val) ? undefined : val);
 
     return (
       <InputNumber


### PR DESCRIPTION
Fixes #4115.

- [x] Bug Fix

## Description

The initial value is empty.
Non-number values are normalized to zero but only for show.

### The fix
Changed normalization to be `undefined` if not a number value, which displays empty, so there's no more confusion.

<img width="130" alt="Screen Shot 2019-09-02 at 9 03 44" src="https://user-images.githubusercontent.com/486954/64093329-9a40c000-cd60-11e9-89a0-5282ef7977bc.png">

