### PR TITLE
Refresh snowflake schema without waking cluster

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -106,11 +106,7 @@ class Snowflake(BaseQueryRunner):
 
     def get_schema(self, get_stats=False):
         query = """
-        SELECT col.table_schema,
-               col.table_name,
-               col.column_name
-        FROM {database}.information_schema.columns col
-        WHERE col.table_schema <> 'INFORMATION_SCHEMA'
+        show columns in database {database} schema INFORMATION_SCHEMA
         """.format(database=self.configuration['database'])
 
         results, error = self.run_query(query, None)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
This PR allows the refreshing of Snow Flake schema based data sources, without waking 
any clusters. It uses SHOW COLUMNS query instead of SELECT.
## Related Tickets & Documents
Fixes issue #4217 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
None. This is a backend change