### PR TITLE
Postgres: make sure table from the public schema doesn't get merged with table from other schemas

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -63,6 +63,33 @@ def _wait(conn, timeout=None):
             raise psycopg2.OperationalError("select.error received")
 
 
+def build_schema(query_result, schema):
+    # By default we omit the public schema name from the table name. But there are 
+    # edge cases, where this might cause conflicts. For example:
+    # * We have a schema named "main" with table "users".
+    # * We have a table named "main.users" in the public schema. 
+    # (while this feels unlikely, this actually happened)
+    # In this case if we omit the schema name for the public table, we will have
+    # a conflict.
+
+    full_table_name = lambda r: u'{}.{}'.format(r['table_schema'], r['table_name'])
+    table_names = set(map(full_table_name, query_result['rows']))
+
+    for row in query_result['rows']:
+        if row['table_schema'] != 'public':
+            table_name = full_table_name(row)
+        else:
+            if row['table_name'] in table_names:
+                table_name = u'{}."{}"'.format(row['table_schema'], row['table_name'])
+            else:
+                table_name = row['table_name']
+
+        if table_name not in schema:
+            schema[table_name] = {'name': table_name, 'columns': []}
+
+        schema[table_name]['columns'].append(row['column_name'])
+
+
 class PostgreSQL(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
 
@@ -112,17 +139,8 @@ class PostgreSQL(BaseSQLQueryRunner):
 
         results = json_loads(results)
 
-        for row in results['rows']:
-            if row['table_schema'] != 'public':
-                table_name = u'{}.{}'.format(row['table_schema'],
-                                             row['table_name'])
-            else:
-                table_name = row['table_name']
+        build_schema(results, schema)
 
-            if table_name not in schema:
-                schema[table_name] = {'name': table_name, 'columns': []}
-
-            schema[table_name]['columns'].append(row['column_name'])
 
     def _get_tables(self, schema):
         '''

--- a/tests/query_runner/test_pg.py
+++ b/tests/query_runner/test_pg.py
@@ -1,0 +1,23 @@
+
+from unittest import TestCase
+from redash.query_runner.pg import build_schema
+
+
+class TestBuildSchema(TestCase):
+    def test_handles_dups_between_public_and_other_schemas(self):
+        results = {
+            'rows': [
+                {'table_schema': 'public', 'table_name': 'main.users', 'column_name': 'id'},
+                {'table_schema': 'main', 'table_name': 'users', 'column_name': 'id'},
+                {'table_schema': 'main', 'table_name': 'users', 'column_name': 'name'},
+            ]
+        }
+
+        schema = {}
+
+        build_schema(results, schema)
+
+        self.assertIn('main.users', schema.keys())
+        self.assertListEqual(schema['main.users']['columns'], ['id', 'name'])
+        self.assertIn('public."main.users"', schema.keys())
+        self.assertListEqual(schema['public."main.users"']['columns'], ['id'])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

This pull request addresses an edge case in Postgres' schema handling: 

By default we omit the public schema name from the table name. But there are edge cases, where this might cause conflicts. For example:

* We have a schema named "main" with table "users".
* We have a table named "main.users" in the public schema. 

(while this feels unlikely, this actually happened)

In this case if we omit the schema name for the public table, we will have a conflict. This pull reuqest makes sure that if such collision exists, we will name the public schema table as `public."main.users"` (quotes are needed because of the dot).

This is probably relevant to other data sources, but for now limiting the change to the Postgres data source to make the change smaller and simpler.
