### PR TITLE
Sort schema columns alphabetically

### DIFF
--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -200,12 +200,13 @@ class DataSourceSchemaResource(BaseResource):
             response["error"] = {"code": 2, "message": "Error retrieving schema."}
 
         try:
-            sorted_schema = [{"name": i['name'], "columns": sorted(i['columns'])} for i in schema]
+            sorted_schema = [{"name": i['name'], "columns": sorted(i['columns'])}
+                for i in sorted(schema, key=lambda x: x['name'])]
             response["schema"] = sorted_schema
         except Exception:
             logging.exception(
                 "Error sorting schema columns for data_source {}"\
-                .format(self.data_source.id))
+                .format(data_source_id))
             response['schema'] = schema
 
         return response

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -190,7 +190,7 @@ class DataSourceSchemaResource(BaseResource):
         response = {}
 
         try:
-            response["schema"] = data_source.get_schema(refresh)
+            schema = data_source.get_schema(refresh)
         except NotSupported:
             response["error"] = {
                 "code": 1,
@@ -198,6 +198,15 @@ class DataSourceSchemaResource(BaseResource):
             }
         except Exception:
             response["error"] = {"code": 2, "message": "Error retrieving schema."}
+
+        try:
+            sorted_schema = [{"name": i['name'], "columns": sorted(i['columns'])} for i in schema]
+            response["schema"] = sorted_schema
+        except Exception:
+            logging.exception(
+                "Error sorting schema columns for data_source {}"\
+                .format(self.data_source.id))
+            response['schema'] = schema
 
         return response
 

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -190,7 +190,7 @@ class DataSourceSchemaResource(BaseResource):
         response = {}
 
         try:
-            schema = data_source.get_schema(refresh)
+            response['schema'] = data_source.get_schema(refresh)
         except NotSupported:
             response["error"] = {
                 "code": 1,
@@ -198,16 +198,6 @@ class DataSourceSchemaResource(BaseResource):
             }
         except Exception:
             response["error"] = {"code": 2, "message": "Error retrieving schema."}
-
-        try:
-            sorted_schema = [{"name": i['name'], "columns": sorted(i['columns'])}
-                for i in sorted(schema, key=lambda x: x['name'])]
-            response["schema"] = sorted_schema
-        except Exception:
-            logging.exception(
-                "Error sorting schema columns for data_source {}"\
-                .format(data_source_id))
-            response['schema'] = schema
 
         return response
 

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -190,7 +190,7 @@ class DataSourceSchemaResource(BaseResource):
         response = {}
 
         try:
-            response['schema'] = data_source.get_schema(refresh)
+            response["schema"] = data_source.get_schema(refresh)
         except NotSupported:
             response["error"] = {
                 "code": 1,

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -190,12 +190,15 @@ class DataSource(BelongsToOrgMixin, db.Model):
             schema = query_runner.get_schema(get_stats=refresh)
 
             try:
-                out_schema = [{"name": i['name'], "columns": sorted(i['columns'])}
-                for i in sorted(schema, key=lambda x: x['name'])]
+                out_schema = [
+                    {"name": i["name"], "columns": sorted(i["columns"])}
+                    for i in sorted(schema, key=lambda x: x["name"])
+                ]
 
             except Exception:
-                logging.exception("Error sorting schema columns for data_source {}"\
-                    .format(self.id))
+                logging.exception(
+                    "Error sorting schema columns for data_source {}".format(self.id)
+                )
                 out_schema = schema
 
             redis_connection.set(self._schema_key, json_dumps(out_schema))

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -187,9 +187,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
         if cache is None:
             query_runner = self.query_runner
-            schema = sorted(
-                query_runner.get_schema(get_stats=refresh), key=lambda t: t["name"]
-            )
+            schema = query_runner.get_schema(get_stats=refresh)
 
             redis_connection.set(self._schema_key, json_dumps(schema))
         else:

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -196,12 +196,12 @@ class DataSource(BelongsToOrgMixin, db.Model):
                     "Error sorting schema columns for data_source {}".format(self.id)
                 )
                 out_schema = schema
-
-            redis_connection.set(self._schema_key, json_dumps(out_schema))
+            finally:
+                redis_connection.set(self._schema_key, json_dumps(out_schema))
         else:
-            schema = json_loads(cache)
+            out_schema = json_loads(cache)
 
