### PR TITLE
Support download as TSV File

### DIFF
--- a/client/app/components/EditVisualizationButton/QueryControlDropdown.jsx
+++ b/client/app/components/EditVisualizationButton/QueryControlDropdown.jsx
@@ -27,12 +27,24 @@ export function QueryControlDropdown(props) {
       )}
       <Menu.Item>
         <QueryResultsLink
+          fileType="csv"
           disabled={props.queryExecuting || !props.queryResult.getData || !props.queryResult.getData()}
           query={props.query}
           queryResult={props.queryResult}
           embed={props.embed}
           apiKey={props.apiKey}>
           <Icon type="file" /> Download as CSV File
+        </QueryResultsLink>
+      </Menu.Item>
+      <Menu.Item>
+        <QueryResultsLink
+          fileType="tsv"
+          disabled={props.queryExecuting || !props.queryResult.getData || !props.queryResult.getData()}
+          query={props.query}
+          queryResult={props.queryResult}
+          embed={props.embed}
+          apiKey={props.apiKey}>
+          <Icon type="file" /> Download as TSV File
         </QueryResultsLink>
       </Menu.Item>
       <Menu.Item>

--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -37,6 +37,15 @@ function visualizationWidgetMenuOptions({ widget, canEditDashboard, onParameters
         "Download as CSV File"
       )}
     </Menu.Item>,
