### PR TITLE
Snowflake: switch to simpler query for fetching columns

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -126,13 +126,7 @@ class Snowflake(BaseQueryRunner):
         return data, error
 
     def get_schema(self, get_stats=False):
-        query = """
-        SHOW COLUMNS IN DATABASE {database}
-        """.format(
-            database=self.configuration["database"]
-        )
-
-        results, error = self._run_query_without_warehouse(query)
+        results, error = self._run_query_without_warehouse("SHOW COLUMNS")
 
         if error is not None:
             raise Exception("Failed getting schema.")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Because we already call USE DATABASE before running SHOW COLUMNS adding IN DATABASE is redundant, but causes an error if the user specifies a schema along with database name.