### PR TITLE
Show more workers per page

### DIFF
--- a/client/app/components/admin/RQStatus.jsx
+++ b/client/app/components/admin/RQStatus.jsx
@@ -47,6 +47,11 @@ export function WorkersTable({ loading, items }) {
       columns={workersColumns}
       rowKey="name"
       dataSource={items}
+      pagination={{
+        defaultPageSize: 25,
+        pageSizeOptions: [10, 25, 50],
+        showSizeChanger: true,
+      }}
     />
   );
 }


### PR DESCRIPTION
In the admin status page (available at `/admin/queries/jobs`) there is a list of workers. We should increase the numbers of workers shown on each page (statically or provide a dropdown) to allow deployments with a larger amount of workers to be easier to observe.