### PR TITLE
Parameter feedback - #2 Client errors in query page

### DIFF
--- a/client/app/components/EditParameterSettingsDialog.jsx
+++ b/client/app/components/EditParameterSettingsDialog.jsx
@@ -179,6 +179,7 @@ function EditParameterSettingsDialog(props) {
         {param.type === 'enum' && (
           <Form.Item label="Values" help="Dropdown list values (newline delimited)" {...formItemProps}>
             <Input.TextArea
+              data-test="EnumTextArea"
               rows={3}
               value={param.enumOptions}
               onChange={e => setParam({ ...param, enumOptions: e.target.value })}

--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -5,7 +5,7 @@ import Input from 'antd/lib/input';
 import InputNumber from 'antd/lib/input-number';
 import DateParameter from '@/components/dynamic-parameters/DateParameter';
 import DateRangeParameter from '@/components/dynamic-parameters/DateRangeParameter';
-import { isEqual } from 'lodash';
+import { isEqual, trim } from 'lodash';
 import { QueryBasedParameterInput } from './QueryBasedParameterInput';
 
 import './ParameterValueInput.less';
@@ -59,7 +59,7 @@ class ParameterValueInput extends React.Component {
   }
 
   onSelect = (value) => {
-    const isDirty = !isEqual(value, this.props.value);
+    const isDirty = !isEqual(trim(value), trim(this.props.value));
     this.setState({ value, isDirty });
     this.props.onSelect(value, isDirty);
   }
@@ -140,13 +140,11 @@ class ParameterValueInput extends React.Component {
     const { className } = this.props;
     const { value } = this.state;
 
-    const normalize = val => (isNaN(val) ? undefined : val);
-
     return (
       <InputNumber
         className={className}
-        value={normalize(value)}
-        onChange={val => this.onSelect(normalize(val))}
+        value={value}
+        onChange={val => this.onSelect(val)}
       />
     );
   }

--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { size, filter, forEach, extend, get } from 'lodash';
+import { size, filter, forEach, extend, get, includes } from 'lodash';
 import { react2angular } from 'react2angular';
 import { SortableContainer, SortableElement, DragHandle } from '@/components/sortable';
 import { $location } from '@/services/ng';
@@ -34,6 +34,7 @@ export class Parameters extends React.Component {
     queryResultErrorData: PropTypes.shape({
       parameters: PropTypes.objectOf(PropTypes.string),
     }),
+    unsavedParameters: PropTypes.arrayOf(PropTypes.string),
   };
 
   static defaultProps = {
@@ -44,6 +45,7 @@ export class Parameters extends React.Component {
     onPendingValuesChange: () => {},
     onParametersEdit: () => {},
     queryResultErrorData: {},
+    unsavedParameters: null,
   };
 
   constructor(props) {
@@ -140,7 +142,22 @@ export class Parameters extends React.Component {
     const { queryResultErrorData } = this.props;
     const error = get(queryResultErrorData, ['parameters', param.name], false);
     if (error) {
-      return [error, 'error'];
+      const feedback = <Tooltip title={error}>{error}</Tooltip>;
+      return [feedback, 'error'];
+    }
+
+    // unsaved
+    const { unsavedParameters } = this.props;
+    if (includes(unsavedParameters, param.name)) {
+      const feedback = (
+        <>
+          Unsaved{' '}
+          <Tooltip title='Click the "Save" button to preserve this parameter.'>
+            <i className="fa fa-question-circle" />
+          </Tooltip>
+        </>
+      );
+      return [feedback, 'warning'];
     }
 
     return [];
@@ -172,7 +189,7 @@ export class Parameters extends React.Component {
         </div>
         <Form.Item
           validateStatus={touched ? '' : status}
-          help={feedback ? <Tooltip title={feedback}>{feedback}</Tooltip> : null}
+          help={feedback || null}
         >
           <ParameterValueInput
             type={param.type}

--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { size, filter, forEach, extend } from 'lodash';
+import { size, filter, forEach, extend, get } from 'lodash';
 import { react2angular } from 'react2angular';
 import { SortableContainer, SortableElement, DragHandle } from '@/components/sortable';
 import { $location } from '@/services/ng';
 import { Parameter } from '@/services/parameters';
 import ParameterApplyButton from '@/components/ParameterApplyButton';
 import ParameterValueInput from '@/components/ParameterValueInput';
+import Form from 'antd/lib/form';
+import Tooltip from 'antd/lib/tooltip';
 import EditParameterSettingsDialog from './EditParameterSettingsDialog';
 import { toHuman } from '@/filters';
 
@@ -29,6 +31,9 @@ export class Parameters extends React.Component {
     onValuesChange: PropTypes.func,
     onPendingValuesChange: PropTypes.func,
     onParametersEdit: PropTypes.func,
+    queryResultErrorData: PropTypes.shape({
+      parameters: PropTypes.objectOf(PropTypes.string),
+    }),
   };
 
   static defaultProps = {
@@ -38,24 +43,34 @@ export class Parameters extends React.Component {
     onValuesChange: () => {},
     onPendingValuesChange: () => {},
     onParametersEdit: () => {},
+    queryResultErrorData: {},
   };
 
   constructor(props) {
     super(props);
     const { parameters } = props;
-    this.state = { parameters };
+    this.state = {
+      parameters,
+      touched: {},
+    };
+
     if (!props.disableUrlUpdate) {
       updateUrl(parameters);
     }
   }
 
   componentDidUpdate = (prevProps) => {
-    const { parameters, disableUrlUpdate } = this.props;
+    const { parameters, disableUrlUpdate, queryResultErrorData } = this.props;
     if (prevProps.parameters !== parameters) {
       this.setState({ parameters });
       if (!disableUrlUpdate) {
         updateUrl(parameters);
       }
+    }
+
+    // reset touched flags on new error data
+    if (prevProps.queryResultErrorData !== queryResultErrorData) {
+      this.setState({ touched: {} });
     }
   };
 
@@ -69,14 +84,15 @@ export class Parameters extends React.Component {
 
   setPendingValue = (param, value, isDirty) => {
     const { onPendingValuesChange } = this.props;
-    this.setState(({ parameters }) => {
+    this.setState(({ parameters, touched }) => {
       if (isDirty) {
         param.setPendingValue(value);
+        touched[param.name] = true;
       } else {
         param.clearPendingValue();
       }
       onPendingValuesChange();
-      return { parameters };
+      return { parameters, touched };
     });
   };
 
@@ -109,17 +125,32 @@ export class Parameters extends React.Component {
     EditParameterSettingsDialog
       .showModal({ parameter })
       .result.then((updated) => {
-        this.setState(({ parameters }) => {
+        this.setState(({ parameters, touched }) => {
+          touched[parameter.name] = true;
           const updatedParameter = extend(parameter, updated);
           parameters[index] = Parameter.create(updatedParameter, updatedParameter.parentQueryId);
           onParametersEdit();
-          return { parameters };
+          return { parameters, touched };
         });
       });
   };
 
+  getParameterFeedback = (param) => {
+    // error msg
+    const { queryResultErrorData } = this.props;
+    const error = get(queryResultErrorData, ['parameters', param.name], false);
+    if (error) {
+      return [error, 'error'];
+    }
+
+    return [];
+  };
+
   renderParameter(param, index) {
     const { editable } = this.props;
+    const touched = this.state.touched[param.name];
+    const [feedback, status] = this.getParameterFeedback(param);
+
     return (
       <div
         key={param.name}
@@ -139,14 +170,19 @@ export class Parameters extends React.Component {
             </button>
           )}
         </div>
-        <ParameterValueInput
-          type={param.type}
-          value={param.normalizedValue}
-          parameter={param}
-          enumOptions={param.enumOptions}
-          queryId={param.queryId}
-          onSelect={(value, isDirty) => this.setPendingValue(param, value, isDirty)}
-        />
+        <Form.Item
+          validateStatus={touched ? '' : status}
+          help={feedback ? <Tooltip title={feedback}>{feedback}</Tooltip> : null}
+        >
+          <ParameterValueInput
+            type={param.type}
+            value={param.normalizedValue}
+            parameter={param}
+            enumOptions={param.enumOptions}
+            queryId={param.queryId}
+            onSelect={(value, isDirty) => this.setPendingValue(param, value, isDirty)}
+          />
+        </Form.Item>
       </div>
     );
   }

--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -87,7 +87,7 @@ export class Parameters extends React.Component {
     this.setState(({ parameters, touched }) => {
       if (isDirty) {
         param.setPendingValue(value);
-        touched[param.name] = true;
+        touched = { ...touched, [param.name]: true };
       } else {
         param.clearPendingValue();
       }
@@ -126,7 +126,7 @@ export class Parameters extends React.Component {
       .showModal({ parameter })
       .result.then((updated) => {
         this.setState(({ parameters, touched }) => {
-          touched[parameter.name] = true;
+          touched = { ...touched, [parameter.name]: true };
           const updatedParameter = extend(parameter, updated);
           parameters[index] = Parameter.create(updatedParameter, updatedParameter.parentQueryId);
           onParametersEdit();

--- a/client/app/components/Parameters.less
+++ b/client/app/components/Parameters.less
@@ -3,7 +3,7 @@
 .parameter-block {
   display: inline-block;
   background: white;
-  padding: 0 12px 6px 0;
+  padding: 0 12px 17px 0;
   vertical-align: top;
   z-index: 1;
 
@@ -15,11 +15,30 @@
 
   .parameter-container.sortable-container & {
     margin: 4px 0 0 4px;
-    padding: 3px 6px 6px;
+    padding: 3px 6px 19px;
   }
 
   &.parameter-dragged {
     box-shadow:  0 4px 9px -3px rgba(102, 136, 153, 0.15);
+  }
+
+  .ant-form-item {
+    margin-bottom: 0 !important;
+  }
+
+  .ant-form-explain {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -20px;
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ant-form-item-control {
+    line-height: normal;
   }
 }
 

--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -75,6 +75,8 @@ RefreshIndicator.defaultProps = { refreshStartedAt: null };
 
 function VisualizationWidgetHeader({ widget, refreshStartedAt, parameters, onParametersUpdate }) {
   const canViewQuery = currentUser.hasPermission('view_query');
+  const queryResult = widget.getQueryResult();
+  const errorData = queryResult && queryResult.getErrorData();
 
   return (
     <>
@@ -90,8 +92,8 @@ function VisualizationWidgetHeader({ widget, refreshStartedAt, parameters, onPar
         </div>
       </div>
       {!isEmpty(parameters) && (
-        <div className="m-b-10">
-          <Parameters parameters={parameters} onValuesChange={onParametersUpdate} />
+        <div className="m-b-5">
+          <Parameters parameters={parameters} queryResultErrorData={errorData} onValuesChange={onParametersUpdate} />
         </div>
       )}
     </>

--- a/client/app/components/queries/visualization-embed.html
+++ b/client/app/components/queries/visualization-embed.html
@@ -13,7 +13,7 @@
 
   <div class="col-md-12 query__vis">
     <div class="p-t-15 p-b-10" ng-if="$ctrl.query.hasParameters() && !$ctrl.hideParametersUI">
-      <parameters parameters="$ctrl.query.getParametersDefs()" on-values-change="$ctrl.refreshQueryResults"></parameters>
+      <parameters parameters="$ctrl.query.getParametersDefs()" query-result-error-data="$ctrl.errorData" on-values-change="$ctrl.refreshQueryResults"></parameters>
     </div>
 
     <div ng-if="$ctrl.error">

--- a/client/app/components/queries/visualization-embed.js
+++ b/client/app/components/queries/visualization-embed.js
@@ -14,6 +14,7 @@ const VisualizationEmbed = {
     this.refreshQueryResults = () => {
       this.loading = true;
       this.error = null;
+      this.errorData = {};
       this.refreshStartedAt = moment();
       this.query
         .getQueryResultPromise()
@@ -24,6 +25,7 @@ const VisualizationEmbed = {
         .catch((error) => {
           this.loading = false;
           this.error = error.getError();
+          this.errorData = error.getErrorData();
         });
     };
 

--- a/client/app/pages/dashboards/dashboard.html
+++ b/client/app/pages/dashboards/dashboard.html
@@ -93,8 +93,8 @@
     </label>
   </div>
 
-  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0" data-test="DashboardParameters">
-    <parameters parameters="$ctrl.globalParameters" on-values-change="$ctrl.refreshDashboard"></parameters>
+  <div class="m-b-10 p-t-15 p-l-15 p-r-15 p-b-5 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0" data-test="DashboardParameters">
+    <parameters parameters="$ctrl.globalParameters" query-result-error-data="$ctrl.dashboard.getQueryResultsErrorData()" on-values-change="$ctrl.refreshDashboard"></parameters>
   </div>
 
   <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.filters | notEmpty">

--- a/client/app/pages/dashboards/public-dashboard-page.html
+++ b/client/app/pages/dashboards/public-dashboard-page.html
@@ -1,8 +1,8 @@
 <div class="container p-t-10 p-b-20" ng-if="$ctrl.dashboard">
   <page-header title="$ctrl.dashboard.name"></page-header>
 
-  <div class="m-b-10 p-15 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0">
-    <parameters parameters="$ctrl.globalParameters" on-values-change="$ctrl.refreshDashboard"></parameters>
+  <div class="m-b-10 p-t-15 p-l-15 p-r-15 p-b-5 bg-white tiled" ng-if="$ctrl.globalParameters.length > 0">
+    <parameters parameters="$ctrl.globalParameters" query-result-error-data="$ctrl.dashboard.getQueryResultsErrorData()" on-values-change="$ctrl.refreshDashboard"></parameters>
   </div>
 
   <div class="m-b-5">

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -200,7 +200,7 @@
             <div class="d-flex flex-column p-b-15 p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
               <div class="p-t-15 p-b-5" ng-if="query.hasParameters()">
                 <parameters parameters="query.getParametersDefs()" query-result-error-data="queryResult.getErrorData()" editable="sourceMode && canEdit" disable-url-update="query.isNew()"
-                  on-values-change="executeQuery" on-pending-values-change="applyParametersChanges" on-parameters-edit="onParametersUpdated"></parameters>
+                  on-values-change="executeQuery" on-pending-values-change="applyParametersChanges" on-parameters-edit="onParametersUpdated" unsaved-parameters="getUnsavedParameters()"></parameters>
               </div>
               <!-- Query Execution Status -->
 

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -199,7 +199,7 @@
           <section class="flex-fill p-relative t-body query-visualizations-wrapper">
             <div class="d-flex flex-column p-b-15 p-absolute static-position__mobile" style="left: 0; top: 0; right: 0; bottom: 0;">
               <div class="p-t-15 p-b-5" ng-if="query.hasParameters()">
-                <parameters parameters="query.getParametersDefs()" editable="sourceMode && canEdit" disable-url-update="query.isNew()"
+                <parameters parameters="query.getParametersDefs()" query-result-error-data="queryResult.getErrorData()" editable="sourceMode && canEdit" disable-url-update="query.isNew()"
                   on-values-change="executeQuery" on-pending-values-change="applyParametersChanges" on-parameters-edit="onParametersUpdated"></parameters>
               </div>
               <!-- Query Execution Status -->

--- a/client/app/pages/queries/source-view.js
+++ b/client/app/pages/queries/source-view.js
@@ -1,4 +1,4 @@
-import { map, debounce } from 'lodash';
+import { map, debounce, isEmpty, isEqual } from 'lodash';
 import template from './query.html';
 import EditParameterSettingsDialog from '@/components/EditParameterSettingsDialog';
 
@@ -109,6 +109,22 @@ function QuerySourceCtrl(
   $scope.$watch('query.query', (newQueryText) => {
     $scope.isDirty = newQueryText !== queryText;
   });
+
+  $scope.unsavedParameters = null;
+  $scope.getUnsavedParameters = () => {
+    if (!$scope.isDirty || !queryText) {
+      return null;
+    }
+    const unsavedParameters = $scope.query.$parameters.getUnsavedParameters(queryText);
+    if (isEmpty(unsavedParameters)) {
+      return null;
+    }
+    // avoiding Angular infdig (ANGULAR_REMOVE_ME)
+    if (!isEqual(unsavedParameters, $scope.unsavedParameters)) {
+      $scope.unsavedParameters = unsavedParameters;
+    }
+    return $scope.unsavedParameters;
+  };
 }
 
 export default function init(ngModule) {

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -249,6 +249,39 @@ function DashboardService($resource, $http, $location, currentUser) {
     });
   };
 
+  let currentQueryResultsErrorData; // swap for useMemo ANGULAR_REMOVE_ME
+  resource.prototype.getQueryResultsErrorData = function getQueryResultsErrorData() {
+    const dashboardErrors = _.map(this.widgets, (widget) => {
+      // get result
+      const result = widget.getQueryResult();
+      if (!result) {
+        return null;
+      }
+
+      // get error data
+      const errorData = result.getErrorData();
+      if (_.isEmpty(errorData)) {
+        return null;
+      }
+
+      // dashboard params only
+      const localParamNames = _.map(widget.getLocalParameters(), p => p.name);
+      const filtered = _.omit(errorData.parameters, localParamNames);
+
+      return filtered;
+    });
+
+    const merged = _.assign({}, ...dashboardErrors);
+    const errorData = _.isEmpty(merged) ? null : { parameters: merged };
+
+    // avoiding Angular infdig (ANGULAR_REMOVE_ME)
+    if (!_.isEqual(currentQueryResultsErrorData, errorData)) {
+      currentQueryResultsErrorData = errorData;
+    }
+
+    return currentQueryResultsErrorData;
+  };
+
   return resource;
 }
 

--- a/client/app/services/parameters/NumberParameter.js
+++ b/client/app/services/parameters/NumberParameter.js
@@ -1,4 +1,4 @@
-import { toNumber, isNull } from 'lodash';
+import { toNumber, trim } from 'lodash';
 import { Parameter } from '.';
 
 class NumberParameter extends Parameter {
@@ -9,11 +9,11 @@ class NumberParameter extends Parameter {
 
   // eslint-disable-next-line class-methods-use-this
   normalizeValue(value) {
-    if (isNull(value)) {
+    if (!trim(value)) {
       return null;
     }
     const normalizedValue = toNumber(value);
-    return !isNaN(normalizedValue) ? normalizedValue : null;
+    return !isNaN(normalizedValue) ? normalizedValue : value;
   }
 }
 

--- a/client/app/services/parameters/TextParameter.js
+++ b/client/app/services/parameters/TextParameter.js
@@ -1,4 +1,4 @@
-import { toString, isEmpty } from 'lodash';
+import { toString, isEmpty, trim } from 'lodash';
 import { Parameter } from '.';
 
 class TextParameter extends Parameter {
@@ -14,6 +14,13 @@ class TextParameter extends Parameter {
       return null;
     }
     return normalizedValue;
+  }
+
+  getExecutionValue() {
+    if (!trim(this.value)) {
+      return null;
+    }
+    return this.value;
   }
 }
 

--- a/client/app/services/parameters/tests/NumberParameter.test.js
+++ b/client/app/services/parameters/tests/NumberParameter.test.js
@@ -17,10 +17,5 @@ describe('NumberParameter', () => {
       const normalizedValue = param.normalizeValue(42);
       expect(normalizedValue).toBe(42);
     });
-
-    test('returns null when not possible to convert to number', () => {
-      const normalizedValue = param.normalizeValue('notanumber');
-      expect(normalizedValue).toBeNull();
-    });
   });
 });

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -132,7 +132,7 @@ function QueryResultService($resource, $timeout, $q, QueryResultError, Auth) {
         this.status = 'processing';
       } else if (this.job.status === 4) {
         this.status = statuses[this.job.status];
-        this.deferred.reject(new QueryResultError(this.job.error));
+        this.deferred.reject(new QueryResultError(this.job.error, this.job.error_data));
       } else {
         this.status = undefined;
       }
@@ -164,6 +164,10 @@ function QueryResultService($resource, $timeout, $q, QueryResultError, Auth) {
       }
 
       return this.job.error;
+    }
+
+    getErrorData() {
+      return this.job.error_data || undefined;
     }
 
     getLog() {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -140,8 +140,9 @@ class Parameters {
 
 function QueryResultErrorFactory($q) {
   class QueryResultError {
-    constructor(errorMessage) {
+    constructor(errorMessage, errorData = {}) {
       this.errorMessage = errorMessage;
+      this.errorData = errorData;
       this.updatedAt = moment.utc();
     }
 
@@ -151,6 +152,10 @@ function QueryResultErrorFactory($q) {
 
     getError() {
       return this.errorMessage;
+    }
+
+    getErrorData() {
+      return this.errorData || undefined;
     }
 
     toPromise() {

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -1,4 +1,4 @@
-import { createQuery } from '../../support/redash-api';
+import { createQuery, createDashboard, addWidget } from '../../support/redash-api';
 
 const { get } = Cypress._;
 
@@ -612,6 +612,81 @@ describe('Parameter', () => {
       cy.visit(`/queries/${this.query.id}`);
       expectValueValidationError();
       cy.percySnapshot('Validation error in query page');
+    });
+
+    it('shows unsaved feedback in query page', function () {
+      cy.visit(`/queries/${this.query.id}/source`);
+
+      cy.getByTestId('QueryEditor')
+        .get('.ace_text-input')
+        .type(' {{ newparam }}', { force: true, parseSpecialCharSequences: false });
+
+      cy.getByTestId('ParameterName-newparam')
+        .find('.ant-form-item-control')
+        .should('have.class', 'has-warning')
+        .find('.ant-form-explain')
+        .as('Feedback');
+
+      cy.get('@Feedback')
+        .should('contain.text', 'Unsaved')
+        .should('not.have.class', 'show-help-appear'); // assures ant animation ended for screenshot
+
+      cy.percySnapshot('Unsaved feedback in query page');
+
+      cy.getByTestId('SaveButton').click();
+      cy.get('@Feedback').should('not.exist');
+    });
+
+    it('shows validation error in visualization embed', function () {
+      cy.visit(`/embed/query/${this.query.id}/visualization/${this.vizId}?api_key=${this.query.api_key}`);
+      expectValueValidationError();
+      cy.percySnapshot('Validation error in visualization embed');
+    });
+
+    it('shows validation error in widget-level parameter', function () {
+      createDashboard('Foo')
+        .then(({ slug, id }) => {
+          this.dashboardUrl = `/dashboard/${slug}`;
+          return addWidget(id, this.vizId, {
+            parameterMappings: {
+              'test-parameter': {
+                type: 'widget-level',
+                title: '',
+                name: 'test-parameter',
+                mapTo: 'test-parameter',
+                value: null,
+              },
+            },
+          });
+        })
+        .then(() => {
+          cy.visit(this.dashboardUrl);
+        });
+      expectValueValidationError();
+      cy.percySnapshot('Validation error in widget-level parameter');
+    });
+
+    it('shows validation error in dashboard-level parameter', function () {
+      createDashboard('Foo')
+        .then(({ slug, id }) => {
+          this.dashboardUrl = `/dashboard/${slug}`;
+          return addWidget(id, this.vizId, {
+            parameterMappings: {
+              'test-parameter': {
+                type: 'dashboard-level',
+                title: '',
+                name: 'test-parameter',
+                mapTo: 'test-parameter',
+                value: null,
+              },
+            },
+          });
+        })
+        .then(() => {
+          cy.visit(this.dashboardUrl);
+        });
+      expectValueValidationError();
+      cy.percySnapshot('Validation error in dashboard-level parameter');
     });
   });
 

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -17,6 +17,14 @@ describe('Parameter', () => {
       });
   };
 
+  const expectValueValidationError = (edit, expectedInvalidString = 'Required parameter') => {
+    cy.getByTestId('ParameterName-test-parameter')
+      .find('.ant-form-item-control')
+      .should('have.class', 'has-error')
+      .find('.ant-form-explain')
+      .should('contain.text', expectedInvalidString);
+  };
+
   beforeEach(() => {
     cy.login();
   });
@@ -28,7 +36,7 @@ describe('Parameter', () => {
         query: "SELECT '{{test-parameter}}' AS parameter",
         options: {
           parameters: [
-            { name: 'test-parameter', title: 'Test Parameter', type: 'text' },
+            { name: 'test-parameter', title: 'Test Parameter', type: 'text', value: 'text' },
           ],
         },
       };
@@ -56,6 +64,16 @@ describe('Parameter', () => {
           .type('Redash');
       });
     });
+
+    it('shows validation error when value is empty', () => {
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('input')
+        .clear();
+
+      cy.getByTestId('ParameterApplyButton').click();
+
+      expectValueValidationError();
+    });
   });
 
   describe('Number Parameter', () => {
@@ -65,7 +83,7 @@ describe('Parameter', () => {
         query: "SELECT '{{test-parameter}}' AS parameter",
         options: {
           parameters: [
-            { name: 'test-parameter', title: 'Test Parameter', type: 'number' },
+            { name: 'test-parameter', title: 'Test Parameter', type: 'number', value: 1 },
           ],
         },
       };
@@ -102,6 +120,16 @@ describe('Parameter', () => {
           .find('input')
           .type('{selectall}42');
       });
+    });
+
+    it('shows validation error when value is empty', () => {
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('input')
+        .clear();
+
+      cy.getByTestId('ParameterApplyButton').click();
+
+      expectValueValidationError();
     });
   });
 
@@ -177,6 +205,36 @@ describe('Parameter', () => {
         cy.contains('li.ant-select-dropdown-menu-item', 'value2')
           .click();
       });
+    });
+
+    it('shows validation error when empty', () => {
+      cy.getByTestId('ParameterSettings-test-parameter').click();
+      cy.getByTestId('EnumTextArea').clear();
+      cy.clickThrough(`
+        SaveParameterSettings
+        ExecuteButton
+      `);
+
+      expectValueValidationError();
+    });
+
+    it('shows validation error when multi-selection is empty', () => {
+      cy.clickThrough(`
+        ParameterSettings-test-parameter
+        AllowMultipleValuesCheckbox
+        QuotationSelect
+        DoubleQuotationMarkOption
+        SaveParameterSettings
+      `);
+
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('.ant-select-remove-icon')
+        .click();
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      expectValueValidationError();
     });
   });
 
@@ -306,6 +364,22 @@ describe('Parameter', () => {
     it('sets dirty state when edited', () => {
       expectDirtyStateChange(() => selectCalendarDate('15'));
     });
+
+    it('shows validation error when value is empty', () => {
+      selectCalendarDate('15');
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('.ant-calendar-picker-clear')
+        .click({ force: true });
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      expectValueValidationError();
+    });
   });
 
   describe('Date and Time Parameter', () => {
@@ -396,6 +470,32 @@ describe('Parameter', () => {
           .click();
       });
     });
+
+    it('shows validation error when value is empty', () => {
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('input')
+        .as('Input')
+        .click({ force: true });
+
+      cy.get('.ant-calendar-date-panel')
+        .contains('.ant-calendar-date', '15')
+        .click();
+
+      cy.get('.ant-calendar-ok-btn')
+        .click();
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('.ant-calendar-picker-clear')
+        .click({ force: true });
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      expectValueValidationError();
+    });
   });
 
   describe('Date Range Parameter', () => {
@@ -468,6 +568,22 @@ describe('Parameter', () => {
 
     it('sets dirty state when edited', () => {
       expectDirtyStateChange(() => selectCalendarDateRange('15', '20'));
+    });
+
+    it('shows validation error when value is empty', () => {
+      selectCalendarDateRange('15', '20');
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      cy.getByTestId('ParameterName-test-parameter')
+        .find('.ant-calendar-picker-clear')
+        .click({ force: true });
+
+      cy.getByTestId('ParameterApplyButton')
+        .click();
+
+      expectValueValidationError();
     });
   });
 

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -1,5 +1,7 @@
 import { createQuery } from '../../support/redash-api';
 
+const { get } = Cypress._;
+
 describe('Parameter', () => {
   const expectDirtyStateChange = (edit) => {
     cy.getByTestId('ParameterName-test-parameter')
@@ -584,6 +586,31 @@ describe('Parameter', () => {
         .click();
 
       expectValueValidationError();
+    });
+  });
+
+  describe('Inline feedback', () => {
+    beforeEach(function () {
+      const queryData = {
+        query: 'SELECT {{ test-parameter }}',
+        options: {
+          parameters: [
+            { name: 'test-parameter', title: 'Param', type: 'number', value: null },
+          ],
+        },
+      };
+
+      createQuery(queryData, false)
+        .then((query) => {
+          this.query = query;
+          this.vizId = get(query, 'visualizations.0.id');
+        });
+    });
+
+    it('shows validation error in query page', function () {
+      cy.visit(`/queries/${this.query.id}`);
+      expectValueValidationError();
+      cy.percySnapshot('Validation error in query page');
     });
   });
 

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -24,7 +24,8 @@ describe('Parameter', () => {
       .find('.ant-form-item-control')
       .should('have.class', 'has-error')
       .find('.ant-form-explain')
-      .should('contain.text', expectedInvalidString);
+      .should('contain.text', expectedInvalidString)
+      .should('not.have.class', 'show-help-enter'); // assures ant animation ended for screenshot
   };
 
   beforeEach(() => {


### PR DESCRIPTION
- [x] Feature

## Description
Now that #4312 brings query result `errorData`, we can show them inline in context.
**This PR is for the query page only**
<img width="522" alt="Screen Shot 2019-10-30 at 19 44 58" src="https://user-images.githubusercontent.com/486954/67884021-c6ed3a00-fb4d-11e9-97c3-29ebedbed949.png">

Notice, since the client is oblivious to the error's meaning (it's evaluated in the server), it can't be responsible for it's hiding. For instance, if a parameter was left empty, it displays "Required parameter". Once the user fills the field in, the client doesn't know that the error has been fulfilled - so it can't hide the error.
This causes a jarring user experience. As a user you expect the error indication to disappear immediately when fixed. To mitigate this I implemented a "touched" flag on each parameter which removes the red indication but keeps the error text visible, until re-evaluated by the server. This works well.
Any change to parameter - be it value or settings - toggles on the "touched" flag. The flag resets when the error data from the server has changed.

To accommodate the error messages, more bottom spacing has been given to the parameters.

