### PR TITLE
Reduce RQ status load time (Python 3)

### DIFF
--- a/client/app/pages/admin/Jobs.jsx
+++ b/client/app/pages/admin/Jobs.jsx
@@ -40,10 +40,9 @@ class Jobs extends React.Component {
   }
 
   processQueues = ({ queues, workers }) => {
-    const queueCounters = values(queues).map(({ name, started, queued }) => ({
-      name,
+    const queueCounters = values(queues).map(({ started, ...rest }) => ({
       started: started.length,
-      queued: queued.length,
+      ...rest,
     }));
 
     const overallCounters = queueCounters.reduce(

--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -155,7 +155,7 @@ def rq_queues():
         q.name: {
             'name': q.name,
             'started': fetch_jobs(q, StartedJobRegistry(queue=q).get_job_ids()),
-            'queued': fetch_jobs(q, q.job_ids)
+            'queued': len(q.job_ids)
         } for q in Queue.all(connection=redis_connection)}
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
The RQ job status page was loading job information for all queued jobs, but for those, we only care about the amount. This PR fixes this.

Running a small benchmark - for 60k queued jobs, this PR has reduced the load time from approx 34 seconds to 2 seconds.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
