### PR TITLE
Add maildev to the dev stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     depends_on:
       - postgres
       - redis
+      - email
     ports:
       - "5000:5000"
       - "5678:5678"
@@ -46,4 +47,9 @@ services:
     ports:
       - "15432:5432"
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
+    restart: unless-stopped
+  email:
+    image: djfarrelly/maildev
+    ports:
+      - "1080:80"
     restart: unless-stopped

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -210,13 +210,13 @@ CELERYD_WORKER_TASK_LOG_FORMAT = os.environ.get(
                     'task_id=%(task_id)s %(message)s')))
 
 # Mail settings:
-MAIL_SERVER = os.environ.get('REDASH_MAIL_SERVER', 'localhost')
+MAIL_SERVER = os.environ.get('REDASH_MAIL_SERVER', 'email')
 MAIL_PORT = int(os.environ.get('REDASH_MAIL_PORT', 25))
 MAIL_USE_TLS = parse_boolean(os.environ.get('REDASH_MAIL_USE_TLS', 'false'))
 MAIL_USE_SSL = parse_boolean(os.environ.get('REDASH_MAIL_USE_SSL', 'false'))
 MAIL_USERNAME = os.environ.get('REDASH_MAIL_USERNAME', None)
 MAIL_PASSWORD = os.environ.get('REDASH_MAIL_PASSWORD', None)
-MAIL_DEFAULT_SENDER = os.environ.get('REDASH_MAIL_DEFAULT_SENDER', None)
+MAIL_DEFAULT_SENDER = os.environ.get('REDASH_MAIL_DEFAULT_SENDER', 'do-not-reply@redash.io')
 MAIL_MAX_EMAILS = os.environ.get('REDASH_MAIL_MAX_EMAILS', None)
 MAIL_ASCII_ATTACHMENTS = parse_boolean(os.environ.get('REDASH_MAIL_ASCII_ATTACHMENTS', 'false'))
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -216,7 +216,7 @@ MAIL_USE_TLS = parse_boolean(os.environ.get('REDASH_MAIL_USE_TLS', 'false'))
 MAIL_USE_SSL = parse_boolean(os.environ.get('REDASH_MAIL_USE_SSL', 'false'))
 MAIL_USERNAME = os.environ.get('REDASH_MAIL_USERNAME', None)
 MAIL_PASSWORD = os.environ.get('REDASH_MAIL_PASSWORD', None)
-MAIL_DEFAULT_SENDER = os.environ.get('REDASH_MAIL_DEFAULT_SENDER', 'do-not-reply@redash.io')
+MAIL_DEFAULT_SENDER = os.environ.get('REDASH_MAIL_DEFAULT_SENDER', 'john@example.com')
 MAIL_MAX_EMAILS = os.environ.get('REDASH_MAIL_MAX_EMAILS', None)
 MAIL_ASCII_ATTACHMENTS = parse_boolean(os.environ.get('REDASH_MAIL_ASCII_ATTACHMENTS', 'false'))
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
[Maildev](https://github.com/djfarrelly/MailDev) adds a simple interface for receiving e-mail in dev mode. This PR adds maildev to the development Docker stack and configures the app to use it. E-mails can be found at `http://localhost:1080`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/289488/65428127-7c74f100-de1c-11e9-9586-7f0825b18885.png)
