### PR TITLE
Fix Map visualization: L.layerGroup cannot compute its bounds

### DIFF
--- a/client/app/visualizations/map/initMap.js
+++ b/client/app/visualizations/map/initMap.js
@@ -94,7 +94,7 @@ function createMarkerClusterGroup(color) {
 function createMarkersLayer(options, { color, points }) {
   const { classify, clusterMarkers, customizeMarkers } = options;
 
-  const result = clusterMarkers ? createMarkerClusterGroup(color) : L.layerGroup();
+  const result = clusterMarkers ? createMarkerClusterGroup(color) : L.featureGroup();
 
   // create markers
   each(points, ({ lat, lon, row }) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

When creating new Map visualization with clustering disabled, map will crash on save because markers layer (`L.layerGroup`) does not have a method to compute its bounds.

Solution: use `L.featureGroup` that is derived from `L.layerGroup` and has all necessary methods.