### PR TITLE
Fix Visualization scrollbar in query editor

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -245,11 +245,6 @@ a.label-tag {
     align-content: space-around;
     padding: 0;
     overflow-x: hidden;
-
-    .pivot-table-visualization-container > table,
-    .visualization-renderer > .visualization-renderer-wrapper {
-      overflow: visible;
-    }
   }
   .row {
     background: #fff;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
Noticed it for [this visualization](https://redash-preview.netlify.com/queries/278/source#509), in a mobile resolution. The scrollbar does not exist:

![image](https://user-images.githubusercontent.com/3356951/74965621-56b43e00-53f4-11ea-99fd-f3d0add30185.png)

So this PR removes an `overflow: visible` that was applied only for the Query Editor. since it didn't happen on the Query View page, it should be safe to have the same prop value as in there.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/3356951/74965892-c4606a00-53f4-11ea-89fa-8e04370ad92d.png)

