### PR TITLE
Refine Timer and TimeAgo components (get rid of force update)

### DIFF
--- a/client/app/components/TimeAgo.jsx
+++ b/client/app/components/TimeAgo.jsx
@@ -1,10 +1,9 @@
 import moment from "moment";
 import { isNil } from "lodash";
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { Moment } from "@/components/proptypes";
 import { clientConfig } from "@/services/auth";
-import useForceUpdate from "@/lib/hooks/useForceUpdate";
 import Tooltip from "antd/lib/tooltip";
 
 function toMoment(value) {
@@ -14,18 +13,20 @@ function toMoment(value) {
 
 export default function TimeAgo({ date, placeholder, autoUpdate }) {
   const startDate = toMoment(date);
-
-  const value = startDate ? startDate.fromNow() : placeholder;
-  const title = startDate ? startDate.format(clientConfig.dateTimeFormat) : "";
-
-  const forceUpdate = useForceUpdate();
+  const [value, setValue] = useState(null);
+  const title = useMemo(() => (startDate ? startDate.format(clientConfig.dateTimeFormat) : null), [startDate]);
 
   useEffect(() => {
+    function update() {
+      setValue(startDate ? startDate.fromNow() : placeholder);
+    }
+    update();
+
     if (autoUpdate) {
-      const timer = setInterval(forceUpdate, 30 * 1000);
+      const timer = setInterval(update, 30 * 1000);
       return () => clearInterval(timer);
     }
-  }, [autoUpdate, forceUpdate]);
+  }, [autoUpdate, startDate, placeholder]);
 
   return (
     <Tooltip title={title}>
@@ -35,10 +36,7 @@ export default function TimeAgo({ date, placeholder, autoUpdate }) {
 }
 
 TimeAgo.propTypes = {
-  // `date` and `placeholder` used in `getDerivedStateFromProps`
-  // eslint-disable-next-line react/no-unused-prop-types
   date: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date), Moment]),
-  // eslint-disable-next-line react/no-unused-prop-types
   placeholder: PropTypes.string,
   autoUpdate: PropTypes.bool,
 };

--- a/client/app/components/Timer.jsx
+++ b/client/app/components/Timer.jsx
@@ -1,22 +1,25 @@
-import React, { useMemo, useEffect } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import moment from "moment";
 import PropTypes from "prop-types";
 import { Moment } from "@/components/proptypes";
-import useForceUpdate from "@/lib/hooks/useForceUpdate";
 
 export default function Timer({ from }) {
   const startTime = useMemo(() => moment(from).valueOf(), [from]);
-  const forceUpdate = useForceUpdate();
+  const [value, setValue] = useState(null);
 
   useEffect(() => {
-    const timer = setInterval(forceUpdate, 1000);
+    function update() {
+      const diff = moment.now() - startTime;
+      const format = diff > 1000 * 60 * 60 ? "HH:mm:ss" : "mm:ss"; // no HH under an hour
+      setValue(moment.utc(diff).format(format));
+    }
+    update();
+
+    const timer = setInterval(update, 1000);
     return () => clearInterval(timer);
-  }, [forceUpdate]);
+  }, [startTime]);
 
-  const diff = moment.now() - startTime;
-  const format = diff > 1000 * 60 * 60 ? "HH:mm:ss" : "mm:ss"; // no HH under an hour
-
-  return <span className="rd-timer">{moment.utc(diff).format(format)}</span>;
+  return <span className="rd-timer">{value}</span>;
 }
 
 Timer.propTypes = {

--- a/client/app/lib/hooks/useForceUpdate.js
+++ b/client/app/lib/hooks/useForceUpdate.js
@@ -1,6 +1,0 @@
-import { useState } from "react";
-
-export default function useForceUpdate() {
-  const [, setValue] = useState(false);
-  return () => setValue(value => !value);
-}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Other

## Description

`forceUpdate` is a sort of anti-pattern, but when we implemented these components we didn't have enough experience with React hooks and used a force update as workaround. This PR changes the implementation to be more clear and React-way.