### PR TITLE
Fix get_next_path tests

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -271,4 +271,10 @@ def get_next_path(unsafe_next_path):
     parts[1] = ''  # clear netloc
     safe_next_path = urlunsplit(parts)
 
+    # If the original path was a URL, we might end up with an empty
+    # safe url, which will redirect to the login page. Changing to 
+    # relative root to redirect to the app root after login.
+    if not safe_next_path:
+        safe_next_path = './'
+
     return safe_next_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask==1.1.1
-Werkzeug==0.16.0
 Jinja2==2.10.3
 itsdangerous==1.1.0
 click==6.7

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,7 +47,6 @@ class BaseTestCase(TestCase):
         self.app = create_app()
         self.db = db
         self.app.config['TESTING'] = True
-        self.app.config['SERVER_NAME'] = 'localhost'
         limiter.enabled = False
         self.app_ctx = self.app.app_context()
         self.app_ctx.push()

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -220,15 +220,15 @@ class TestRedirectToUrlAfterLoggingIn(BaseTestCase):
 
     def test_simple_path_in_next_param(self):
         response = self.post_request('/login?next=queries', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
-        self.assertEqual(response.location, 'http://localhost/queries')
+        self.assertEqual(response.location, 'http://localhost/default/queries')
 
     def test_starts_scheme_url_in_next_param(self):
         response = self.post_request('/login?next=https://redash.io', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
-        self.assertEqual(response.location, 'http://localhost/')
+        self.assertEqual(response.location, 'http://localhost/default/')
 
     def test_without_scheme_url_in_next_param(self):
         response = self.post_request('/login?next=//redash.io', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)
-        self.assertEqual(response.location, 'http://localhost/')
+        self.assertEqual(response.location, 'http://localhost/default/')
 
     def test_without_scheme_with_path_url_in_next_param(self):
         response = self.post_request('/login?next=//localhost/queries', data={'email': self.user.email, 'password': self.password}, org=self.factory.org)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

When passing a relative path for the `location` header (when calling `redirect`), before Werkzeug 0.15 it was joining it with the root path, but after version 0.15 they started using the original path (pallets/werkzeug#693).

This PR fixes the tests to conform with this behavior. This is a non issue in app code, because usually the next URL is crafted by the app itself. This whole code is a security measure.

Also changed the tests initialization a bit to avoid one of the new warnings.

## Related Tickets & Documents

#4251 