### PR TITLE
refresh_queries shouldn't break because of a single query having a bad schedule object

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, contains_eager, joinedload, subqueryload, load_only
 from sqlalchemy.orm.exc import NoResultFound  # noqa: F401
+from sqlalchemy.sql import expression
 from sqlalchemy import func
 from sqlalchemy_utils import generic_relationship
 from sqlalchemy_utils.types import TSVectorType
@@ -617,11 +618,18 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def outdated_queries(cls):
+        with_valid_schedule = and_(
+            Query.schedule.isnot(None),
+            expression.func.coalesce(
+                expression.text("schedule::json->>'interval'"), None
+            ).isnot(None),
+        )
+
         queries = (
             Query.query.options(
                 joinedload(Query.latest_query_data).load_only("retrieved_at")
             )
-            .filter(Query.schedule.isnot(None))
+            .filter(with_valid_schedule)
             .order_by(Query.id)
         )
 
@@ -630,8 +638,6 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         scheduled_queries_executions.refresh()
 
         for query in queries:
-            if query.schedule["interval"] is None:
-                continue
 
             if query.schedule["until"] is not None:
                 schedule_until = pytz.utc.localize(

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -36,6 +36,7 @@ from redash.utils import (
     json_loads,
     mustache_render,
     base_url,
+    sentry,
 )
 from redash.utils.configuration import ConfigurationContainer
 from redash.models.parameterized_query import ParameterizedQuery
@@ -660,11 +661,9 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 query.schedule["disabled"] = True
                 db.session.commit()
 
-                logging.info(
-                    "Could not determine if query %d is outdated due to %s. The schedule for this query has been disabled.",
-                    query.id,
-                    repr(e),
-                )
+                message = "Could not determine if query %d is outdated due to %s. The schedule for this query has been disabled." % (query.id, repr(e))
+                logging.info(message)
+                sentry.capture_message(message)
 
         return list(outdated_queries.values())
 

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -5,6 +5,7 @@ import redis
 from rq import get_current_job
 from rq.job import JobStatus
 from rq.timeouts import JobTimeoutException
+from rq.exceptions import NoSuchJobError
 
 from redash import models, redis_connection, settings
 from redash.query_runner import InterruptException
@@ -43,24 +44,22 @@ def enqueue_query(
             job_id = pipe.get(_job_lock_id(query_hash, data_source.id))
             if job_id:
                 logger.info("[%s] Found existing job: %s", query_hash, job_id)
-                job_exists = Job.exists(job_id)
                 job_complete = None
 
-                if job_exists:
+                try:
                     job = Job.fetch(job_id)
+                    job_exists = True
                     status = job.get_status()
                     job_complete = status in [JobStatus.FINISHED, JobStatus.FAILED]
 
                     if job_complete:
-                        logger.info(
-                            "[%s] job found is complete (%s), removing lock",
-                            query_hash,
-                            status,
-                        )
-                else:
-                    logger.info("[%s] job found has expired, removing lock", query_hash)
+                        message = "job found is complete (%s)" % status
+                except NoSuchJobError:
+                    message = "job found has expired"
+                    job_exists = False
 
                 if job_complete or not job_exists:
+                    logger.info("[%s] %s, removing lock", query_hash, message)
                     redis_connection.delete(_job_lock_id(query_hash, data_source.id))
                     job = None
 

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -8,7 +8,7 @@ from redash.models.parameterized_query import (
     QueryDetachedFromDataSourceError,
 )
 from redash.tasks.failure_report import track_failure
-from redash.utils import json_dumps
+from redash.utils import json_dumps, sentry
 from redash.worker import job, get_job_logger
 
 from .execution import enqueue_query
@@ -88,7 +88,9 @@ def refresh_queries():
             )
             enqueued.append(query)
         except Exception as e:
-            logging.info("Could not enqueue query %d due to %s", query.id, repr(e))
+            message = "Could not enqueue query %d due to %s" % (query.id, repr(e))
+            logging.info(message)
+            sentry.capture_message(message)
 
     status = {
         "outdated_queries_count": len(enqueued),

--- a/redash/utils/sentry.py
+++ b/redash/utils/sentry.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+from funcy import iffy
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -33,3 +34,6 @@ def init():
                 RqIntegration(),
             ],
         )