-        return schema
+        return out_schema
 
     def _sort_schema(self, schema):
         return [

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -189,7 +189,16 @@ class DataSource(BelongsToOrgMixin, db.Model):
             query_runner = self.query_runner
             schema = query_runner.get_schema(get_stats=refresh)
 
-            redis_connection.set(self._schema_key, json_dumps(schema))
+            try:
+                out_schema = [{"name": i['name'], "columns": sorted(i['columns'])}
+                for i in sorted(schema, key=lambda x: x['name'])]
+
+            except Exception:
+                logging.exception("Error sorting schema columns for data_source {}"\
+                    .format(self.id))
+                out_schema = schema
+
+            redis_connection.set(self._schema_key, json_dumps(out_schema))
         else:
             schema = json_loads(cache)
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -190,11 +190,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
             schema = query_runner.get_schema(get_stats=refresh)
 
             try:
-                out_schema = [
-                    {"name": i["name"], "columns": sorted(i["columns"])}
-                    for i in sorted(schema, key=lambda x: x["name"])
-                ]
-
+                out_schema = self._sort_schema(schema)
             except Exception:
                 logging.exception(
                     "Error sorting schema columns for data_source {}".format(self.id)
@@ -206,6 +202,12 @@ class DataSource(BelongsToOrgMixin, db.Model):
             schema = json_loads(cache)
 
         return schema
+
+    def _sort_schema(self, schema):
+        return [
+            {"name": i["name"], "columns": sorted(i["columns"])}
+            for i in sorted(schema, key=lambda x: x["name"])
+        ]
 
     @property
     def _schema_key(self):

--- a/tests/models/test_data_sources.py
+++ b/tests/models/test_data_sources.py
@@ -47,6 +47,27 @@ class DataSourceTest(BaseTestCase):
             self.assertEqual(new_return_value, schema)
             self.assertEqual(patched_get_schema.call_count, 2)
 
+    def test_schema_sorter(self):
+        input_data = [
+            {"name": "zoo", "columns": ["is_zebra", "is_snake", "is_cow"]},
+            {
+                "name": "all_terain_vehicle",
+                "columns": ["has_wheels", "has_engine", "has_all_wheel_drive"],
+            },
+        ]
+
+        expected_output = [
+            {
+                "name": "all_terain_vehicle",
+                "columns": ["has_all_wheel_drive", "has_engine", "has_wheels"],
+            },
+            {"name": "zoo", "columns": ["is_cow", "is_snake", "is_zebra"]},
+        ]
+
+        real_output = self.factory.data_source._sort_schema(input_data)
+
+        self.assertEqual(real_output, expected_output)
+
 
 class TestDataSourceCreate(BaseTestCase):
     def test_adds_data_source_to_default_group(self):

--- a/tests/models/test_data_sources.py
+++ b/tests/models/test_data_sources.py
@@ -68,6 +68,32 @@ class DataSourceTest(BaseTestCase):
 
         self.assertEqual(real_output, expected_output)
 
+    def test_model_uses_schema_sorter(self):
+        orig_schema = [
+            {"name": "zoo", "columns": ["is_zebra", "is_snake", "is_cow"]},
+            {
+                "name": "all_terain_vehicle",
+                "columns": ["has_wheels", "has_engine", "has_all_wheel_drive"],
+            },
+        ]
+
+        sorted_schema = [
+            {
+                "name": "all_terain_vehicle",
+                "columns": ["has_all_wheel_drive", "has_engine", "has_wheels"],
+            },
+            {"name": "zoo", "columns": ["is_cow", "is_snake", "is_zebra"]},
+        ]
+
+        with mock.patch(
+            "redash.query_runner.pg.PostgreSQL.get_schema"
+        ) as patched_get_schema:
+            patched_get_schema.return_value = orig_schema
+
+            out_schema = self.factory.data_source.get_schema()
+
+            self.assertEqual(out_schema, sorted_schema)
+
 
 class TestDataSourceCreate(BaseTestCase):
     def test_adds_data_source_to_default_group(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description
This PR sorts the column names shown in the schema viewer alphabetically at the API level. It also moves table name sorting from the Model code into the `get_schema()` method of the schema resource. If the sort raises an exception then the API returns the columns in the order sent by the query runner.

Users will need to refresh their schemas before the change is visible in the front-end.

## Related Tickets & Documents
https://github.com/redashlabs/product/issues/15. 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Before
![before-edited](https://user-images.githubusercontent.com/17067911/73194847-6e98ea80-40f2-11ea-8aab-0eea958738b4.png)

## After
![after-edited](https://user-images.githubusercontent.com/17067911/73194858-70fb4480-40f2-11ea-88ac-6a1d30a93a9d.png)
