### PR TITLE
Fix unicode encode error by column duplicate in presto datasource

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -106,7 +106,7 @@ class BaseQueryRunner(object):
         for col in columns:
             column_name = col[0]
             if column_name in column_names:
-                column_name = "{}{}".format(column_name, duplicates_counter)
+                column_name = u"{}{}".format(column_name, duplicates_counter)
                 duplicates_counter += 1
 
             column_names.append(column_name)


### PR DESCRIPTION
ex.
select '1' as "测试abc", '2' as "测试abc", '3' as "test_abc", '4' as "test_abc"
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)