### PR TITLE
Fix: Alert page breaks when target query returns null result

### DIFF
--- a/client/app/pages/alert/components/Criteria.jsx
+++ b/client/app/pages/alert/components/Criteria.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { head, includes, toString } from 'lodash';
+import { head, includes, toString, isEmpty } from 'lodash';
 
 import Input from 'antd/lib/input';
 import Icon from 'antd/lib/icon';
@@ -34,7 +34,7 @@ DisabledInput.propTypes = {
 };
 
 export default function Criteria({ columnNames, resultValues, alertOptions, onChange, editMode }) {
-  const columnValue = resultValues && head(resultValues)[alertOptions.column];
+  const columnValue = !isEmpty(resultValues) ? head(resultValues)[alertOptions.column] : null;
   const invalidMessage = (() => {
     // bail if condition is valid for strings
     if (includes(VALID_STRING_CONDITIONS, alertOptions.op)) {

--- a/client/app/pages/alert/components/NotificationTemplate.jsx
+++ b/client/app/pages/alert/components/NotificationTemplate.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { head, isEmpty } from 'lodash';
+import { head, isEmpty, isNull, isUndefined } from 'lodash';
 import Mustache from 'mustache';
 
 import { HelpTrigger } from '@/components/HelpTrigger';
@@ -25,7 +25,7 @@ function normalizeCustomTemplateData(alert, query, columnNames, resultValues) {
     ALERT_URL: `${window.location.origin}/alerts/${alert.id}`,
     QUERY_NAME: query.name,
     QUERY_URL: `${window.location.origin}/queries/${query.id}`,
-    QUERY_RESULT_VALUE: topValue || 'UNKNOWN',
+    QUERY_RESULT_VALUE: isNull(topValue) || isUndefined(topValue) ? 'UNKNOWN' : topValue,
     QUERY_RESULT_ROWS: resultValues,
     QUERY_RESULT_COLS: columnNames,
   };

--- a/client/app/pages/alert/components/NotificationTemplate.jsx
+++ b/client/app/pages/alert/components/NotificationTemplate.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { head } from 'lodash';
+import { head, isEmpty } from 'lodash';
 import Mustache from 'mustache';
 
 import { HelpTrigger } from '@/components/HelpTrigger';
@@ -15,7 +15,7 @@ import './NotificationTemplate.less';
 
 
 function normalizeCustomTemplateData(alert, query, columnNames, resultValues) {
-  const topValue = resultValues && head(resultValues)[alert.options.column];
+  const topValue = !isEmpty(resultValues) ? head(resultValues)[alert.options.column] : null;
 
   return {
     ALERT_STATUS: 'TRIGGERED',
@@ -25,7 +25,7 @@ function normalizeCustomTemplateData(alert, query, columnNames, resultValues) {
     ALERT_URL: `${window.location.origin}/alerts/${alert.id}`,
     QUERY_NAME: query.name,
     QUERY_URL: `${window.location.origin}/queries/${query.id}`,
-    QUERY_RESULT_VALUE: topValue,
+    QUERY_RESULT_VALUE: topValue || 'UNKNOWN',
     QUERY_RESULT_ROWS: resultValues,
     QUERY_RESULT_COLS: columnNames,
   };


### PR DESCRIPTION
- [x] Bug Fix

## Description
Fixes #4249.

The new Alert doesn't assumes query result value.
Added condition in case result is an empty array.

Now empty data looks like this, instead of breaking:

<img width="340" alt="Screen Shot 2019-10-16 at 10 27 04" src="https://user-images.githubusercontent.com/486954/66897391-978fe680-efff-11e9-8239-25577ee0129d.png">
