### PR TITLE
adjust imports to match influxdb 5.2.3

### DIFF
--- a/redash/query_runner/influx_db.py
+++ b/redash/query_runner/influx_db.py
@@ -6,7 +6,7 @@ from redash.utils import json_dumps
 logger = logging.getLogger(__name__)
 
 try:
-    from influxdb import InfluxDBClusterClient
+    from influxdb import InfluxDBClient
 
     enabled = True
 
@@ -68,7 +68,7 @@ class InfluxDB(BaseQueryRunner):
         return "influxdb"
 
     def run_query(self, query, user):
-        client = InfluxDBClusterClient.from_DSN(self.configuration["url"])
+        client = InfluxDBClient.from_dsn(self.configuration["url"])
 
         logger.debug("influxdb url: %s", self.configuration["url"])
         logger.debug("influxdb got query: %s", query)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
As part of #4181, the `influxdb` library was upgraded, but the imports have changed since v2.7.1. Following this PR, InfluxDB is available on Python3, but honestly, beyond static analysis up to `ResultSet.raw`, I can't guarantee it works. Ay thoughts on if and how to test this?

## Related Tickets & Documents
#4181 