### PR TITLE
Restore query execute notifications (missed during React migration)

### DIFF
--- a/client/app/services/notifications.js
+++ b/client/app/services/notifications.js
@@ -1,6 +1,7 @@
 import { find } from "lodash";
 import debug from "debug";
 import recordEvent from "@/services/recordEvent";
+import redashIconUrl from "@/assets/images/redash_icon_small.png";
 
 const logger = debug("redash:notifications");
 
@@ -11,43 +12,38 @@ if (!Notification) {
 
 const hidden = find(["hidden", "webkitHidden", "mozHidden", "msHidden"], prop => prop in document);
 
-class NotificationsService {
-  // eslint-disable-next-line class-methods-use-this
-  get pageVisible() {
-    return !document[hidden];
-  }
+function isPageVisible() {
+  return !document[hidden];
+}
 
-  // eslint-disable-next-line class-methods-use-this
-  getPermissions() {
-    if (Notification && Notification.permission === "default") {
-      Notification.requestPermission(status => {
-        if (Notification.permission !== status) {
-          Notification.permission = status;
-        }
-      });
-    }
-  }
-
-  showNotification(title, content) {
-    if (!Notification || this.pageVisible || Notification.permission !== "granted") {
-      return;
-    }
-
-    // using the 'tag' to avoid showing duplicate notifications
-    const notification = new Notification(title, {
-      tag: title + content,
-      body: content,
-      icon: "/images/redash_icon_small.png",
-    });
-    setTimeout(() => {
-      notification.close();
-    }, 3000);
-    notification.onclick = function onClick() {
-      window.focus();
-      this.close();
-      recordEvent("click", "notification");
-    };
+function getPermissions() {
+  if (Notification && Notification.permission === "default") {
+    Notification.requestPermission();
   }
 }
 
-export default new NotificationsService();
+function showNotification(title, content) {
+  if (!Notification || isPageVisible() || Notification.permission !== "granted") {
+    return;
+  }
+
+  // using the 'tag' to avoid showing duplicate notifications
+  const notification = new Notification(title, {
+    tag: title + content,
+    body: content,
+    icon: redashIconUrl,
+  });
+  setTimeout(() => {
+    notification.close();
+  }, 3000);
+  notification.onclick = function onClick() {
+    window.focus();
+    this.close();
+    recordEvent("click", "notification");
+  };
+}
+
+export default {
+  getPermissions,
+  showNotification,
+};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

In Angular version of application we used to show desktop notifications when query results are updated (or query execution failed). This feature was accidentally dropped during React migration.