### PR TITLE
Add interface to abstract query result persistence

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -252,7 +252,7 @@ QueryResultPersistence = settings.dynamic_settings.QueryResultPersistence or DBP
 
 @python_2_unicode_compatible
 @generic_repr('id', 'org_id', 'data_source_id', 'query_hash', 'runtime', 'retrieved_at')
-class QueryResult(db.Model, BelongsToOrgMixin, QueryResultPersistence):
+class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
     id = Column(db.Integer, primary_key=True)
     org_id = Column(db.Integer, db.ForeignKey('organizations.id'))
     org = db.relationship(Organization)

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -232,19 +232,23 @@ class DataSourceGroup(db.Model):
     __tablename__ = "data_source_groups"
 
 
+DESERIALIZED_DATA_ATTR = '_deserialized_data'
+
 class DBPersistence(object):
     @property
     def data(self):
         if self._data is None:
             return None
 
-        if not hasattr(self, '_deserialized_data'):
-            self._deserialized_data = json_loads(self._data)
+        if not hasattr(self, DESERIALIZED_DATA_ATTR):
+            setattr(self, DESERIALIZED_DATA_ATTR, json_loads(self._data))
 
         return self._deserialized_data
 
     @data.setter
     def data(self, data):
+        if hasattr(self, DESERIALIZED_DATA_ATTR):
+            delattr(self, DESERIALIZED_DATA_ATTR)
         self._data = data
 
 

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -24,7 +24,7 @@ def _load_result(query_id, org):
 
     if query.data_source:
         query_result = models.QueryResult.get_by_id_and_org(query.latest_query_data_id, org)
-        return json_loads(query_result.data)
+        return query_result.data
     else:
         raise QueryDetachedFromDataSourceError(query_id)
 

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -207,7 +207,7 @@ class Python(BaseQueryRunner):
         if query.latest_query_data.data is None:
             raise Exception("Query does not have results yet.")
 
-        return json_loads(query.latest_query_data.data)
+        return query.latest_query_data.data
 
     def get_current_user(self):
         return self._current_user.to_dict()

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -68,7 +68,7 @@ def serialize_query_result(query_result, is_api_user):
 def serialize_query_result_to_csv(query_result):
     s = cStringIO.StringIO()
 
-    query_data = json_loads(query_result.data)
+    query_data = query_result.data
 
     fieldnames, special_columns = _get_column_lists(query_data['columns'] or [])
 
@@ -89,7 +89,7 @@ def serialize_query_result_to_csv(query_result):
 def serialize_query_result_to_xlsx(query_result):
     s = cStringIO.StringIO()
 
-    query_data = json_loads(query_result.data)
+    query_data = query_result.data
     book = xlsxwriter.Workbook(s, {'constant_memory': True})
     sheet = book.add_worksheet("result")
 

--- a/redash/settings/dynamic_settings.py
+++ b/redash/settings/dynamic_settings.py
@@ -10,6 +10,10 @@ def query_time_limit(is_scheduled, user_id, org_id):
     return scheduled_time_limit if is_scheduled else adhoc_time_limit
 
 
