### PR TITLE
Add jsconfig settings with '@' webpack alias

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": "client/app",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
This adds jsconfig settings with weback `@` alias config.

This makes this works:

![jsconfig](https://user-images.githubusercontent.com/3356951/64718040-cd3f2e00-d49b-11e9-90e1-206c254265ad.gif)


## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--