### PR TITLE
(Python 3) Use Redis' decode_responses=True option

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -10,6 +10,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_ipaddr
 from flask_migrate import Migrate
 from statsd import StatsClient
+from urllib.parse import urlparse, urlunparse
 
 from . import settings
 from .app import create_app  # noqa
@@ -39,7 +40,17 @@ def setup_logging():
 
 setup_logging()
 
-redis_connection = redis.from_url(settings.REDIS_URL)
+
+def fix_redis_url(url):
+    """Make sure that the Redis URL includes the `decode_responses` option."""
+    parsed = urlparse(url)
+    query = 'decode_responses=True'
+    if parsed.query:
+        query = "{}&{}".format(parsed.query, query)
+
+    return urlunparse([parsed.scheme, parsed.netloc, parsed.path, parsed.params, query, parsed.fragment])
+
+redis_connection = redis.from_url(fix_redis_url(settings.REDIS_URL))
 mail = Mail()
 migrate = Migrate()
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -37,7 +37,6 @@ def setup_logging():
 
 setup_logging()
 
-
 redis_connection = redis.from_url(settings.REDIS_URL)
 mail = Mail()
 migrate = Migrate()

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -1,8 +1,6 @@
 import logging
 import os
 import sys
-import urllib.request, urllib.parse, urllib.error
-import urllib.parse
 
 import redis
 from flask_mail import Mail
@@ -10,7 +8,6 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_ipaddr
 from flask_migrate import Migrate
 from statsd import StatsClient
-from urllib.parse import urlparse, urlunparse
 
 from . import settings
 from .app import create_app  # noqa
@@ -41,16 +38,7 @@ def setup_logging():
 setup_logging()
 
 
-def fix_redis_url(url):
-    """Make sure that the Redis URL includes the `decode_responses` option."""
-    parsed = urlparse(url)
-    query = 'decode_responses=True'
-    if parsed.query:
-        query = "{}&{}".format(parsed.query, query)
-
-    return urlunparse([parsed.scheme, parsed.netloc, parsed.path, parsed.params, query, parsed.fragment])
-
-redis_connection = redis.from_url(fix_redis_url(settings.REDIS_URL))
+redis_connection = redis.from_url(settings.REDIS_URL)
 mail = Mail()
 migrate = Migrate()
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -176,11 +176,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
     @property
     def pause_reason(self):
-        rv = redis_connection.get(self._pause_key)
-        if not rv:
-            return rv
-
-        return rv.decode()
+        return redis_connection.get(self._pause_key)
 
     def pause(self, reason=None):
         redis_connection.set(self._pause_key, reason or '')

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -39,7 +39,7 @@ def sync_last_active_at():
     for user_id in user_ids:
         timestamp = redis_connection.hget(LAST_ACTIVE_KEY, user_id)
         active_at = dt_from_timestamp(timestamp)
-        user = User.query.filter(User.id == user_id.decode()).first()
+        user = User.query.filter(User.id == user_id).first()
         if user:
             user.active_at = active_at
         redis_connection.hdel(LAST_ACTIVE_KEY, user_id)

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -7,7 +7,10 @@ from flask_talisman import talisman
 from .helpers import fix_assets_path, array_from_string, parse_boolean, int_or_none, set_from_string, add_decode_responses_to_redis_url
 from .organization import DATE_FORMAT, TIME_FORMAT  # noqa
 
-REDIS_URL = add_decode_responses_to_redis_url(os.environ.get('REDASH_REDIS_URL', os.environ.get('REDIS_URL', "redis://localhost:6379/0")))
+# _REDIS_URL is the unchanged REDIS_URL we get from env vars, to be used later with Celery
+_REDIS_URL = os.environ.get('REDASH_REDIS_URL', os.environ.get('REDIS_URL', "redis://localhost:6379/0"))
+# This is the one to use for Redash' own connection:
+REDIS_URL = add_decode_responses_to_redis_url(_REDIS_URL)
 PROXIES_COUNT = int(os.environ.get('REDASH_PROXIES_COUNT', "1"))
 
 STATSD_HOST = os.environ.get('REDASH_STATSD_HOST', "127.0.0.1")
@@ -24,10 +27,10 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
 
 # Celery related settings
-CELERY_BROKER = add_decode_responses_to_redis_url(os.environ.get("REDASH_CELERY_BROKER", REDIS_URL))
-CELERY_RESULT_BACKEND = add_decode_responses_to_redis_url(os.environ.get(
+CELERY_BROKER = os.environ.get("REDASH_CELERY_BROKER", _REDIS_URL)
+CELERY_RESULT_BACKEND = os.environ.get(
     "REDASH_CELERY_RESULT_BACKEND",
-    os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER)))
+    os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER))
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -4,10 +4,10 @@ import ssl
 from funcy import distinct, remove
 from flask_talisman import talisman
 
