### PR TITLE
Added KPI visualization

### DIFF
--- a/client/app/components/dashboards/dashboard-grid.less
+++ b/client/app/components/dashboards/dashboard-grid.less
@@ -113,15 +113,66 @@
     overflow: hidden;
   }
 
-  .counter-visualization-content {
-    position: absolute;
-    left: 10px;
-    top: 15px;
-    right: 10px;
-    bottom: 15px;
-    height: auto;
-    overflow: hidden;
-    padding: 0;
+  .counter-visualization-container {
+    height: 100%;
+
+    .counter-visualization-content {
+      position: absolute;
+      left: 10px;
+      top: 15px;
+      right: 10px;
+      bottom: 15px;
+      height: auto;
+      overflow: hidden;
+      padding: 0;
+    }
+  }
+
+  .kpi-visualization-container {
+    height: 100%;
+
+    .kpi-visualization-content {
+      position: absolute;
+      left: 10px;
+      top: 15px;
+      right: 10px;
+      bottom: 15px;
+      height: auto;
+      overflow: hidden;
+      padding: 0;
+    }
+  }
+}
+
+.query-fixed-layout {
+  .visualization-renderer > .visualization-renderer-wrapper {
+    .counter-visualization-container {
+      // counter is too large on Query pages, so let's add some constraints
+      max-width: 600px;
+      max-height: 400px;
+      // center it
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      margin: auto;
+    }
+  }
+
+  .visualization-renderer > .visualization-renderer-wrapper {
+    .kpi-visualization-container {
+      // kpi widget is too large on Query pages, so let's add some constraints
+      max-width: 600px;
+      max-height: 400px;
+      // center it
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      margin: auto;
+    }
   }
 }
 

--- a/viz-lib/src/visualizations/kpi/Editor/FormatSettings.jsx
+++ b/viz-lib/src/visualizations/kpi/Editor/FormatSettings.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import {Section, Input, InputNumber, Switch, ContextHelp} from "@/components/visualizations/editor";
+import { EditorPropTypes } from "@/visualizations";
+
+import { isValueNumber } from "../utils";
+
+export default function FormatSettings({ options, data, onOptionsChange }) {
+  const inputsEnabled = isValueNumber(data.rows, options);
+  return (
+    <React.Fragment>
+      <Section>
+        <Input
+          layout="horizontal"
+          label={
+            <React.Fragment>
+              Values Format
+              <ContextHelp.NumberFormatSpecs />
+            </React.Fragment>
+          }
+          defaultValue={options.valuesFormat}
+          onChange={e => onOptionsChange({ valuesFormat: e.target.value })}
+        />
+      </Section>
+
+      <Section>
+        <Input
+          layout="horizontal"
+          label={
+            <React.Fragment>
+              Percent Format
+              <ContextHelp.NumberFormatSpecs />
+            </React.Fragment>
+          }
+          defaultValue={options.percentFormat}
+          onChange={e => onOptionsChange({ percentFormat: e.target.value })}
+        />
+      </Section>
+
+      <Section>
+        <Switch
+          defaultChecked={options.showDeltaPercentage}
+          onChange={showDeltaPercentage => onOptionsChange({ showDeltaPercentage })}>
+          Show delta as percentage
+        </Switch>
+      </Section>
+
+      <Section>
+        <Switch
+          defaultChecked={options.showDeltaAmount}
+          onChange={showDeltaAmount => onOptionsChange({ showDeltaAmount })}>
+          Show delta as amount
+        </Switch>
+      </Section>
+
+      <Section>
+        <Switch
+          defaultChecked={options.invertTrendDirection}
+          onChange={invertTrendDirection => onOptionsChange({ invertTrendDirection })}>
+          Invert trend direction
+        </Switch>
+      </Section>
+
+    </React.Fragment>
+  );
+}
+
+FormatSettings.propTypes = EditorPropTypes;

