### PR TITLE
Don't update query's updated_at when updating schedule_failures counter

### DIFF
--- a/redash/tasks/failure_report.py
+++ b/redash/tasks/failure_report.py
@@ -91,6 +91,7 @@ def track_failure(query, error):
     logging.debug(error)
 
     query.schedule_failures += 1
+    query.skip_updated_at = True
     models.db.session.add(query)
     models.db.session.commit()
 

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -275,6 +275,7 @@ class QueryExecutor(object):
                     self.scheduled_query, load=False
                 )
                 self.scheduled_query.schedule_failures = 0
+                self.scheduled_query.skip_updated_at = True
                 models.db.session.add(self.scheduled_query)
 
             query_result = models.QueryResult.store_result(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix