### PR TITLE
Don't allow to fork query while previous fork is still in progress

### DIFF
--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -66,7 +66,7 @@ export default function QueryPageHeader({ query, dataSource, sourceMode, selecte
   const archiveQuery = useArchiveQuery(query, onChange);
   const publishQuery = usePublishQuery(query, onChange);
   const unpublishQuery = useUnpublishQuery(query, onChange);
-  const duplicateQuery = useDuplicateQuery(query);
+  const [isDuplicating, duplicateQuery] = useDuplicateQuery(query);
   const openApiKeyDialog = useApiKeyDialog(query, onChange);
   const openPermissionsEditorDialog = usePermissionsEditorDialog(query);
 
@@ -75,7 +75,7 @@ export default function QueryPageHeader({ query, dataSource, sourceMode, selecte
       createMenu([
         {
           fork: {
-            isEnabled: !queryFlags.isNew && queryFlags.canFork,
+            isEnabled: !queryFlags.isNew && queryFlags.canFork && !isDuplicating,
             title: (
               <React.Fragment>
                 Fork
@@ -111,7 +111,15 @@ export default function QueryPageHeader({ query, dataSource, sourceMode, selecte
           },
         },
       ]),
-    [queryFlags, archiveQuery, unpublishQuery, openApiKeyDialog, openPermissionsEditorDialog, duplicateQuery]
+    [
+      queryFlags,
+      archiveQuery,
+      unpublishQuery,
+      openApiKeyDialog,
+      openPermissionsEditorDialog,
+      isDuplicating,
+      duplicateQuery,
+    ]
   );
 
   return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

It's pretty old issue and it's almost impossible to reproduce it in current app version (when opening new tab - it immediately takes focus and second click goes there). But since it was an easy fix - I decided to add it.

## Related Tickets & Documents

Fixes getredash/redash#173
