### PR TITLE
Fix: If the error message happens to be empty, it will break serailization.

### DIFF
--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -284,6 +284,7 @@ def serialize_job(job):
         updated_at = 0
 
     status = STATUSES[job_status]
+    query_result_id = None
 
     if isinstance(job.result, Exception):
         error = str(job.result)
@@ -292,6 +293,7 @@ def serialize_job(job):
         error = "Query execution cancelled."
     else:
         error = ""
+        query_result_id = job.result
 
     return {
         "job": {
@@ -299,6 +301,6 @@ def serialize_job(job):
             "updated_at": updated_at,
             "status": status,
             "error": error,
-            "query_result_id": job.result if job.is_finished and not error else None,
+            "query_result_id": query_result_id,
         }
     }


### PR DESCRIPTION
- [x] Bug Fix

## Description

This PR fixes a scenario where job serializations can break if the error message is empty.

#4555.