### PR TITLE
Vertica: prevent overwriting row data when duplicated column names exist

### DIFF
--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -132,7 +132,7 @@ class Vertica(BaseSQLQueryRunner):
 
                 columns = self.fetch_columns(column_data)
                 rows = [dict(zip(([c['name'] for c in columns]), r))
-                        for i, r in enumerate(cursor.fetchall())]
+                        for r in cursor.fetchall()]
 
                 data = {'columns': columns, 'rows': rows}
                 json_data = json_dumps(data)

--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -128,12 +128,11 @@ class Vertica(BaseSQLQueryRunner):
 
             # TODO - very similar to pg.py
             if cursor.description is not None:
-                columns_data = [(i[0], i[1]) for i in cursor.description]
+                columns_data = [(i[0], types_map.get(i[1], None)) for i in cursor.description]
 
-                rows = [dict(zip((c[0] for c in columns_data), row)) for row in cursor.fetchall()]
-                columns = [{'name': col[0],
-                            'friendly_name': col[0],
-                            'type': types_map.get(col[1], None)} for col in columns_data]
+                columns = self.fetch_columns(column_data)
+                rows = [dict(zip(([c['name'] for c in columns]), r))
+                        for i, r in enumerate(cursor.fetchall())]
 
                 data = {'columns': columns, 'rows': rows}
                 json_data = json_dumps(data)


### PR DESCRIPTION
This pull request fixes issues with duplicated column names for Vertica query runner.

[fetch_columns](https://github.com/getredash/redash/blob/master/redash/query_runner/__init__.py#L101) method is used for this fix.

**Problem Description:**
If we have columns with the same name in the select statement then the query result is overridden by the value of first column. e.g. 
`select count(*)
    , count(distinct user_id)
    , count(user_id)
from example_table`

**Example:** 
Duplicated column names -- 2nd and 3rd columns' values were overwritten by the 1st column:
<img width="331" alt="vertica_dup_column_name" src="https://user-images.githubusercontent.com/26781701/65920191-404d0d80-e393-11e9-87a3-d122c5c3f669.png">
A simple fix is to give each column a unique name:
<img width="367" alt="vertica_dup_column_name2" src="https://user-images.githubusercontent.com/26781701/65920201-44792b00-e393-11e9-8db8-b94252492ef3.png">


