### PR TITLE
CircleCI workflow improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
   build:
     jobs:
       - backend-lint
-      - backend-unit-tests
+      - backend-unit-tests:
           requires:
             - backend-lint
       - frontend-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2.0
 
+build-docker-image-job: &build-docker-image-job
+  docker:
+    - image: circleci/node:8
+  steps:
+    - setup_remote_docker
+    - checkout
+    - run: sudo apt install python3-pip
+    - run: sudo pip3 install -r requirements_bundles.txt
+    - run: .circleci/update_version
+    - run: npm run bundle
+    - run: .circleci/docker_build
 jobs:
   backend-lint:
     docker:
@@ -89,17 +100,8 @@ jobs:
       - run:
           name: Execute Cypress tests
           command: npm run cypress run-ci
-  build-docker-image:
-    docker:
-      - image: circleci/node:8
-    steps:
-      - setup_remote_docker
-      - checkout
-      - run: sudo apt install python3-pip
-      - run: sudo pip3 install -r requirements_bundles.txt
-      - run: .circleci/update_version
-      - run: npm run bundle
-      - run: .circleci/docker_build
+  build-docker-image: *build-docker-image-job
+  build-preview-docker-image: *build-docker-image-job
 workflows:
   version: 2
   build:
@@ -116,6 +118,15 @@ workflows:
       - frontend-e2e-tests:
           requires:
             - frontend-lint
+      - build-preview-docker-image:
+          requires:
+            - backend-unit-tests
+            - frontend-unit-tests
+            - frontend-e2e-tests
+          filters:
+            branches:
+              only:
+                - master
       - hold:
           type: approval
           requires:
@@ -125,8 +136,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
-                - preview-image
                 - /release\/.*/
       - build-docker-image:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.0
 
 jobs:
-  python-flake8-tests:
+  backend-lint:
     docker:
       - image: circleci/python:3.7.0
     steps:
@@ -104,16 +104,20 @@ workflows:
   version: 2
   build:
     jobs:
-      - python-flake8-tests
+      - backend-lint
       - backend-unit-tests
+          requires:
+            - backend-lint
       - frontend-lint
       - frontend-unit-tests:
           requires:
+            - backend-lint
             - frontend-lint
       - frontend-e2e-tests:
           requires:
             - frontend-lint
-      - build-docker-image:
+      - hold:
+          type: approval
           requires:
             - backend-unit-tests
             - frontend-unit-tests
@@ -124,3 +128,6 @@ workflows:
                 - master
                 - preview-image
                 - /release\/.*/
+      - build-docker-image:
+          requires:
+            - hold


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

- Don't automatically build the Docker image in release branches.
- Make the Python lint step requirement for the follow up steps. When it fails it usually means there is a code error which will prevent the next steps anyway.