### PR TITLE
BigQuery query runner on Python 3

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -205,7 +205,7 @@ class BigQuery(BaseQueryRunner):
 
         rows = []
 
-        while ("rows" in query_reply) and current_row < query_reply["totalRows"]:
+        while ("rows" in query_reply) and current_row < int(query_reply["totalRows"]):
             for row in query_reply["rows"]:
                 rows.append(transform_row(row, query_reply["schema"]["fields"]))
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Seems like BigQuery queries can't run on Python 3 due to `totalRows` being strings which results in `TypeError: '<' not supported between instances of 'str' and 'int'`. This PR fixes that.

## Related Tickets & Documents
#4251 