### PR TITLE
Added setting to hide Plotly mode bar

### DIFF
--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -168,6 +168,14 @@ class OrganizationSettings extends React.Component {
             ))}
           </Select>
         </Form.Item>
+        <Form.Item label="Chart Visualization">
+          <Checkbox
+            name="hide_plotly_mode_bar"
+            checked={formValues.hide_plotly_mode_bar}
+            onChange={e => this.handleChange("hide_plotly_mode_bar", e.target.checked)}>
+            Hide Plotly mode bar
+          </Checkbox>
+        </Form.Item>
         <Form.Item label="Feature Flags">
           <Checkbox
             name="feature_show_permissions_control"

--- a/client/app/visualizations/chart/Renderer/PlotlyChart.jsx
+++ b/client/app/visualizations/chart/Renderer/PlotlyChart.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useContext } from "react";
 import { ErrorBoundaryContext } from "@/components/ErrorBoundary";
 import { RendererPropTypes } from "@/visualizations/prop-types";
 import resizeObserver from "@/services/resizeObserver";
-
+import { clientConfig } from "@/services/auth";
 import getChartData from "../getChartData";
 import { Plotly, prepareData, prepareLayout, updateData, applyLayoutFixes } from "../plotly";
 
@@ -24,7 +24,11 @@ export default function PlotlyChart({ options, data }) {
   useEffect(
     catchErrors(() => {
       if (container) {
-        const plotlyOptions = { showLink: false, displaylogo: false };
+        const plotlyOptions = {
+          showLink: false,
+          displaylogo: false,
+          displayModeBar: !clientConfig.hidePlotlyModeBar
+        };
 
         const chartData = getChartData(data.rows, options);
         const plotlyData = prepareData(chartData, options);

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -285,6 +285,9 @@ def client_config():
         "showPermissionsControl": current_org.get_setting(
             "feature_show_permissions_control"
         ),
+        "hidePlotlyModeBar": current_org.get_setting(
+            "hide_plotly_mode_bar"
+        ),
         "allowCustomJSVisualizations": settings.FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS,
         "autoPublishNamedQueries": settings.FEATURE_AUTO_PUBLISH_NAMED_QUERIES,
         "extendedAlertOptions": settings.FEATURE_EXTENDED_ALERT_OPTIONS,

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -43,6 +43,9 @@ FEATURE_SHOW_PERMISSIONS_CONTROL = parse_boolean(
 SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES = parse_boolean(
     os.environ.get("REDASH_SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES", "false")
 )
+HIDE_PLOTLY_MODE_BAR = parse_boolean(
+    os.environ.get("HIDE_PLOTLY_MODE_BAR", "false")
+)
 
 settings = {
     "beacon_consent": None,
@@ -65,4 +68,5 @@ settings = {
     "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,
     "feature_show_permissions_control": FEATURE_SHOW_PERMISSIONS_CONTROL,
     "send_email_on_failed_scheduled_queries": SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES,
+    "hide_plotly_mode_bar": HIDE_PLOTLY_MODE_BAR,
 }


### PR DESCRIPTION
## What type of PR is this?
- [x] Feature

## Description
This adds an organization setting that allows hiding the Plotly mode bar.

_Note: I wasn't sure if this should be an environmental variable for the entire instance or an organization setting. It "felt" right to make it an org-level setting but I'm not sure what rules you guys follow for this._

## Related Tickets & Documents
https://github.com/getredash/redash/issues/4632
https://discuss.redash.io/t/add-setting-to-hide-plotly-mode-bar/5529

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/768011/74422066-d3e32000-4e02-11ea-836b-74dbe02b9cab.png)
