### PR TITLE
Adjust botocore dependency, so we don't need to update it as often

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -12,7 +12,7 @@ pymssql==2.1.3
 dql==0.5.24
 dynamo3==0.4.7
 boto3==1.9.115
-botocore==1.12.220
+botocore>=1.12.239,<1.13.0
 sasl>=0.1.3
 thrift>=0.8.0
 thrift_sasl>=0.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ mock==2.0.0
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
 pymongo[tls,srv]==3.6.1
-botocore==1.12.220
+botocore>=1.12.239,<1.13.0
 PyAthena>=1.5.0
 ptvsd==4.2.3
 freezegun==0.3.11


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Updated botocore again, as boto3 now requires the latest release (v1.12.239).

With this PR, in theory we shouldn't need to update it manually in future all that much.  Hopefully. :smile:

Without this change, installation gives the following error:

```
boto3 1.9.231 has requirement botocore<1.13.0,>=1.12.239, but you'll have
botocore 1.12.220 which is incompatible.
```