### PR TITLE
Fix treasuredata endpoint

### DIFF
--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -68,7 +68,7 @@ class TreasureData(BaseQueryRunner):
         schema = {}
         if self.configuration.get("get_schema", False):
             try:
-                with tdclient.Client(self.configuration.get("apikey")) as client:
+                with tdclient.Client(self.configuration.get("apikey"),endpoint=self.configuration.get("endpoint")) as client:
                     for table in client.tables(self.configuration.get("db")):
                         table_name = "{}.{}".format(
                             self.configuration.get("db"), table.name

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -53,7 +53,7 @@ class TreasureData(BaseQueryRunner):
                     "default": False,
                 },
             },
-            "required": ["apikey", "db","endpoint"],
+            "required": ["apikey", "db"],
         }
 
     @classmethod

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -53,7 +53,7 @@ class TreasureData(BaseQueryRunner):
                     "default": False,
                 },
             },
-            "required": ["apikey", "db"],
+            "required": ["apikey", "db","endpoint"],
         }
 
     @classmethod


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Other

## Description
So far, TreasureData Query runner could not identify endpoint correctly and uses only `https://api.treasuredata.com`

## Related Tickets & Documents

Closes #3185
