### PR TITLE
Force specific version of Werkzeug to prevent the breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ disposable-email-domains>=0.0.52
 gevent==1.4.0
 supervisor==4.1.0
 supervisor_checks==0.8.1
+werkzeug==0.16.1
 # Install the dependencies of the bin/bundle-extensions script here.
 # It has its own requirements file to simplify the frontend client build process
 -r requirements_bundles.txt


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [X] Bug Fix

## Description
New release of Werkzeug breaks Redash. Force a previous version of Werkzeug to ensure the build works.

## Related Tickets & Documents
#4617  