+
+
+capture_message = iffy(lambda _: settings.SENTRY_DSN, sentry_sdk.capture_message)

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -4,6 +4,7 @@ import uuid
 from mock import patch, Mock
 
 from rq import Connection
+from rq.exceptions import NoSuchJobError
 
 from tests import BaseTestCase
 from redash import redis_connection, rq_redis_connection, models
@@ -33,11 +34,10 @@ def create_job(*args, **kwargs):
     return Job(connection=rq_redis_connection)
 
 
-@patch("redash.tasks.queries.execution.Job.exists", return_value=True)
 @patch("redash.tasks.queries.execution.Job.fetch", side_effect=fetch_job)
 @patch("redash.tasks.queries.execution.Queue.enqueue", side_effect=create_job)
 class TestEnqueueTask(BaseTestCase):
-    def test_multiple_enqueue_of_same_query(self, enqueue, _, __):
+    def test_multiple_enqueue_of_same_query(self, enqueue, _):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -68,7 +68,7 @@ class TestEnqueueTask(BaseTestCase):
 
         self.assertEqual(1, enqueue.call_count)
 
-    def test_multiple_enqueue_of_expired_job(self, enqueue, _, exists):
+    def test_multiple_enqueue_of_expired_job(self, enqueue, fetch_job):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -81,7 +81,8 @@ class TestEnqueueTask(BaseTestCase):
                 {"Username": "Arik", "Query ID": query.id},
             )
 