+# This provides the ability to override the way we store QueryResult's data column.
+# Reference implementation: redash.models.DBPersistence
+QueryResultPersistence = None
+
 # Provide any custom tasks you'd like to run periodically
 def custom_tasks():
     return {

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -385,10 +385,14 @@ class QueryExecutor(object):
                 self.scheduled_query = models.db.session.merge(self.scheduled_query, load=False)
                 self.scheduled_query.schedule_failures = 0
                 models.db.session.add(self.scheduled_query)
-            query_result, updated_query_ids = models.QueryResult.store_result(
+
+            query_result = models.QueryResult.store_result(
                 self.data_source.org_id, self.data_source,
                 self.query_hash, self.query, data,
                 run_time, utcnow())
+            
+            updated_query_ids = models.Query.update_latest_result(query_result)
+
             models.db.session.commit()  # make sure that alert sees the latest query result
             self._log_progress('checking_alerts')
             for query_id in updated_query_ids:

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -1,9 +1,12 @@
 #encoding: utf8
 import datetime
 
+from unittest import TestCase
 from tests import BaseTestCase
+from mock import patch
 
 from redash import models
+from redash.models import DBPersistence
 from redash.utils import utcnow, json_dumps
 
 
@@ -67,3 +70,22 @@ class QueryResultTest(BaseTestCase):
         models.QueryResult.store_result(query.org_id, query.data_source, query.query_hash, query.query_text, "", 0, utcnow())
 
         self.assertEqual(original_updated_at, query.updated_at)
+
+
+class TestDBPersistence(TestCase):
+    def test_updating_data_removes_cached_result(self):
+        p = DBPersistence()
+        p.data = '{"test": 1}'
+        self.assertDictEqual(p.data, {"test": 1})
+        p.data = '{"test": 2}'
+        self.assertDictEqual(p.data, {"test": 2})
+    
+    @patch('redash.models.json_loads')
+    def test_calls_json_loads_only_once(self, json_loads_patch):
+        json_loads_patch.return_value = '1'
+        p = DBPersistence()
+        json_data = '{"test": 1}'
+        p.data = json_data
+        a = p.data
+        b = p.data
+        json_loads_patch.assert_called_once_with(json_data)

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -6,6 +6,7 @@ import mock
 
 from tests import BaseTestCase
 from redash import redis_connection, models
+from redash.utils import json_dumps
 from redash.query_runner.pg import PostgreSQL
 from redash.tasks.queries import QueryExecutionError, enqueue_query, execute_query
 
@@ -57,11 +58,12 @@ class QueryExecutorTests(BaseTestCase):
         """
         cm = mock.patch("celery.app.task.Context.delivery_info", {'routing_key': 'test'})
         with cm, mock.patch.object(PostgreSQL, "run_query") as qr:
-            qr.return_value = ([1, 2], None)
+            query_result_data = {"columns": [], "rows": []}
+            qr.return_value = (json_dumps(query_result_data), None)
             result_id = execute_query("SELECT 1, 2", self.factory.data_source.id, {})
             self.assertEqual(1, qr.call_count)
             result = models.QueryResult.query.get(result_id)
-            self.assertEqual(result.data, '{1,2}')
+            self.assertEqual(result.data, query_result_data)
 
     def test_success_scheduled(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -299,7 +299,7 @@ class QueryArchiveTest(BaseTestCase):
     def test_archived_query_doesnt_return_in_all(self):
         query = self.factory.create_query(schedule={'interval':'1', 'until':None, 'time': None, 'day_of_week':None})
         yesterday = utcnow() - datetime.timedelta(days=1)
-        query_result, _ = models.QueryResult.store_result(
+        query_result = models.QueryResult.store_result(
             query.org_id, query.data_source, query.query_hash, query.query_text,
             "1", 123, yesterday)
 
@@ -438,7 +438,7 @@ class TestQueryResultStoreResult(BaseTestCase):
         self.data = "data"
 
     def test_stores_the_result(self):
-        query_result, _ = models.QueryResult.store_result(
+        query_result = models.QueryResult.store_result(
             self.data_source.org_id, self.data_source, self.query_hash,
             self.query, self.data, self.runtime, self.utcnow)
 
@@ -448,45 +448,6 @@ class TestQueryResultStoreResult(BaseTestCase):
         self.assertEqual(query_result.query_text, self.query)
         self.assertEqual(query_result.query_hash, self.query_hash)
         self.assertEqual(query_result.data_source, self.data_source)
-
-    def test_updates_existing_queries(self):
-        query1 = self.factory.create_query(query_text=self.query)
-        query2 = self.factory.create_query(query_text=self.query)
-        query3 = self.factory.create_query(query_text=self.query)
-
-        query_result, _ = models.QueryResult.store_result(
-            self.data_source.org_id, self.data_source, self.query_hash,
-            self.query, self.data, self.runtime, self.utcnow)
-
-        self.assertEqual(query1.latest_query_data, query_result)
-        self.assertEqual(query2.latest_query_data, query_result)
-        self.assertEqual(query3.latest_query_data, query_result)
-
-    def test_doesnt_update_queries_with_different_hash(self):
-        query1 = self.factory.create_query(query_text=self.query)
-        query2 = self.factory.create_query(query_text=self.query)
-        query3 = self.factory.create_query(query_text=self.query + "123")
-
-        query_result, _ = models.QueryResult.store_result(
-            self.data_source.org_id, self.data_source, self.query_hash,
-            self.query, self.data, self.runtime, self.utcnow)
-
-        self.assertEqual(query1.latest_query_data, query_result)
-        self.assertEqual(query2.latest_query_data, query_result)
-        self.assertNotEqual(query3.latest_query_data, query_result)
-
-    def test_doesnt_update_queries_with_different_data_source(self):
-        query1 = self.factory.create_query(query_text=self.query)
-        query2 = self.factory.create_query(query_text=self.query)
-        query3 = self.factory.create_query(query_text=self.query, data_source=self.factory.create_data_source())
-
-        query_result, _ = models.QueryResult.store_result(
-            self.data_source.org_id, self.data_source, self.query_hash,
-            self.query, self.data, self.runtime, self.utcnow)
-
-        self.assertEqual(query1.latest_query_data, query_result)
-        self.assertEqual(query2.latest_query_data, query_result)
-        self.assertNotEqual(query3.latest_query_data, query_result)
 
 
 class TestEvents(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -435,14 +435,14 @@ class TestQueryResultStoreResult(BaseTestCase):
         self.query_hash = gen_query_hash(self.query)
         self.runtime = 123
         self.utcnow = utcnow()
-        self.data = "data"
+        self.data = '{"a": 1}'
 
     def test_stores_the_result(self):
         query_result = models.QueryResult.store_result(
             self.data_source.org_id, self.data_source, self.query_hash,
             self.query, self.data, self.runtime, self.utcnow)
 
-        self.assertEqual(query_result.data, self.data)
+        self.assertEqual(query_result._data, self.data)
         self.assertEqual(query_result.runtime, self.runtime)
         self.assertEqual(query_result.retrieved_at, self.utcnow)
         self.assertEqual(query_result.query_text, self.query)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

This is a step towards supporting different backends (S3, filesystem, etc) for storing query results (the actual data). In this PR we're abstracting the persistence from the model. The default implementation keeps storing it in the DB as it was until now.

We DO NOT recommend creating extensions based on this, as the interface will probably change. Current interface has limitations like preventing streaming data, which we would like to eventually support.

## Related Tickets & Documents

#78