### PR TITLE
Fix dragged parameter wrapping in some cases

### DIFF
--- a/client/app/components/Parameters.less
+++ b/client/app/components/Parameters.less
@@ -20,6 +20,7 @@
 
   &.parameter-dragged {
     box-shadow:  0 4px 9px -3px rgba(102, 136, 153, 0.15);
+    width: auto !important;
   }
 }
 

--- a/client/app/components/Parameters.less
+++ b/client/app/components/Parameters.less
@@ -6,6 +6,7 @@
   padding: 0 12px 6px 0;
   vertical-align: top;
   z-index: 1;
+  white-space: nowrap;
 
   .drag-handle {
     padding: 0 5px;
@@ -20,7 +21,6 @@
 
   &.parameter-dragged {
     box-shadow:  0 4px 9px -3px rgba(102, 136, 153, 0.15);
-    width: auto !important;
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
While checking the Preview I noticed this (avail [here](https://redash-preview.netlify.com/queries/264/source?p_dropdown=1)):

![parameters-dragging-issue](https://user-images.githubusercontent.com/3356951/69908559-16cc5480-13cb-11ea-9709-34495e695959.gif)

The `width: auto` was removed in #4199 and it handles this, so I added it back (LMK if you think it deserves a comment on css)

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
After:
![parameters-dragging-fixed](https://user-images.githubusercontent.com/3356951/69908709-a70b9900-13cd-11ea-9a5c-9a59e063e8fc.gif)
