### PR TITLE
Extend result_ttl for refresh_queries

### DIFF
--- a/redash/schedule.py
+++ b/redash/schedule.py
@@ -32,7 +32,7 @@ def schedule_periodic_jobs():
         job.delete()
 
     jobs = [
-        {"func": refresh_queries, "interval": 30},
+        {"func": refresh_queries, "interval": 30, "result_ttl": 600},
         {"func": empty_schedules, "interval": timedelta(minutes=60)},
         {"func": refresh_schemas, "interval": timedelta(minutes=settings.SCHEMAS_REFRESH_SCHEDULE)},
         {"func": sync_user_details, "timeout": 60, "ttl": 45, "interval": timedelta(minutes=1)},


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When `refresh_queries` runs after a long period of not running, it may take a while. Currently, since the implicit `result_ttl` is `interval * 2`, the the job must finish under a minute (30 * 2). This PR sets the `result_ttl` to 10 minutes, which should suffice in order to keep rescheduling after longer runs of `refresh_queries`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
