### PR TITLE
Fix duplicate column name bug

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -105,7 +105,7 @@ class BaseQueryRunner(object):
 
         for col in columns:
             column_name = col[0]
-            if column_name in column_names:
+            while column_name in column_names:
                 column_name = "{}{}".format(column_name, duplicates_counter)
                 duplicates_counter += 1
 


### PR DESCRIPTION
- [X] Bug Fix

## Description

The existing code to ensure that we don't have duplicate column names has a bug if it picks a new column name that's the same as an existing column. This can be achieved with:

`select 1 a, 2 a1, 3 a;`

Changing `if` to `while` fixes this.
