### PR TITLE
Fix all occurrences of B306: BaseException.message has been deprecated

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -71,7 +71,7 @@ def run_query(query, parameters, data_source, query_id, max_age=0):
     try:
         query.apply(parameters)
     except (InvalidParameterError, QueryDetachedFromDataSourceError) as e:
-        abort(400, message=e.message)
+        abort(400, message=str(e))
 
     if query.missing_params:
         return error_response(
@@ -186,7 +186,7 @@ class QueryResultDropdownResource(BaseResource):
         try:
             return dropdown_values(query_id, self.current_org)
         except QueryDetachedFromDataSourceError as e:
-            abort(400, message=e.message)
+            abort(400, message=str(e))
 
 
 class QueryDropdownsResource(BaseResource):

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -252,7 +252,7 @@ class Athena(BaseQueryRunner):
         except Exception as ex:
             if cursor.query_id:
                 cursor.cancel()
-            error = ex.message
+            error = str(ex)
             json_data = None
 
         return json_data, error

--- a/redash/query_runner/db2.py
+++ b/redash/query_runner/db2.py
@@ -132,7 +132,7 @@ class DB2(BaseSQLQueryRunner):
             error = "Query interrupted. Please retry."
             json_data = None
         except ibm_db_dbi.DatabaseError as e:
-            error = e.message
+            error = str(e)
             json_data = None
         except (KeyboardInterrupt, InterruptException):
             connection.cancel()

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -134,7 +134,7 @@ class DynamoDBSQL(BaseSQLQueryRunner):
             )
             json_data = None
         except (SyntaxError, RuntimeError) as e:
-            error = e.message
+            error = str(e)
             json_data = None
         except KeyboardInterrupt:
             if engine and engine.connection:

--- a/redash/query_runner/graphite.py
+++ b/redash/query_runner/graphite.py
@@ -89,7 +89,7 @@ class Graphite(BaseQueryRunner):
                 error = "Failed getting results (%d)" % response.status_code
         except Exception as ex:
             data = None
-            error = ex.message
+            error = str(ex)
 
         return data, error
 

--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -124,10 +124,10 @@ class Impala(BaseSQLQueryRunner):
             cursor.close()
         except DatabaseError as e:
             json_data = None
-            error = e.message
+            error = str(e)
         except RPCError as e:
             json_data = None
-            error = "Metastore Error [%s]" % e.message
+            error = "Metastore Error [%s]" % str(e)
         except KeyboardInterrupt:
             connection.cancel()
             error = "Query cancelled by user."

--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -82,7 +82,7 @@ class InfluxDB(BaseQueryRunner):
             error = None
         except Exception as ex:
             json_data = None
-            error = ex.message
+            error = str(ex)
 
         return json_data, error
 

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -159,7 +159,7 @@ class Oracle(BaseSQLQueryRunner):
                 json_data = json_dumps(data)
                 connection.commit()
         except cx_Oracle.DatabaseError as err:
-            error = "Query failed. {}.".format(err.message)
+            error = "Query failed. {}.".format(str(err))
             json_data = None
         except KeyboardInterrupt:
             connection.cancel()

--- a/redash/query_runner/phoenix.py
+++ b/redash/query_runner/phoenix.py
@@ -110,7 +110,7 @@ class Phoenix(BaseQueryRunner):
         except Error as e:
             json_data = None
             error = "code: {}, sql state:{}, message: {}".format(
-                e.code, e.sqlstate, e.message
+                e.code, e.sqlstate, str(e)
             )
         except (KeyboardInterrupt, InterruptException) as e:
             error = "Query cancelled by user."

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -120,9 +120,9 @@ class Presto(BaseQueryRunner):
             error = None
         except DatabaseError as db:
             json_data = None
-            default_message = "Unspecified DatabaseError: {0}".format(db.message)
-            if isinstance(db.message, dict):
-                message = db.message.get("failureInfo", {"message", None}).get(
+            default_message = "Unspecified DatabaseError: {0}".format(str(db))
+            if isinstance(db.args[0], dict):
+                message = db.args[0].get("failureInfo", {"message", None}).get(
                     "message"
                 )
             else:
@@ -134,9 +134,7 @@ class Presto(BaseQueryRunner):
             json_data = None
         except Exception as ex:
             json_data = None
-            error = ex.message
-            if not isinstance(error, str):
-                error = str(error)
+            error = str(ex)
 
         return json_data, error
 

--- a/redash/query_runner/script.py
+++ b/redash/query_runner/script.py
@@ -74,7 +74,7 @@ class Script(BaseQueryRunner):
             script = query_to_script_path(self.configuration["path"], query)
             return run_script(script, self.configuration["shell"])
         except IOError as e:
-            return None, e.message
+            return None, str(e)
         except subprocess.CalledProcessError as e:
             return None, str(e)
         except KeyboardInterrupt:

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -112,7 +112,7 @@ class TreasureData(BaseQueryRunner):
         except errors.InternalError as e:
             json_data = None
             error = "%s: %s" % (
-                e.message,
+                str(e),
                 cursor.show_job()
                 .get("debug", {})
                 .get("stderr", "No stderr message in the response"),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
`BaseException.message` has been deprecated as of Python 2.6 and is removed in Python 3. Use `str(e)` to access the user-readable message. Use `e.args` to access arguments passed to the exception.

## Related Tickets & Documents
#4181 