### PR TITLE
Auto-refresh admin status page

### DIFF
--- a/client/app/pages/admin/Jobs.jsx
+++ b/client/app/pages/admin/Jobs.jsx
@@ -25,19 +25,28 @@ class Jobs extends React.Component {
     workers: [],
   };
 
+  _refreshTimer = null;
+
   componentDidMount() {
     recordEvent('view', 'page', 'admin/rq_status');
-    $http
-      .get('/api/admin/queries/rq_status')
-      .then(({ data }) => this.processQueues(data))
-      .catch(error => this.handleError(error));
+    this.refresh();
   }
 
   componentWillUnmount() {
     // Ignore data after component unmounted
+    clearTimeout(this._refreshTimer);
     this.processQueues = () => {};
     this.handleError = () => {};
   }
+
+  refresh = () => {
+    $http
+      .get('/api/admin/queries/rq_status')
+      .then(({ data }) => this.processQueues(data))
+      .catch(error => this.handleError(error));
+
+    this._refreshTimer = setTimeout(this.refresh, 60 * 1000);
+  };
 
   processQueues = ({ queues, workers }) => {
     const queueCounters = values(queues).map(({ started, ...rest }) => ({


### PR DESCRIPTION
The admin status page (available at `/admin/queries/jobs`) is often used when monitoring the state of the system. It will be easier to keep track if it auto-refreshes.