### PR TITLE
Table visualization: Show which columns are being used for search

### DIFF
--- a/client/app/visualizations/table/Renderer.jsx
+++ b/client/app/visualizations/table/Renderer.jsx
@@ -77,16 +77,15 @@ export default function Renderer({ options, data, context }) {
   const onSearchInputChange = useCallback(event => setSearchTerm(event.target.value), [setSearchTerm]);
 
   const tableColumns = useMemo(() => {
-    return prepareColumns(
-      options.columns,
-      <SearchInput ref={searchInputRef} searchColumns={searchColumns} onChange={onSearchInputChange} />,
-      orderBy,
-      newOrderBy => {
-        setOrderBy(newOrderBy);
-        // Remove text selection - may occur accidentally
-        document.getSelection().removeAllRanges();
-      }
-    );
+    const searchInput =
+      searchColumns.length > 0 ? (
+        <SearchInput ref={searchInputRef} searchColumns={searchColumns} onChange={onSearchInputChange} />
+      ) : null;
+    return prepareColumns(options.columns, searchInput, orderBy, newOrderBy => {
+      setOrderBy(newOrderBy);
+      // Remove text selection - may occur accidentally
+      document.getSelection().removeAllRanges();
+    });
   }, [options.columns, searchColumns, searchInputRef, onSearchInputChange, orderBy, setOrderBy]);
 
   const preparedRows = useMemo(() => sortRows(filterRows(initRows(data.rows), searchTerm, searchColumns), orderBy), [

--- a/client/app/visualizations/table/Renderer.jsx
+++ b/client/app/visualizations/table/Renderer.jsx
@@ -1,12 +1,71 @@
-import { filter } from "lodash";
+import { filter, map, initial, last, reduce } from "lodash";
 import React, { useMemo, useState, useRef, useCallback, useEffect } from "react";
 import Table from "antd/lib/table";
 import Input from "antd/lib/input";
+import Icon from "antd/lib/icon";
+import Popover from "antd/lib/popover";
 import { RendererPropTypes } from "@/visualizations/prop-types";
 
 import { prepareColumns, initRows, filterRows, sortRows } from "./utils";
 
 import "./renderer.less";
+
+function joinColumns(array, separator = ", ") {
+  return reduce(
+    array,
+    (result, item, index) => {
+      if (index > 0) {
+        result.push(separator);
+      }
+      result.push(item);
+      return result;
+    },
+    []
+  );
+}
+
+function getSearchColumns(columns, { limit = Infinity, renderColumn = col => col.title } = {}) {
+  const firstColumns = map(columns.slice(0, limit), col => renderColumn(col));
+  const restColumns = map(columns.slice(limit), col => col.title);
+  if (restColumns.length > 0) {
+    return [...joinColumns(firstColumns), ` and ${restColumns.length} others`];
+  }
+  if (firstColumns.length > 1) {
+    return [...joinColumns(initial(firstColumns)), ` and `, last(firstColumns)];
+  }
+  return firstColumns;
+}
+
+function SearchInputInfoIcon({ searchColumns }) {
+  return (
+    <Popover
+      arrowPointAtCenter
+      placement="topRight"
+      content={
+        <div className="table-visualization-search-info-content">
+          Search {getSearchColumns(searchColumns, { renderColumn: col => <code key={col.name}>{col.title}</code> })}
+        </div>
+      }>
+      <Icon className="table-visualization-search-info-icon" type="info-circle" theme="filled" />
+    </Popover>
+  );
+}
+
+const SearchInput = React.forwardRef(({ searchColumns, ...props }, ref) => {
+  if (searchColumns.length <= 0) {
+    return null;
+  }
+
+  const searchColumnsLimit = 3;
+  return (
+    <Input.Search
+      {...props}
+      ref={ref}
+      placeholder={`Search ${getSearchColumns(searchColumns, { limit: searchColumnsLimit }).join("")}...`}
+      suffix={searchColumns.length > searchColumnsLimit ? <SearchInputInfoIcon searchColumns={searchColumns} /> : null}
+    />
+  );
+});
 
 export default function Renderer({ options, data, context }) {
   const [searchTerm, setSearchTerm] = useState("");
@@ -18,16 +77,16 @@ export default function Renderer({ options, data, context }) {
   const onSearchInputChange = useCallback(event => setSearchTerm(event.target.value), [setSearchTerm]);
 
   const tableColumns = useMemo(() => {
-    const searchInput =
-      searchColumns.length > 0 ? (
-        <Input.Search ref={searchInputRef} placeholder="Search..." onChange={onSearchInputChange} />
-      ) : null;
-
-    return prepareColumns(options.columns, searchInput, orderBy, newOrderBy => {
-      setOrderBy(newOrderBy);
-      // Remove text selection - may occur accidentally
-      document.getSelection().removeAllRanges();
-    });
+    return prepareColumns(
+      options.columns,
+      <SearchInput ref={searchInputRef} searchColumns={searchColumns} onChange={onSearchInputChange} />,
+      orderBy,
+      newOrderBy => {
+        setOrderBy(newOrderBy);
+        // Remove text selection - may occur accidentally
+        document.getSelection().removeAllRanges();
+      }
+    );
   }, [options.columns, searchColumns, searchInputRef, onSearchInputChange, orderBy, setOrderBy]);
 
   const preparedRows = useMemo(() => sortRows(filterRows(initRows(data.rows), searchTerm, searchColumns), orderBy), [

--- a/client/app/visualizations/table/renderer.less
+++ b/client/app/visualizations/table/renderer.less
@@ -125,3 +125,15 @@
   }
   /* END */
 }
+
+.table-visualization-search-info-content {
+  max-width: 400px;
+}
+
+.table-visualization-search-info-icon {
+  margin: 0 5px 0 0;
+
+  &:not(:hover):not(:active) {
+    color: @text-color-secondary;
+  }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Input placeholder: show column separated by comma (last column separated with "and"). If more than N=3 columns used for search - show first N columns separated by comma and add suffix "and K others".

If there are more than N column used for search - show info icon with a popover containing a list of all columns used for search.

## Related Tickets & Documents

Closes redashlabs/product#33

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/12139186/75171630-9baddc80-5734-11ea-893c-664c0b393313.png)
![image](https://user-images.githubusercontent.com/12139186/75171584-8a64d000-5734-11ea-8120-18e5aad8083c.png)
![image](https://user-images.githubusercontent.com/12139186/75171533-6d300180-5734-11ea-8185-a4d1dc7b6821.png)

