### PR TITLE
Parameter feedback - #6 Better value normalization

### DIFF
--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -5,7 +5,7 @@ import Input from 'antd/lib/input';
 import InputNumber from 'antd/lib/input-number';
 import DateParameter from '@/components/dynamic-parameters/DateParameter';
 import DateRangeParameter from '@/components/dynamic-parameters/DateRangeParameter';
-import { isEqual } from 'lodash';
+import { isEqual, trim } from 'lodash';
 import { QueryBasedParameterInput } from './QueryBasedParameterInput';
 
 import './ParameterValueInput.less';
@@ -59,7 +59,7 @@ class ParameterValueInput extends React.Component {
   }
 
   onSelect = (value) => {
-    const isDirty = !isEqual(value, this.props.value);
+    const isDirty = !isEqual(trim(value), trim(this.props.value));
     this.setState({ value, isDirty });
     this.props.onSelect(value, isDirty);
   }
@@ -140,13 +140,11 @@ class ParameterValueInput extends React.Component {
     const { className } = this.props;
     const { value } = this.state;
 
-    const normalize = val => (isNaN(val) ? undefined : val);
-
     return (
       <InputNumber
         className={className}
-        value={normalize(value)}
-        onChange={val => this.onSelect(normalize(val))}
+        value={value}
+        onChange={val => this.onSelect(val)}
       />
     );
   }

--- a/client/app/services/parameters/NumberParameter.js
+++ b/client/app/services/parameters/NumberParameter.js
@@ -1,4 +1,4 @@
-import { toNumber, isNull } from 'lodash';
+import { toNumber, trim } from 'lodash';
 import { Parameter } from '.';
 
 class NumberParameter extends Parameter {
@@ -9,11 +9,11 @@ class NumberParameter extends Parameter {
 
   // eslint-disable-next-line class-methods-use-this
   normalizeValue(value) {
-    if (isNull(value)) {
+    if (!trim(value)) {
       return null;
     }
     const normalizedValue = toNumber(value);
-    return !isNaN(normalizedValue) ? normalizedValue : null;
+    return !isNaN(normalizedValue) ? normalizedValue : value;
   }
 }
 

--- a/client/app/services/parameters/TextParameter.js
+++ b/client/app/services/parameters/TextParameter.js
@@ -1,4 +1,4 @@
-import { toString, isEmpty } from 'lodash';
+import { toString, isEmpty, trim } from 'lodash';
 import { Parameter } from '.';
 
 class TextParameter extends Parameter {
@@ -14,6 +14,13 @@ class TextParameter extends Parameter {
       return null;
     }
     return normalizedValue;
+  }
+
+  getExecutionValue() {
+    if (!trim(this.value)) {
+      return null;
+    }
+    return this.value;
   }
 }
 

--- a/client/app/services/parameters/tests/NumberParameter.test.js
+++ b/client/app/services/parameters/tests/NumberParameter.test.js
@@ -17,10 +17,5 @@ describe('NumberParameter', () => {
       const normalizedValue = param.normalizeValue(42);
       expect(normalizedValue).toBe(42);
     });
-
-    test('returns null when not possible to convert to number', () => {
-      const normalizedValue = param.normalizeValue('notanumber');
-      expect(normalizedValue).toBeNull();
-    });
   });
 });


### PR DESCRIPTION
- [x] Bug Fix

## Description
Text and Number parameters need some tweaking in terms of value normalization.

### Text parameter
1. An empty text field value is converted to `null` but multiple spaces do not and should. Now trimming.
2. Adding spaces to value triggered `dirty` indication. Now it won't.

### Number parameter
1. Empty value sent `0` to server. Now sending `null` instead, displaying "Required parameter" error.
2. Typing non-number values would disappear on blur/apply. Now sending value as is, displaying "Invalid value" error.

Screenshots have been added inline in code.