--- a/viz-lib/src/visualizations/kpi/Editor/GeneralSettings.jsx
+++ b/viz-lib/src/visualizations/kpi/Editor/GeneralSettings.jsx
@@ -1,0 +1,53 @@
+import { map } from "lodash";
+import React from "react";
+import { Section, Select, Input, InputNumber, Switch } from "@/components/visualizations/editor";
+import { EditorPropTypes } from "@/visualizations";
+
+export default function GeneralSettings({ options, data, visualizationName, onOptionsChange }) {
+  return (
+    <React.Fragment>
+
+      <Section>
+        <Select
+          layout="horizontal"
+          label="Current Value Column Name"
+          defaultValue={options.currentValueColName}
+          onChange={currentValueColName => onOptionsChange({ currentValueColName })}>
+          {map(data.columns, col => (
+            <Select.Option key={col.name}>
+              {col.name}
+            </Select.Option>
+          ))}
+        </Select>
+      </Section>
+
+      <Section>
+        <Select
+          layout="horizontal"
+          label="Target Value Column Name"
+          defaultValue={options.targetValueColName}
+          onChange={targetValueColName => onOptionsChange({ targetValueColName })}>
+          <Select.Option value="">No target value</Select.Option>
+          {map(data.columns, col => (
+            <Select.Option key={col.name}>
+              {col.name}
+            </Select.Option>
+          ))}
+        </Select>
+      </Section>
+
+      <Section>
+        <Input
+          layout="horizontal"
+          label="Target Value Prefix Label"
+          placeholder="Current"
+          defaultValue={options.targetValuePrefixLabel}
+          onChange={e => onOptionsChange({ targetValuePrefixLabel: e.target.value })}
+        />
+      </Section>
+
+    </React.Fragment>
+  );
+}
+
+GeneralSettings.propTypes = EditorPropTypes;

--- a/viz-lib/src/visualizations/kpi/Editor/index.js
+++ b/viz-lib/src/visualizations/kpi/Editor/index.js
@@ -1,0 +1,9 @@
+import createTabbedEditor from "@/components/visualizations/editor/createTabbedEditor";
+
+import GeneralSettings from "./GeneralSettings";
+import FormatSettings from "./FormatSettings";
+
+export default createTabbedEditor([
+  { key: "General", title: "General", component: GeneralSettings },
+  { key: "Format", title: "Format", component: FormatSettings },
+]);

