### PR TITLE
Update EditInPlace to use Antd components

### DIFF
--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -2,15 +2,16 @@ import React from "react";
 import PropTypes from "prop-types";
 import { react2angular } from "react2angular";
 import { trim } from "lodash";
+import Input from "antd/lib/input";
 
 export class EditInPlace extends React.Component {
   static propTypes = {
     ignoreBlanks: PropTypes.bool,
     isEditable: PropTypes.bool,
-    editor: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.string,
     onDone: PropTypes.func.isRequired,
+    textArea: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -18,6 +19,7 @@ export class EditInPlace extends React.Component {
     isEditable: true,
     placeholder: "",
     value: "",
+    textArea: false,
   };
 
   constructor(props) {
@@ -26,12 +28,12 @@ export class EditInPlace extends React.Component {
       editing: false,
     };
     this.inputRef = React.createRef();
-    const self = this;
-    this.componentDidUpdate = (prevProps, prevState) => {
-      if (self.state.editing && !prevState.editing) {
-        self.inputRef.current.focus();
-      }
-    };
+  }
+
+  componentDidUpdate(_, prevState) {
+    if (this.state.editing && !prevState.editing) {
+      this.inputRef.current.focus();
+    }
   }
 
   startEditing = () => {
@@ -40,8 +42,8 @@ export class EditInPlace extends React.Component {
     }
   };
 
-  stopEditing = () => {
-    const newValue = trim(this.inputRef.current.value);
+  stopEditing = currentValue => {
+    const newValue = trim(currentValue);
     const ignorableBlank = this.props.ignoreBlanks && newValue === "";
     if (!ignorableBlank && newValue !== this.props.value) {
       this.props.onDone(newValue);
@@ -49,10 +51,10 @@ export class EditInPlace extends React.Component {
     this.setState({ editing: false });
   };
 
-  keyDown = event => {
+  handleKeyDown = event => {
     if (event.keyCode === 13 && !event.shiftKey) {
       event.preventDefault();
-      this.stopEditing();
+      this.stopEditing(event.target.value);
     } else if (event.keyCode === 27) {
       this.setState({ editing: false });
     }
@@ -68,14 +70,17 @@ export class EditInPlace extends React.Component {
     </span>
   );
 
-  renderEdit = () =>
-    React.createElement(this.props.editor, {
-      ref: this.inputRef,
-      className: "rd-form-control",
-      defaultValue: this.props.value,
-      onBlur: this.stopEditing,
-      onKeyDown: this.keyDown,
-    });
+  renderEdit = () => {
+    const InputComponent = this.props.textArea ? Input.TextArea : Input;
+    return (
+      <InputComponent
+        ref={this.inputRef}
+        defaultValue={this.props.value}
+        onBlur={e => this.stopEditing(e.target.value)}
+        onKeyDown={this.handleKeyDown}
+      />
+    );
+  };
 
   render() {
     return (

--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -12,7 +12,7 @@ export class EditInPlace extends React.Component {
     placeholder: PropTypes.string,
     value: PropTypes.string,
     onDone: PropTypes.func.isRequired,
-    textArea: PropTypes.bool,
+    multiline: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -20,7 +20,7 @@ export class EditInPlace extends React.Component {
     isEditable: true,
     placeholder: "",
     value: "",
-    textArea: false,
+    multiline: false,
   };
 
   constructor(props) {
@@ -72,7 +72,7 @@ export class EditInPlace extends React.Component {
   );
 
   renderEdit = () => {
-    const InputComponent = this.props.textArea ? Input.TextArea : Input;
+    const InputComponent = this.props.multiline ? Input.TextArea : Input;
     return (
       <InputComponent
         ref={this.inputRef}

--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 import { react2angular } from "react2angular";
 import { trim } from "lodash";
 import Input from "antd/lib/input";
@@ -84,7 +85,7 @@ export class EditInPlace extends React.Component {
 
   render() {
     return (
-      <span className={"edit-in-place" + (this.state.editing ? " active" : "")}>
+      <span className={cx("edit-in-place", { active: this.state.editing }, this.props.className)}>
         {this.state.editing ? this.renderEdit() : this.renderNormal()}
       </span>
     );

--- a/client/app/components/EditInPlace.jsx
+++ b/client/app/components/EditInPlace.jsx
@@ -13,6 +13,7 @@ export class EditInPlace extends React.Component {
     value: PropTypes.string,
     onDone: PropTypes.func.isRequired,
     multiline: PropTypes.bool,
+    editorProps: PropTypes.object,
   };
 
   static defaultProps = {
@@ -21,6 +22,7 @@ export class EditInPlace extends React.Component {
     placeholder: "",
     value: "",
     multiline: false,
+    editorProps: {},
   };
 
   constructor(props) {
@@ -72,13 +74,15 @@ export class EditInPlace extends React.Component {
   );
 
   renderEdit = () => {
-    const InputComponent = this.props.multiline ? Input.TextArea : Input;
+    const { multiline, value, editorProps } = this.props;
+    const InputComponent = multiline ? Input.TextArea : Input;
     return (
       <InputComponent
         ref={this.inputRef}
-        defaultValue={this.props.value}
+        defaultValue={value}
         onBlur={e => this.stopEditing(e.target.value)}
         onKeyDown={this.handleKeyDown}
+        {...editorProps}
       />
     );
   };

--- a/client/app/components/groups/GroupName.jsx
+++ b/client/app/components/groups/GroupName.jsx
@@ -22,7 +22,6 @@ export default function GroupName({ group, onChange, ...props }) {
         className="edit-in-place"
         isEditable={canEdit}
         ignoreBlanks
-        editor="input"
         onDone={name => updateGroupName(group, name, onChange)}
         value={group.name}
       />

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -46,7 +46,6 @@ function DashboardPageTitle({ dashboardOptions }) {
           isEditable={editingLayout}
           onDone={name => updateDashboard({ name })}
           value={dashboard.name}
-          editor="input"
           ignoreBlanks
         />
       </h3>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -106,7 +106,7 @@
       <div ng-if="!sourceMode" style="flex-grow: 1;">&nbsp;</div>
 
       <div class="query-metadata query-metadata--description" ng-if="!query.isNew()">
-        <edit-in-place is-editable="canEdit" on-done="saveDescription" text-area="true" placeholder="'Add description'" ignore-blanks='false'
+        <edit-in-place is-editable="canEdit" on-done="saveDescription" multiline="true" placeholder="'Add description'" ignore-blanks='false'
           value="query.description" markdown="true">
         </edit-in-place>
       </div>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -24,7 +24,7 @@
           <favorites-control ng-if="!query.isNew()" item="query"></favorites-control>
           <h3>
             <edit-in-place class="m-r-5" is-editable="canEdit" on-done="saveName"
-              ignore-blanks="true" value="query.name" editor="'input'"></edit-in-place>
+              ignore-blanks="true" value="query.name"></edit-in-place>
             <query-tags-control
               class="query-tags" ng-class="{'query-tags__empty': query.tags.length == 0}"
               tags="query.tags" is-draft="query.is_draft" is-archived="query.is_archived"
@@ -106,7 +106,7 @@
       <div ng-if="!sourceMode" style="flex-grow: 1;">&nbsp;</div>
 
       <div class="query-metadata query-metadata--description" ng-if="!query.isNew()">
-        <edit-in-place is-editable="canEdit" on-done="saveDescription" editor="'textarea'" placeholder="'Add description'" ignore-blanks='false'
+        <edit-in-place is-editable="canEdit" on-done="saveDescription" text-area="true" placeholder="'Add description'" ignore-blanks='false'
           value="query.description" markdown="true">
         </edit-in-place>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description
This updates EditInPlace to use Antd components instead of rd-form.

I considered using Antd's Typography, but it's not 100% the same thing and Typography doesn't seem to support multi-line with Shift+enter or Textarea as editor.

Anyway, most of the existing EditInPlace's didn't change, aside from the titles that now have a smaller font-size when being edited:

**Before**
![before](https://user-images.githubusercontent.com/3356951/71451930-c7750c00-275d-11ea-90c9-6be0abe472d7.png)

**After**
![after](https://user-images.githubusercontent.com/3356951/71451936-d065dd80-275d-11ea-9889-d7b1935373ef.png)

Also took the opportunity to allow `className` in the component.