### PR TITLE
Oracle: update DSN construction to support special characters in user/password.

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -63,17 +63,7 @@ class Oracle(BaseSQLQueryRunner):
         return "oracle"
 
     def __init__(self, configuration):
-        super(Oracle, self).__init__(configuration)
-
-        dsn = cx_Oracle.makedsn(
-            self.configuration["host"],
-            self.configuration["port"],
-            service_name=self.configuration["servicename"],
-        )
-
-        self.connection_string = "{}/{}@{}".format(
-            self.configuration["user"], self.configuration["password"], dsn
-        )
+        super(Oracle, self).__init__(configuration)       
 
     def _get_tables(self, schema):
         query = """
@@ -130,10 +120,12 @@ class Oracle(BaseSQLQueryRunner):
                 )
 
     def run_query(self, query, user):
+        
         dsn_t = cx_Oracle.makedsn(
             self.configuration["host"],
             self.configuration["port"],
             service_name=self.configuration["servicename"])
+        
         connection = cx_Oracle.connect(user=self.configuration["user"],password=self.configuration["password"], dsn=dsn_t)
         connection.outputtypehandler = Oracle.output_handler
 

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -62,9 +62,6 @@ class Oracle(BaseSQLQueryRunner):
     def type(cls):
         return "oracle"
 
-    def __init__(self, configuration):
-        super(Oracle, self).__init__(configuration)       
-
     def _get_tables(self, schema):
         query = """
         SELECT
@@ -120,13 +117,12 @@ class Oracle(BaseSQLQueryRunner):
                 )
 
     def run_query(self, query, user):
-        
-        dsn_t = cx_Oracle.makedsn(
+        dsn = cx_Oracle.makedsn(
             self.configuration["host"],
             self.configuration["port"],
             service_name=self.configuration["servicename"])
         
-        connection = cx_Oracle.connect(user=self.configuration["user"],password=self.configuration["password"], dsn=dsn_t)
+        connection = cx_Oracle.connect(user=self.configuration["user"],password=self.configuration["password"], dsn=dsn)
         connection.outputtypehandler = Oracle.output_handler
 
         cursor = connection.cursor()

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -130,7 +130,11 @@ class Oracle(BaseSQLQueryRunner):
                 )
 
     def run_query(self, query, user):
-        connection = cx_Oracle.connect(self.connection_string)
+        dsn_t = cx_Oracle.makedsn(
+            self.configuration["host"],
+            self.configuration["port"],
+            service_name=self.configuration["servicename"])
+        connection = cx_Oracle.connect(user=self.configuration["user"],password=self.configuration["password"], dsn=dsn_t)
         connection.outputtypehandler = Oracle.output_handler
 
         cursor = connection.cursor()


### PR DESCRIPTION
The reason I propose this change is to fix an issue when oracle password has an @
example of connection string: user/p@ssword@host

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Currently oracle.py is building a query string, but if the DB password has an @ it doesn't work cause it build a connection string like: user/p@ssword@host

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
