### PR TITLE
Avoid purging jobs which have already been deleted

### DIFF
--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -71,7 +71,7 @@ def purge_failed_jobs():
         for queue in Queue.all():
             failed_job_ids = FailedJobRegistry(queue=queue).get_job_ids()
             failed_jobs = Job.fetch_many(failed_job_ids, rq_redis_connection)
-            stale_jobs = [job for job in failed_jobs if (datetime.utcnow() - job.ended_at).seconds > settings.JOB_DEFAULT_FAILURE_TTL]
+            stale_jobs = [job for job in failed_jobs if job and (datetime.utcnow() - job.ended_at).seconds > settings.JOB_DEFAULT_FAILURE_TTL]
 
             for job in stale_jobs:
                 job.delete()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
[`Job.fetch_many` will return `None`](https://github.com/rq/rq/blob/v1.1.0/rq/job.py#L306) for jobs that have already been deleted elsewhere, so we shouldn't try to purge them (accessing `.ended_at` on `None` will cause the purge job to fail).