### PR TITLE
Fix comparison error when scale is None

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -35,7 +35,7 @@ class Oracle(BaseSQLQueryRunner):
     @classmethod
     def get_col_type(cls, col_type, scale):
         if col_type == cx_Oracle.NUMBER:
-            return TYPE_FLOAT if (scale or 0) > 0 else TYPE_INTEGER
+            return TYPE_INTEGER if scale is False else TYPE_FLOAT
         else:
             return TYPES_MAP.get(col_type, None)
 

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -35,7 +35,7 @@ class Oracle(BaseSQLQueryRunner):
     @classmethod
     def get_col_type(cls, col_type, scale):
         if col_type == cx_Oracle.NUMBER:
-            return TYPE_FLOAT if scale > 0 else TYPE_INTEGER
+            return TYPE_FLOAT if (scale or 0) > 0 else TYPE_INTEGER
         else:
             return TYPES_MAP.get(col_type, None)
 

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -35,7 +35,11 @@ class Oracle(BaseSQLQueryRunner):
     @classmethod
     def get_col_type(cls, col_type, scale):
         if col_type == cx_Oracle.NUMBER:
-            return TYPE_INTEGER if scale is False else TYPE_FLOAT
+            if scale is None:
+                return TYPE_INTEGER
+            if scale > 0:
+                return TYPE_FLOAT
+            return TYPE_INTEGER
         else:
             return TYPES_MAP.get(col_type, None)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prevents `'>' not supported between instances of 'NoneType' and 'int'` error when scale is `None`

## Related Tickets & Documents

Closes #4786.
