### PR TITLE
Avoid timing out when no timeout is set

### DIFF
--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -50,8 +50,11 @@ class HardLimitingWorker(BaseWorker):
         self.log.warning("Job %s has been cancelled.", job.id)
 
     def soft_limit_exceeded(self, job):
-        seconds_under_monitor = (utcnow() - self.monitor_started).seconds
-        return seconds_under_monitor > job.timeout + self.grace_period
+        if job.timeout < 0:
+            return False
+        else:
+            seconds_under_monitor = (utcnow() - self.monitor_started).seconds
+            return seconds_under_monitor > job.timeout + self.grace_period
 
     def enforce_hard_limit(self, job):
         self.log.warning(

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -50,11 +50,13 @@ class HardLimitingWorker(BaseWorker):
         self.log.warning("Job %s has been cancelled.", job.id)
 
     def soft_limit_exceeded(self, job):
-        if job.timeout < 0:
-            return False
-        else:
+        job_has_time_limit = job.timeout != -1
+
+        if job_has_time_limit:
             seconds_under_monitor = (utcnow() - self.monitor_started).seconds
             return seconds_under_monitor > job.timeout + self.grace_period
+        else:
+            return False
 
     def enforce_hard_limit(self, job):
         self.log.warning(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Following #4626, query execution jobs were set to never time out by default, but our `Worker` implementation would enforce a hard limit if soft limits + grace period (15s) are not handled. In this case, if a time limit is not set, jobs would time out after `-1 + 15 = 14` seconds.