### PR TITLE
Fix: properly encode UTF-8 filenames in query results request

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,9 +1,11 @@
 import logging
 import time
 
+import unicodedata
 from flask import make_response, request
 from flask_login import current_user
 from flask_restful import abort
+from werkzeug.urls import url_quote
 from redash import models, settings
 from redash.handlers.base import BaseResource, get_object_or_404, record_event
 from redash.permissions import (
@@ -126,6 +128,25 @@ def get_download_filename(query_result, query, filetype):
     else:
         filename = str(query_result.id)
     return "{}_{}.{}".format(filename, retrieved_at, filetype)
+
+
+def content_disposition_filenames(attachment_filename):
+    if not isinstance(attachment_filename, str):
+        attachment_filename = attachment_filename.decode("utf-8")
+
+    try:
+        attachment_filename = attachment_filename.encode("ascii")
+    except UnicodeEncodeError:
+        filenames = {
+            "filename": unicodedata.normalize("NFKD", attachment_filename).encode(
+                "ascii", "ignore"
+            ),
+            "filename*": "UTF-8''%s" % url_quote(attachment_filename, safe=b""),
+        }
+    else:
+        filenames = {"filename": attachment_filename}
+
+    return filenames
 
 
 class QueryResultListResource(BaseResource):
@@ -381,9 +402,8 @@ class QueryResultResource(BaseResource):
 
             filename = get_download_filename(query_result, query, filetype)
 
-            response.headers.add_header(
-                "Content-Disposition", 'attachment; filename="{}"'.format(filename)
-            )
+            filenames = content_disposition_filenames(filename)
+            response.headers.add("Content-Disposition", "attachment", **filenames)
 
             return response
 

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -29,6 +29,16 @@ class TestQueryResultsCacheHeaders(BaseTestCase):
         self.assertEqual(404, rv.status_code)
 
 
+class TestQueryResultsContentDispositionHeaders(BaseTestCase):
+    def test_supports_unicode(self):
+        query_result = self.factory.create_query_result()
+        query = self.factory.create_query(name="עברית", latest_query_data=query_result)
+
+        rv = self.make_request("get", "/api/queries/{}/results.json".format(query.id))
+        # This is what gunicorn will do with it
+        rv.headers['Content-Disposition'].encode('ascii')
+
+
 class TestQueryResultListAPI(BaseTestCase):
     def test_get_existing_result(self):
         query_result = self.factory.create_query_result()

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -36,7 +36,10 @@ class TestQueryResultsContentDispositionHeaders(BaseTestCase):
 
         rv = self.make_request("get", "/api/queries/{}/results.json".format(query.id))
         # This is what gunicorn will do with it
-        rv.headers['Content-Disposition'].encode('ascii')
+        try:
+            rv.headers['Content-Disposition'].encode('ascii')
+        except Exception as e:
+            self.fail(repr(e))            
 
 
 class TestQueryResultListAPI(BaseTestCase):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Ended up copying the implementation from Flask's `send_file` helper function, because `send_file` doesn't really fit our use case.

## Related Tickets & Documents

Closes #4332.