### PR TITLE
Fix dashboard editing permissions not working

### DIFF
--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -120,6 +120,7 @@ function DashboardMoreOptionsButton({ dashboardOptions }) {
     archiveDashboard,
     managePermissions,
     gridDisabled,
+    isDashboardOwnerOrAdmin,
   } = dashboardOptions;
 
   const archive = () => {
@@ -143,7 +144,7 @@ function DashboardMoreOptionsButton({ dashboardOptions }) {
           <Menu.Item className={cx({ hidden: gridDisabled })}>
             <a onClick={() => setEditingLayout(true)}>Edit</a>
           </Menu.Item>
-          {clientConfig.showPermissionsControl && (
+          {clientConfig.showPermissionsControl && isDashboardOwnerOrAdmin && (
             <Menu.Item>
               <a onClick={managePermissions}>Manage Permissions</a>
             </Menu.Item>

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -38,6 +38,13 @@ function useDashboard(dashboardData) {
   const [gridDisabled, setGridDisabled] = useState(false);
   const globalParameters = useMemo(() => dashboard.getParametersDefs(), [dashboard]);
   const canEditDashboard = useMemo(() => !dashboard.is_archived && dashboard.can_edit, [dashboard]);
+  const isDashboardOwnerOrAdmin = useMemo(
+    () =>
+      !dashboard.is_archived &&
+      has(dashboard, "user.id") &&
+      (currentUser.id === dashboard.user.id || currentUser.hasPermission("admin")),
+    [dashboard]
+  );
   const hasOnlySafeQueries = useMemo(
     () => every(dashboard.widgets, w => (w.getQuery() ? w.getQuery().is_safe : true)),
     [dashboard]
@@ -204,6 +211,7 @@ function useDashboard(dashboardData) {
     refreshWidget,
     removeWidget,
     canEditDashboard,
+    isDashboardOwnerOrAdmin,
     refreshRate,
     setRefreshRate,
     disableRefreshRate,

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -37,7 +37,7 @@ function useDashboard(dashboardData) {
   const [refreshing, setRefreshing] = useState(false);
   const [gridDisabled, setGridDisabled] = useState(false);
   const globalParameters = useMemo(() => dashboard.getParametersDefs(), [dashboard]);
-  const canEditDashboard = useMemo(() => !dashboard.is_archived && dashboard.can_edit, [dashboard]);
+  const canEditDashboard = !dashboard.is_archived && dashboard.can_edit;
   const isDashboardOwnerOrAdmin = useMemo(
     () =>
       !dashboard.is_archived &&

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -37,13 +37,7 @@ function useDashboard(dashboardData) {
   const [refreshing, setRefreshing] = useState(false);
   const [gridDisabled, setGridDisabled] = useState(false);
   const globalParameters = useMemo(() => dashboard.getParametersDefs(), [dashboard]);
-  const canEditDashboard = useMemo(
-    () =>
-      !dashboard.is_archived &&
-      has(dashboard, "user.id") &&
-      (currentUser.id === dashboard.user.id || currentUser.hasPermission("admin")),
-    [dashboard]
-  );
+  const canEditDashboard = useMemo(() => !dashboard.is_archived && dashboard.can_edit, [dashboard]);
   const hasOnlySafeQueries = useMemo(
     () => every(dashboard.widgets, w => (w.getQuery() ? w.getQuery().is_safe : true)),
     [dashboard]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
This updates the check for `canEditDashboard` to use the resource attribute `can_edit`.

## Related Tickets & Documents
Fixes #4612 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--