### PR TITLE
Job timeout doesn't kill the mysql query

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -14,7 +14,7 @@ from redash.query_runner import (
 )
 from redash.settings import parse_boolean
 from redash.utils import json_dumps, json_loads
-from redash.tasks.worker import attach_to_timeout_signal, JobTimeoutException
+from redash.tasks.worker import JobTimeoutException
 
 try:
     import MySQLdb
@@ -157,7 +157,6 @@ class Mysql(BaseSQLQueryRunner):
         thread_id = ""
         r = Result()
         t = None
-        attach_to_timeout_signal()
 
         try:
             connection = self._connection()

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -130,13 +130,6 @@ class HardLimitingWorker(BaseWorker):
             )
 
 
-def attach_to_timeout_signal():
-    def cancel_job(signum, frame):
-        raise JobTimeoutException()
-
-    signal.signal(signal.SIGALRM, cancel_job)
-
-
 Job = CancellableJob
 Queue = CancellableQueue
 Worker = HardLimitingWorker

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -4,7 +4,7 @@ import signal
 import time
 from rq import Worker as BaseWorker, Queue as BaseQueue, get_current_job
 from rq.utils import utcnow
-from rq.timeouts import UnixSignalDeathPenalty, HorseMonitorTimeoutException
+from rq.timeouts import UnixSignalDeathPenalty, HorseMonitorTimeoutException, JobTimeoutException
 from rq.job import Job as BaseJob, JobStatus
 
 
@@ -128,6 +128,13 @@ class HardLimitingWorker(BaseWorker):
                 exc_string="Work-horse process was terminated unexpectedly "
                 "(waitpid returned %s)" % ret_val,
             )
+
+
+def attach_to_timeout_signal():
+    def cancel_job(signum, frame):
+        raise JobTimeoutException()
+
+    signal.signal(signal.SIGALRM, cancel_job)
 
 
 Job = CancellableJob


### PR DESCRIPTION
I'm using the master branch. During refreshing one of my dashboards, a **mysql query** reached the timeout which raised the "**query execution time limit**".
I thought the timeout handler would also kill the related sql query in mysql server while it didn't. So there are lots of stuck sql queries in the mysql server.

So is that possible to also kill the related running query in the database server during handling the timeout?

Thanks.