### PR TITLE
Set default query execution time limit to unlimited

### DIFF
--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -222,13 +222,13 @@ STATIC_ASSETS_PATH = fix_assets_path(
     os.environ.get("REDASH_STATIC_ASSETS_PATH", "../client/dist/")
 )
 
-# Time limit for scheduled queries. Set this to -1 to execute without a time limit.
+# Time limit (in seconds) for scheduled queries. Set this to -1 to execute without a time limit.
 SCHEDULED_QUERY_TIME_LIMIT = int(
-    os.environ.get("REDASH_SCHEDULED_QUERY_TIME_LIMIT", 3600)
+    os.environ.get("REDASH_SCHEDULED_QUERY_TIME_LIMIT", -1)
 )
 
-# Time limit for adhoc queries. Set this to -1 to execute without a time limit.
-ADHOC_QUERY_TIME_LIMIT = int(os.environ.get("REDASH_ADHOC_QUERY_TIME_LIMIT", 3600))
+# Time limit (in seconds) for adhoc queries. Set this to -1 to execute without a time limit.
+ADHOC_QUERY_TIME_LIMIT = int(os.environ.get("REDASH_ADHOC_QUERY_TIME_LIMIT", -1))
 
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 12))
 JOB_DEFAULT_FAILURE_TTL = int(

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -222,6 +222,14 @@ STATIC_ASSETS_PATH = fix_assets_path(
     os.environ.get("REDASH_STATIC_ASSETS_PATH", "../client/dist/")
 )
 
+# Time limit for scheduled queries. Set this to -1 to execute without a time limit.
+SCHEDULED_QUERY_TIME_LIMIT = int(
+    os.environ.get("REDASH_SCHEDULED_QUERY_TIME_LIMIT", 3600)
+)
+
+# Time limit for adhoc queries. Set this to -1 to execute without a time limit.
+ADHOC_QUERY_TIME_LIMIT = int(os.environ.get("REDASH_ADHOC_QUERY_TIME_LIMIT", 3600))
+
 JOB_EXPIRY_TIME = int(os.environ.get("REDASH_JOB_EXPIRY_TIME", 3600 * 12))
 JOB_DEFAULT_FAILURE_TTL = int(
     os.environ.get("REDASH_JOB_DEFAULT_FAILURE_TTL", 7 * 24 * 60 * 60)

--- a/redash/settings/dynamic_settings.py
+++ b/redash/settings/dynamic_settings.py
@@ -1,17 +1,11 @@
-import os
-from .helpers import int_or_none
-
-
 # Replace this method with your own implementation in case you want to limit the time limit on certain queries or users.
 def query_time_limit(is_scheduled, user_id, org_id):
-    scheduled_time_limit = int_or_none(
-        os.environ.get("REDASH_SCHEDULED_QUERY_TIME_LIMIT", None)
-    )
-    adhoc_time_limit = int_or_none(
-        os.environ.get("REDASH_ADHOC_QUERY_TIME_LIMIT", None)
-    )
+    from redash import settings
 
-    return scheduled_time_limit if is_scheduled else adhoc_time_limit
+    if is_scheduled:
+        return settings.SCHEDULED_QUERY_TIME_LIMIT
+    else:
+        return settings.ADHOC_QUERY_TIME_LIMIT
 
 
 def periodic_jobs():


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
After migrating query executions to RQ, time limits were implicitly set by RQ to 180 seconds. This PR changes the default to 1 hour and adds some docs on how to remove time limits.