### PR TITLE
Query Snippets: Use onClick instead of link for 'Click here' option

### DIFF
--- a/client/app/pages/query-snippets/QuerySnippetsList.jsx
+++ b/client/app/pages/query-snippets/QuerySnippetsList.jsx
@@ -152,7 +152,7 @@ class QuerySnippetsList extends React.Component {
           There are no query snippets yet.
             {policy.isCreateQuerySnippetEnabled() && (
               <div className="m-t-5">
-                <a href="/query_snippets/new">Click here</a> to add one.
+                <a className="clickable" onClick={() => this.showSnippetDialog()}>Click here</a> to add one.
               </div>
             )}
           </div>

--- a/client/app/pages/query-snippets/QuerySnippetsList.jsx
+++ b/client/app/pages/query-snippets/QuerySnippetsList.jsx
@@ -78,13 +78,13 @@ class QuerySnippetsList extends React.Component {
     if (isNewOrEditPage) {
       if (querySnippetId === 'new') {
         if (policy.isCreateQuerySnippetEnabled()) {
-          this.showSnippetDialog();
+          this.showSnippetDialog(null, false);
         } else {
           navigateTo('/query_snippets');
         }
       } else {
         QuerySnippet.get({ id: querySnippetId }).$promise
-          .then(this.showSnippetDialog)
+          .then(querySnippet => this.showSnippetDialog(querySnippet, false))
           .catch((error = {}) => {
             // ANGULAR_REMOVE_ME This code is related to Angular's HTTP services
             if (error.status && error.data) {
@@ -116,9 +116,11 @@ class QuerySnippetsList extends React.Component {
     });
   }
 
-  showSnippetDialog = (querySnippet = null) => {
+  showSnippetDialog = (querySnippet = null, updateUrl = true) => {
     const canSave = !querySnippet || canEditQuerySnippet(querySnippet);
-    navigateTo('/query_snippets/' + get(querySnippet, 'id', 'new'), true, false);
+    if (updateUrl) {
+      navigateTo('/query_snippets/' + get(querySnippet, 'id', 'new'), true, false);
+    }
     QuerySnippetDialog.showModal({
       querySnippet,
       onSubmit: this.saveQuerySnippet,
@@ -126,7 +128,8 @@ class QuerySnippetsList extends React.Component {
     }).result
       .then(() => this.props.controller.update())
       .finally(() => {
-        navigateTo('/query_snippets', true, false);
+        const toggleNavigationReload = !updateUrl;
+        navigateTo('/query_snippets', true, toggleNavigationReload);
       });
   };
 

--- a/client/app/pages/query-snippets/QuerySnippetsList.jsx
+++ b/client/app/pages/query-snippets/QuerySnippetsList.jsx
@@ -78,13 +78,13 @@ class QuerySnippetsList extends React.Component {
     if (isNewOrEditPage) {
       if (querySnippetId === 'new') {
         if (policy.isCreateQuerySnippetEnabled()) {
-          this.showSnippetDialog(null, false);
+          this.showSnippetDialog();
         } else {
           navigateTo('/query_snippets');
         }
       } else {
         QuerySnippet.get({ id: querySnippetId }).$promise
-          .then(querySnippet => this.showSnippetDialog(querySnippet, false))
+          .then(this.showSnippetDialog)
           .catch((error = {}) => {
             // ANGULAR_REMOVE_ME This code is related to Angular's HTTP services
             if (error.status && error.data) {
@@ -116,11 +116,9 @@ class QuerySnippetsList extends React.Component {
     });
   }
 
-  showSnippetDialog = (querySnippet = null, updateUrl = true) => {
+  showSnippetDialog = (querySnippet = null) => {
     const canSave = !querySnippet || canEditQuerySnippet(querySnippet);
-    if (updateUrl) {
-      navigateTo('/query_snippets/' + get(querySnippet, 'id', 'new'), true, false);
-    }
+    navigateTo('/query_snippets/' + get(querySnippet, 'id', 'new'), true, false);
     QuerySnippetDialog.showModal({
       querySnippet,
       onSubmit: this.saveQuerySnippet,
@@ -128,8 +126,7 @@ class QuerySnippetsList extends React.Component {
     }).result
       .then(() => this.props.controller.update())
       .finally(() => {
-        const toggleNavigationReload = !updateUrl;
-        navigateTo('/query_snippets', true, toggleNavigationReload);
+        navigateTo('/query_snippets', true, false);
       });
   };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
This avoids the following issue:
![query-snippets-issue](https://user-images.githubusercontent.com/3356951/64927924-86c53880-d7e7-11e9-9fc0-0f1ca74d71a1.gif)

What happens is that when you open `/query_snippets/new` directly the logic that changes the url will keep the same controller, so when you try to reach the same url again (by clicking on "click here") it doesn't do anything.

The simplest approach was to use an `onClick` event to open the creation dialog.

## Related Tickets & Documents
Fixes #4140 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
