### PR TITLE
Add ability to use Ant's Table loading property when using ItemsTable

### DIFF
--- a/client/app/components/items-list/components/ItemsTable.jsx
+++ b/client/app/components/items-list/components/ItemsTable.jsx
@@ -72,6 +72,7 @@ Columns.custom.sortable = sortable;
 
 export default class ItemsTable extends React.Component {
   static propTypes = {
+    loading: PropTypes.bool,
     // eslint-disable-next-line react/forbid-prop-types
     items: PropTypes.arrayOf(PropTypes.object),
     columns: PropTypes.arrayOf(PropTypes.shape({
@@ -89,6 +90,7 @@ export default class ItemsTable extends React.Component {
   };
 
   static defaultProps = {
+    loading: false,
     items: [],
     columns: [],
     showHeader: true,
@@ -150,6 +152,7 @@ export default class ItemsTable extends React.Component {
     return (
       <Table
         className={classNames('table-data', { 'ant-table-headerless': !showHeader })}
+        loading={this.props.loading}
         columns={columns}
         showHeader={showHeader}
         dataSource={rows}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

Needed for something we use in the SaaS version, but we should probably use this in some places in this codebase as well.