### PR TITLE
Fix: query results query runner fails to load cached results.

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -55,8 +55,10 @@ def get_query_results(user, query_id, bring_from_cache):
         )
         if error:
             raise Exception("Failed loading results for query id {}.".format(query.id))
+        else:
+            results = json_loads(results)
 
-    return json_loads(results)
+    return results
 
 
 def create_tables_from_query_ids(user, connection, query_ids, cached_query_ids=[]):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Following the refactor we did to `QueryResult` needed to update the usage in the QueryResult query runner.