### PR TITLE
sync_user_details doens't really need a custom TTL

### DIFF
--- a/redash/tasks/schedule.py
+++ b/redash/tasks/schedule.py
@@ -61,7 +61,6 @@ def periodic_job_definitions():
         {
             "func": sync_user_details,
             "timeout": 60,
-            "ttl": 45,
             "interval": timedelta(minutes=1),
         },
         {"func": purge_failed_jobs, "interval": timedelta(days=1)},


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Theoretically, `sync_user_details` execution could be delayed and the key may expire, which will prevent it from being run until the scheduler restarts. There's actually no point in a custom TTL for `sync_user_details` using `rq-scheduler`.