### PR TITLE
Save new query before adding visualization

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -35,6 +35,7 @@ import useAddToDashboardDialog from "./hooks/useAddToDashboardDialog";
 import useEmbedDialog from "./hooks/useEmbedDialog";
 import useAddNewParameterDialog from "./hooks/useAddNewParameterDialog";
 import useEditScheduleDialog from "./hooks/useEditScheduleDialog";
+import useAddVisualizationDialog from "./hooks/useAddVisualizationDialog";
 import useEditVisualizationDialog from "./hooks/useEditVisualizationDialog";
 import useDeleteVisualization from "./hooks/useDeleteVisualization";
 import useFormatQuery from "./hooks/useFormatQuery";
@@ -136,13 +137,6 @@ function QuerySource(props) {
     setQuery(newQuery);
   });
 
-  const addVisualization = useEditVisualizationDialog(query, queryResult, (newQuery, visualization) => {
-    setQuery(newQuery);
-    setSelectedVisualization(visualization.id);
-  });
-  const editVisualization = useEditVisualizationDialog(query, queryResult, newQuery => setQuery(newQuery));
-  const deleteVisualization = useDeleteVisualization(query, setQuery);
-
   const handleSchemaItemSelect = useCallback(schemaItem => {
     if (editorRef.current) {
       editorRef.current.paste(schemaItem);
@@ -181,6 +175,13 @@ function QuerySource(props) {
       saveQuery().finally(() => setIsQuerySaving(false));
     }
   }, [isQuerySaving, saveQuery]);
+
+  const addVisualization = useAddVisualizationDialog(query, queryResult, doSaveQuery, (newQuery, visualization) => {
+    setQuery(newQuery);
+    setSelectedVisualization(visualization.id);
+  });
+  const editVisualization = useEditVisualizationDialog(query, queryResult, newQuery => setQuery(newQuery));
+  const deleteVisualization = useDeleteVisualization(query, setQuery);
 
   return (
     <div className="query-page-wrapper">

--- a/client/app/pages/queries/hooks/useAddVisualizationDialog.js
+++ b/client/app/pages/queries/hooks/useAddVisualizationDialog.js
@@ -1,0 +1,25 @@
+import { useState, useCallback, useEffect } from "react";
+import useQueryFlags from "./useQueryFlags";
+import useEditVisualizationDialog from "./useEditVisualizationDialog";
+
+export default function useAddVisualizationDialog(query, queryResult, saveQuery, onChange) {
+  const queryFlags = useQueryFlags(query);
+  const editVisualization = useEditVisualizationDialog(query, queryResult, onChange);
+  const [shouldOpenDialog, setShouldOpenDialog] = useState(false);
+
+  useEffect(() => {
+    if (!queryFlags.isNew && shouldOpenDialog) {
+      setShouldOpenDialog(false);
+      editVisualization();
+    }
+  }, [queryFlags.isNew, shouldOpenDialog, editVisualization]);
+
+  return useCallback(() => {
+    if (queryFlags.isNew) {
+      setShouldOpenDialog(true);
+      saveQuery();
+    } else {
+      editVisualization();
+    }
+  }, [queryFlags.isNew, saveQuery, editVisualization]);
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Restore feature accidentally removed during React migration: when trying to add a first visualization to a new query, save the query first (otherwise visualization couldn't be saved).