### PR TITLE
Adjust RQ job priorities

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      QUEUES: "periodic default schemas"
   celery-worker:
     build: .
     command: dev_celery_worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
-      QUEUES: "default periodic schemas"
+      QUEUES: "periodic default schemas"
   celery-worker:
     build: .
     command: dev_celery_worker

--- a/redash/cli/rq.py
+++ b/redash/cli/rq.py
@@ -29,7 +29,7 @@ def worker(queues):
     configure_mappers()
 
     if not queues:
-        queues = ['periodic', 'default', 'schemas']
+        queues = ['periodic', 'emails', 'default', 'schemas']
 
     with Connection(rq_redis_connection):
         w = Worker(queues)

--- a/redash/cli/rq.py
+++ b/redash/cli/rq.py
@@ -22,14 +22,15 @@ def scheduler():
 
 @manager.command()
 @argument('queues', nargs=-1)
-def worker(queues='default'):
+def worker(queues):
     # Configure any SQLAlchemy mappers loaded until now so that the mapping configuration 
     # will already be available to the forked work horses and they won't need 
     # to spend valuable time re-doing that on every fork.
     configure_mappers()
 
     if not queues:
-        queues = ('default',)
+        queues = ['periodic', 'default', 'schemas']
+
     with Connection(rq_redis_connection):
         w = Worker(queues)
         w.work()

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -45,7 +45,7 @@ def subscribe(form):
     requests.post('https://beacon.redash.io/subscribe', json=data)
 
 
-@job('default')
+@job('emails')
 def send_mail(to, subject, html, text):
     try:
         message = Message(recipients=to,


### PR DESCRIPTION
Currently, all RQ jobs are distributed between 3 queues:

1. `periodic` - handles periodic jobs stated in `schedule.py`.
2. `schemas` - handles `refresh_schemas` jobs.
3. `default` - for all other jobs.

A couple of issues that this causes:

1. Since different types of jobs go to `default`, it's hard to get an understanding of the current distribution of jobs. A solution to this might be to split `default` into job-specific queues, then we could just observe the queue size.
2. Within `periodic`, the `refresh_queries` job needs to have the highest priority.
3. Within `default`, the `send_email` jobs needs to have the highest priority.