### PR TITLE
Fix Redash 8 requirements...

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -8,7 +8,7 @@ pyhive==0.5.1
 pymongo[tls,srv]==3.6.1
 vertica-python==0.8.0
 td-client==0.8.0
-pymssql==2.1.3
+pymssql==2.1.4
 dql==0.5.24
 dynamo3==0.4.7
 boto3==1.9.115
@@ -32,3 +32,5 @@ phoenixdb==0.7
 certifi
 pydgraph==1.2.0
 azure-kusto-data==0.0.32
+# pandas is a requirement for pymapd but pip will pick versions that are python3 only
+pandas==0.24.0


### PR DESCRIPTION
Due to $REASONS I've found myself deploying Redash against fresh builds of Python 2.7.17 with nothing else installed and have run across a couple of problems.

This change bumps pymssql to a version that builds cleanly (with fix for pymssql/issues/520) and clamps the pandas package (a dependency of pymapd) to a version that doesn't require python 3.