### PR TITLE
remove the annoying quoted hover from EmptyState

### DIFF
--- a/client/app/components/empty-state/EmptyState.jsx
+++ b/client/app/components/empty-state/EmptyState.jsx
@@ -40,7 +40,7 @@ Step.defaultProps = {
 
 export function EmptyState({
   icon,
-  title,
+  header,
   description,
   illustration,
   helpLink,
@@ -75,7 +75,7 @@ export function EmptyState({
   return (
     <div className="empty-state bg-white tiled">
       <div className="empty-state__summary">
-        {title && <h4>{title}</h4>}
+        {header && <h4>{header}</h4>}
         <h2>
           <i className={icon} />
         </h2>
@@ -148,7 +148,7 @@ export function EmptyState({
 
 EmptyState.propTypes = {
   icon: PropTypes.string,
-  title: PropTypes.string,
+  header: PropTypes.string,
   description: PropTypes.string.isRequired,
   illustration: PropTypes.string.isRequired,
   helpLink: PropTypes.string.isRequired,
@@ -161,7 +161,7 @@ EmptyState.propTypes = {
 
 EmptyState.defaultProps = {
   icon: null,
-  title: null,
+  header: null,
 
   onboardingMode: false,
   showAlertStep: false,

--- a/client/app/pages/home/home.html
+++ b/client/app/pages/home/home.html
@@ -21,7 +21,7 @@
     <a ng-click="$ctrl.verifyEmail()">Resend email</a>.
   </div>
   <empty-state
-    title="'Welcome to Redash 👋'"
+    header="'Welcome to Redash 👋'"
     description="'Connect to any data source, easily visualize and share your data'"
     illustration="'dashboard'"
     help-link="'https://redash.io/help/user-guide/getting-started'"


### PR DESCRIPTION
- [x] Bug Fix

## Description
`<EmptyState>` uses a `title` proptype. When used in conjunction with the `title` attribute, the result is an annoying hover message which includes the single quotes required by by react2angular.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:

![image](https://user-images.githubusercontent.com/289488/65386314-cee1df00-dd42-11e9-86d9-48d7493d4cbd.png)

After:

![image](https://user-images.githubusercontent.com/289488/65386308-bc67a580-dd42-11e9-97fe-8be1a44d29d4.png)

#thingsThatNobodyCaresAbout