### PR TITLE
Salesforce - adjust import to match simple-salesforce 0.74.3

### DIFF
--- a/redash/query_runner/salesforce.py
+++ b/redash/query_runner/salesforce.py
@@ -15,8 +15,8 @@ from redash.utils import json_dumps
 logger = logging.getLogger(__name__)
 
 try:
-    from simple_salesforce import Salesforce as SimpleSalesforce
-    from simple_salesforce.api import SalesforceError, DEFAULT_API_VERSION
+    from simple_salesforce import Salesforce as SimpleSalesforce, SalesforceError
+    from simple_salesforce.api import DEFAULT_API_VERSION
 
     enabled = True
 except ImportError as e:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When switching to Python 3, `simple-salesforce` has been updated. However the location of `SaleforceError` has changed from `api` to `exceptions`, so this PR adjusts that import.

## Related Tickets & Documents
#4181 