### PR TITLE
Use correct logger when enqueuing a query execution.

### DIFF
--- a/redash/tasks/failure_report.py
+++ b/redash/tasks/failure_report.py
@@ -1,10 +1,12 @@
-import logging
 import datetime
 import re
 from collections import Counter
 from redash.tasks.general import send_mail
 from redash import redis_connection, settings, models
 from redash.utils import json_dumps, json_loads, base_url, render_template
+from redash.worker import get_job_logger
+
+logger = get_job_logger(__name__)
 
 
 def key(user_id):
@@ -88,7 +90,7 @@ def notify_of_failure(message, query):
 
 
 def track_failure(query, error):
-    logging.debug(error)
+    logger.debug(error)
 
     query.schedule_failures += 1
     query.skip_updated_at = True

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -36,17 +36,17 @@ def refresh_queries():
     with statsd_client.timer("manager.outdated_queries_lookup"):
         for query in models.Query.outdated_queries():
             if settings.FEATURE_DISABLE_REFRESH_QUERIES:
-                logging.info("Disabled refresh queries.")
+                logger.info("Disabled refresh queries.")
             elif query.org.is_disabled:
-                logging.debug(
+                logger.debug(
                     "Skipping refresh of %s because org is disabled.", query.id
                 )
             elif query.data_source is None:
-                logging.debug(
+                logger.debug(
                     "Skipping refresh of %s because the datasource is none.", query.id
                 )
             elif query.data_source.paused:
-                logging.debug(
+                logger.debug(
                     "Skipping refresh of %s because datasource - %s is paused (%s).",
                     query.id,
                     query.data_source.name,
@@ -117,7 +117,7 @@ def cleanup_query_results():
     the database in case of many such results.
     """
 
-    logging.info(
+    logger.info(
         "Running query results clean up (removing maximum of %d unused results, that are %d days old or more)",
         settings.QUERY_RESULTS_CLEANUP_COUNT,
         settings.QUERY_RESULTS_CLEANUP_MAX_AGE,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

Previously this was using the default logger instance which made things
harder to debug in production.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)