### PR TITLE
Migrate Query page to React: Visualization Tabs

### DIFF
--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -16,8 +16,11 @@ import { EditVisualizationButton } from "@/components/EditVisualizationButton";
 import useQueryResult from "@/lib/hooks/useQueryResult";
 import { pluralize } from "@/filters";
 
+import useVisualizationTabHandler from "./utils/useVisualizationTabHandler";
+
 function QueryView({ query }) {
   const canEdit = useMemo(() => currentUser.canEdit(query) || query.can_edit, [query]);
+  const [selectedTab, setSelectedTab] = useVisualizationTabHandler(query.visualizations);
   const parameters = useMemo(() => query.getParametersDefs(), [query]);
   const [dataSource, setDataSource] = useState();
   const queryResult = useMemo(() => query.getQueryResult(), [query]);
@@ -67,7 +70,13 @@ function QueryView({ query }) {
         </div>
         <div className="query-content tiled bg-white p-15 m-t-15">
           {query.hasParameters() && <Parameters parameters={parameters} />}
-          <QueryVisualizationTabs queryResult={queryResult} visualizations={query.visualizations} />
+          <QueryVisualizationTabs
+            queryResult={queryResult}
+            visualizations={query.visualizations}
+            showNewVisualizationButton={query.can_edit}
+            selectedTab={selectedTab}
+            onChangeTab={setSelectedTab}
+          />
           <Divider />
           <div className="d-flex align-items-center">
             <EditVisualizationButton />

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -7,8 +7,14 @@ import Button from "antd/lib/button";
 
 const { TabPane } = Tabs;
 
-export default function QueryVisualizationTabs({ visualizations, queryResult, selectedTab,
-  showNewVisualizationButton, onChangeTab, onClickNewVisualization }) {
+export default function QueryVisualizationTabs({
+  visualizations,
+  queryResult,
+  selectedTab,
+  showNewVisualizationButton,
+  onChangeTab,
+  onClickNewVisualization,
+}) {
   const tabsProps = {};
   if (find(visualizations, { id: selectedTab })) {
     tabsProps.activeKey = `${selectedTab}`;

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -7,23 +7,26 @@ import Button from "antd/lib/button";
 
 const { TabPane } = Tabs;
 
-export default function QueryVisualizationTabs({ visualizations, queryResult, currentVisualizationId }) {
+export default function QueryVisualizationTabs({ visualizations, queryResult, selectedTab,
+  showNewVisualizationButton, onChangeTab, onClickNewVisualization }) {
   const tabsProps = {};
-  if (find(visualizations, { id: currentVisualizationId })) {
-    tabsProps.activeKey = `${currentVisualizationId}`;
+  if (find(visualizations, { id: selectedTab })) {
+    tabsProps.activeKey = `${selectedTab}`;
+  }
+
+  if (showNewVisualizationButton) {
+    tabsProps.tabBarExtraContent = (
+      <Button onClick={onClickNewVisualization}>
+        <i className="fa fa-plus" />
+        <span className="m-l-5 hidden-xs">New Visualization</span>
+      </Button>
+    );
   }
 
   const orderedVisualizations = orderBy(visualizations, ["id"]);
 
   return (
-    <Tabs
-      {...tabsProps}
-      tabBarExtraContent={
-        <Button>
-          <i className="fa fa-plus m-r-5" />
-          New Visualization
-        </Button>
-      }>
+    <Tabs {...tabsProps} onChange={activeKey => onChangeTab(+activeKey)}>
       {orderedVisualizations.map(visualization => (
         <TabPane key={`${visualization.id}`} tab={visualization.name}>
           <VisualizationRenderer visualization={visualization} queryResult={queryResult} context="query" />
@@ -36,6 +39,17 @@ export default function QueryVisualizationTabs({ visualizations, queryResult, cu
 QueryVisualizationTabs.propTypes = {
   queryResult: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   visualizations: PropTypes.arrayOf(PropTypes.object),
-  currentVisualizationId: PropTypes.number,
+  selectedTab: PropTypes.number,
+  showNewVisualizationButton: PropTypes.bool,
+  onChangeTab: PropTypes.func,
+  onClickNewVisualization: PropTypes.func,
 };
-QueryVisualizationTabs.defaultProps = { queryResult: null, visualizations: [], currentVisualizationId: null };
+
+QueryVisualizationTabs.defaultProps = {
+  queryResult: null,
+  visualizations: [],
+  selectedTab: null,
+  showNewVisualizationButton: false,
+  onChangeTab: () => {},
+  onClickNewVisualization: () => {},
+};

--- a/client/app/pages/queries/utils/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/utils/useVisualizationTabHandler.js
@@ -12,18 +12,15 @@ export default function useVisualizationTabHandler(visualizations) {
   const [selectedTab, setSelectedTab] = useState(+$location.hash() || firstVisualization.id);
 
   useEffect(() => {
-    const newHashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
-    if ($location.hash() !== newHashValue) {
-      updateUrlHash(newHashValue);
+    const hashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
+    if ($location.hash() !== hashValue) {
+      updateUrlHash(hashValue);
     }
-  }, [firstVisualization.id, selectedTab]);
 
-  useEffect(() => {
     const unwatch = $rootScope.$watch(
       () => $location.hash(),
       () => {
-        const expectedHashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
-        if ($location.hash() !== expectedHashValue) {
+        if ($location.hash() !== hashValue) {
           setSelectedTab(+$location.hash() || firstVisualization.id);
         }
       },

--- a/client/app/pages/queries/utils/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/utils/useVisualizationTabHandler.js
@@ -23,7 +23,7 @@ export default function useVisualizationTabHandler(visualizations) {
         if ($location.hash() !== hashValue) {
           setSelectedTab(+$location.hash() || firstVisualization.id);
         }
-      },
+      }
     );
     return unwatch;
   }, [firstVisualization.id, selectedTab]);

--- a/client/app/pages/queries/utils/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/utils/useVisualizationTabHandler.js
@@ -12,9 +12,9 @@ export default function useVisualizationTabHandler(visualizations) {
   const [selectedTab, setSelectedTab] = useState(+$location.hash() || firstVisualization.id);
 
   useEffect(() => {
-    const hashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
-    if ($location.hash() !== hashValue) {
-      updateUrlHash(hashValue);
+    const newHashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
+    if ($location.hash() !== newHashValue) {
+      updateUrlHash(newHashValue);
     }
   }, [firstVisualization.id, selectedTab]);
 
@@ -22,8 +22,8 @@ export default function useVisualizationTabHandler(visualizations) {
     const unwatch = $rootScope.$watch(
       () => $location.hash(),
       () => {
-        const hashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
-        if ($location.hash() !== hashValue) {
+        const expectedHashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
+        if ($location.hash() !== expectedHashValue) {
           setSelectedTab(+$location.hash() || firstVisualization.id);
         }
       },

--- a/client/app/pages/queries/utils/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/utils/useVisualizationTabHandler.js
@@ -1,0 +1,30 @@
+import { useState, useEffect, useMemo } from "react";
+import { first, orderBy, isFunction } from "lodash";
+import { $location, $rootScope } from "@/services/ng";
+
+function updateUrlHash(...args) {
+  $location.hash(...args);
+  $rootScope.$applyAsync();
+}
+
+export default function useVisualizationTabHandler(visualizations, onAddVisualizationInUrl) {
+  const firstVisualization = useMemo(() => first(orderBy(visualizations, ["id"])), [visualizations]);
+  const [selectedTab, setSelectedTab] = useState(+$location.hash() || firstVisualization.id);
+
+  useEffect(() => {
+    if ($location.hash() !== "add") {
+      updateUrlHash(selectedTab !== firstVisualization.id ? selectedTab : null);
+    }
+  }, [firstVisualization.id, selectedTab]);
+
+  useEffect(() => {
+    if ($location.hash() === "add") {
+      updateUrlHash(null);
+      if (isFunction(onAddVisualizationInUrl)) {
+        onAddVisualizationInUrl();
+      }
+    }
+  }, [onAddVisualizationInUrl]);
+
+  return [selectedTab, setSelectedTab];
+}

--- a/client/app/pages/queries/utils/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/utils/useVisualizationTabHandler.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { first, orderBy, isFunction } from "lodash";
+import { first, orderBy } from "lodash";
 import { $location, $rootScope } from "@/services/ng";
 
 function updateUrlHash(...args) {
@@ -7,24 +7,29 @@ function updateUrlHash(...args) {
   $rootScope.$applyAsync();
 }
 
-export default function useVisualizationTabHandler(visualizations, onAddVisualizationInUrl) {
+export default function useVisualizationTabHandler(visualizations) {
   const firstVisualization = useMemo(() => first(orderBy(visualizations, ["id"])), [visualizations]);
   const [selectedTab, setSelectedTab] = useState(+$location.hash() || firstVisualization.id);
 
   useEffect(() => {
-    if ($location.hash() !== "add") {
-      updateUrlHash(selectedTab !== firstVisualization.id ? selectedTab : null);
+    const hashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
+    if ($location.hash() !== hashValue) {
+      updateUrlHash(hashValue);
     }
   }, [firstVisualization.id, selectedTab]);
 
   useEffect(() => {
-    if ($location.hash() === "add") {
-      updateUrlHash(null);
-      if (isFunction(onAddVisualizationInUrl)) {
-        onAddVisualizationInUrl();
-      }
-    }
-  }, [onAddVisualizationInUrl]);
+    const unwatch = $rootScope.$watch(
+      () => $location.hash(),
+      () => {
+        const hashValue = selectedTab !== firstVisualization.id ? `${selectedTab}` : null;
+        if ($location.hash() !== hashValue) {
+          setSelectedTab(+$location.hash() || firstVisualization.id);
+        }
+      },
+    );
+    return unwatch;
+  }, [firstVisualization.id, selectedTab]);
 
   return [selectedTab, setSelectedTab];
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description
This finishes changes to `VisualizationTabs` and adds a `useVisualizationTabHandler` that also handles url hash updates. (Didn't add the Visualization Dialog to Query View yet -- will add in a next PR along with other updates)

## Related Tickets & Documents
#4429

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![VIsualizationTabs](https://user-images.githubusercontent.com/3356951/70953815-740e0a00-2049-11ea-950f-7a7b7ffb0fc5.gif)
