### PR TITLE
fix error when scale is None Type

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -35,7 +35,7 @@ class Oracle(BaseSQLQueryRunner):
     @classmethod
     def get_col_type(cls, col_type, scale):
         if col_type == cx_Oracle.NUMBER:
-            return TYPE_FLOAT if scale > 0 else TYPE_INTEGER
+            return TYPE_FLOAT if scale == None or scale > 0 else TYPE_INTEGER
         else:
             return TYPES_MAP.get(col_type, None)
 


### PR DESCRIPTION
#4189  What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
when use sql
```
select count(*) from table
```
scale is None type.  in python3: 
```
None > 0
```
TypeError: '>' not supported between instances of 'NoneType' and 'int'

