### PR TITLE
Fix: no need to encode strings anymore

### DIFF
--- a/redash/destinations/email.py
+++ b/redash/destinations/email.py
@@ -46,7 +46,6 @@ class Email(BaseDestination):
         logging.debug("Notifying: %s", recipients)
 
         try:
-            alert_name = alert.name
             state = new_state.upper()
             if alert.custom_subject:
                 subject = alert.custom_subject
@@ -54,7 +53,7 @@ class Email(BaseDestination):
                 subject_template = options.get(
                     "subject_template", settings.ALERTS_DEFAULT_MAIL_SUBJECT_TEMPLATE
                 )
-                subject = subject_template.format(alert_name=alert_name, state=state)
+                subject = subject_template.format(alert_name=alert.name, state=state)
 
             message = Message(recipients=recipients, subject=subject, html=html)
             mail.send(message)

--- a/redash/destinations/email.py
+++ b/redash/destinations/email.py
@@ -46,7 +46,7 @@ class Email(BaseDestination):
         logging.debug("Notifying: %s", recipients)
 
         try:
-            alert_name = alert.name.encode("utf-8", "ignore")
+            alert_name = alert.name
             state = new_state.upper()
             if alert.custom_subject:
                 subject = alert.custom_subject

--- a/redash/query_runner/axibase_tsd.py
+++ b/redash/query_runner/axibase_tsd.py
@@ -176,7 +176,7 @@ class AxibaseTSD(BaseQueryRunner):
             minInsertDate=self.configuration.get("min_insert_date", None),
             limit=self.configuration.get("limit", 5000),
         )
-        metrics_list = [i.name.encode("utf-8") for i in ml]
+        metrics_list = [i.name for i in ml]
         metrics_list.append("atsd_series")
         schema = {}
         default_columns = [

--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -61,7 +61,7 @@ class ClickHouse(BaseSQLQueryRunner):
         try:
             r = requests.post(
                 url,
-                data=data.encode("utf-8"),
+                data=data,
                 stream=stream,
                 timeout=self.configuration.get("timeout", 30),
                 params={

--- a/redash/query_runner/yandex_metrica.py
+++ b/redash/query_runner/yandex_metrica.py
@@ -105,7 +105,7 @@ class YandexMetrica(BaseSQLQueryRunner):
         for row in counters[self.list_path]:
             owner = row.get("owner_login")
             counter = "{0} | {1}".format(
-                row.get("name", "Unknown").encode("utf-8"), row.get("id", "Unknown")
+                row.get("name", "Unknown"), row.get("id", "Unknown")
             )
             if owner not in schema:
                 schema[owner] = {"name": owner, "columns": []}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

The `encode` call is a relic from Python 2 an no longer needed.

## Related Tickets & Documents

Closes #4611.