### PR TITLE
Remove builtins invalid in Python 3 from Python runner

### DIFF
--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -39,10 +39,10 @@ class Python(BaseQueryRunner):
     should_annotate_query = False
 
     safe_builtins = (
-        'sorted', 'reversed', 'map', 'reduce', 'any', 'all',
+        'sorted', 'reversed', 'map', 'any', 'all',
         'slice', 'filter', 'len', 'next', 'enumerate',
-        'sum', 'abs', 'min', 'max', 'round', 'cmp', 'divmod',
-        'str', 'unicode', 'int', 'float', 'complex',
+        'sum', 'abs', 'min', 'max', 'round', 'divmod',
+        'str', 'int', 'float', 'complex',
         'tuple', 'set', 'list', 'dict', 'bool',
     )
 
@@ -261,7 +261,7 @@ class Python(BaseQueryRunner):
             #       One option is to use ETA with Celery + timeouts on workers
             #       And replacement of worker process every X requests handled.
 
-            exec((code), restricted_globals, self._script_locals)
+            exec(code, restricted_globals, self._script_locals)
 
             result = self._script_locals['result']
             result['log'] = self._custom_print.lines


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
A few builtins were available in Python 2.7 but not anymore
in Python 3, making the runner fail to start.

## Related Tickets & Documents
#4181