### PR TITLE
Exposing setting for overriding template directory

### DIFF
--- a/redash/app.py
+++ b/redash/app.py
@@ -10,7 +10,7 @@ class Redash(Flask):
     def __init__(self, *args, **kwargs):
         kwargs.update(
             {
-                "template_folder": settings.STATIC_ASSETS_PATH,
+                "template_folder": settings.FLASK_TEMPLATE_PATH,
                 "static_folder": settings.STATIC_ASSETS_PATH,
                 "static_url_path": "/static",
             }

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -229,7 +229,9 @@ LDAP_SEARCH_DN = os.environ.get(
 STATIC_ASSETS_PATH = fix_assets_path(
     os.environ.get("REDASH_STATIC_ASSETS_PATH", "../client/dist/")
 )
-
+FLASK_TEMPLATE_PATH = fix_assets_path(
+    os.environ.get("REDASH_FLASK_TEMPLATE_PATH", STATIC_ASSETS_PATH)
+)
 # Time limit (in seconds) for scheduled queries. Set this to -1 to execute without a time limit.
 SCHEDULED_QUERY_TIME_LIMIT = int(
     os.environ.get("REDASH_SCHEDULED_QUERY_TIME_LIMIT", -1)


### PR DESCRIPTION
#4189  What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When using some of the customized login flows such as `REMOTE_USER` the deployed site breaks due to not finding template files. This change updated the app default to use the existing Flask templates directory rather than the compiled static assets directory which only contains an index.html file.