-from .helpers import fix_assets_path, array_from_string, parse_boolean, int_or_none, set_from_string
+from .helpers import fix_assets_path, array_from_string, parse_boolean, int_or_none, set_from_string, fix_redis_url
 from .organization import DATE_FORMAT, TIME_FORMAT  # noqa
 
-REDIS_URL = os.environ.get('REDASH_REDIS_URL', os.environ.get('REDIS_URL', "redis://localhost:6379/0"))
+REDIS_URL = fix_redis_url(os.environ.get('REDASH_REDIS_URL', os.environ.get('REDIS_URL', "redis://localhost:6379/0")))
 PROXIES_COUNT = int(os.environ.get('REDASH_PROXIES_COUNT', "1"))
 
 STATSD_HOST = os.environ.get('REDASH_STATSD_HOST', "127.0.0.1")

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -4,10 +4,10 @@ import ssl
 from funcy import distinct, remove
 from flask_talisman import talisman
 
-from .helpers import fix_assets_path, array_from_string, parse_boolean, int_or_none, set_from_string, fix_redis_url
+from .helpers import fix_assets_path, array_from_string, parse_boolean, int_or_none, set_from_string, add_decode_responses_to_redis_url
 from .organization import DATE_FORMAT, TIME_FORMAT  # noqa
 
-REDIS_URL = fix_redis_url(os.environ.get('REDASH_REDIS_URL', os.environ.get('REDIS_URL', "redis://localhost:6379/0")))
+REDIS_URL = add_decode_responses_to_redis_url(os.environ.get('REDASH_REDIS_URL', os.environ.get('REDIS_URL', "redis://localhost:6379/0")))
 PROXIES_COUNT = int(os.environ.get('REDASH_PROXIES_COUNT', "1"))
 
 STATSD_HOST = os.environ.get('REDASH_STATSD_HOST', "127.0.0.1")
@@ -24,10 +24,10 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
 
 # Celery related settings
-CELERY_BROKER = os.environ.get("REDASH_CELERY_BROKER", REDIS_URL)
-CELERY_RESULT_BACKEND = os.environ.get(
+CELERY_BROKER = add_decode_responses_to_redis_url(os.environ.get("REDASH_CELERY_BROKER", REDIS_URL))
+CELERY_RESULT_BACKEND = add_decode_responses_to_redis_url(os.environ.get(
     "REDASH_CELERY_RESULT_BACKEND",
-    os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER))
+    os.environ.get("REDASH_CELERY_BACKEND", CELERY_BROKER)))
 CELERY_RESULT_EXPIRES = int(os.environ.get(
     "REDASH_CELERY_RESULT_EXPIRES",
     os.environ.get("REDASH_CELERY_TASK_RESULT_EXPIRES", 3600 * 4)))

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse, urlunparse
 
 
 def fix_assets_path(path):
@@ -34,3 +35,13 @@ def int_or_none(value):
         return value
 
     return int(value)
+
+
+def fix_redis_url(url):
+    """Make sure that the Redis URL includes the `decode_responses` option."""
+    parsed = urlparse(url)
+    query = 'decode_responses=True'
+    if parsed.query:
+        query = "{}&{}".format(parsed.query, query)
+
+    return urlunparse([parsed.scheme, parsed.netloc, parsed.path, parsed.params, query, parsed.fragment])

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -37,11 +37,14 @@ def int_or_none(value):
     return int(value)
 
 
-def fix_redis_url(url):
+def add_decode_responses_to_redis_url(url):
     """Make sure that the Redis URL includes the `decode_responses` option."""
     parsed = urlparse(url)
+
     query = 'decode_responses=True'
-    if parsed.query:
+    if parsed.query and 'decode_responses' not in parsed.query:
         query = "{}&{}".format(parsed.query, query)
+    elif 'decode_responses' in parsed.query:
+        query = parsed.query
 
     return urlunparse([parsed.scheme, parsed.netloc, parsed.path, parsed.params, query, parsed.fragment])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -157,7 +157,7 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         self.assertIn(query, queries)
 
     def test_outdated_queries_works_scheduled_queries_tracker(self):
-        two_hours_ago = datetime.datetime.now() - datetime.timedelta(hours=2)
+        two_hours_ago = utcnow() - datetime.timedelta(hours=2)
         query = self.factory.create_query(schedule={'interval':'3600', 'time': None, 'until':None, 'day_of_week':None})
         query_result = self.factory.create_query_result(query=query, retrieved_at=two_hours_ago)
         query.latest_query_data = query_result


### PR DESCRIPTION
This is replacing #4230 with an actual fix: the reason for the test failure was that the key wasn't a string representation of the query id, but a bytes one.

To avoid similar issues in the future, I changed the Redis connection creation to use the `decode_responses` option.