### PR TITLE
Fix Add Widget always shows recent queries list

### DIFF
--- a/client/app/components/QuerySelector.jsx
+++ b/client/app/components/QuerySelector.jsx
@@ -11,6 +11,10 @@ import useSearchResults from "@/lib/hooks/useSearchResults";
 
 const { Option } = Select;
 function search(term) {
+  if (term === null) {
+    return Promise.resolve(null);
+  }
+
   // get recent
   if (!term) {
     return Query.recent().then(results => results.filter(item => !item.is_draft)); // filter out draft


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
Seems it was introduced in #4423 with the change to `useSearchResults` (there was some logic to set results to `null` when a query was selected). Added it in here when the term is `null`.

## Related Tickets & Documents
Fixes #4656.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![fix-add-widget](https://user-images.githubusercontent.com/3356951/74768371-386d0780-5267-11ea-8f7b-96f36f4a24e5.gif)
