### PR TITLE
Fix: Failing alert test

### DIFF
--- a/client/cypress/support/redash-api/index.js
+++ b/client/cypress/support/redash-api/index.js
@@ -106,6 +106,7 @@ export function createUser({ name, email, password }) {
     method: 'POST',
     url: 'api/users',
     body: { name, email },
+    qs: { no_invite: 1 },
     failOnStatusCode: false,
   })
     .then((xhr) => {

--- a/client/cypress/support/redash-api/index.js
+++ b/client/cypress/support/redash-api/index.js
@@ -123,12 +123,17 @@ export function createUser({ name, email, password }) {
       const id = get(body, 'id');
       assert.isDefined(id, 'User api call returns user id');
 
-      return cy.request({
-        url: body.invite_link,
-        method: 'POST',
-        form: true,
-        body: { password },
-      });
+      if (body.is_invitation_pending) {
+        const url = get(body, 'invite_link');
+        assert.isDefined(url, 'User api call returns user invite link');
+
+        return cy.request({
+          url,
+          method: 'POST',
+          form: true,
+          body: { password },
+        });
+      }
     });
 }
 


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes alert [test failure](https://dashboard.cypress.io/#/projects/924cka/runs/1542/failures).

### The bug
When email server is configured in Redash, user creation api omits `invite_link` which the test was dependent on.
I assume this succeeded in the feature branch tests cause it wasn't up to date with https://github.com/getredash/redash/pull/4173.

### The fix
Added `no_invite` to api request and now the `invite_link` does appear and test continues.
Also added clear error if this prop doesn't show up in the future.