### PR TITLE
Google Analytics runner - iterate over keys the Python 3 way

### DIFF
--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -163,11 +163,8 @@ class GoogleAnalytics(BaseSQLQueryRunner):
         try:
             params = json_loads(query)
         except:
-            params = parse_qs(urlparse(query).query, keep_blank_values=True)
-            for key in [*params]:
-                params[key] = ",".join(params[key])
-                if "-" in key:
-                    params[key.replace("-", "_")] = params.pop(key)
+            query_string = parse_qs(urlparse(query).query, keep_blank_values=True) 
+            params = {k.replace('-', '_'): ",".join(v) for k,v in query_string.items()}
 
         if "mcf:" in params["metrics"] and "ga:" in params["metrics"]:
             raise Exception("Can't mix mcf: and ga: metrics.")

--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -164,7 +164,7 @@ class GoogleAnalytics(BaseSQLQueryRunner):
             params = json_loads(query)
         except:
             params = parse_qs(urlparse(query).query, keep_blank_values=True)
-            for key in params.keys():
+            for key in [*params]:
                 params[key] = ",".join(params[key])
                 if "-" in key:
                     params[key.replace("-", "_")] = params.pop(key)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Following #4181, Google Analytics queries were broken since dict `.keys()` returns `dict_keys`, which would in turn yield wrong results when iterating over param values, resulting in errors such as
> Parameter "end_date" value "y,e,s,t,e,r,d,a,y" does not match the pattern "[0-9]{4}-[0-9]{2}-[0-9]{2}|today|yesterday|[0-9]+(daysAgo)" 

## Related Tickets & Documents
#4181 