### PR TITLE
Add loading state to Query save button

### DIFF
--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -106,7 +106,7 @@ export default function EditorControl({
             loading={saveButtonProps.loading}
             onClick={saveButtonProps.onClick}
             data-test="SaveButton">
-            <span className="fa fa-floppy-o" />
+            {!saveButtonProps.loading && <span className="fa fa-floppy-o" />}
             {saveButtonProps.text}
           </Button>
         </ButtonTooltip>

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -103,6 +103,7 @@ export default function EditorControl({
           <Button
             className="query-editor-controls-button m-l-5"
             disabled={saveButtonProps.disabled}
+            loading={saveButtonProps.loading}
             onClick={saveButtonProps.onClick}
             data-test="SaveButton">
             <span className="fa fa-floppy-o" />
@@ -132,6 +133,7 @@ const ButtonPropsPropType = PropTypes.oneOfType([
   PropTypes.shape({
     title: PropTypes.node,
     disabled: PropTypes.bool,
+    loading: PropTypes.bool,
     onClick: PropTypes.func,
     text: PropTypes.node,
     shortcut: PropTypes.string,

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -283,7 +283,7 @@ function QuerySource(props) {
                           text: (
                             <React.Fragment>
                               <span className="hidden-xs">Save</span>
-                              {isDirty ? "*" : null}
+                              {isDirty && !isQuerySaving ? "*" : null}
                             </React.Fragment>
                           ),
                           shortcut: "mod+s",

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -173,6 +173,15 @@ function QuerySource(props) {
     ]
   );
 
+  const [isQuerySaving, setIsQuerySaving] = useState(false);
+
+  const doSaveQuery = useCallback(() => {
+    if (!isQuerySaving) {
+      setIsQuerySaving(true);
+      saveQuery().finally(() => setIsQuerySaving(false));
+    }
+  }, [isQuerySaving, saveQuery]);
+
   return (
     <div className="query-page-wrapper">
       <QuerySourceAlerts query={query} dataSourcesAvailable={!dataSourcesLoaded || dataSources.length > 0} />
@@ -278,7 +287,8 @@ function QuerySource(props) {
                             </React.Fragment>
                           ),
                           shortcut: "mod+s",
-                          onClick: saveQuery,
+                          onClick: doSaveQuery,
+                          loading: isQuerySaving,
                         }
                       }
                       executeButtonProps={{


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix
- [x] Other

## Description
This adds a loading state to the Query Save button, the main reason is to avoid multiple query created when the connection is not that good.

## Related Tickets & Documents
Fixes #4548 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![fix-multiple-query-saves](https://user-images.githubusercontent.com/3356951/72462741-88603680-37b0-11ea-8db4-e4d4e4a3e284.gif)