-            exists.return_value = False
+            # "expire" the previous job
+            fetch_job.side_effect = NoSuchJobError
 
             enqueue_query(
                 query.query_text,
@@ -95,7 +96,7 @@ class TestEnqueueTask(BaseTestCase):
         self.assertEqual(2, enqueue.call_count)
 
     @patch("redash.settings.dynamic_settings.query_time_limit", return_value=60)
-    def test_limits_query_time(self, _, enqueue, __, ___):
+    def test_limits_query_time(self, _, enqueue, __):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -111,7 +112,7 @@ class TestEnqueueTask(BaseTestCase):
         _, kwargs = enqueue.call_args
         self.assertEqual(60, kwargs.get("job_timeout"))
 
-    def test_multiple_enqueue_of_different_query(self, enqueue, _, __):
+    def test_multiple_enqueue_of_different_query(self, enqueue, _):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -159,16 +159,26 @@ class ShouldScheduleNextTest(TestCase):
 
 
 class QueryOutdatedQueriesTest(BaseTestCase):
+    def schedule(self, **kwargs):
+        schedule = {"interval": None, "time": None, "until": None, "day_of_week": None}
+        schedule.update(**kwargs)
+        return schedule
+
+    def create_scheduled_query(self, **kwargs):
+        return self.factory.create_query(schedule=self.schedule(**kwargs))
+
+    def fake_previous_execution(self, query, **kwargs):
+        retrieved_at = utcnow() - datetime.timedelta(**kwargs)
+        query_result = self.factory.create_query_result(
+            retrieved_at=retrieved_at,
+            query_text=query.query_text,
+            query_hash=query.query_hash,
+        )
+        query.latest_query_data = query_result
+
     # TODO: this test can be refactored to use mock version of should_schedule_next to simplify it.
     def test_outdated_queries_skips_unscheduled_queries(self):
-        query = self.factory.create_query(
-            schedule={
-                "interval": None,
-                "time": None,
-                "until": None,
-                "day_of_week": None,
-            }
-        )
+        query = self.create_scheduled_query()
         query_with_none = self.factory.create_query(schedule=None)
 
         queries = models.Query.outdated_queries()
@@ -177,71 +187,33 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         self.assertNotIn(query_with_none, queries)
 
     def test_outdated_queries_works_with_ttl_based_schedule(self):
-        two_hours_ago = utcnow() - datetime.timedelta(hours=2)
-        query = self.factory.create_query(
-            schedule={
-                "interval": "3600",
-                "time": None,
-                "until": None,
-                "day_of_week": None,
-            }
-        )
-        query_result = self.factory.create_query_result(
-            query=query.query_text, retrieved_at=two_hours_ago
-        )
-        query.latest_query_data = query_result
+        query = self.create_scheduled_query(interval="3600")
+        self.fake_previous_execution(query, hours=2)
 
         queries = models.Query.outdated_queries()
+
         self.assertIn(query, queries)
 
     def test_outdated_queries_works_scheduled_queries_tracker(self):
-        two_hours_ago = utcnow() - datetime.timedelta(hours=2)
-        query = self.factory.create_query(
-            schedule={
-                "interval": "3600",
-                "time": None,
-                "until": None,
-                "day_of_week": None,
-            }
-        )
-        query_result = self.factory.create_query_result(
-            query=query, retrieved_at=two_hours_ago
-        )
-        query.latest_query_data = query_result
-
+        query = self.create_scheduled_query(interval="3600")
+        self.fake_previous_execution(query, hours=2)
         models.scheduled_queries_executions.update(query.id)
 
         queries = models.Query.outdated_queries()
+
         self.assertNotIn(query, queries)
 
     def test_skips_fresh_queries(self):
-        half_an_hour_ago = utcnow() - datetime.timedelta(minutes=30)
-        query = self.factory.create_query(
-            schedule={
-                "interval": "3600",
-                "time": None,
-                "until": None,
-                "day_of_week": None,
-            }
-        )
-        query_result = self.factory.create_query_result(
-            query=query.query_text, retrieved_at=half_an_hour_ago
-        )
-        query.latest_query_data = query_result
+        query = self.create_scheduled_query(interval="3600")
+        self.fake_previous_execution(query, minutes=30)
 
         queries = models.Query.outdated_queries()
+
         self.assertNotIn(query, queries)
 
     def test_outdated_queries_works_with_specific_time_schedule(self):
         half_an_hour_ago = utcnow() - datetime.timedelta(minutes=30)
-        query = self.factory.create_query(
-            schedule={
-                "interval": "86400",
-                "time": half_an_hour_ago.strftime("%H:%M"),
-                "until": None,
-                "day_of_week": None,
-            }
-        )
+        query = self.create_scheduled_query(interval="86400", time=half_an_hour_ago.strftime("%H:%M"))
         query_result = self.factory.create_query_result(
             query=query.query_text,
             retrieved_at=half_an_hour_ago - datetime.timedelta(days=1),
@@ -256,32 +228,14 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         Only one query per data source with the same text will be reported by
         Query.outdated_queries().
         """
-        query = self.factory.create_query(
-            schedule={
-                "interval": "60",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            }
-        )
+        query = self.create_scheduled_query(interval="60")
         query2 = self.factory.create_query(
-            schedule={
-                "interval": "60",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            },
+            schedule=self.schedule(interval="60"),
             query_text=query.query_text,
             query_hash=query.query_hash,
         )
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(
-            retrieved_at=retrieved_at,
-            query_text=query.query_text,
-            query_hash=query.query_hash,
-        )
-        query.latest_query_data = query_result
-        query2.latest_query_data = query_result
+        self.fake_previous_execution(query, minutes=10)
+        self.fake_previous_execution(query2, minutes=10)
 
         self.assertEqual(list(models.Query.outdated_queries()), [query2])
 
@@ -291,32 +245,16 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         Query.outdated_queries() even if they have the same query text.
         """
         query = self.factory.create_query(
-            schedule={
-                "interval": "60",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            },
+            schedule=self.schedule(interval="60"),
             data_source=self.factory.create_data_source(),
         )
         query2 = self.factory.create_query(
-            schedule={
-                "interval": "60",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            },
+            schedule=self.schedule(interval="60"),
             query_text=query.query_text,
             query_hash=query.query_hash,
         )
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(
-            retrieved_at=retrieved_at,
-            query_text=query.query_text,
-            query_hash=query.query_hash,
-        )
-        query.latest_query_data = query_result
-        query2.latest_query_data = query_result
+        self.fake_previous_execution(query, minutes=10)
+        self.fake_previous_execution(query2, minutes=10)
 
         outdated_queries = models.Query.outdated_queries()
         self.assertEqual(len(outdated_queries), 2)
@@ -328,32 +266,14 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         If multiple queries with the same text exist, only ones that are
         scheduled to be refreshed are reported by Query.outdated_queries().
         """
-        query = self.factory.create_query(
-            schedule={
-                "interval": "60",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            }
-        )
+        query = self.create_scheduled_query(interval="60")
         query2 = self.factory.create_query(
-            schedule={
-                "interval": "3600",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            },
+            schedule=self.schedule(interval="3600"),
             query_text=query.query_text,
             query_hash=query.query_hash,
         )
-        retrieved_at = utcnow() - datetime.timedelta(minutes=10)
-        query_result = self.factory.create_query_result(
-            retrieved_at=retrieved_at,
-            query_text=query.query_text,
-            query_hash=query.query_hash,
-        )
-        query.latest_query_data = query_result
-        query2.latest_query_data = query_result
+        self.fake_previous_execution(query, minutes=10)
+        self.fake_previous_execution(query2, minutes=10)
 
         self.assertEqual(list(models.Query.outdated_queries()), [query])
 
@@ -363,25 +283,14 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         for scheduling future execution.
         """
         query = self.factory.create_query(
-            schedule={
-                "interval": "60",
-                "until": None,
-                "time": None,
-                "day_of_week": None,
-            },
+            schedule=self.schedule(interval="60"),
             schedule_failures=4,
         )
-        retrieved_at = utcnow() - datetime.timedelta(minutes=16)
-        query_result = self.factory.create_query_result(
-            retrieved_at=retrieved_at,
-            query_text=query.query_text,
-            query_hash=query.query_hash,
-        )
-        query.latest_query_data = query_result
+        self.fake_previous_execution(query, minutes=16)
 
         self.assertEqual(list(models.Query.outdated_queries()), [])
 
-        query_result.retrieved_at = utcnow() - datetime.timedelta(minutes=17)
+        self.fake_previous_execution(query, minutes=17)
         self.assertEqual(list(models.Query.outdated_queries()), [query])
 
     def test_schedule_until_after(self):
@@ -390,21 +299,11 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         Query.outdated_queries() after the given time is past.
         """
         one_day_ago = (utcnow() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
-        two_hours_ago = utcnow() - datetime.timedelta(hours=2)
-        query = self.factory.create_query(
-            schedule={
-                "interval": "3600",
-                "until": one_day_ago,
-                "time": None,
-                "day_of_week": None,
-            }
-        )
-        query_result = self.factory.create_query_result(
-            query=query.query_text, retrieved_at=two_hours_ago
-        )
-        query.latest_query_data = query_result
+        query = self.create_scheduled_query(interval="3600", until=one_day_ago)
+        self.fake_previous_execution(query, hours=2)
 
         queries = models.Query.outdated_queries()
+
         self.assertNotIn(query, queries)
 
     def test_schedule_until_before(self):
@@ -413,22 +312,27 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         Query.outdated_queries() before the given time is past.
         """
         one_day_from_now = (utcnow() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
-        two_hours_ago = utcnow() - datetime.timedelta(hours=2)
-        query = self.factory.create_query(
-            schedule={
-                "interval": "3600",
-                "until": one_day_from_now,
-                "time": None,
-                "day_of_week": None,
-            }
-        )
-        query_result = self.factory.create_query_result(
-            query=query.query_text, retrieved_at=two_hours_ago
-        )
-        query.latest_query_data = query_result
+        query = self.create_scheduled_query(interval="3600", until=one_day_from_now)
+        self.fake_previous_execution(query, hours=2)
 
         queries = models.Query.outdated_queries()
+
         self.assertIn(query, queries)
+
+    def test_skips_and_disables_faulty_queries(self):
+        faulty_query = self.create_scheduled_query(until="pigs fly")
+        valid_query = self.create_scheduled_query(interval="60")
+        self.fake_previous_execution(valid_query, minutes=10)
+
+        queries = models.Query.outdated_queries()
+
+        self.assertEqual(list(models.Query.outdated_queries()), [valid_query])
+        self.assertTrue(faulty_query.schedule.get("disabled"))
+
+    def test_skips_disabled_schedules(self):
+        query = self.create_scheduled_query(disabled=True)
+        queries = models.Query.outdated_queries()
+        self.assertNotIn(query, queries)
 
 
 class QueryArchiveTest(BaseTestCase):


### PR DESCRIPTION
### Issue Summary

We recently had an issue where a single query had a bad schedule object:

```json
{
    "interval": 604800, 
    "until": null,
    "day_of_week": "Sunday", 
    "time": "Invalid date"
}
```

And it caused `Query.outdated_queries` to blow up, which in turn stopped `refresh_queries` from working.

We should make sure there is enough exception handling that a single query won't stop the scheduler from working.

### Technical details:

* Redash Version: 8