### PR TITLE
Admin status page's current tab does not preserve

### DIFF
--- a/client/app/components/admin/RQStatus.jsx
+++ b/client/app/components/admin/RQStatus.jsx
@@ -49,7 +49,7 @@ export function WorkersTable({ loading, items }) {
       dataSource={items}
       pagination={{
         defaultPageSize: 25,
-        pageSizeOptions: [10, 25, 50],
+        pageSizeOptions: ['10', '25', '50'],
         showSizeChanger: true,
       }}
     />

--- a/client/app/pages/admin/Jobs.jsx
+++ b/client/app/pages/admin/Jobs.jsx
@@ -16,6 +16,7 @@ import moment from 'moment';
 
 class Jobs extends React.Component {
   state = {
+    activeTab: location.hash.replace('#', '') || null,
     isLoading: true,
     error: null,
 
@@ -67,7 +68,12 @@ class Jobs extends React.Component {
   };
 
   render() {
-    const { isLoading, error, queueCounters, startedJobs, overallCounters, workers } = this.state;
+    const { isLoading, error, queueCounters, startedJobs, overallCounters, workers, activeTab } = this.state;
+
+    const changeTab = (newTab) => {
+      location.replace(`${location.pathname}#${newTab}`);
+      this.setState({ activeTab: newTab });
+    };
 
     return (
       <Layout activeTab="jobs">
@@ -87,7 +93,7 @@ class Jobs extends React.Component {
                 </Grid.Col>
               </Grid.Row>
 
-              <Tabs defaultActiveKey="queues" animated={false}>
+              <Tabs activeKey={activeTab || 'queues'} onTabClick={changeTab} animated={false}>
                 <Tabs.TabPane key="queues" tab="Queues">
                   <QueuesTable loading={isLoading} items={queueCounters} />
                 </Tabs.TabPane>


### PR DESCRIPTION
When viewing the Celery/RQ admin status pages (at `/admin/queries/jobs` and `/admin/queries/tasks`), there are several tabs (for Queues, Workers, Other Tasks) that are not part of the URL, so whenever you visit the page, it defaults to the first tab.