### PR TITLE
Update botocore, to get pass pip warning

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ mock==2.0.0
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
 pymongo[tls,srv]==3.6.1
-botocore==1.12.115
+botocore==1.12.220
 PyAthena>=1.5.0
 ptvsd==4.2.3
 freezegun==0.3.11


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Update the botocore dependency, so pip passes.

Without this, pip errors out.