### PR TITLE
Restore archived dashboards via API

### DIFF
--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -197,6 +197,7 @@ class DashboardResource(BaseResource):
                 "version",
                 "tags",
                 "is_draft",
+                "is_archived",
                 "dashboard_filters_enabled",
             ),
         )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This PR adds the ability to un-archive a Dashboard via the API. I'd like to add an associated feature to `redash-toolbelt` so that SaaS users can restore archived dashboards without contacting support.

## Related Tickets & Documents

redashlabs/product#47

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A
