### PR TITLE
Pin Cypress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:ci": "npm run lint -- --format junit --output-file /tmp/test-results/eslint/results.xml",
     "test": "TZ=Africa/Khartoum jest",
     "test:watch": "jest --watch",
-    "cypress:install": "npm install --no-save cypress@^3.1.5 @percy/cypress@^0.2.3 atob@2.1.2",
+    "cypress:install": "npm install --no-save cypress@3.4.1 @percy/cypress@^0.2.3 atob@2.1.2",
     "cypress": "node client/cypress/cypress.js"
   },
   "repository": {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

All Cypress builds started failing this morning. As it might be related to the new (3.5.0) release, trying to pin to a specific version until we have more details.