### PR TITLE
Add "use-debounce" dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18154,6 +18154,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-debounce": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.1.0.tgz",
+      "integrity": "sha512-DEf3L/ZKkOSTARk/DHlC6KAAJKwMqpck8Zx06SM2Wr+LfU1TzhO8hZRzB/qbpSQqREYWQes24n1q9doeTMqF4g=="
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "react-sortable-hoc": "^1.10.1",
     "react2angular": "^3.2.1",
     "tinycolor2": "^1.4.1",
-    "ui-select": "^0.19.8"
+    "ui-select": "^0.19.8",
+    "use-debounce": "^3.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Add `use-debounce` dependency - currently needed for several PRs (getredash/redash#4139, getredash/redash#4175, getredash/redash#4267)
