### PR TITLE
Fix Cypress issues after React version of Query Pages

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -153,7 +153,7 @@ function QuerySource(props) {
 
   const doExecuteQuery = useCallback(
     (skipParametersDirtyFlag = false) => {
-      if (!queryFlags.canExecute || (!skipParametersDirtyFlag && areParametersDirty) || isQueryExecuting) {
+      if (!queryFlags.canExecute || (!skipParametersDirtyFlag && (areParametersDirty || isQueryExecuting))) {
         return;
       }
       if (isDirty || !isEmpty(selectedText)) {

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -59,7 +59,7 @@ function QueryView(props) {
 
   const doExecuteQuery = useCallback(
     (skipParametersDirtyFlag = false) => {
-      if (!queryFlags.canExecute || (!skipParametersDirtyFlag && areParametersDirty) || isQueryExecuting) {
+      if (!queryFlags.canExecute || (!skipParametersDirtyFlag && (areParametersDirty || isQueryExecuting))) {
         return;
       }
       executeQuery();

--- a/client/cypress/integration/visualizations/pivot_spec.js
+++ b/client/cypress/integration/visualizations/pivot_spec.js
@@ -96,9 +96,8 @@ describe("Pivot", () => {
       cy.visit(`queries/${this.queryId}/source#${visualization.id}`);
       cy.getByTestId("ExecuteButton").click();
 
-      cy.getByTestId(`QueryPageVisualization${visualization.id}`)
-        .find(".pvtGrandTotal")
-        .should("have.text", "11"); // assert number of rows is 11
+      // assert number of rows is 11
+      cy.getByTestId(`QueryPageVisualization${visualization.id}`).contains(".pvtGrandTotal", "11");
 
       cy.getByTestId("QueryEditor")
         .get(".ace_text-input")
@@ -109,9 +108,8 @@ describe("Pivot", () => {
       cy.getByTestId("SaveButton").click();
       cy.getByTestId("ExecuteButton").click();
 
-      cy.getByTestId(`QueryPageVisualization${visualization.id}`)
-        .find(".pvtGrandTotal")
-        .should("have.text", "12"); // assert number of rows is 12
+      // assert number of rows is 12
+      cy.getByTestId(`QueryPageVisualization${visualization.id}`).contains(".pvtGrandTotal", "12");
     });
   });
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
After the React version of the query pages, a couple of specs started to show some flakyness. I decided to investigate, since it could be related to a real issue, so this PR has two fixes:

- **Pivot Spec**: for some reason the `.pvtGrandTotal` was pointing a different value in Cypress, and in the screenshot it looked ok... I assumed it was just a different way of rendering that caused it, so I changed the assertion method;
- **Parmeter Spec**: this one is a real issue and deserves a small discussion: previously to the React Migration of the query pages we used to allow the user to Re-execute a query while it's running when parameters are changed. This can cause overflow on queries execution since the user can trigger a query multiple times. On the other hand, it can also be annoying when you trigger a query with wrong parameters and has to wait for it to finish.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--