### PR TITLE
Dynamic Form: boolean fields related fixes

### DIFF
--- a/client/app/components/dynamic-form/DynamicForm.jsx
+++ b/client/app/components/dynamic-form/DynamicForm.jsx
@@ -57,8 +57,13 @@ class DynamicForm extends React.Component {
     super(props);
 
     const hasFilledExtraField = some(props.fields, field => {
-      const { extra, initialValue } = field;
-      return extra && (!isEmpty(initialValue) || isNumber(initialValue) || (isBoolean(initialValue) && initialValue));
+      const { extra, initialValue, placeholder } = field;
+      return (
+        extra &&
+        (!isEmpty(initialValue) ||
+          isNumber(initialValue) ||
+          (isBoolean(initialValue) && initialValue.toString() !== placeholder))
+      );
     });
 
     const inProgressActions = {};

--- a/client/app/components/dynamic-form/DynamicForm.jsx
+++ b/client/app/components/dynamic-form/DynamicForm.jsx
@@ -100,7 +100,7 @@ class DynamicForm extends React.Component {
     this.props.form.validateFieldsAndScroll((err, values) => {
       Object.entries(values).forEach(([key, value]) => {
         const initialValue = this.props.fields.find(f => f.name === key).initialValue;
-        if ((initialValue === null || initialValue === undefined || initialValue === '') && value === '') {
+        if ((initialValue === null || initialValue === undefined || initialValue === "") && value === "") {
           values[key] = null;
         }
       });

--- a/client/app/components/dynamic-form/dynamicFormHelper.js
+++ b/client/app/components/dynamic-form/dynamicFormHelper.js
@@ -9,7 +9,7 @@ function orderedInputs(properties, order, targetOptions) {
       name: key,
       title: properties[key].title,
       type: properties[key].type,
-      placeholder: properties[key].default && properties[key].default.toString(),
+      placeholder: (properties[key].default === false || properties[key].default) && properties[key].default.toString(),
       required: properties[key].required,
       extra: properties[key].extra,
       initialValue: targetOptions[key],

--- a/client/app/components/dynamic-form/dynamicFormHelper.js
+++ b/client/app/components/dynamic-form/dynamicFormHelper.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { each, includes, isUndefined, isEmpty, map } from "lodash";
+import { each, includes, isUndefined, isEmpty, isNil, map } from "lodash";
 
 function orderedInputs(properties, order, targetOptions) {
   const inputs = new Array(order.length);
@@ -9,7 +9,7 @@ function orderedInputs(properties, order, targetOptions) {
       name: key,
       title: properties[key].title,
       type: properties[key].type,
-      placeholder: (properties[key].default === false || properties[key].default) && properties[key].default.toString(),
+      placeholder: isNil(properties[key].default) ? null : properties[key].default.toString(),
       required: properties[key].required,
       extra: properties[key].extra,
       initialValue: targetOptions[key],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Two fixes:

* When a boolean field had default value of `false` we would set `false` as the default value instead of the string value, which fails prop types.
* When an extra boolean field had default value of true it would make the extra fields section to be open.