### PR TITLE
Fix verification email url on home page

### DIFF
--- a/client/app/pages/home/Home.jsx
+++ b/client/app/pages/home/Home.jsx
@@ -38,7 +38,7 @@ function DeprecatedEmbedFeatureAlert() {
 
 function EmailNotVerifiedAlert() {
   const verifyEmail = () => {
-    axios.post("verification_email").then(data => {
+    axios.post("verification_email/").then(data => {
       notification.success(data.message);
     });
   };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
While clicking on `Resend email` in a local saas env I noticed it was returning 500. Following the log entry below it was possible to infer that this link actually needs the slash :grimacing:, so I added it 

> A request was sent to this URL (http://[host]/verification_email) but a redirect was issued automatically by the routing system to "http://[host]/verification_email/".  The URL was defined with a trailing slash so Flask will automatically redirect to the URL with the trailing slash if it was accessed without one.  Make sure to directly send your POST-request to this URL since we can\'t make browsers or HTTP clients redirect with form data reliably or without user interaction.\n\nNote: this exception is only raised in debug mode

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--