### PR TITLE
Percy snapshot: make sure query results are consistent

### DIFF
--- a/client/cypress/integration/embed/share_embed_spec.js
+++ b/client/cypress/integration/embed/share_embed_spec.js
@@ -6,7 +6,7 @@ describe('Embedded Queries', () => {
   });
 
   it('can be shared without parameters', () => {
-    createQuery({ query: 'select name from users' })
+    createQuery({ query: 'select name from users order by name' })
       .then((query) => {
         cy.visit(`/queries/${query.id}/source`);
         cy.getByTestId('ExecuteButton').click();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

Make sure the query results have the same order in all screenshots.

Example failure this should fix: https://percy.io/Redash/redash/builds/2821287/view/180328320/1280?mode=diff&browser=chrome&snapshot=180328320