### PR TITLE
Fix prettier commandline option to be recursive

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "npm run lint:base  -- --fix --ext .js --ext .jsx ./client",
     "lint:base": "eslint --config ./client/.eslintrc.js --ignore-path ./client/.eslintignore",
     "lint:ci": "npm run lint -- --format junit --output-file /tmp/test-results/eslint/results.xml",
-    "prettier": "prettier --write client/app/**/*.{js,jsx} client/cypress/**/*.js",
+    "prettier": "prettier --write 'client/app/**/*.{js,jsx}' 'client/cypress/**/*.js'",
     "test": "TZ=Africa/Khartoum jest",
     "test:watch": "jest --watch",
     "cypress:install": "npm install --no-save cypress@~3.6.1 @percy/cypress@^2.2.0 atob@2.1.2",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
`prettier` command is not recursive when scanning the files. Need to add quotes in package.json. See [doc](https://prettier.io/docs/en/cli.html).
[Note] After this fix, rinning `npm run prettier` fixes multiple /cypress files, but those are untouched in this PR.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
