### PR TITLE
Use column types provided by server rather than trying to derive them from the values

### DIFF
--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -257,7 +257,7 @@ describe('Parameter', () => {
     beforeEach(() => {
       const queryData = {
         name: 'Date Parameter',
-        query: "SELECT '{{test-parameter}}' AS parameter",
+        query: "SELECT DATE('{{test-parameter}}') AS parameter",
         options: {
           parameters: [
             { name: 'test-parameter', title: 'Test Parameter', type: 'date', value: null },

--- a/client/cypress/integration/visualizations/table/.mocks/all-cell-types.js
+++ b/client/cypress/integration/visualizations/table/.mocks/all-cell-types.js
@@ -5,7 +5,7 @@ export const query = `
     'hello, <b>world</b>' AS html,
     'hello, <b>world</b>' AS html2,
     'Link: http://example.com' AS html3,
-    '1995-09-03T07:45' AS "date",
+    TIMESTAMP '1995-09-03T07:45' AS "date",
     true AS bool,
     '[{"a": 3.14, "b": "test", "c": [], "d": {}}, false, [null, 123], "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."]' AS json,
     'ukr' AS img,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Bug Fix

## Description
For background see:

https://discuss.redash.io/t/hex-for-binary-data/4900/11

Be warned, first time I've touched Javascript!

Start using the column types in the JSON document rather than trying to derive them from the values. Now a MySQL query like SELECT "2019-01-01", date("2019-01-01"); will return a string and a date.

I don't think the 'float' thing was ever actually being set in the old logic; and I can't see what our require the JSON.stringify() logic.