### PR TITLE
Bug fix: Query view doesn't sync parameters when selecting and deleting

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -424,7 +424,7 @@ class Parameters {
     const fallback = () => map(this.query.options.parameters, i => i.name);
 
     let parameters = [];
-    if (this.query.query) {
+    if (this.query.query !== undefined) {
       try {
         const parts = Mustache.parse(this.query.query);
         parameters = uniq(collectParams(parts));
@@ -434,7 +434,7 @@ class Parameters {
         parameters = fallback();
       }
     } else {
-      parameters = [];
+      parameters = fallback();
     }
 
     return parameters;

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -434,7 +434,7 @@ class Parameters {
         parameters = fallback();
       }
     } else {
-      parameters = fallback();
+      parameters = [];
     }
 
     return parameters;


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #4141 and #4142.

When query is empty, it populates the parameters from `fallback()` which returns a cached version.
This fix returns an empty param array instead.

### Testing #4141 fix
1. Write a query with a param
2. Delete the query text
3. Param is now removed

### Testing #4142 fix
Netlify preview query 215 breaks on master https://redash-preview.netlify.com/queries/215
But is ok on https://deploy-preview-4146--redash-preview.netlify.com/queries/215