### PR TITLE
webpack: remove children from output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -181,6 +181,7 @@ const config = {
   },
   devtool: isProduction ? "source-map" : "cheap-eval-module-source-map",
   stats: {
+    children: false,
     modules: false,
     chunkModules: false
   },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Removes from webpack output messages like:

```
Child mini-css-extract-plugin node_modules/css-loader/index.js??ref--7-1!node_modules/less-loader/dist/cjs.js??ref--7-2!client/app/visualizations/chart/Editor/editor.less:
    Entrypoint mini-css-extract-plugin = *
Child mini-css-extract-plugin node_modules/css-loader/index.js??ref--7-1!node_modules/less-loader/dist/cjs.js??ref--7-2!client/app/visualizations/chart/Renderer/renderer.less:
    Entrypoint mini-css-extract-plugin = *
Child mini-css-extract-plugin node_modules/css-loader/index.js??ref--7-1!node_modules/less-loader/dist/cjs.js??ref--7-2!client/app/visualizations/choropleth/Renderer/renderer.less:
    Entrypoint mini-css-extract-plugin = *
```