--- a/viz-lib/src/visualizations/kpi/Renderer.jsx
+++ b/viz-lib/src/visualizations/kpi/Renderer.jsx
@@ -1,0 +1,80 @@
+import { isFinite } from "lodash";
+import React, { useState, useEffect } from "react";
+import cx from "classnames";
+import resizeObserver from "@/services/resizeObserver";
+import { RendererPropTypes } from "@/visualizations";
+
+import { getKpiData } from "./utils";
+
+import "./render.less";
+
+function getContainerStyles(scale) {
+  return {
+    msTransform: `scale(${scale})`,
+    MozTransform: `scale(${scale})`,
+    WebkitTransform: `scale(${scale})`,
+    transform: `scale(${scale})`,
+  };
+}
+
+function getCounterScale(container) {
+  const inner = container.firstChild;
+  const scale = Math.min(container.offsetWidth / inner.offsetWidth, container.offsetHeight / inner.offsetHeight);
+  return Number(isFinite(scale) ? scale : 1).toFixed(2); // keep only two decimal places;
+}
+
+export default function Renderer({ data, options, visualizationName }) {
+  const [scale, setScale] = useState("1.00");
+  const [container, setContainer] = useState(null);
+
+  useEffect(() => {
+    if (container) {
+      const unwatch = resizeObserver(container, () => {
+        setScale(getCounterScale(container));
+      });
+      return unwatch;
+    }
+  }, [container]);
+
+  useEffect(() => {
+    if (container) {
+      // update scaling when options or data change (new formatting, values, etc.
+      // may change inner container dimensions which will not be tracked by `resizeObserver`);
+      setScale(getCounterScale(container));
+    }
+  }, [data, options, container]);
+
+  const {
+    currentValue,
+    trendDirection,
+    deltaValue,
+    targetValuePrefixLabel,
+    targetValue,
+  } = getKpiData(data.rows, options);
+  return (
+    <div className="kpi-visualization-container">
+      <div className="kpi-visualization-content" ref={setContainer}>
+        <div style={getContainerStyles(scale)}>
+
+          <div className="kpi-visualization-current-value">
+            {currentValue}
+          </div>
+
+          {targetValue && (
+            <div className={cx("kpi-visualization-delta-value", "trend-" + trendDirection)}>
+              {deltaValue}
+            </div>
+          )}
+
+          {targetValue && (
+            <div className="kpi-visualization-target-value">
+              {targetValuePrefixLabel} ({targetValue})
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Renderer.propTypes = RendererPropTypes;

--- a/viz-lib/src/visualizations/kpi/index.js
+++ b/viz-lib/src/visualizations/kpi/index.js
@@ -1,0 +1,20 @@
+import Renderer from "./Renderer";
+import Editor from "./Editor";
+
+const DEFAULT_OPTIONS = {
+  currentValueColName: "current_value",
+  targetValueColName: "target_value",
+  valuesFormat: "0,0[.]00",
+  percentFormat: "0[.]00%",
+};
+
+export default {
+  type: "KPI",
+  name: "KPI",
+  getOptions: options => ({ ...DEFAULT_OPTIONS, ...options }),
+  Renderer,
+  Editor,
+
+  defaultColumns: 2,
+  defaultRows: 5,
+}

--- a/viz-lib/src/visualizations/kpi/render.less
+++ b/viz-lib/src/visualizations/kpi/render.less
@@ -1,0 +1,44 @@
+.kpi-visualization-container {
+  display: block;
+  text-align: center;
+  padding: 15px 10px;
+  overflow: hidden;
+  position: relative;
+
+  .kpi-visualization-content {
+    margin: 0;
+    padding: 0;
+    font-size: 80px;
+    line-height: normal;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    .kpi-visualization-current-value {
+      font-size: 1em;
+      display: block;
+      margin-bottom: 10px;
+    }
+
+    .kpi-visualization-delta-value, .kpi-visualization-target-value {
+      font-size: .4em;
+      line-height: 1.3;
+    }
+
+    .kpi-visualization-delta-value {
+      &.trend-positive {
+        color: #5cb85c;
+      }
+
+      &.trend-negative {
+        color: #d9534f;
+      }
+    }
+
+    .kpi-visualization-target-value {
+      color: #ccc;
+    }
+  }
+}

--- a/viz-lib/src/visualizations/kpi/utils.js
+++ b/viz-lib/src/visualizations/kpi/utils.js
@@ -1,0 +1,90 @@
+import { isNumber } from "lodash";
+import {createNumberFormatter} from "@/lib/value-format";
+
+export function getKpiData(rows, options) {
+  if (rows.length === 0 || !options.currentValueColName) {
+    return {};
+  }
+
+  const formatValue = createNumberFormatter(options.valuesFormat);
+  const formatPercentage = createNumberFormatter(options.percentFormat);
+
+  const row = rows[0];
+  const currentValue = row[options.currentValueColName];
+
+  let targetValue;
+  let trendDirection;
+  let deltaAmount;
+  let deltaPercentage;
+  let deltaPrefix;
+  if (options.targetValueColName) {
+    targetValue = row[options.targetValueColName];
+
+    deltaAmount = currentValue - targetValue;
+
+    if (deltaAmount > 0) {
+      deltaPrefix = "+";
+    } else if (deltaAmount < 0) {
+      deltaPrefix = "-";
+    } else {
+      deltaPrefix = "+/-";
+    }
+
+    const trendDelta = options.invertTrendDirection ? deltaAmount * -1.0 : deltaAmount;
+
+    if (trendDelta > 0) {
+      trendDirection = "positive";
+    } else if (trendDelta < 0) {
+      trendDirection = "negative";
+    } else {
+      trendDirection = "neutral";
+    }
+
+    deltaPercentage = (currentValue / targetValue) * 100.0 - 100;
+  }
+
+  let deltaPercentageString;
+  if (options.showDeltaPercentage) {
+    deltaPercentageString = formatPercentage(Math.abs(deltaPercentage));
+  }
+
+  let deltaAmountString;
+  if (options.showDeltaAmount) {
+    deltaAmountString = formatValue(Math.abs(deltaAmount), options);
+  }
+
+  let deltaValueString;
+  if (deltaPercentageString) {
+    if (deltaAmountString) {
+      deltaValueString = `${deltaPercentageString} (${deltaAmountString})`
+    } else {
+      deltaValueString = deltaPercentageString;
+    }
+  } else if (deltaAmountString) {
+    deltaValueString = deltaAmountString;
+  }
+
+  let deltaValue;
+  if (deltaValueString) {
+    deltaValue = `${deltaPrefix} ${deltaValueString}`;
+  }
+
+  return {
+    currentValue: formatValue(currentValue, options),
+    trendDirection: trendDirection,
+    deltaValue: deltaValue,
+    targetValuePrefixLabel: options.targetValuePrefixLabel,
+    targetValue: targetValue ? formatValue(targetValue, options) : null
+  };
+}
+
+export function isValueNumber(rows, options) {
+  if (rows.length > 0) {
+    const currentValueColName = options.currentValueColName;
+    if (currentValueColName) {
+      return isNumber(rows[0][currentValueColName]);
+    }
+  }
+
+  return false;
+}

--- a/viz-lib/src/visualizations/registeredVisualizations.js
+++ b/viz-lib/src/visualizations/registeredVisualizations.js
@@ -14,6 +14,7 @@ import sankeyVisualization from "./sankey";
 import sunburstVisualization from "./sunburst";
 import tableVisualization from "./table";
 import wordCloudVisualization from "./word-cloud";
+import kpiVisualization from "./kpi";
 
 const VisualizationConfig = PropTypes.shape({
   type: PropTypes.string.isRequired,
@@ -72,6 +73,7 @@ each(
     sunburstVisualization,
     tableVisualization,
     wordCloudVisualization,
+    kpiVisualization,
   ]),
   registerVisualization
 );


### PR DESCRIPTION
## What type of PR is this?
- [x] Feature

## Description

This is a new visualization meant for business KPIs. Ideally, Redash would have a plugin system and some sort of marketplace where this could live. However, since that seems far away, I think it still makes sense to consider adding this visualization to the core codebase, because it seems like this would be one of the most common use-cases for companies using Redash.

Unlike other visualizations, this one is a bit more opinionated in terms of the data it's meant to represent, hence the name "KPI". It has some similarities with the existing counter visualization, but also offers a number of features that wouldn't make sense for the more generic counter:

- it can show both a current and a target value and calculate the delta automatically as both percentage or absolute numbers
- it allows configuration for whether the percentage and/or the absolute delta value should be shown, or neither
- it allows configuration of whether a positive or negative delta is either good or bad
- it allows custom labels for the target value so entirely different metrics could be shown also

## Screenshots

![image](https://user-images.githubusercontent.com/768011/74332071-dfbedb80-4d49-11ea-8606-eecbc7a8d9bc.png)
![image](https://user-images.githubusercontent.com/768011/74332305-4e039e00-4d4a-11ea-9a06-1f7e90dec54f.png)
![image](https://user-images.githubusercontent.com/768011/74334863-a2f5e300-4d4f-11ea-8181-e4eaddc1ce5d.png)