+    <Menu.Item key="download_tsv" disabled={isQueryResultEmpty}>
+      {!isQueryResultEmpty ? (
+        <a href={downloadLink("tsv")} download={downloadName("tsv")} target="_self">
+          Download as TSV File
+        </a>
+      ) : (
+        "Download as TSV File"
+      )}
+    </Menu.Item>,
     <Menu.Item key="download_excel" disabled={isQueryResultEmpty}>
       {!isQueryResultEmpty ? (
         <a href={downloadLink("xlsx")} download={downloadName("xlsx")} target="_self">

--- a/client/app/components/queries/VisualizationEmbed.jsx
+++ b/client/app/components/queries/VisualizationEmbed.jsx
@@ -52,12 +52,24 @@ function VisualizationEmbedFooter({ query, queryResults, updatedAt, refreshStart
     <Menu>
       <Menu.Item>
         <QueryResultsLink
+          fileType="csv"
           query={query}
           queryResult={queryResults}
           apiKey={$routeParams.api_key}
           disabled={!queryResults || !queryResults.getData || !queryResults.getData()}
           embed>
           <Icon type="file" /> Download as CSV File
+        </QueryResultsLink>
+      </Menu.Item>
+      <Menu.Item>
+        <QueryResultsLink
+          fileType="tsv"
+          query={query}
+          queryResult={queryResults}
+          apiKey={$routeParams.api_key}
+          disabled={!queryResults || !queryResults.getData || !queryResults.getData()}
+          embed>
+          <Icon type="file" /> Download as TSV File
         </QueryResultsLink>
       </Menu.Item>
       <Menu.Item>

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -30,7 +30,7 @@ from redash.models.parameterized_query import (
 )
 from redash.serializers import (
     serialize_query_result,
-    serialize_query_result_to_csv,
+    serialize_query_result_to_dsv,
     serialize_query_result_to_xlsx,
 )
 
@@ -400,12 +400,12 @@ class QueryResultResource(BaseResource):
     @staticmethod
     def make_csv_response(query_result):
         headers = {"Content-Type": "text/csv; charset=UTF-8"}
-        return make_response(serialize_query_result_to_csv(query_result), 200, headers)
+        return make_response(serialize_query_result_to_dsv(query_result, ","), 200, headers)
 
     @staticmethod
     def make_tsv_response(query_result):
         headers = {"Content-Type": "text/tab-separated-values; charset=UTF-8"}
-        return make_response(serialize_query_result_to_csv(query_result, "\t"), 200, headers)
+        return make_response(serialize_query_result_to_dsv(query_result, "\t"), 200, headers)
 
     @staticmethod
     def make_excel_response(query_result):

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -368,6 +368,8 @@ class QueryResultResource(BaseResource):
                 response = self.make_json_response(query_result)
             elif filetype == "xlsx":
                 response = self.make_excel_response(query_result)
+            elif filetype == "tsv":
+                response = self.make_tsv_response(query_result)
             else:
                 response = self.make_csv_response(query_result)
 
@@ -399,6 +401,11 @@ class QueryResultResource(BaseResource):
     def make_csv_response(query_result):
         headers = {"Content-Type": "text/csv; charset=UTF-8"}
         return make_response(serialize_query_result_to_csv(query_result), 200, headers)
+
+    @staticmethod
+    def make_tsv_response(query_result):
+        headers = {"Content-Type": "text/tab-separated-values; charset=UTF-8"}
+        return make_response(serialize_query_result_to_csv(query_result, "\t"), 200, headers)
 
     @staticmethod
     def make_excel_response(query_result):

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -364,14 +364,13 @@ class QueryResultResource(BaseResource):
 
                 self.record_event(event)
 
-            if filetype == "json":
-                response = self.make_json_response(query_result)
-            elif filetype == "xlsx":
-                response = self.make_excel_response(query_result)
-            elif filetype == "tsv":
-                response = self.make_tsv_response(query_result)
-            else:
-                response = self.make_csv_response(query_result)
+            response_builders = {
+                'json': self.make_json_response,
+                'xlsx': self.make_excel_response,
+                'csv': self.make_csv_response,
+                'tsv': self.make_tsv_response
+            }
+            response = response_builders[filetype](query_result)
 
             if len(settings.ACCESS_CONTROL_ALLOW_ORIGIN) > 0:
                 self.add_cors_headers(response.headers)
@@ -392,7 +391,8 @@ class QueryResultResource(BaseResource):
         else:
             abort(404, message="No cached result found for this query.")
 
-    def make_json_response(self, query_result):
+    @staticmethod
+    def make_json_response(query_result):
         data = json_dumps({"query_result": query_result.to_dict()})
         headers = {"Content-Type": "application/json"}
         return make_response(data, 200, headers)

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -14,7 +14,7 @@ from redash.models.parameterized_query import ParameterizedQuery
 
 from .query_result import (
     serialize_query_result,
-    serialize_query_result_to_csv,
+    serialize_query_result_to_dsv,
     serialize_query_result_to_xlsx,
 )
 

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -78,7 +78,7 @@ def serialize_query_result(query_result, is_api_user):
         return query_result.to_dict()
 
 
-def serialize_query_result_to_csv(query_result, delimiter = ","):
+def serialize_query_result_to_dsv(query_result, delimiter):
     s = io.StringIO()
 
     query_data = query_result.data

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -78,14 +78,14 @@ def serialize_query_result(query_result, is_api_user):
         return query_result.to_dict()
 
 
-def serialize_query_result_to_csv(query_result):
+def serialize_query_result_to_csv(query_result, delimiter = ","):
     s = io.StringIO()
 
     query_data = query_result.data
 
     fieldnames, special_columns = _get_column_lists(query_data["columns"] or [])
 
-    writer = csv.DictWriter(s, extrasaction="ignore", fieldnames=fieldnames)
+    writer = csv.DictWriter(s, extrasaction="ignore", fieldnames=fieldnames, delimiter=delimiter)
     writer.writeheader()
 
     for row in query_data["rows"]:

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -38,17 +38,13 @@ class QueryResultSerializationTest(BaseTestCase):
 
 
 class DsvSerializationTest(BaseTestCase):
-    def get_csv_content(self):
+    def delimited_content(self, delimiter):
         query_result = self.factory.create_query_result(data=json_dumps(data))
-        return serialize_query_result_to_dsv(query_result, ",")
-
-    def get_tsv_content(self):
-        query_result = self.factory.create_query_result(data=json_dumps(data))
-        return serialize_query_result_to_dsv(query_result, "\t")
+        return serialize_query_result_to_dsv(query_result, delimiter)
 
     def test_serializes_booleans_correctly(self):
         with self.app.test_request_context("/"):
-            parsed = csv.DictReader(io.StringIO(self.get_csv_content()))
+            parsed = csv.DictReader(io.StringIO(self.delimited_content(",")))
         rows = list(parsed)
 
         self.assertEqual(rows[0]["bool"], "true")
@@ -57,7 +53,7 @@ class DsvSerializationTest(BaseTestCase):
 
     def test_serializes_datatime_with_correct_format(self):
         with self.app.test_request_context("/"):
-            parsed = csv.DictReader(io.StringIO(self.get_csv_content()))
+            parsed = csv.DictReader(io.StringIO(self.delimited_content(",")))
         rows = list(parsed)
 
         self.assertEqual(rows[0]["datetime"], "26/05/19 12:39")
@@ -69,15 +65,16 @@ class DsvSerializationTest(BaseTestCase):
 
     def test_serializes_datatime_as_is_in_case_of_error(self):
         with self.app.test_request_context("/"):
-            parsed = csv.DictReader(io.StringIO(self.get_csv_content()))
+            parsed = csv.DictReader(io.StringIO(self.delimited_content(",")))
         rows = list(parsed)
 
         self.assertEqual(rows[3]["datetime"], "459")
         self.assertEqual(rows[3]["date"], "123")
 
     def test_serializes_tsv_format(self):
+        delimiter = "\t"
         with self.app.test_request_context("/"):
-            parsed = csv.DictReader(io.StringIO(self.get_tsv_content()), delimiter="\t")
+            parsed = csv.DictReader(io.StringIO(self.delimited_content(delimiter)), delimiter=delimiter)
         rows = list(parsed)
 
         self.assertEqual(rows[0]["datetime"], "26/05/19 12:39")

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -42,6 +42,10 @@ class DsvSerializationTest(BaseTestCase):
         query_result = self.factory.create_query_result(data=json_dumps(data))
         return serialize_query_result_to_dsv(query_result, ",")
 
+    def get_tsv_content(self):
+        query_result = self.factory.create_query_result(data=json_dumps(data))
+        return serialize_query_result_to_dsv(query_result, "\t")
+
     def test_serializes_booleans_correctly(self):
         with self.app.test_request_context("/"):
             parsed = csv.DictReader(io.StringIO(self.get_csv_content()))
@@ -70,3 +74,13 @@ class DsvSerializationTest(BaseTestCase):
 
         self.assertEqual(rows[3]["datetime"], "459")
         self.assertEqual(rows[3]["date"], "123")
+
+    def test_serializes_tsv_format(self):
+        with self.app.test_request_context("/"):
+            parsed = csv.DictReader(io.StringIO(self.get_tsv_content()), delimiter="\t")
+        rows = list(parsed)
+
+        self.assertEqual(rows[0]["datetime"], "26/05/19 12:39")
+        self.assertEqual(rows[1]["bool"], "false")
+        self.assertEqual(rows[2]["date"], "")
+        self.assertEqual(rows[3]["datetime"], "459")

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -6,7 +6,7 @@ from tests import BaseTestCase
 
 from redash import models
 from redash.utils import utcnow, json_dumps
-from redash.serializers import serialize_query_result, serialize_query_result_to_csv
+from redash.serializers import serialize_query_result, serialize_query_result_to_dsv
 
 
 data = {
@@ -37,10 +37,10 @@ class QueryResultSerializationTest(BaseTestCase):
         self.assertSetEqual(set(["data", "retrieved_at"]), set(serialized.keys()))
 
 
-class CsvSerializationTest(BaseTestCase):
+class DsvSerializationTest(BaseTestCase):
     def get_csv_content(self):
         query_result = self.factory.create_query_result(data=json_dumps(data))
-        return serialize_query_result_to_csv(query_result)
+        return serialize_query_result_to_dsv(query_result, ",")
 
     def test_serializes_booleans_correctly(self):
         with self.app.test_request_context("/"):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

Re:dash supports CSV/Excel formats to download.
CSV format is text type, but there are comma in the result.

It is sometimes noise, TSV format must be useful to see the raw result by pasting.

## Related Tickets & Documents

https://discuss.redash.io/t/can-i-download-result-as-text-format/5171

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/2405380/70850971-6f274a00-1ed3-11ea-9b13-d6fd2d9736f1.png)
![image](https://user-images.githubusercontent.com/2405380/70850976-7b130c00-1ed3-11ea-840e-7f563be99996.png)
![image](https://user-images.githubusercontent.com/2405380/70850982-86fece00-1ed3-11ea-8250-e6e5b80bb9f0.png)
