### PR TITLE
pagerduty.py: Change default summary text

### DIFF
--- a/redash/destinations/pagerduty.py
+++ b/redash/destinations/pagerduty.py
@@ -12,7 +12,7 @@ except ImportError:
 class PagerDuty(BaseDestination):
 
     KEY_STRING = '{alert_id}_{query_id}'
-    DESCRIPTION_STR = u'Alert - Redash Alert: {alert_name}'
+    DESCRIPTION_STR = u'Alert: {alert_name}'
 
     @classmethod
     def enabled(cls):
@@ -29,7 +29,7 @@ class PagerDuty(BaseDestination):
                 },
                 'description': {
                     'type': 'string',
-                    'title': 'Description for the event, defaults to query',
+                    'title': 'Description for the event, defaults to alert name',
                 }
             },
             "required": ["integration_key"]

--- a/redash/destinations/pagerduty.py
+++ b/redash/destinations/pagerduty.py
@@ -12,7 +12,7 @@ except ImportError:
 class PagerDuty(BaseDestination):
 
     KEY_STRING = '{alert_id}_{query_id}'
-    DESCRIPTION_STR = u'Alert - Redash Query #{query_id}: {query_name}'
+    DESCRIPTION_STR = u'Alert - Redash Alert: {alert_name}'
 
     @classmethod
     def enabled(cls):
@@ -46,7 +46,7 @@ class PagerDuty(BaseDestination):
         elif options.get('description'):
             default_desc = options.get('description')
         else:
-            default_desc = self.DESCRIPTION_STR.format(query_id=query.id, query_name=query.name)
+            default_desc = self.DESCRIPTION_STR.format(alert_name=alert.name)
 
         incident_key = self.KEY_STRING.format(alert_id=alert.id, query_id=query.id)
         data = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description
Change is made to use alert name in PagerDuty's alert
destination default summary text instead of
query id and name

## Related Tickets & Documents
Closes #4223 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
