### PR TITLE
Fix: Misleading warning when trying to download results of unsaved query

### DIFF
--- a/client/app/components/EditVisualizationButton/QueryResultsLink.jsx
+++ b/client/app/components/EditVisualizationButton/QueryResultsLink.jsx
@@ -20,7 +20,7 @@ export default function QueryResultsLink(props) {
   }
 
   return (
-    <a target="_self" disabled={props.disabled} href={href}>
+    <a target="_blank" rel="noopener noreferrer" disabled={props.disabled} href={href} download>
       {props.children}
     </a>
   );


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #4218

Changed to `target="_blank"` so there's no redirect prompt.
Added `download` attribute to prevent new tab from opening.