### PR TITLE
Fix the DB migration so that the correct key is used for encrypting DS credentials

### DIFF
--- a/migrations/versions/98af61feea92_add_encrypted_options_to_data_sources.py
+++ b/migrations/versions/98af61feea92_add_encrypted_options_to_data_sources.py
@@ -29,7 +29,7 @@ def upgrade():
     data_sources = table(
         'data_sources',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('encrypted_options', ConfigurationContainer.as_mutable(EncryptedConfiguration(sa.Text, settings.SECRET_KEY, FernetEngine))),
+        sa.Column('encrypted_options', ConfigurationContainer.as_mutable(EncryptedConfiguration(sa.Text, settings.DATASOURCE_SECRET_KEY, FernetEngine))),
         sa.Column('options', ConfigurationContainer.as_mutable(Configuration)))
 
     conn = op.get_bind()


### PR DESCRIPTION
Without this upgrades from at least v5 (and earlier) won't work.

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

For background, see: 

https://discuss.redash.io/t/database-migration-using-incorrect-key-for-encryption/4833/4

