### PR TITLE
RQ: simplify logging of jobs

### DIFF
--- a/redash/cli/rq.py
+++ b/redash/cli/rq.py
@@ -33,7 +33,7 @@ def worker(queues):
         queues = ['periodic', 'emails', 'default', 'schemas']
 
     with Connection(rq_redis_connection):
-        w = Worker(queues)
+        w = Worker(queues, log_job_description=False)
         w.work()
 
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -215,7 +215,7 @@ CELERYD_WORKER_TASK_LOG_FORMAT = os.environ.get(
                     'task_id=%(task_id)s %(message)s')))
 RQ_WORKER_JOB_LOG_FORMAT = os.environ.get("REDASH_RQ_WORKER_JOB_LOG_FORMAT",
                                           (LOG_PREFIX + '[%(asctime)s][PID:%(process)d][%(levelname)s][%(name)s] '
-                                           'job.description=%(job_description)s '
+                                           'job.func_name=%(job_func_name)s '
                                            'job.id=%(job_id)s %(message)s'))
 
 # Mail settings:

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -25,7 +25,7 @@ class CurrentJobFilter(logging.Filter):
         current_job = get_current_job()
 
         record.job_id = current_job.id if current_job else ''
-        record.job_description = current_job.description if current_job else ''
+        record.job_func_name = current_job.func_name if current_job else ''
 
         return True
 


### PR DESCRIPTION
RQ logs the arguments the task was called with. This creates too verbose logs and might leak information where it not supposed to go (specially in the case of `execute_query`).

We should switch it log only the job name.