### PR TITLE
Cypress: Make sure params are saved before reload

### DIFF
--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -605,8 +605,13 @@ describe('Parameter', () => {
     };
 
     it('is possible to rearrange parameters', function () {
+      cy.server();
+      cy.route('POST', 'api/queries/*').as('QuerySave');
+
       dragParam('param1', this.paramWidth, 1);
+      cy.wait('@QuerySave');
       dragParam('param4', -this.paramWidth, 1);
+      cy.wait('@QuerySave');
 
       cy.reload();
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
This makes sure Parameters were saved before reloading the page, to avoid flakyness in the Parameters spec.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--
