### PR TITLE
Fix: number based alerts evaluation isn't working

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -2,6 +2,7 @@ import datetime
 import calendar
 import logging
 import time
+import numbers
 import pytz
 
 from six import text_type

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -792,11 +792,18 @@ OPERATORS = {
 
 
 def next_state(op, value, threshold):
-    if isinstance(value, numbers.Number):
+    if isinstance(value, numbers.Number) and not isinstance(value, bool):
         try:
             threshold = float(threshold)
         except ValueError:
             return Alert.UNKNOWN_STATE
+    # If it's a boolean cast to string and lower case, because upper cased
+    # boolean value is Python specific and most likely will be confusing to
+    # users.
+    elif isinstance(value, bool):
+        value = str(value).lower()
+    else:
+        value = str(value)
 
     if op(value, threshold):
         new_state = Alert.TRIGGERED_STATE

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from tests import BaseTestCase
-from redash.models import Alert, db
+from redash.models import Alert, db, next_state, OPERATORS
 from redash.utils import json_dumps
 
 

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -82,3 +82,7 @@ class TestNextState(TestCase):
 
     def test_string_value(self):
         self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get('=='), "string", "string"))
+    
+    def test_boolean_value(self):
+        self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get('=='), False, 'false'))
+        self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get('!='), False, 'true'))

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -1,3 +1,4 @@
+from unittest import TestCase
 from tests import BaseTestCase
 from redash.models import Alert, db
 from redash.utils import json_dumps
@@ -44,15 +45,19 @@ def get_results(value):
 
 
 class TestAlertEvaluate(BaseTestCase):
-    def create_alert(self, results, column='foo'):
+    def create_alert(self, results, column='foo', value="1"):
         result = self.factory.create_query_result(data=results)
         query = self.factory.create_query(latest_query_data_id=result.id)
-        alert = self.factory.create_alert(query_rel=query, options={'op': 'equals', 'column': column, 'value': 1})
+        alert = self.factory.create_alert(query_rel=query, options={'op': 'equals', 'column': column, 'value': value})
         return alert
 
     def test_evaluate_triggers_alert_when_equal(self):
         alert = self.create_alert(get_results(1))
         self.assertEqual(alert.evaluate(), Alert.TRIGGERED_STATE)
+
+    def test_evaluate_number_value_and_string_threshold(self):
+        alert = self.create_alert(get_results(1), value="string")
+        self.assertEqual(alert.evaluate(), Alert.UNKNOWN_STATE)
 
     def test_evaluate_return_unknown_when_missing_column(self):
         alert = self.create_alert(get_results(1), column='bar')
@@ -62,3 +67,18 @@ class TestAlertEvaluate(BaseTestCase):
         results = json_dumps({'rows': [], 'columns': [{'name': 'foo', 'type': 'STRING'}]})
         alert = self.create_alert(results)
         self.assertEqual(alert.evaluate(), Alert.UNKNOWN_STATE)
+
+
+class TestNextState(TestCase):
+    def test_numeric_value(self):
+        self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get('=='), 1, "1"))
+        self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get('=='), 1, "1.0"))
+    
+    def test_numeric_value_and_plain_string(self):
+        self.assertEqual(Alert.UNKNOWN_STATE, next_state(OPERATORS.get('=='), 1, "string"))
+
+    def test_non_numeric_value(self):
+        self.assertEqual(Alert.OK_STATE, next_state(OPERATORS.get('=='), "1", "1.0"))
+
+    def test_string_value(self):
+        self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get('=='), "string", "string"))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Following the alerts new UI, all the threshold values are saved as strings. This change casts the value into a number, if the query result value is a number.

## Related Tickets & Documents

Closes #4279.