### PR TITLE
Optimize work horse forking

### DIFF
--- a/redash/cli/rq.py
+++ b/redash/cli/rq.py
@@ -6,6 +6,7 @@ import datetime
 from click import argument
 from flask.cli import AppGroup
 from rq import Connection, Worker
+from sqlalchemy.orm import configure_mappers
 
 from redash import rq_redis_connection
 from redash.schedule import rq_scheduler, schedule_periodic_jobs
@@ -22,6 +23,11 @@ def scheduler():
 @manager.command()
 @argument('queues', nargs=-1)
 def worker(queues='default'):
+    # Configure any SQLAlchemy mappers loaded until now so that the mapping configuration 
+    # will already be available to the forked work horses and they won't need 
+    # to spend valuable time re-doing that on every fork.
+    configure_mappers()
+
     if not queues:
         queues = ('default',)
     with Connection(rq_redis_connection):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We've noticed that worker horses are consuming a lot of CPU. After some profiling, I realized that `configure_mapping` is called every time a work horse is forked (i.e. for every job). This PR calls `configure_mapping` once in the parent worker process, which is then available to the forked horses. We've seen significant performance improvement with this.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
