### PR TITLE
Choropleth: allow to use custom maps

### DIFF
--- a/client/app/visualizations/choropleth/Editor/FormatSettings.jsx
+++ b/client/app/visualizations/choropleth/Editor/FormatSettings.jsx
@@ -1,4 +1,6 @@
-import React from "react";
+import { map } from "lodash";
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
 import { useDebouncedCallback } from "use-debounce";
 import * as Grid from "antd/lib/grid";
 import {
@@ -12,49 +14,29 @@ import {
 } from "@/components/visualizations/editor";
 import { EditorPropTypes } from "@/visualizations/prop-types";
 
-function TemplateFormatHint({ mapType }) {
-  // eslint-disable-line react/prop-types
+import useLoadGeoJson from "../hooks/useLoadGeoJson";
+import { getGeoJsonFields } from "./utils";
+
+function TemplateFormatHint({ geoJsonProperties }) {
   return (
     <ContextHelp placement="topLeft" arrowPointAtCenter>
       <div className="p-b-5">
-        All query result columns can be referenced using <code>{"{{ column_name }}"}</code> syntax.
+        <div>
+          All query result columns can be referenced using <code>{"{{ column_name }}"}</code> syntax.
+        </div>
+        <div>
+          Use <code>{"{{ @@value }}"}</code> to access formatted value.
+        </div>
       </div>
-      <div className="p-b-5">Use special names to access additional properties:</div>
-      <div>
-        <code>{"{{ @@value }}"}</code> formatted value;
-      </div>
-      {mapType === "countries" && (
+      {geoJsonProperties.length > 0 && (
         <React.Fragment>
-          <div>
-            <code>{"{{ @@name }}"}</code> short country name;
-          </div>
-          <div>
-            <code>{"{{ @@name_long }}"}</code> full country name;
-          </div>
-          <div>
-            <code>{"{{ @@abbrev }}"}</code> abbreviated country name;
-          </div>
-          <div>
-            <code>{"{{ @@iso_a2 }}"}</code> two-letter ISO country code;
-          </div>
-          <div>
-            <code>{"{{ @@iso_a3 }}"}</code> three-letter ISO country code;
-          </div>
-          <div>
-            <code>{"{{ @@iso_n3 }}"}</code> three-digit ISO country code.
-          </div>
-        </React.Fragment>
-      )}
-      {mapType === "subdiv_japan" && (
-        <React.Fragment>
-          <div>
-            <code>{"{{ @@name }}"}</code> Prefecture name in English;
-          </div>
-          <div>
-            <code>{"{{ @@name_local }}"}</code> Prefecture name in Kanji;
-          </div>
-          <div>
-            <code>{"{{ @@iso_3166_2 }}"}</code> five-letter ISO subdivision code (JP-xx);
+          <div className="p-b-5">GeoJSON properties could be accessed by these names:</div>
+          <div style={{ maxHeight: 300, overflow: "auto" }}>
+            {map(geoJsonProperties, property => (
+              <div key={property}>
+                <code>{`{{ @@${property}}}`}</code>
+              </div>
+            ))}
           </div>
         </React.Fragment>
       )}
@@ -62,10 +44,20 @@ function TemplateFormatHint({ mapType }) {
   );
 }
 
+TemplateFormatHint.propTypes = {
+  geoJsonProperties: PropTypes.arrayOf(PropTypes.string),
+};
+
+TemplateFormatHint.defaultProps = {
+  geoJsonProperties: [],
+};
+
 export default function GeneralSettings({ options, onOptionsChange }) {
   const [onOptionsChangeDebounced] = useDebouncedCallback(onOptionsChange, 200);
+  const [geoJson] = useLoadGeoJson(options.mapUrl);
+  const geoJsonFields = useMemo(() => getGeoJsonFields(geoJson), [geoJson]);
 
-  const templateFormatHint = <TemplateFormatHint mapType={options.mapType} />;
+  const templateFormatHint = <TemplateFormatHint geoJsonProperties={geoJsonFields} />;
 
   return (
     <div className="choropleth-visualization-editor-format-settings">

--- a/client/app/visualizations/choropleth/Editor/GeneralSettings.jsx
+++ b/client/app/visualizations/choropleth/Editor/GeneralSettings.jsx
@@ -1,88 +1,94 @@
-import { map } from "lodash";
-import React, { useMemo } from "react";
+import { isString, map, filter, find } from "lodash";
+import React, { useMemo, useState, useCallback } from "react";
+import * as Grid from "antd/lib/grid";
 import { EditorPropTypes } from "@/visualizations/prop-types";
 import { Section, Select } from "@/components/visualizations/editor";
-import { inferCountryCodeType } from "./utils";
+
+import useLoadGeoJson from "../hooks/useLoadGeoJson";
+import availableMaps from "../maps";
+import { getGeoJsonFields } from "./utils";
+
+function getMapLabel(mapUrl) {
+  const result = find(availableMaps, item => item.url === mapUrl);
+  return result ? result.name : mapUrl;
+}
 
 export default function GeneralSettings({ options, data, onOptionsChange }) {
-  const countryCodeTypes = useMemo(() => {
-    switch (options.mapType) {
-      case "countries":
-        return {
-          name: "Short name",
-          name_long: "Full name",
-          abbrev: "Abbreviated name",
-          iso_a2: "ISO code (2 letters)",
-          iso_a3: "ISO code (3 letters)",
-          iso_n3: "ISO code (3 digits)",
-        };
-      case "subdiv_japan":
-        return {
-          name: "Name",
-          name_local: "Name (local)",
-          iso_3166_2: "ISO-3166-2",
-        };
-      default:
-        return {};
-    }
-  }, [options.mapType]);
+  const [geoJson, isLoadingGeoJson] = useLoadGeoJson(options.mapUrl);
+  const geoJsonFields = useMemo(() => getGeoJsonFields(geoJson), [geoJson]);
+  const [customGeoJsonUrl, setCustomGeoJsonUrl] = useState(null);
 
-  const handleChangeAndInferType = newOptions => {
-    newOptions.countryCodeType =
-      inferCountryCodeType(
-        newOptions.mapType || options.mapType,
-        data ? data.rows : [],
-        newOptions.countryCodeColumn || options.countryCodeColumn
-      ) || options.countryCodeType;
-    onOptionsChange(newOptions);
-  };
+  // While geoJson is loading - show last selected field in select
+  const targetFields = isLoadingGeoJson ? filter([options.targetField], isString) : geoJsonFields;
+
+  const handleMapUrlChange = useCallback(
+    mapUrl => {
+      if (!mapUrl) {
+        setCustomGeoJsonUrl(null);
+      }
+      onOptionsChange({ mapUrl: mapUrl || null });
+    },
+    [onOptionsChange]
+  );
 
   return (
     <React.Fragment>
       <Section>
         <Select
-          label="Map type"
+          label="Map URL"
           className="w-100"
-          data-test="Choropleth.Editor.MapType"
-          defaultValue={options.mapType}
-          onChange={mapType => handleChangeAndInferType({ mapType })}>
-          <Select.Option key="countries" data-test="Choropleth.Editor.MapType.Countries">
-            Countries
-          </Select.Option>
-          <Select.Option key="subdiv_japan" data-test="Choropleth.Editor.MapType.Japan">
-            Japan/Prefectures
-          </Select.Option>
-        </Select>
-      </Section>
-
-      <Section>
-        <Select
-          label="Key column"
-          className="w-100"
-          data-test="Choropleth.Editor.KeyColumn"
-          defaultValue={options.countryCodeColumn}
-          onChange={countryCodeColumn => handleChangeAndInferType({ countryCodeColumn })}>
-          {map(data.columns, ({ name }) => (
-            <Select.Option key={name} data-test={`Choropleth.Editor.KeyColumn.${name}`}>
-              {name}
+          data-test="Choropleth.Editor.MapUrl"
+          showSearch
+          showArrow
+          filterOption={false}
+          allowClear
+          placeholder="Choose map or type GeoJSON URL..."
+          value={options.mapUrl || undefined}
+          onSearch={value => setCustomGeoJsonUrl(value !== "" ? value : null)}
+          onChange={handleMapUrlChange}>
+          {customGeoJsonUrl && <Select.Option key={customGeoJsonUrl}>{customGeoJsonUrl}</Select.Option>}
+          {map(availableMaps, ({ url: mapUrl }, mapKey) => (
+            <Select.Option key={mapUrl} data-test={`Choropleth.Editor.MapUrl.${mapKey}`}>
+              {getMapLabel(mapUrl)}
             </Select.Option>
           ))}
         </Select>
       </Section>
 
       <Section>
-        <Select
-          label="Key type"
-          className="w-100"
-          data-test="Choropleth.Editor.KeyType"
-          value={options.countryCodeType}
-          onChange={countryCodeType => onOptionsChange({ countryCodeType })}>
-          {map(countryCodeTypes, (name, type) => (
-            <Select.Option key={type} data-test={`Choropleth.Editor.KeyType.${type}`}>
-              {name}
-            </Select.Option>
-          ))}
-        </Select>
+        <Grid.Row gutter={15}>
+          <Grid.Col span={12}>
+            <Select
+              label="Key column"
+              className="w-100"
+              data-test="Choropleth.Editor.KeyColumn"
+              disabled={data.columns.length === 0}
+              defaultValue={options.keyColumn}
+              onChange={keyColumn => onOptionsChange({ keyColumn })}>
+              {map(data.columns, ({ name }) => (
+                <Select.Option key={name} data-test={`Choropleth.Editor.KeyColumn.${name}`}>
+                  {name}
+                </Select.Option>
+              ))}
+            </Select>
+          </Grid.Col>
+          <Grid.Col span={12}>
+            <Select
+              label="Target Field"
+              className="w-100"
+              data-test="Choropleth.Editor.TargetField"
+              disabled={isLoadingGeoJson || targetFields.length === 0}
+              loading={isLoadingGeoJson}
+              value={options.targetField}
+              onChange={targetField => onOptionsChange({ targetField })}>
+              {map(targetFields, field => (
+                <Select.Option key={field} data-test={`Choropleth.Editor.TargetField.${field}`}>
+                  {field}
+                </Select.Option>
+              ))}
+            </Select>
+          </Grid.Col>
+        </Grid.Row>
       </Section>
 
       <Section>
@@ -90,6 +96,7 @@ export default function GeneralSettings({ options, data, onOptionsChange }) {
           label="Value column"
           className="w-100"
           data-test="Choropleth.Editor.ValueColumn"
+          disabled={data.columns.length === 0}
           defaultValue={options.valueColumn}
           onChange={valueColumn => onOptionsChange({ valueColumn })}>
           {map(data.columns, ({ name }) => (

--- a/client/app/visualizations/choropleth/Editor/utils.js
+++ b/client/app/visualizations/choropleth/Editor/utils.js
@@ -1,38 +1,15 @@
 /* eslint-disable import/prefer-default-export */
 
-import _ from "lodash";
+import { isObject, isArray, reduce, keys, uniq } from "lodash";
 
-export function inferCountryCodeType(mapType, data, countryCodeField) {
-  const regexMap = {
-    countries: {
-      iso_a2: /^[a-z]{2}$/i,
-      iso_a3: /^[a-z]{3}$/i,
-      iso_n3: /^[0-9]{3}$/i,
+export function getGeoJsonFields(geoJson) {
+  const features = isObject(geoJson) && isArray(geoJson.features) ? geoJson.features : [];
+  return reduce(
+    features,
+    (result, feature) => {
+      const properties = isObject(feature) && isObject(feature.properties) ? feature.properties : {};
+      return uniq([...result, ...keys(properties)]);
     },
-    subdiv_japan: {
-      name: /^[a-z]+$/i,
-      name_local: /^[\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]+$/i,
-      iso_3166_2: /^JP-[0-9]{2}$/i,
-    },
-  };
-
-  const regex = regexMap[mapType];
-
-  const initState = _.mapValues(regex, () => 0);
-
-  const result = _.chain(data)
-    .reduce((memo, item) => {
-      const value = item[countryCodeField];
-      if (_.isString(value)) {
-        _.each(regex, (r, k) => {
-          memo[k] += r.test(value) ? 1 : 0;
-        });
-      }
-      return memo;
-    }, initState)
-    .toPairs()
-    .reduce((memo, item) => (item[1] > memo[1] ? item : memo))
-    .value();
-
-  return result[1] / data.length >= 0.9 ? result[0] : null;
+    []
+  );
 }

--- a/client/app/visualizations/choropleth/Renderer/index.jsx
+++ b/client/app/visualizations/choropleth/Renderer/index.jsx
@@ -1,48 +1,20 @@
 import { omit, merge } from "lodash";
 import React, { useState, useEffect } from "react";
-import { axios } from "@/services/axios";
 import { RendererPropTypes } from "@/visualizations/prop-types";
 import useMemoWithDeepCompare from "@/lib/hooks/useMemoWithDeepCompare";
 
+import useLoadGeoJson from "../hooks/useLoadGeoJson";
 import initChoropleth from "./initChoropleth";
 import { prepareData } from "./utils";
 import "./renderer.less";
 
-import countriesDataUrl from "../maps/countries.geo.json";
-import subdivJapanDataUrl from "../maps/japan.prefectures.geo.json";
-
-function getDataUrl(type) {
-  switch (type) {
-    case "countries":
-      return countriesDataUrl;
-    case "subdiv_japan":
-      return subdivJapanDataUrl;
-    default:
-      return null;
-  }
-}
-
 export default function Renderer({ data, options, onOptionsChange }) {
   const [container, setContainer] = useState(null);
-  const [geoJson, setGeoJson] = useState(null);
+  const [geoJson] = useLoadGeoJson(options.mapUrl);
 
   const optionsWithoutBounds = useMemoWithDeepCompare(() => omit(options, ["bounds"]), [options]);
 
   const [map, setMap] = useState(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    axios.get(getDataUrl(options.mapType)).then(data => {
-      if (!cancelled) {
-        setGeoJson(data);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [options.mapType]);
 
   useEffect(() => {
     if (container) {
@@ -58,7 +30,7 @@ export default function Renderer({ data, options, onOptionsChange }) {
     if (map) {
       map.updateLayers(
         geoJson,
-        prepareData(data.rows, optionsWithoutBounds.countryCodeColumn, optionsWithoutBounds.valueColumn),
+        prepareData(data.rows, optionsWithoutBounds.keyColumn, optionsWithoutBounds.valueColumn),
         options // detect changes for all options except bounds, but pass them all!
       );
     }

--- a/client/app/visualizations/choropleth/Renderer/initChoropleth.js
+++ b/client/app/visualizations/choropleth/Renderer/initChoropleth.js
@@ -35,9 +35,9 @@ const CustomControl = L.Control.extend({
 });
 
 function prepareLayer({ feature, layer, data, options, limits, colors, formatValue }) {
-  const value = getValueForFeature(feature, data, options.countryCodeType);
+  const value = getValueForFeature(feature, data, options.targetField);
   const valueFormatted = formatValue(value);
-  const featureData = prepareFeatureProperties(feature, valueFormatted, data, options.countryCodeType);
+  const featureData = prepareFeatureProperties(feature, valueFormatted, data, options.targetField);
   const color = getColorByValue(value, limits, colors, options.colors.noValue);
 
   layer.setStyle({
@@ -67,6 +67,19 @@ function prepareLayer({ feature, layer, data, options, limits, colors, formatVal
       fillColor: color,
     });
   });
+}
+
+function validateBounds(bounds, fallbackBounds) {
+  if (bounds) {
+    bounds = L.latLngBounds(bounds[0], bounds[1]);
+    if (bounds.isValid()) {
+      return bounds;
+    }
+  }
+  if (fallbackBounds && fallbackBounds.isValid()) {
+    return fallbackBounds;
+  }
+  return null;
 }
 
 export default function initChoropleth(container) {
@@ -123,9 +136,12 @@ export default function initChoropleth(container) {
       },
     }).addTo(_map);
 
-    const bounds = _choropleth.getBounds();
-    _map.fitBounds(options.bounds || bounds, { animate: false, duration: 0 });
-    _map.setMaxBounds(bounds);
+    const mapBounds = _choropleth.getBounds();
+    const bounds = validateBounds(options.bounds, mapBounds);
+    if (bounds) {
+      _map.fitBounds(bounds, { animate: false, duration: 0 });
+      _map.setMaxBounds(mapBounds);
+    }
 
     // send updated bounds to editor; delay this to avoid infinite update loop
     setTimeout(() => {
@@ -149,8 +165,8 @@ export default function initChoropleth(container) {
   function updateBounds(bounds) {
     if (!boundsChangedFromMap) {
       const layerBounds = _choropleth ? _choropleth.getBounds() : _map.getBounds();
-      bounds = bounds ? L.latLngBounds(bounds[0], bounds[1]) : layerBounds;
-      if (bounds.isValid()) {
+      bounds = validateBounds(bounds, layerBounds);
+      if (bounds) {
         _map.fitBounds(bounds, { animate: false, duration: 0 });
       }
     }

--- a/client/app/visualizations/choropleth/Renderer/utils.js
+++ b/client/app/visualizations/choropleth/Renderer/utils.js
@@ -18,17 +18,17 @@ export function createNumberFormatter(format, placeholder) {
   };
 }
 
-export function prepareData(data, countryCodeField, valueField) {
-  if (!countryCodeField || !valueField) {
+export function prepareData(data, keyColumn, valueColumn) {
+  if (!keyColumn || !valueColumn) {
     return {};
   }
 
   const result = {};
   each(data, item => {
-    if (item[countryCodeField]) {
-      const value = parseFloat(item[valueField]);
-      result[item[countryCodeField]] = {
-        code: item[countryCodeField],
+    if (item[keyColumn]) {
+      const value = parseFloat(item[valueColumn]);
+      result[item[keyColumn]] = {
+        code: item[keyColumn],
         value: isFinite(value) ? value : undefined,
         item,
       };
@@ -37,18 +37,18 @@ export function prepareData(data, countryCodeField, valueField) {
   return result;
 }
 
-export function prepareFeatureProperties(feature, valueFormatted, data, countryCodeType) {
+export function prepareFeatureProperties(feature, valueFormatted, data, targetField) {
   const result = {};
   each(feature.properties, (value, key) => {
     result["@@" + key] = value;
   });
   result["@@value"] = valueFormatted;
-  const datum = data[feature.properties[countryCodeType]] || {};
+  const datum = data[feature.properties[targetField]] || {};
   return extend(result, datum.item);
 }
 
-export function getValueForFeature(feature, data, countryCodeType) {
-  const code = feature.properties[countryCodeType];
+export function getValueForFeature(feature, data, targetField) {
+  const code = feature.properties[targetField];
   if (isString(code) && isObject(data[code])) {
     return data[code].value;
   }
@@ -70,7 +70,7 @@ export function createScale(features, data, options) {
   // Calculate limits
   const values = uniq(
     filter(
-      map(features, feature => getValueForFeature(feature, data, options.countryCodeType)),
+      map(features, feature => getValueForFeature(feature, data, options.targetField)),
       isFinite
     )
   );

--- a/client/app/visualizations/choropleth/getOptions.js
+++ b/client/app/visualizations/choropleth/getOptions.js
@@ -1,11 +1,12 @@
-import { merge } from "lodash";
+import { isNil, merge } from "lodash";
 import ColorPalette from "./ColorPalette";
+import availableMaps from "./maps";
 
 const DEFAULT_OPTIONS = {
-  mapType: "countries",
-  countryCodeColumn: "",
-  countryCodeType: "iso_a3",
-  valueColumn: "",
+  mapUrl: availableMaps.countries.url,
+  keyColumn: null,
+  targetField: null,
+  valueColumn: null,
   clusteringMode: "e",
   steps: 5,
   valueFormat: "0,0.00",
@@ -33,5 +34,19 @@ const DEFAULT_OPTIONS = {
 };
 
 export default function getOptions(options) {
-  return merge({}, DEFAULT_OPTIONS, options);
+  const result = merge({}, DEFAULT_OPTIONS, options);
+
+  // backward compatibility
+  if (!isNil(result.mapType)) {
+    result.mapUrl = availableMaps[result.mapType] ? availableMaps[result.mapType].url : null;
+    delete result.mapType;
+
+    result.keyColumn = result.countryCodeColumn;
+    delete result.countryCodeColumn;
+
+    result.targetField = result.countryCodeType;
+    delete result.countryCodeType;
+  }
+
+  return result;
 }

--- a/client/app/visualizations/choropleth/hooks/useLoadGeoJson.js
+++ b/client/app/visualizations/choropleth/hooks/useLoadGeoJson.js
@@ -1,0 +1,39 @@
+import { isString, isObject } from "lodash";
+import { useState, useEffect } from "react";
+import { axios } from "@/services/axios";
+
+const defaultGeoJson = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+// TODO: It needs some cache
+export default function useLoadGeoJson(mapUrl) {
+  const [geoJson, setGeoJson] = useState(defaultGeoJson);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isString(mapUrl)) {
+      setIsLoading(true);
+      let cancelled = false;
+      axios
+        .get(mapUrl)
+        .catch(() => defaultGeoJson)
+        .then(data => {
+          if (!cancelled) {
+            setGeoJson(isObject(data) ? data : defaultGeoJson);
+            setIsLoading(false);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    } else {
+      setGeoJson(defaultGeoJson);
+      setIsLoading(false);
+    }
+  }, [mapUrl]);
+
+  return [geoJson, isLoading];
+}

--- a/client/app/visualizations/choropleth/maps/index.js
+++ b/client/app/visualizations/choropleth/maps/index.js
@@ -1,0 +1,13 @@
+import countriesDataUrl from "./countries.geo.json";
+import subdivJapanDataUrl from "./japan.prefectures.geo.json";
+
+export default {
+  countries: {
+    name: "Countries",
+    url: countriesDataUrl,
+  },
+  subdiv_japan: {
+    name: "Japan/Prefectures",
+    url: subdivJapanDataUrl,
+  },
+};

--- a/client/cypress/integration/visualizations/choropleth_spec.js
+++ b/client/cypress/integration/visualizations/choropleth_spec.js
@@ -49,12 +49,12 @@ describe("Choropleth", () => {
 
     cy.clickThrough(`
       VisualizationEditor.Tabs.General
-      Choropleth.Editor.MapType
-      Choropleth.Editor.MapType.Countries
+      Choropleth.Editor.MapUrl
+      Choropleth.Editor.MapUrl.Countries
       Choropleth.Editor.KeyColumn
       Choropleth.Editor.KeyColumn.name
-      Choropleth.Editor.KeyType
-      Choropleth.Editor.KeyType.name
+      Choropleth.Editor.TargetField
+      Choropleth.Editor.TargetField.name
       Choropleth.Editor.ValueColumn
       Choropleth.Editor.ValueColumn.value
     `);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Allow user to type arbitrary GeoJSON URL; existing build-it maps are available as dropdown options. Also, now instead of setting "Key Type" (type of key field from query result) user should map query result field to one of GeoJSON field.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/12139186/73343749-cb7ad900-4289-11ea-8b2b-bc924fa7e64e.png)
![image](https://user-images.githubusercontent.com/12139186/73343718-bc942680-4289-11ea-8d5e-5a7fff73b014.png)
