### PR TITLE
refreshing snowflake schema w/o waking cluster

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -112,7 +112,7 @@ class Snowflake(BaseQueryRunner):
 
         return json_data, error
 
-    def _run_query_without_warehouse(self, query, user):
+    def _run_query_without_warehouse(self, query):
         connection = self._get_connection()
         cursor = connection.cursor()
 
@@ -134,7 +134,7 @@ class Snowflake(BaseQueryRunner):
         SHOW COLUMNS IN DATABASE {database}
         """.format(database=self.configuration['database'])
 
-        results, error = self._run_query_without_warehouse(query, None)
+        results, error = self._run_query_without_warehouse(query)
 
         if error is not None:
             raise Exception("Failed getting schema.")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Refreshing snowflake schema w/o waking cluster. Used `show columns` for this which executes the command w/o having to require a warehouse.
Created a new internal function in the query runner `__run_query_without_warehouse` instead of modifying the existing `run_query` function so as to not change the definition as specified in the base class

## Related Tickets & Documents

#4217 
