### PR TITLE
Base duplicate index on column names

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from contextlib import ExitStack
 from functools import wraps
 
@@ -213,14 +214,14 @@ class BaseQueryRunner(object):
 
     def fetch_columns(self, columns):
         column_names = set()
-        duplicates_counter = 1
+        duplicates_counters = defaultdict(int)
         new_columns = []
 
         for col in columns:
             column_name = col[0]
-            if column_name in column_names:
-                column_name = "{}{}".format(column_name, duplicates_counter)
-                duplicates_counter += 1
+            while column_name in column_names:
+                duplicates_counters[col[0]] += 1
+                column_name = "{}{}".format(col[0], duplicates_counters[col[0]])
 
             column_names.add(column_name)
             new_columns.append({"name": column_name, "friendly_name": column_name, "type": col[1]})

--- a/tests/query_runner/test_basequeryrunner.py
+++ b/tests/query_runner/test_basequeryrunner.py
@@ -1,0 +1,34 @@
+import unittest
+
+from redash.query_runner import BaseQueryRunner
+
+
+class TestBaseQueryRunner(unittest.TestCase):
+    def setUp(self):
+        self.query_runner = BaseQueryRunner({})
+
+    def test_duplicate_column_names_assigned_correctly(self):
+        original_column_names = [
+            ("name", bool),
+            ("created_at", bool),
+            ("updated_at", bool),
+            ("name", bool),
+            ("created_at", bool),
+            ("updated_at", bool),
+        ]
+        expected = [
+            {"name": "name", "friendly_name": "name", "type": bool},
+            {"name": "created_at", "friendly_name": "created_at", "type": bool},
+            {"name": "updated_at", "friendly_name": "updated_at", "type": bool},
+            {"name": "name1", "friendly_name": "name1", "type": bool},
+            {"name": "created_at1", "friendly_name": "created_at1", "type": bool},
+            {"name": "updated_at1", "friendly_name": "updated_at1", "type": bool},
+        ]
+
+        new_columns = self.query_runner.fetch_columns(original_column_names)
+
+        self.assertEqual(new_columns, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

I've noticed that duplicate column names are indexed according to the amount of duplicates, and not based off the actual column name duplicates. For example: if you join the users table with the organizations table you would see `name, created_at, updated_at, name1, created_at2, updated_at3` where I would expect `name, created_at, updated_at, name1, created_at1, updated_at1`.

Not sure if this is intentional, and also it will probably break existing queries, so feel free to reject this :)