### PR TITLE
Fix double-scrollbar when in fullscreen

### DIFF
--- a/client/app/assets/less/inc/base.less
+++ b/client/app/assets/less/inc/base.less
@@ -25,8 +25,10 @@ body {
     position: relative;
     
     &.headless {
-        padding-top: 10px;
-        
+        app-view {
+            padding-top: 10px;
+        }
+
         .nav.app-header, .navbar {
             display: none;
         }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

When using fullscreen mode inside an embedded report, a double scrollbar appears because padding is added to the `body` but the container is set to be `min-height: 100vh`. This PR fixes it.