### PR TITLE
Separated Alert to View / Edit / New page components

### DIFF
--- a/client/app/assets/less/inc/alert.less
+++ b/client/app/assets/less/inc/alert.less
@@ -2,7 +2,7 @@
     flex-grow: 1;
     
     input {
-        margin: -0.2em 0; // 
+        margin: -0.2em 0;
         width: 100%;
         min-width: 170px;
     }

--- a/client/app/components/proptypes.js
+++ b/client/app/components/proptypes.js
@@ -126,7 +126,7 @@ export const Alert = PropTypes.shape({
   rearm: PropTypes.number,
   state: PropTypes.oneOf(['ok', 'triggered', 'unknown']),
   user: UserProfile,
-  query: Query.isRequired,
+  query: Query,
   options: PropTypes.shape({
     column: PropTypes.string,
     op: PropTypes.string,

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -68,6 +68,11 @@ class AlertPage extends React.Component {
           // force view mode if can't edit
           if (!canEdit) {
             this.setState({ mode: MODES.VIEW });
+            notification.warn(
+              'You cannot edit this alert',
+              'You do not have sufficient permissions to edit this alert, and have been redirected to the view-only page.',
+              { duration: 0 },
+            );
           }
 
           this.setState({ alert, canEdit, pendingRearm: alert.rearm });

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular';
-import { head, includes, template as templateBuilder, trim } from 'lodash';
-import cx from 'classnames';
+import { head, includes, trim, template } from 'lodash';
 
 import { $route } from '@/services/ng';
 import { currentUser } from '@/services/auth';
@@ -11,90 +9,29 @@ import notification from '@/services/notification';
 import { Alert as AlertService } from '@/services/alert';
 import { Query as QueryService } from '@/services/query';
 
-import { HelpTrigger } from '@/components/HelpTrigger';
 import LoadingState from '@/components/items-list/components/LoadingState';
-import { TimeAgo } from '@/components/TimeAgo';
+import AlertView from './AlertView';
+import AlertEdit from './AlertEdit';
+import AlertNew from './AlertNew';
 
-import Form from 'antd/lib/form';
-import Button from 'antd/lib/button';
-import Tooltip from 'antd/lib/tooltip';
-import Icon from 'antd/lib/icon';
 import Modal from 'antd/lib/modal';
-import Input from 'antd/lib/input';
-import Dropdown from 'antd/lib/dropdown';
-import Menu from 'antd/lib/menu';
 
-import Criteria from './components/Criteria';
-import NotificationTemplate from './components/NotificationTemplate';
-import Rearm from './components/Rearm';
-import Query from './components/Query';
-import AlertDestinations from './components/AlertDestinations';
-import { STATE_CLASS } from '../alerts/AlertsList';
 import { routesToAngularRoutes } from '@/lib/utils';
-import PromiseRejectionError from '@/lib/promise-rejection-error';
 
+const MODES = {
+  NEW: 0,
+  VIEW: 1,
+  EDIT: 2,
+};
 
-const defaultNameBuilder = templateBuilder('<%= query.name %>: <%= options.column %> <%= options.op %> <%= options.value %>');
-const spinnerIcon = <i className="fa fa-spinner fa-pulse m-r-5" />;
+const defaultNameBuilder = template('<%= query.name %>: <%= options.column %> <%= options.op %> <%= options.value %>');
 
-function isNewAlert() {
-  return $route.current.params.alertId === 'new';
-}
-
-function HorizontalFormItem({ children, label, className, ...props }) {
-  const labelCol = { span: 4 };
-  const wrapperCol = { span: 16 };
-  if (!label) {
-    wrapperCol.offset = 4;
+export function getDefaultName(alert) {
+  if (!alert.query) {
+    return 'New Alert';
   }
-
-  className = cx('alert-form-item', className);
-
-  return (
-    <Form.Item labelCol={labelCol} wrapperCol={wrapperCol} label={label} className={className} {...props}>
-      { children }
-    </Form.Item>
-  );
+  return defaultNameBuilder(alert);
 }
-
-HorizontalFormItem.propTypes = {
-  children: PropTypes.node,
-  label: PropTypes.string,
-  className: PropTypes.string,
-};
-
-HorizontalFormItem.defaultProps = {
-  children: null,
-  label: null,
-  className: null,
-};
-
-function AlertState({ state, lastTriggered }) {
-  return (
-    <div className="alert-state">
-      <span className={`alert-state-indicator label ${STATE_CLASS[state]}`}>Status: {state}</span>
-      {state === 'unknown' && (
-        <div className="ant-form-explain">
-          Alert condition has not been evaluated.
-        </div>
-      )}
-      {lastTriggered && (
-        <div className="ant-form-explain">
-          Last triggered <span className="alert-last-triggered"><TimeAgo date={lastTriggered} /></span>
-        </div>
-      )}
-    </div>
-  );
-}
-
-AlertState.propTypes = {
-  state: PropTypes.string.isRequired,
-  lastTriggered: PropTypes.string,
-};
-
-AlertState.defaultProps = {
-  lastTriggered: null,
-};
 
 class AlertPage extends React.Component {
   _isMounted = false;
@@ -103,39 +40,37 @@ class AlertPage extends React.Component {
     alert: null,
     queryResult: null,
     pendingRearm: null,
-    editMode: false,
     canEdit: false,
-    saving: false,
-    canceling: false,
+    mode: null,
   }
 
   componentDidMount() {
     this._isMounted = true;
+    const { mode } = $route.current.locals;
+    this.setState({ mode });
 
-    if (isNewAlert()) {
+    if (mode === MODES.NEW) {
       this.setState({
         alert: new AlertService({
           options: {
             op: 'greater than',
             value: 1,
           },
-          pendingRearm: 0,
         }),
-        editMode: true,
-        canEdit: true,
+        pendingRearm: 0,
       });
     } else {
       const { alertId } = $route.current.params;
-      const { editMode } = $route.current.locals;
       AlertService.get({ id: alertId }).$promise.then((alert) => {
-        const canEdit = currentUser.canEdit(alert);
         if (this._isMounted) {
-          this.setState({
-            alert,
-            pendingRearm: alert.rearm,
-            editMode: editMode && canEdit,
-            canEdit,
-          });
+          const canEdit = currentUser.canEdit(alert);
+
+          // force view mode if can't edit
+          if (!canEdit) {
+            this.setState({ mode: MODES.VIEW });
+          }
+
+          this.setState({ alert, canEdit, pendingRearm: alert.rearm });
           this.onQuerySelected(alert.query);
         }
       }).catch((err) => {
@@ -150,13 +85,19 @@ class AlertPage extends React.Component {
     this._isMounted = false;
   }
 
-  getDefaultName = () => {
-    const { alert } = this.state;
-    if (!alert.query) {
-      return 'New Alert';
-    }
-    return defaultNameBuilder(alert);
-  }
+  save = () => {
+    const { alert, pendingRearm } = this.state;
+
+    alert.name = trim(alert.name) || getDefaultName(alert);
+    alert.rearm = pendingRearm || null;
+
+    return alert.$save().then(() => {
+      notification.success('Saved.');
+      navigateTo(`/alerts/${alert.id}`, true);
+    }).catch(() => {
+      notification.error('Failed saving alert.');
+    });
+  };
 
   onQuerySelected = (query) => {
     this.setState(({ alert }) => ({
@@ -182,6 +123,13 @@ class AlertPage extends React.Component {
     }
   }
 
+  onNameChange = (name) => {
+    const { alert } = this.state;
+    this.setState({
+      alert: Object.assign(alert, { name }),
+    });
+  }
+
   onRearmChange = (pendingRearm) => {
     this.setState({ pendingRearm });
   }
@@ -193,47 +141,6 @@ class AlertPage extends React.Component {
       alert: Object.assign(alert, { options }),
     });
   }
-
-  setName = (name) => {
-    const { alert } = this.state;
-    this.setState({
-      alert: Object.assign(alert, { name }),
-    });
-  }
-
-  edit = () => {
-    const { id } = this.state.alert;
-    navigateTo(`/alerts/${id}/edit`, true);
-  }
-
-  save = () => {
-    const { alert, pendingRearm } = this.state;
-
-    alert.name = trim(alert.name) || this.getDefaultName();
-    alert.rearm = pendingRearm || null;
-
-    this.setState({ saving: true, alert });
-
-    alert.$save().then(() => {
-      if (isNewAlert()) {
-        notification.success('Created new Alert.');
-      } else {
-        notification.success('Saved.');
-      }
-      navigateTo(`/alerts/${alert.id}`, true);
-    }).catch(() => {
-      notification.error('Failed saving alert.');
-      if (this._isMounted) {
-        this.setState({ saving: false });
-      }
-    });
-  };
-
-  cancel = () => {
-    const { alert } = this.state;
-    this.setState({ canceling: true });
-    navigateTo(`/alerts/${alert.id}`, true);
-  };
 
   delete = () => {
     const { alert } = this.state;
@@ -264,144 +171,24 @@ class AlertPage extends React.Component {
       return <LoadingState className="m-t-30" />;
     }
 
-    const isNew = isNewAlert();
-    const { query, name, options } = alert;
-    const { queryResult, editMode, pendingRearm, canEdit, saving, canceling } = this.state;
+    const { queryResult, mode, canEdit, pendingRearm } = this.state;
+    const commonProps = {
+      alert,
+      queryResult,
+      pendingRearm,
+      delete: this.delete,
+      save: this.save,
+      onQuerySelected: this.onQuerySelected,
+      onRearmChange: this.onRearmChange,
+      onNameChange: this.onNameChange,
+      onCriteriaChange: this.setAlertOptions,
+    };
 
     return (
       <div className="container alert-page">
-        <div className="p-b-10 m-l-0 m-r-0 page-header--new">
-          <div className="d-flex">
-            <h3>
-              {editMode && query ? (
-                <Input className="f-inherit" placeholder={this.getDefaultName()} value={name} onChange={e => this.setName(e.target.value)} />
-              ) : name || this.getDefaultName() }
-            </h3>
-            <span className="alert-actions">
-              {editMode && (
-                <>
-                  {!isNew && (
-                    <>
-                      <Button className="m-r-5" onClick={() => this.cancel()}>
-                        {canceling ? spinnerIcon : <i className="fa fa-times m-r-5" />}
-                        Cancel
-                      </Button>
-                      <Button type="primary" onClick={() => this.save()}>
-                        {saving ? spinnerIcon : <i className="fa fa-check m-r-5" />}
-                        Save Changes
-                      </Button>
-                    </>
-                  )}
-                </>
-              )}
-              {!editMode && canEdit && (
-                <Button type="default" onClick={() => this.edit()}><i className="fa fa-edit m-r-5" />Edit</Button>
-              )}
-              {canEdit && !isNew && (
-                <Dropdown
-                  className="m-l-5"
-                  trigger={['click']}
-                  placement="bottomRight"
-                  overlay={(
-                    <Menu>
-                      <Menu.Item>
-                        <a onClick={() => this.delete()}>Delete Alert</a>
-                      </Menu.Item>
-                    </Menu>
-                  )}
-                >
-                  <Button><Icon type="ellipsis" rotate={90} /></Button>
-                </Dropdown>
-              )}
-            </span>
-          </div>
-        </div>
-        <div className="row bg-white tiled p-20">
-          <div className={cx('d-flex', { 'col-md-8': !editMode })}>
-            <Form className="flex-fill">
-              {isNew && (
-                <div className="m-b-30">
-                  Start by selecting the query that you would like to monitor using the search bar.
-                  <br />
-                  Keep in mind that Alerts do not work with queries that use parameters.
-                </div>
-              )}
-              {!editMode && (
-                <HorizontalFormItem>
-                  <AlertState state={alert.state} lastTriggered={alert.last_triggered_at} />
-                </HorizontalFormItem>
-              )}
-              <HorizontalFormItem label="Query">
-                <Query query={query} onChange={this.onQuerySelected} editMode={editMode} />
-              </HorizontalFormItem>
-              {query && !queryResult && (
-                <HorizontalFormItem className="m-t-30">
-                  <Icon type="loading" className="m-r-5" /> Loading query data
-                </HorizontalFormItem>
-              )}
-              {queryResult && options && (
-                <>
-                  <HorizontalFormItem label="Trigger when" className="alert-criteria">
-                    <Criteria
-                      columnNames={queryResult.getColumnNames()}
-                      resultValues={queryResult.getData()}
-                      alertOptions={options}
-                      onChange={this.setAlertOptions}
-                      editMode={editMode}
-                    />
-                  </HorizontalFormItem>
-                  {editMode ? (
-                    <>
-                      <HorizontalFormItem label="When triggered, send notification">
-                        <Rearm value={pendingRearm || 0} onChange={this.onRearmChange} editMode />
-                      </HorizontalFormItem>
-                      <HorizontalFormItem label="Template">
-                        <NotificationTemplate
-                          alert={alert}
-                          query={query}
-                          columnNames={queryResult.getColumnNames()}
-                          resultValues={queryResult.getData()}
-                          subject={options.custom_subject}
-                          setSubject={subject => this.setAlertOptions({ custom_subject: subject })}
-                          body={options.custom_body}
-                          setBody={body => this.setAlertOptions({ custom_body: body })}
-                        />
-                      </HorizontalFormItem>
-                    </>
-                  ) : (
-                    <HorizontalFormItem label="Notifications" className="form-item-line-height-normal">
-                      <Rearm value={pendingRearm || 0} />
-                      <br />
-                      Set to {options.custom_subject || options.custom_body ? 'custom' : 'default'} notification template.
-                    </HorizontalFormItem>
-                  )}
-                </>
-              )}
-              {isNew && (
-                <HorizontalFormItem>
-                  <Button type="primary" onClick={this.save} disabled={!query} className="btn-create-alert">Create Alert</Button>
-                </HorizontalFormItem>
-              )}
-            </Form>
-            {editMode && (
-              <HelpTrigger className="f-13" type="ALERT_SETUP">
-                Setup Instructions <i className="fa fa-question-circle" />
-              </HelpTrigger>
-            )}
-          </div>
-          {!editMode && alert.id && (
-            <div className="col-md-4">
-              <h4>Destinations{' '}
-                <Tooltip title="Open Alert Destinations page in a new tab.">
-                  <a href="/destinations" target="_blank">
-                    <i className="fa fa-external-link f-13" />
-                  </a>
-                </Tooltip>
-              </h4>
-              <AlertDestinations alertId={alert.id} />
-            </div>
-          )}
-        </div>
+        {mode === MODES.NEW && <AlertNew {...commonProps} />}
+        {mode === MODES.VIEW && <AlertView canEdit={canEdit} {...commonProps} />}
+        {mode === MODES.EDIT && <AlertEdit {...commonProps} />}
       </div>
     );
   }
@@ -412,13 +199,19 @@ export default function init(ngModule) {
 
   return routesToAngularRoutes([
     {
+      path: '/alerts/new',
+      title: 'New Alert',
+      mode: MODES.NEW,
+    },
+    {
       path: '/alerts/:alertId',
       title: 'Alert',
-      editMode: false,
-    }, {
+      mode: MODES.VIEW,
+    },
+    {
       path: '/alerts/:alertId/edit',
       title: 'Alert',
-      editMode: true,
+      mode: MODES.EDIT,
     },
   ], {
     template: '<alert-page></alert-page>',

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -17,6 +17,7 @@ import AlertNew from './AlertNew';
 import Modal from 'antd/lib/modal';
 
 import { routesToAngularRoutes } from '@/lib/utils';
+import PromiseRejectionError from '@/lib/promise-rejection-error';
 
 const MODES = {
   NEW: 0,
@@ -58,6 +59,7 @@ class AlertPage extends React.Component {
           },
         }),
         pendingRearm: 0,
+        canEdit: true,
       });
     } else {
       const { alertId } = $route.current.params;
@@ -200,6 +202,7 @@ class AlertPage extends React.Component {
       onRearmChange: this.onRearmChange,
       onNameChange: this.onNameChange,
       onCriteriaChange: this.setAlertOptions,
+      onNotificationTemplateChange: this.setAlertOptions,
     };
 
     return (

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -93,7 +93,8 @@ class AlertPage extends React.Component {
 
     return alert.$save().then(() => {
       notification.success('Saved.');
-      navigateTo(`/alerts/${alert.id}`, true);
+      navigateTo(`/alerts/${alert.id}`, true, false);
+      this.setState({ mode: MODES.VIEW });
     }).catch(() => {
       notification.error('Failed saving alert.');
     });
@@ -148,7 +149,7 @@ class AlertPage extends React.Component {
     const doDelete = () => {
       alert.$delete(() => {
         notification.success('Alert deleted successfully.');
-        navigateTo('/alerts', true);
+        navigateTo('/alerts');
       }, () => {
         notification.error('Failed deleting alert.');
       });
@@ -163,6 +164,18 @@ class AlertPage extends React.Component {
       maskClosable: true,
       autoFocusButton: null,
     });
+  }
+
+  edit = () => {
+    const { id } = this.state.alert;
+    navigateTo(`/alerts/${id}/edit`, true, false);
+    this.setState({ mode: MODES.EDIT });
+  }
+
+  cancel = () => {
+    const { id } = this.state.alert;
+    navigateTo(`/alerts/${id}`, true, false);
+    this.setState({ mode: MODES.VIEW });
   }
 
   render() {
@@ -187,8 +200,8 @@ class AlertPage extends React.Component {
     return (
       <div className="container alert-page">
         {mode === MODES.NEW && <AlertNew {...commonProps} />}
-        {mode === MODES.VIEW && <AlertView canEdit={canEdit} {...commonProps} />}
-        {mode === MODES.EDIT && <AlertEdit {...commonProps} />}
+        {mode === MODES.VIEW && <AlertView canEdit={canEdit} onEdit={this.edit} {...commonProps} />}
+        {mode === MODES.EDIT && <AlertEdit cancel={this.cancel} {...commonProps} />}
       </div>
     );
   }

--- a/client/app/pages/alert/AlertEdit.jsx
+++ b/client/app/pages/alert/AlertEdit.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import navigateTo from '@/services/navigateTo';
-
 import { HelpTrigger } from '@/components/HelpTrigger';
 import { Alert as AlertType } from '@/components/proptypes';
 
@@ -46,9 +44,8 @@ export default class AlertEdit extends React.Component {
   }
 
   cancel = () => {
-    const { alert } = this.props;
     this.setState({ canceling: true });
-    navigateTo(`/alerts/${alert.id}`, true);
+    this.props.cancel();
   };
 
   render() {
@@ -122,6 +119,7 @@ AlertEdit.propTypes = {
   pendingRearm: PropTypes.number,
   delete: PropTypes.func.isRequired,
   save: PropTypes.func.isRequired,
+  cancel: PropTypes.func.isRequired,
   onQuerySelected: PropTypes.func.isRequired,
   onNameChange: PropTypes.func.isRequired,
   onCriteriaChange: PropTypes.func.isRequired,

--- a/client/app/pages/alert/AlertEdit.jsx
+++ b/client/app/pages/alert/AlertEdit.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import navigateTo from '@/services/navigateTo';
+
+import { HelpTrigger } from '@/components/HelpTrigger';
+import { Alert as AlertType } from '@/components/proptypes';
+
+import Form from 'antd/lib/form';
+import Button from 'antd/lib/button';
+import Icon from 'antd/lib/icon';
+import Dropdown from 'antd/lib/dropdown';
+import Menu from 'antd/lib/menu';
+
+import Title from './components/Title';
+import Criteria from './components/Criteria';
+import Rearm from './components/Rearm';
+import Query from './components/Query';
+import HorizontalFormItem from './components/HorizontalFormItem';
+
+const spinnerIcon = <i className="fa fa-spinner fa-pulse m-r-5" />;
+
+export default class AlertEdit extends React.Component {
+  _isMounted = false;
+
+  state = {
+    saving: false,
+    canceling: false,
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  save = () => {
+    this.setState({ saving: true });
+    this.props.save().catch(() => {
+      if (this._isMounted) {
+        this.setState({ saving: false });
+      }
+    });
+  }
+
+  cancel = () => {
+    const { alert } = this.props;
+    this.setState({ canceling: true });
+    navigateTo(`/alerts/${alert.id}`, true);
+  };
+
+  render() {
+    const { alert, queryResult, pendingRearm } = this.props;
+    const { onQuerySelected, onNameChange, onRearmChange, onCriteriaChange } = this.props;
+    const { query, name, options } = alert;
+    const { saving, canceling } = this.state;
+
+    return (
+      <>
+        <Title name={name} alert={alert} onChange={onNameChange} editMode>
+          <Button className="m-r-5" onClick={() => this.cancel()}>
+            {canceling ? spinnerIcon : <i className="fa fa-times m-r-5" />}
+            Cancel
+          </Button>
+          <Button type="primary" onClick={() => this.save()}>
+            {saving ? spinnerIcon : <i className="fa fa-check m-r-5" />}
+            Save Changes
+          </Button>
+          <Dropdown
+            className="m-l-5"
+            trigger={['click']}
+            placement="bottomRight"
+            overlay={(
+              <Menu>
+                <Menu.Item>
+                  <a onClick={this.props.delete}>Delete Alert</a>
+                </Menu.Item>
+              </Menu>
+            )}
+          >
+            <Button><Icon type="ellipsis" rotate={90} /></Button>
+          </Dropdown>
+        </Title>
+        <div className="row bg-white tiled p-20">
+          <div className="d-flex">
+            <Form className="flex-fill">
+              <HorizontalFormItem label="Query">
+                <Query query={query} onChange={onQuerySelected} editMode />
+              </HorizontalFormItem>
+              {query && !queryResult && (
+                <HorizontalFormItem className="m-t-30">
+                  <Icon type="loading" className="m-r-5" /> Loading query data
+                </HorizontalFormItem>
+              )}
+              {queryResult && options && (
+                <>
+                  <HorizontalFormItem label="Trigger when" className="alert-criteria">
+                    <Criteria
+                      columnNames={queryResult.getColumnNames()}
+                      resultValues={queryResult.getData()}
+                      alertOptions={options}
+                      onChange={onCriteriaChange}
+                      editMode
+                    />
+                  </HorizontalFormItem>
+                  <HorizontalFormItem label="When triggered, send notification">
+                    <Rearm value={pendingRearm || 0} onChange={onRearmChange} editMode />
+                  </HorizontalFormItem>
+                </>
+              )}
+            </Form>
+            <HelpTrigger className="f-13" type="ALERT_SETUP">
+              Setup Instructions <i className="fa fa-question-circle" />
+            </HelpTrigger>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+AlertEdit.propTypes = {
+  alert: AlertType.isRequired,
+  queryResult: PropTypes.object, // eslint-disable-line react/forbid-prop-types,
+  pendingRearm: PropTypes.number,
+  delete: PropTypes.func.isRequired,
+  save: PropTypes.func.isRequired,
+  onQuerySelected: PropTypes.func.isRequired,
+  onNameChange: PropTypes.func.isRequired,
+  onCriteriaChange: PropTypes.func.isRequired,
+  onRearmChange: PropTypes.func.isRequired,
+};
+
+AlertEdit.defaultProps = {
+  queryResult: null,
+  pendingRearm: null,
+};

--- a/client/app/pages/alert/AlertEdit.jsx
+++ b/client/app/pages/alert/AlertEdit.jsx
@@ -87,13 +87,8 @@ export default class AlertEdit extends React.Component {
           <div className="d-flex">
             <Form className="flex-fill">
               <HorizontalFormItem label="Query">
-                <Query query={query} onChange={onQuerySelected} editMode />
+                <Query query={query} queryResult={queryResult} onChange={onQuerySelected} editMode />
               </HorizontalFormItem>
-              {query && !queryResult && (
-                <HorizontalFormItem className="m-t-30">
-                  <Icon type="loading" className="m-r-5" /> Loading query data
-                </HorizontalFormItem>
-              )}
               {queryResult && options && (
                 <>
                   <HorizontalFormItem label="Trigger when" className="alert-criteria">

--- a/client/app/pages/alert/AlertEdit.jsx
+++ b/client/app/pages/alert/AlertEdit.jsx
@@ -12,8 +12,10 @@ import Menu from 'antd/lib/menu';
 
 import Title from './components/Title';
 import Criteria from './components/Criteria';
+import NotificationTemplate from './components/NotificationTemplate';
 import Rearm from './components/Rearm';
 import Query from './components/Query';
+
 import HorizontalFormItem from './components/HorizontalFormItem';
 
 const spinnerIcon = <i className="fa fa-spinner fa-pulse m-r-5" />;
@@ -49,7 +51,7 @@ export default class AlertEdit extends React.Component {
   };
 
   render() {
-    const { alert, queryResult, pendingRearm } = this.props;
+    const { alert, queryResult, pendingRearm, onNotificationTemplateChange } = this.props;
     const { onQuerySelected, onNameChange, onRearmChange, onCriteriaChange } = this.props;
     const { query, name, options } = alert;
     const { saving, canceling } = this.state;
@@ -100,6 +102,18 @@ export default class AlertEdit extends React.Component {
                   <HorizontalFormItem label="When triggered, send notification">
                     <Rearm value={pendingRearm || 0} onChange={onRearmChange} editMode />
                   </HorizontalFormItem>
+                  <HorizontalFormItem label="Template">
+                    <NotificationTemplate
+                      alert={alert}
+                      query={query}
+                      columnNames={queryResult.getColumnNames()}
+                      resultValues={queryResult.getData()}
+                      subject={options.custom_subject}
+                      setSubject={subject => onNotificationTemplateChange({ custom_subject: subject })}
+                      body={options.custom_body}
+                      setBody={body => onNotificationTemplateChange({ custom_body: body })}
+                    />
+                  </HorizontalFormItem>
                 </>
               )}
             </Form>
@@ -124,6 +138,7 @@ AlertEdit.propTypes = {
   onNameChange: PropTypes.func.isRequired,
   onCriteriaChange: PropTypes.func.isRequired,
   onRearmChange: PropTypes.func.isRequired,
+  onNotificationTemplateChange: PropTypes.func.isRequired,
 };
 
 AlertEdit.defaultProps = {

--- a/client/app/pages/alert/AlertNew.jsx
+++ b/client/app/pages/alert/AlertNew.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { HelpTrigger } from '@/components/HelpTrigger';
+import { Alert as AlertType } from '@/components/proptypes';
+
+import Form from 'antd/lib/form';
+import Icon from 'antd/lib/icon';
+import Button from 'antd/lib/button';
+
+import Title from './components/Title';
+import Criteria from './components/Criteria';
+import Rearm from './components/Rearm';
+import Query from './components/Query';
+import HorizontalFormItem from './components/HorizontalFormItem';
+
+export default class AlertNew extends React.Component {
+  state = {
+    saving: false,
+  };
+
+  save = () => {
+    this.setState({ saving: true });
+    this.props.save().catch(() => {
+      this.setState({ saving: false });
+    });
+  }
+
+  render() {
+    const { alert, queryResult, pendingRearm } = this.props;
+    const { onQuerySelected, onNameChange, onRearmChange, onCriteriaChange } = this.props;
+    const { query, name, options } = alert;
+    const { saving } = this.state;
+
+    return (
+      <>
+        <Title alert={alert} name={name} onChange={onNameChange} editMode />
+        <div className="row bg-white tiled p-20">
+          <div className="d-flex">
+            <Form className="flex-fill">
+              <div className="m-b-30">
+                Start by selecting the query that you would like to monitor using the search bar.
+                <br />
+                Keep in mind that Alerts do not work with queries that use parameters.
+              </div>
+              <HorizontalFormItem label="Query">
+                <Query query={query} onChange={onQuerySelected} editMode />
+              </HorizontalFormItem>
+              {query && !queryResult && (
+                <HorizontalFormItem className="m-t-30">
+                  <Icon type="loading" className="m-r-5" /> Loading query data
+                </HorizontalFormItem>
+              )}
+              {queryResult && options && (
+                <>
+                  <HorizontalFormItem label="Trigger when" className="alert-criteria">
+                    <Criteria
+                      columnNames={queryResult.getColumnNames()}
+                      resultValues={queryResult.getData()}
+                      alertOptions={options}
+                      onChange={onCriteriaChange}
+                      editMode
+                    />
+                  </HorizontalFormItem>
+                  <HorizontalFormItem label="When triggered, send notification">
+                    <Rearm value={pendingRearm || 0} onChange={onRearmChange} editMode />
+                  </HorizontalFormItem>
+                </>
+              )}
+              <HorizontalFormItem>
+                <Button type="primary" onClick={this.save} disabled={!query} className="btn-create-alert">
+                  {saving && <i className="fa fa-spinner fa-pulse m-r-5" />}
+                  Create Alert
+                </Button>
+              </HorizontalFormItem>
+            </Form>
+            <HelpTrigger className="f-13" type="ALERT_SETUP">
+              Setup Instructions <i className="fa fa-question-circle" />
+            </HelpTrigger>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+AlertNew.propTypes = {
+  alert: AlertType.isRequired,
+  queryResult: PropTypes.object, // eslint-disable-line react/forbid-prop-types,
+  pendingRearm: PropTypes.number,
+  onQuerySelected: PropTypes.func.isRequired,
+  save: PropTypes.func.isRequired,
+  onNameChange: PropTypes.func.isRequired,
+  onRearmChange: PropTypes.func.isRequired,
+  onCriteriaChange: PropTypes.func.isRequired,
+};
+
+AlertNew.defaultProps = {
+  queryResult: null,
+  pendingRearm: null,
+};

--- a/client/app/pages/alert/AlertNew.jsx
+++ b/client/app/pages/alert/AlertNew.jsx
@@ -5,7 +5,6 @@ import { HelpTrigger } from '@/components/HelpTrigger';
 import { Alert as AlertType } from '@/components/proptypes';
 
 import Form from 'antd/lib/form';
-import Icon from 'antd/lib/icon';
 import Button from 'antd/lib/button';
 
 import Title from './components/Title';
@@ -44,13 +43,8 @@ export default class AlertNew extends React.Component {
                 Keep in mind that Alerts do not work with queries that use parameters.
               </div>
               <HorizontalFormItem label="Query">
-                <Query query={query} onChange={onQuerySelected} editMode />
+                <Query query={query} queryResult={queryResult} onChange={onQuerySelected} editMode />
               </HorizontalFormItem>
-              {query && !queryResult && (
-                <HorizontalFormItem className="m-t-30">
-                  <Icon type="loading" className="m-r-5" /> Loading query data
-                </HorizontalFormItem>
-              )}
               {queryResult && options && (
                 <>
                   <HorizontalFormItem label="Trigger when" className="alert-criteria">

--- a/client/app/pages/alert/AlertNew.jsx
+++ b/client/app/pages/alert/AlertNew.jsx
@@ -9,6 +9,7 @@ import Button from 'antd/lib/button';
 
 import Title from './components/Title';
 import Criteria from './components/Criteria';
+import NotificationTemplate from './components/NotificationTemplate';
 import Rearm from './components/Rearm';
 import Query from './components/Query';
 import HorizontalFormItem from './components/HorizontalFormItem';
@@ -26,7 +27,7 @@ export default class AlertNew extends React.Component {
   }
 
   render() {
-    const { alert, queryResult, pendingRearm } = this.props;
+    const { alert, queryResult, pendingRearm, onNotificationTemplateChange } = this.props;
     const { onQuerySelected, onNameChange, onRearmChange, onCriteriaChange } = this.props;
     const { query, name, options } = alert;
     const { saving } = this.state;
@@ -59,6 +60,18 @@ export default class AlertNew extends React.Component {
                   <HorizontalFormItem label="When triggered, send notification">
                     <Rearm value={pendingRearm || 0} onChange={onRearmChange} editMode />
                   </HorizontalFormItem>
+                  <HorizontalFormItem label="Template">
+                    <NotificationTemplate
+                      alert={alert}
+                      query={query}
+                      columnNames={queryResult.getColumnNames()}
+                      resultValues={queryResult.getData()}
+                      subject={options.custom_subject}
+                      setSubject={subject => onNotificationTemplateChange({ custom_subject: subject })}
+                      body={options.custom_body}
+                      setBody={body => onNotificationTemplateChange({ custom_body: body })}
+                    />
+                  </HorizontalFormItem>
                 </>
               )}
               <HorizontalFormItem>
@@ -87,6 +100,7 @@ AlertNew.propTypes = {
   onNameChange: PropTypes.func.isRequired,
   onRearmChange: PropTypes.func.isRequired,
   onCriteriaChange: PropTypes.func.isRequired,
+  onNotificationTemplateChange: PropTypes.func.isRequired,
 };
 
 AlertNew.defaultProps = {

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import navigateTo from '@/services/navigateTo';
+
+import { TimeAgo } from '@/components/TimeAgo';
+import { Alert as AlertType } from '@/components/proptypes';
+
+import Form from 'antd/lib/form';
+import Button from 'antd/lib/button';
+import Icon from 'antd/lib/icon';
+import Dropdown from 'antd/lib/dropdown';
+import Menu from 'antd/lib/menu';
+
+import Title from './components/Title';
+import Criteria from './components/Criteria';
+import Rearm from './components/Rearm';
+import Query from './components/Query';
+import HorizontalFormItem from './components/HorizontalFormItem';
+import { STATE_CLASS } from '../alerts/AlertsList';
+
+
+function AlertState({ state, lastTriggered }) {
+  return (
+    <div className="alert-state">
+      <span className={`alert-state-indicator label ${STATE_CLASS[state]}`}>Status: {state}</span>
+      {state === 'unknown' && (
+        <div className="ant-form-explain">
+          Alert condition has not been evaluated.
+        </div>
+      )}
+      {lastTriggered && (
+        <div className="ant-form-explain">
+          Last triggered <span className="alert-last-triggered"><TimeAgo date={lastTriggered} /></span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+AlertState.propTypes = {
+  state: PropTypes.string.isRequired,
+  lastTriggered: PropTypes.string,
+};
+
+AlertState.defaultProps = {
+  lastTriggered: null,
+};
+
+export default class AlertView extends React.Component {
+  edit = () => {
+    const { id } = this.props.alert;
+    navigateTo(`/alerts/${id}/edit`, true);
+  }
+
+  render() {
+    const { alert, queryResult, canEdit } = this.props;
+    const { query, name, options, rearm } = alert;
+
+    return (
+      <>
+        <Title name={name} alert={alert}>
+          {canEdit && (
+            <>
+              <Button type="default" onClick={() => this.edit()}><i className="fa fa-edit m-r-5" />Edit</Button>
+              <Dropdown
+                className="m-l-5"
+                trigger={['click']}
+                placement="bottomRight"
+                overlay={(
+                  <Menu>
+                    <Menu.Item>
+                      <a onClick={this.props.delete}>Delete Alert</a>
+                    </Menu.Item>
+                  </Menu>
+                )}
+              >
+                <Button><Icon type="ellipsis" rotate={90} /></Button>
+              </Dropdown>
+            </>
+          )}
+        </Title>
+        <div className="row bg-white tiled p-20">
+          <div className="d-flex col-md-8">
+            <Form className="flex-fill">
+              <HorizontalFormItem>
+                <AlertState state={alert.state} lastTriggered={alert.last_triggered_at} />
+              </HorizontalFormItem>
+              <HorizontalFormItem label="Query">
+                <Query query={query} onChange={this.onQuerySelected} />
+              </HorizontalFormItem>
+              {query && !queryResult && (
+                <HorizontalFormItem className="m-t-30">
+                  <Icon type="loading" className="m-r-5" /> Loading query data
+                </HorizontalFormItem>
+              )}
+              {queryResult && options && (
+                <>
+                  <HorizontalFormItem label="Trigger when" className="alert-criteria">
+                    <Criteria
+                      columnNames={queryResult.getColumnNames()}
+                      resultValues={queryResult.getData()}
+                      alertOptions={options}
+                    />
+                  </HorizontalFormItem>
+                  <HorizontalFormItem label="Notifications" className="form-item-line-height-normal">
+                    <Rearm value={rearm || 0} />
+                  </HorizontalFormItem>
+                </>
+              )}
+            </Form>
+          </div>
+          <div className="col-md-4">
+            <h4>Destinations</h4>
+            <div><i className="fa fa-hand-o-right" /> In next PR</div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+AlertView.propTypes = {
+  alert: AlertType.isRequired,
+  queryResult: PropTypes.object, // eslint-disable-line react/forbid-prop-types,
+  canEdit: PropTypes.bool.isRequired,
+  delete: PropTypes.func.isRequired,
+};
+
+AlertView.defaultProps = {
+  queryResult: null,
+};

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 import { TimeAgo } from '@/components/TimeAgo';
 import { Alert as AlertType } from '@/components/proptypes';
@@ -9,6 +10,7 @@ import Button from 'antd/lib/button';
 import Icon from 'antd/lib/icon';
 import Dropdown from 'antd/lib/dropdown';
 import Menu from 'antd/lib/menu';
+import Tooltip from 'antd/lib/tooltip';
 
 import Title from './components/Title';
 import Criteria from './components/Criteria';
@@ -53,25 +55,23 @@ export default class AlertView extends React.Component {
     return (
       <>
         <Title name={name} alert={alert}>
-          {canEdit && (
-            <>
-              <Button type="default" onClick={onEdit}><i className="fa fa-edit m-r-5" />Edit</Button>
-              <Dropdown
-                className="m-l-5"
-                trigger={['click']}
-                placement="bottomRight"
-                overlay={(
-                  <Menu>
-                    <Menu.Item>
-                      <a onClick={this.props.delete}>Delete Alert</a>
-                    </Menu.Item>
-                  </Menu>
-                )}
-              >
-                <Button><Icon type="ellipsis" rotate={90} /></Button>
-              </Dropdown>
-            </>
-          )}
+          <Tooltip title={canEdit ? '' : 'You do not have sufficient permissions to edit this alert'}>
+            <Button type="default" onClick={canEdit ? onEdit : null} className={cx({ disabled: !canEdit })}><i className="fa fa-edit m-r-5" />Edit</Button>
+            <Dropdown
+              className={cx('m-l-5', { disabled: !canEdit })}
+              trigger={[canEdit ? 'click' : undefined]}
+              placement="bottomRight"
+              overlay={(
+                <Menu>
+                  <Menu.Item>
+                    <a onClick={this.props.delete}>Delete Alert</a>
+                  </Menu.Item>
+                </Menu>
+              )}
+            >
+              <Button><Icon type="ellipsis" rotate={90} /></Button>
+            </Dropdown>
+          </Tooltip>
         </Title>
         <div className="row bg-white tiled p-20">
           <div className="d-flex col-md-8">

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -87,7 +87,7 @@ export default class AlertView extends React.Component {
                 <AlertState state={alert.state} lastTriggered={alert.last_triggered_at} />
               </HorizontalFormItem>
               <HorizontalFormItem label="Query">
-                <Query query={query} onChange={this.onQuerySelected} />
+                <Query query={query} queryResult={queryResult} onChange={this.onQuerySelected} />
               </HorizontalFormItem>
               {query && !queryResult && (
                 <HorizontalFormItem className="m-t-30">

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import navigateTo from '@/services/navigateTo';
-
 import { TimeAgo } from '@/components/TimeAgo';
 import { Alert as AlertType } from '@/components/proptypes';
 
@@ -48,13 +46,8 @@ AlertState.defaultProps = {
 };
 
 export default class AlertView extends React.Component {
-  edit = () => {
-    const { id } = this.props.alert;
-    navigateTo(`/alerts/${id}/edit`, true);
-  }
-
   render() {
-    const { alert, queryResult, canEdit } = this.props;
+    const { alert, queryResult, canEdit, onEdit } = this.props;
     const { query, name, options, rearm } = alert;
 
     return (
@@ -62,7 +55,7 @@ export default class AlertView extends React.Component {
         <Title name={name} alert={alert}>
           {canEdit && (
             <>
-              <Button type="default" onClick={() => this.edit()}><i className="fa fa-edit m-r-5" />Edit</Button>
+              <Button type="default" onClick={onEdit}><i className="fa fa-edit m-r-5" />Edit</Button>
               <Dropdown
                 className="m-l-5"
                 trigger={['click']}
@@ -125,6 +118,7 @@ AlertView.propTypes = {
   queryResult: PropTypes.object, // eslint-disable-line react/forbid-prop-types,
   canEdit: PropTypes.bool.isRequired,
   delete: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
 };
 
 AlertView.defaultProps = {

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -16,6 +16,7 @@ import Title from './components/Title';
 import Criteria from './components/Criteria';
 import Rearm from './components/Rearm';
 import Query from './components/Query';
+import AlertDestinations from './components/AlertDestinations';
 import HorizontalFormItem from './components/HorizontalFormItem';
 import { STATE_CLASS } from '../alerts/AlertsList';
 
@@ -98,14 +99,22 @@ export default class AlertView extends React.Component {
                   </HorizontalFormItem>
                   <HorizontalFormItem label="Notifications" className="form-item-line-height-normal">
                     <Rearm value={rearm || 0} />
+                    <br />
+                    Set to {options.custom_subject || options.custom_body ? 'custom' : 'default'} notification template.
                   </HorizontalFormItem>
                 </>
               )}
             </Form>
           </div>
           <div className="col-md-4">
-            <h4>Destinations</h4>
-            <div><i className="fa fa-hand-o-right" /> In next PR</div>
+            <h4>Destinations{' '}
+              <Tooltip title="Open Alert Destinations page in a new tab.">
+                <a href="/destinations" target="_blank">
+                  <i className="fa fa-external-link f-13" />
+                </a>
+              </Tooltip>
+            </h4>
+            <AlertDestinations alertId={alert.id} />
           </div>
         </div>
       </>

--- a/client/app/pages/alert/components/Criteria.jsx
+++ b/client/app/pages/alert/components/Criteria.jsx
@@ -118,6 +118,11 @@ Criteria.propTypes = {
   columnNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   resultValues: PropTypes.arrayOf(PropTypes.object).isRequired,
   alertOptions: AlertOptionsType.isRequired,
-  onChange: PropTypes.func.isRequired,
-  editMode: PropTypes.bool.isRequired,
+  onChange: PropTypes.func,
+  editMode: PropTypes.bool,
+};
+
+Criteria.defaultProps = {
+  onChange: () => {},
+  editMode: false,
 };

--- a/client/app/pages/alert/components/HorizontalFormItem.jsx
+++ b/client/app/pages/alert/components/HorizontalFormItem.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import Form from 'antd/lib/form';
+
+export default function HorizontalFormItem({ children, label, className, ...props }) {
+  const labelCol = { span: 4 };
+  const wrapperCol = { span: 16 };
+  if (!label) {
+    wrapperCol.offset = 4;
+  }
+
+  className = cx('alert-form-item', className);
+
+  return (
+    <Form.Item labelCol={labelCol} wrapperCol={wrapperCol} label={label} className={className} {...props}>
+      { children }
+    </Form.Item>
+  );
+}
+
+HorizontalFormItem.propTypes = {
+  children: PropTypes.node,
+  label: PropTypes.string,
+  className: PropTypes.string,
+};
+
+HorizontalFormItem.defaultProps = {
+  children: null,
+  label: null,
+  className: null,
+};

--- a/client/app/pages/alert/components/Query.jsx
+++ b/client/app/pages/alert/components/Query.jsx
@@ -47,10 +47,12 @@ export default function QueryFormItem({ query, onChange, editMode }) {
 
 QueryFormItem.propTypes = {
   query: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  onChange: PropTypes.func.isRequired,
-  editMode: PropTypes.bool.isRequired,
+  onChange: PropTypes.func,
+  editMode: PropTypes.bool,
 };
 
 QueryFormItem.defaultProps = {
   query: null,
+  onChange: () => {},
+  editMode: false,
 };

--- a/client/app/pages/alert/components/Query.jsx
+++ b/client/app/pages/alert/components/Query.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 import { QuerySelector } from '@/components/QuerySelector';
 import { SchedulePhrase } from '@/components/queries/SchedulePhrase';
+import { Query as QueryType } from '@/components/proptypes';
 
 import Tooltip from 'antd/lib/tooltip';
 import Icon from 'antd/lib/icon';
 
 import './Query.less';
 
-export default function QueryFormItem({ query, onChange, editMode }) {
+export default function QueryFormItem({ query, queryResult, onChange, editMode }) {
   const queryHint = query && query.schedule ? (
     <small>
       Scheduled to refresh <i className="alert-query-schedule"><SchedulePhrase schedule={query.schedule} isNew={false} /></i>
@@ -41,18 +42,25 @@ export default function QueryFormItem({ query, onChange, editMode }) {
       <div className="ant-form-explain">
         {query && queryHint}
       </div>
+      {query && !queryResult && (
+        <div className="m-t-30">
+          <Icon type="loading" className="m-r-5" /> Loading query data
+        </div>
+      )}
     </>
   );
 }
 
 QueryFormItem.propTypes = {
-  query: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  query: QueryType,
+  queryResult: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   onChange: PropTypes.func,
   editMode: PropTypes.bool,
 };
 
 QueryFormItem.defaultProps = {
   query: null,
+  queryResult: null,
   onChange: () => {},
   editMode: false,
 };

--- a/client/app/pages/alert/components/Title.jsx
+++ b/client/app/pages/alert/components/Title.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Input from 'antd/lib/input';
+import { getDefaultName } from '../Alert';
+
+import { Alert as AlertType } from '@/components/proptypes';
+
+
+export default function Title({ alert, editMode, name, onChange, children }) {
+  const defaultName = getDefaultName(alert);
+  return (
+    <div className="p-b-10 m-l-0 m-r-0 page-header--new">
+      <div className="d-flex">
+        <h3>
+          {editMode && alert.query ? (
+            <Input className="f-inherit" placeholder={defaultName} value={name} onChange={e => onChange(e.target.value)} />
+          ) : name || defaultName }
+        </h3>
+        <span className="alert-actions">{ children }</span>
+      </div>
+    </div>
+  );
+}
+
+Title.propTypes = {
+  alert: AlertType.isRequired,
+  name: PropTypes.string,
+  children: PropTypes.node,
+  onChange: PropTypes.func,
+  editMode: PropTypes.bool,
+};
+
+Title.defaultProps = {
+  name: null,
+  children: null,
+  onChange: null,
+  editMode: false,
+};


### PR DESCRIPTION
- [x] Refactor

## Description
By request in [comment](https://github.com/getredash/redash/pull/4153/files?file-filters%5B%5D=.js&file-filters%5B%5D=.jsx&file-filters%5B%5D=.less#r327473471) for separation of mega file, now Alert.jsx renders:

```jsx
<div className="container alert-page">
  {mode === MODES.NEW && <AlertNew {...commonProps} />}
  {mode === MODES.VIEW && <AlertView canEdit={canEdit} {...commonProps} />}
  {mode === MODES.EDIT && <AlertEdit {...commonProps} />}
</div>
```

Also, made abstracted the alert name component into:
```jsx
<Title alert={alert} name={name} onChange={onNameChange} editMode />
```