### PR TITLE
(WIP) feat: Added Australia to Choropleth visualisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+./client/app/visualizations/choropleth/maps/australia.postcodes.geo.json filter=lfs diff=lfs merge=lfs -text

--- a/client/app/visualizations/choropleth/Editor/FormatSettings.jsx
+++ b/client/app/visualizations/choropleth/Editor/FormatSettings.jsx
@@ -37,6 +37,12 @@ function TemplateFormatHint({ mapType }) { // eslint-disable-line react/prop-typ
               <div><code>{'{{ @@iso_3166_2 }}'}</code> five-letter ISO subdivision code (JP-xx);</div>
             </React.Fragment>
           )}
+          {mapType === 'postcode_australia' && (
+            <React.Fragment>
+              <div><code>{'{{ @@name }}'}</code> Postcode or Suburb name in English;</div>
+              <div><code>{'{{ @@postcode }}'}</code> four digit post code (xxxx);</div>
+            </React.Fragment>
+          )}
         </React.Fragment>
       )}
     >

--- a/client/app/visualizations/choropleth/Editor/GeneralSettings.jsx
+++ b/client/app/visualizations/choropleth/Editor/GeneralSettings.jsx
@@ -22,6 +22,11 @@ export default function GeneralSettings({ options, data, onOptionsChange }) {
           name_local: 'Name (local)',
           iso_3166_2: 'ISO-3166-2',
         };
+      case 'postcode_australia':
+        return {
+          name: 'Name',
+          postcode: 'Postcode',
+        };
       default:
         return {};
     }
@@ -49,6 +54,7 @@ export default function GeneralSettings({ options, data, onOptionsChange }) {
         >
           <Select.Option key="countries" data-test="Choropleth.Editor.MapType.Countries">Countries</Select.Option>
           <Select.Option key="subdiv_japan" data-test="Choropleth.Editor.MapType.Japan">Japan/Prefectures</Select.Option>
+          <Select.Option key="postcode_australia" data-test="Choropleth.Editor.MapType.Australia">Australia/Postcodes</Select.Option>
         </Select>
       </div>
 

--- a/client/app/visualizations/choropleth/Editor/utils.js
+++ b/client/app/visualizations/choropleth/Editor/utils.js
@@ -11,8 +11,11 @@ export function inferCountryCodeType(mapType, data, countryCodeField) {
     },
     subdiv_japan: {
       name: /^[a-z]+$/i,
-      name_local: /^[\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]+$/i,
       iso_3166_2: /^JP-[0-9]{2}$/i,
+    },
+    postcode_australia: {
+      name: /^[a-z]+$/i,
+      postcode: /^[0-9]{4}$/i,
     },
   };
 

--- a/client/app/visualizations/choropleth/Renderer/index.jsx
+++ b/client/app/visualizations/choropleth/Renderer/index.jsx
@@ -10,11 +10,13 @@ import './renderer.less';
 
 import countriesDataUrl from '../maps/countries.geo.json';
 import subdivJapanDataUrl from '../maps/japan.prefectures.geo.json';
+import postcodesAustraliaDataUrl from '../maps/australia.postcodes.geo.json';
 
 function getDataUrl(type) {
   switch (type) {
     case 'countries': return countriesDataUrl;
     case 'subdiv_japan': return subdivJapanDataUrl;
+    case 'postcode_australia': return postcodesAustraliaDataUrl;
     default: return null;
   }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Adding the Australian postcode map for Choropleth visualisation options

## Related Tickets & Documents
related issue, discusses the need for making Choropleth more customisable: https://github.com/getredash/redash/issues/2317
and this discussion talks about the same: https://discuss.redash.io/t/choropleth-map-per-regions/4437/3
While this is a good feature for future releases, I wanted to add Australian map, just so we can use this in our redash instance till the feature for custom GeoJson is available.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

WIP