### PR TITLE
Hide unavailable page links to non-admin users in settings and header

### DIFF
--- a/client/app/components/SettingsWrapper.jsx
+++ b/client/app/components/SettingsWrapper.jsx
@@ -17,11 +17,13 @@ function wrapSettingsTab(options, WrappedComponent) {
           <PageHeader title="Settings" />
           <div className="bg-white tiled">
             <Menu selectedKeys={[activeItem && activeItem.title]} selectable={false} mode="horizontal">
-              {settingsMenu.items.map(item => (
-                <Menu.Item key={item.title}>
-                  <a href={item.path}>{item.title}</a>
-                </Menu.Item>
-              ))}
+              {settingsMenu.items
+                .filter(item => item.isAvailable())
+                .map(item => (
+                  <Menu.Item key={item.title}>
+                    <a href={item.path}>{item.title}</a>
+                  </Menu.Item>
+                ))}
             </Menu>
             <div className="p-15">
               <div>

--- a/client/app/components/app-header/AppHeader.jsx
+++ b/client/app/components/app-header/AppHeader.jsx
@@ -134,7 +134,7 @@ function DesktopNavbar() {
                       <a href="query_snippets">Query Snippets</a>
                     </Menu.Item>
                   )}
-                  {currentUser.hasPermission("list_users") && (
+                  {currentUser.isAdmin && (
                     <Menu.Item key="destinations">
                       <a href="destinations">Alert Destinations</a>
                     </Menu.Item>

--- a/client/app/services/settingsMenu.js
+++ b/client/app/services/settingsMenu.js
@@ -1,4 +1,5 @@
 import { isFunction, extend, omit, sortBy, find } from "lodash";
+import { currentUser } from "@/services/auth";
 
 class SettingsMenuItem {
   constructor(menuItem) {
@@ -10,6 +11,10 @@ class SettingsMenuItem {
 
   isActive(path) {
     return path.startsWith(this.pathPrefix);
+  }
+
+  isAvailable() {
+    return this.permission === undefined || currentUser.hasPermission(this.permission);
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Found this while testing the $http -> axios PR, since it was quick and I had a few minutes, just pushed.

Since #4323, tab links in settings were appearing to all users (data sources and alert destinations for example). This PR hides them again.

I can add a Cypress test to it tomorrow if you think it's worth it :)

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--