### PR TITLE
Perform cleanup on job timeouts

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -5,7 +5,7 @@ import requests
 
 from redash import settings
 from redash.utils import json_loads
-from redash.tasks.worker import JobTimeoutException
+from rq.timeouts import JobTimeoutException
 
 logger = logging.getLogger(__name__)
 

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -5,6 +5,7 @@ import requests
 
 from redash import settings
 from redash.utils import json_loads
+from redash.tasks.worker import JobTimeoutException
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,7 @@ __all__ = [
     "BaseQueryRunner",
     "BaseHTTPQueryRunner",
     "InterruptException",
+    "JobTimeoutException",
     "BaseSQLQueryRunner",
     "TYPE_DATETIME",
     "TYPE_BOOLEAN",

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -244,16 +244,10 @@ class Athena(BaseQueryRunner):
             }
             json_data = json_dumps(data, ignore_nan=True)
             error = None
-        except (KeyboardInterrupt, InterruptException):
+        except Exception:
             if cursor.query_id:
                 cursor.cancel()
-            error = "Query cancelled by user."
-            json_data = None
-        except Exception as ex:
-            if cursor.query_id:
-                cursor.cancel()
-            error = str(ex)
-            json_data = None
+            raise
 
         return json_data, error
 

--- a/redash/query_runner/axibase_tsd.py
+++ b/redash/query_runner/axibase_tsd.py
@@ -155,10 +155,9 @@ class AxibaseTSD(BaseQueryRunner):
         except SQLException as e:
             json_data = None
             error = e.content
-        except (KeyboardInterrupt, InterruptException):
+        except (KeyboardInterrupt, InterruptException, JobTimeoutException):
             sql.cancel_query(query_id)
-            error = "Query cancelled by user."
-            json_data = None
+            raise
 
         return json_data, error
 

--- a/redash/query_runner/azure_kusto.py
+++ b/redash/query_runner/azure_kusto.py
@@ -129,9 +129,6 @@ class AzureKusto(BaseQueryRunner):
                 error = err.args[1][0]["error"]["@message"]
             except (IndexError, KeyError):
                 error = err.args[1]
-        except KeyboardInterrupt:
-            json_data = None
-            error = "Query cancelled by user."
 
         return json_data, error
 

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -332,9 +332,6 @@ class BigQuery(BaseQueryRunner):
                 error = json_loads(e.content)["error"]["message"]
             else:
                 error = e.content
-        except KeyboardInterrupt:
-            error = "Query cancelled by user."
-            json_data = None
 
         return json_data, error
 

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -129,9 +129,6 @@ class Cassandra(BaseQueryRunner):
             json_data = json_dumps(data, cls=CassandraJSONEncoder)
 
             error = None
-        except KeyboardInterrupt:
-            error = "Query cancelled by user."
-            json_data = None
 
         return json_data, error
 

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -93,44 +93,42 @@ class Cassandra(BaseQueryRunner):
 
     def run_query(self, query, user):
         connection = None
-        try:
-            if self.configuration.get("username", "") and self.configuration.get(
-                "password", ""
-            ):
-                auth_provider = PlainTextAuthProvider(
-                    username="{}".format(self.configuration.get("username", "")),
-                    password="{}".format(self.configuration.get("password", "")),
-                )
-                connection = Cluster(
-                    [self.configuration.get("host", "")],
-                    auth_provider=auth_provider,
-                    port=self.configuration.get("port", ""),
-                    protocol_version=self.configuration.get("protocol", 3),
-                )
-            else:
-                connection = Cluster(
-                    [self.configuration.get("host", "")],
-                    port=self.configuration.get("port", ""),
-                    protocol_version=self.configuration.get("protocol", 3),
-                )
-            session = connection.connect()
-            session.set_keyspace(self.configuration["keyspace"])
-            session.default_timeout = self.configuration.get("timeout", 10)
-            logger.debug("Cassandra running query: %s", query)
-            result = session.execute(query)
+        
+        if self.configuration.get("username", "") and self.configuration.get(
+            "password", ""
+        ):
+            auth_provider = PlainTextAuthProvider(
+                username="{}".format(self.configuration.get("username", "")),
+                password="{}".format(self.configuration.get("password", "")),
+            )
+            connection = Cluster(
+                [self.configuration.get("host", "")],
+                auth_provider=auth_provider,
+                port=self.configuration.get("port", ""),
+                protocol_version=self.configuration.get("protocol", 3),
+            )
+        else:
+            connection = Cluster(
+                [self.configuration.get("host", "")],
+                port=self.configuration.get("port", ""),
+                protocol_version=self.configuration.get("protocol", 3),
+            )
+        session = connection.connect()
+        session.set_keyspace(self.configuration["keyspace"])
+        session.default_timeout = self.configuration.get("timeout", 10)
+        logger.debug("Cassandra running query: %s", query)
+        result = session.execute(query)
 
-            column_names = result.column_names
+        column_names = result.column_names
 
-            columns = self.fetch_columns([(c, "string") for c in column_names])
+        columns = self.fetch_columns([(c, "string") for c in column_names])
 
-            rows = [dict(zip(column_names, row)) for row in result]
+        rows = [dict(zip(column_names, row)) for row in result]
 
-            data = {"columns": columns, "rows": rows}
-            json_data = json_dumps(data, cls=CassandraJSONEncoder)
+        data = {"columns": columns, "rows": rows}
+        json_data = json_dumps(data, cls=CassandraJSONEncoder)
 
-            error = None
-
-        return json_data, error
+        return json_data, None
 
 
 class ScyllaDB(Cassandra):

--- a/redash/query_runner/couchbase.py
+++ b/redash/query_runner/couchbase.py
@@ -148,15 +148,12 @@ class Couchbase(BaseQueryRunner):
             raise Exception("Couchbase connection error")
 
     def run_query(self, query, user):
-        try:
-            result = self.call_service(query, user)
+        result = self.call_service(query, user)
 
-            rows, columns = parse_results(result.json()["results"])
-            data = {"columns": columns, "rows": rows}
+        rows, columns = parse_results(result.json()["results"])
+        data = {"columns": columns, "rows": rows}
 
-            return json_dumps(data), None
-        except KeyboardInterrupt:
-            return None, "Query cancelled by user."
+        return json_dumps(data), None
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/db2.py
+++ b/redash/query_runner/db2.py
@@ -134,10 +134,9 @@ class DB2(BaseSQLQueryRunner):
         except ibm_db_dbi.DatabaseError as e:
             error = str(e)
             json_data = None
-        except (KeyboardInterrupt, InterruptException):
+        except (KeyboardInterrupt, InterruptException, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             connection.close()
 

--- a/redash/query_runner/drill.py
+++ b/redash/query_runner/drill.py
@@ -94,20 +94,17 @@ class Drill(BaseHTTPQueryRunner):
     def run_query(self, query, user):
         drill_url = os.path.join(self.configuration["url"], "query.json")
 
-        try:
-            payload = {"queryType": "SQL", "query": query}
+        payload = {"queryType": "SQL", "query": query}
 
-            response, error = self.get_response(
-                drill_url, http_method="post", json=payload
-            )
-            if error is not None:
-                return None, error
+        response, error = self.get_response(
+            drill_url, http_method="post", json=payload
+        )
+        if error is not None:
+            return None, error
 
-            results = parse_response(response.json())
+        results = parse_response(response.json())
 
-            return json_dumps(results), None
-        except KeyboardInterrupt:
-            return None, "Query cancelled by user."
+        return json_dumps(results), None
 
     def get_schema(self, get_stats=False):
 

--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -133,14 +133,10 @@ class DynamoDBSQL(BaseSQLQueryRunner):
                 e.lineno, e.column, e.line
             )
             json_data = None
-        except (SyntaxError, RuntimeError) as e:
-            error = str(e)
-            json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             if engine and engine.connection:
                 engine.connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
 
         return json_data, error
 

--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -437,9 +437,6 @@ class Kibana(BaseElasticSearch):
                 raise Exception("Advanced queries are not supported")
 
             json_data = json_dumps({"columns": result_columns, "rows": result_rows})
-        except KeyboardInterrupt:
-            error = "Query cancelled by user."
-            json_data = None
         except requests.HTTPError as e:
             logger.exception(e)
             error = "Failed to execute query. Return Code: {0}   Reason: {1}".format(
@@ -497,10 +494,9 @@ class ElasticSearch(BaseElasticSearch):
             )
 
             json_data = json_dumps({"columns": result_columns, "rows": result_rows})
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             logger.exception(e)
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         except requests.HTTPError as e:
             logger.exception(e)
             error = "Failed to execute query. Return Code: {0}   Reason: {1}".format(

--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -142,11 +142,10 @@ class Hive(BaseSQLQueryRunner):
             data = {"columns": columns, "rows": rows}
             json_data = json_dumps(data)
             error = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             if connection:
                 connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         except DatabaseError as e:
             try:
                 error = e.args[0].status.errorMessage

--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -128,10 +128,9 @@ class Impala(BaseSQLQueryRunner):
         except RPCError as e:
             json_data = None
             error = "Metastore Error [%s]" % str(e)
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             if connection:
                 connection.close()

--- a/redash/query_runner/memsql_ds.py
+++ b/redash/query_runner/memsql_ds.py
@@ -135,10 +135,9 @@ class MemSQL(BaseSQLQueryRunner):
             data = {"columns": columns, "rows": rows}
             json_data = json_dumps(data)
             error = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             cursor.close()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             if cursor:
                 cursor.close()

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -155,10 +155,9 @@ class SqlServer(BaseSQLQueryRunner):
                 # Connection errors are `args[0][1]`
                 error = e.args[0][1]
             json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             if connection:
                 connection.close()

--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -149,10 +149,9 @@ class SQLServerODBC(BaseSQLQueryRunner):
                 # Connection errors are `args[0][1]`
                 error = e.args[0][1]
             json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             if connection:
                 connection.close()

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -161,10 +161,9 @@ class Oracle(BaseSQLQueryRunner):
         except cx_Oracle.DatabaseError as err:
             error = "Query failed. {}.".format(str(err))
             json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             connection.close()
 

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -224,10 +224,9 @@ class PostgreSQL(BaseSQLQueryRunner):
         except psycopg2.DatabaseError as e:
             error = str(e)
             json_data = None
-        except (KeyboardInterrupt, InterruptException):
+        except (KeyboardInterrupt, InterruptException, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             connection.close()
 

--- a/redash/query_runner/phoenix.py
+++ b/redash/query_runner/phoenix.py
@@ -112,12 +112,6 @@ class Phoenix(BaseQueryRunner):
             error = "code: {}, sql state:{}, message: {}".format(
                 e.code, e.sqlstate, str(e)
             )
-        except (KeyboardInterrupt, InterruptException) as e:
-            error = "Query cancelled by user."
-            json_data = None
-        except Exception as ex:
-            json_data = None
-            error = str(ex)
         finally:
             if connection:
                 connection.close()

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -128,13 +128,9 @@ class Presto(BaseQueryRunner):
             else:
                 message = None
             error = default_message if message is None else message
-        except (KeyboardInterrupt, InterruptException) as e:
+        except (KeyboardInterrupt, InterruptException, JobTimeoutException):
             cursor.cancel()
-            error = "Query cancelled by user."
-            json_data = None
-        except Exception as ex:
-            json_data = None
-            error = str(ex)
+            raise
 
         return json_data, error
 

--- a/redash/query_runner/prometheus.py
+++ b/redash/query_runner/prometheus.py
@@ -164,9 +164,6 @@ class Prometheus(BaseQueryRunner):
 
         except requests.RequestException as e:
             return None, str(e)
-        except KeyboardInterrupt:
-            error = "Query cancelled by user."
-            json_data = None
 
         return json_data, error
 

--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -287,9 +287,6 @@ class Python(BaseQueryRunner):
             result = self._script_locals["result"]
             result["log"] = self._custom_print.lines
             json_data = json_dumps(result)
-        except KeyboardInterrupt:
-            error = "Query cancelled by user."
-            json_data = None
         except Exception as e:
             error = str(type(e)) + " " + str(e)
             json_data = None

--- a/redash/query_runner/qubole.py
+++ b/redash/query_runner/qubole.py
@@ -3,8 +3,12 @@ import requests
 import logging
 from io import StringIO
 
-from redash.query_runner import BaseQueryRunner, register
-from redash.query_runner import TYPE_STRING
+from redash.query_runner import (
+    BaseQueryRunner,
+    register,
+    JobTimeoutException,
+    TYPE_STRING,
+)
 from redash.utils import json_dumps
 
 try:

--- a/redash/query_runner/qubole.py
+++ b/redash/query_runner/qubole.py
@@ -130,11 +130,10 @@ class Qubole(BaseQueryRunner):
                 ]
 
             json_data = json_dumps({"columns": columns, "rows": rows})
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             logging.info("Sending KILL signal to Qubole Command Id: %s", cmd.id)
             cmd.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
 
         return json_data, error
 

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -4,7 +4,13 @@ import sqlite3
 
 from redash import models
 from redash.permissions import has_access, view_only
-from redash.query_runner import BaseQueryRunner, TYPE_STRING, guess_type, register
+from redash.query_runner import (
+    BaseQueryRunner,
+    TYPE_STRING,
+    guess_type,
+    register,
+    JobTimeoutException,
+)
 from redash.utils import json_dumps, json_loads
 
 logger = logging.getLogger(__name__)
@@ -158,10 +164,9 @@ class Results(BaseQueryRunner):
             else:
                 error = "Query completed but it returned no data."
                 json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             connection.close()
         return json_data, error

--- a/redash/query_runner/script.py
+++ b/redash/query_runner/script.py
@@ -77,8 +77,6 @@ class Script(BaseQueryRunner):
             return None, str(e)
         except subprocess.CalledProcessError as e:
             return None, str(e)
-        except KeyboardInterrupt:
-            return None, "Query cancelled by user."
 
 
 register(Script)

--- a/redash/query_runner/sqlite.py
+++ b/redash/query_runner/sqlite.py
@@ -1,7 +1,7 @@
 import logging
 import sqlite3
 
-from redash.query_runner import BaseSQLQueryRunner, register
+from redash.query_runner import BaseSQLQueryRunner, register, JobTimeoutException
 from redash.utils import json_dumps, json_loads
 
 logger = logging.getLogger(__name__)
@@ -72,10 +72,9 @@ class Sqlite(BaseSQLQueryRunner):
             else:
                 error = "Query completed but it returned no data."
                 json_data = None
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, JobTimeoutException):
             connection.cancel()
-            error = "Query cancelled by user."
-            json_data = None
+            raise
         finally:
             connection.close()
         return json_data, error

--- a/redash/query_runner/url.py
+++ b/redash/query_runner/url.py
@@ -12,30 +12,27 @@ class Url(BaseHTTPQueryRunner):
     def run_query(self, query, user):
         base_url = self.configuration.get("url", None)
 
-        try:
-            query = query.strip()
+        query = query.strip()
 
-            if base_url is not None and base_url != "":
-                if query.find("://") > -1:
-                    return None, "Accepting only relative URLs to '%s'" % base_url
+        if base_url is not None and base_url != "":
+            if query.find("://") > -1:
+                return None, "Accepting only relative URLs to '%s'" % base_url
 
-            if base_url is None:
-                base_url = ""
+        if base_url is None:
+            base_url = ""
 
-            url = base_url + query
+        url = base_url + query
 
-            response, error = self.get_response(url)
-            if error is not None:
-                return None, error
+        response, error = self.get_response(url)
+        if error is not None:
+            return None, error
 
-            json_data = response.content.strip()
+        json_data = response.content.strip()
 
-            if json_data:
-                return json_data, None
-            else:
-                return None, "Got empty response from '{}'.".format(url)
-        except KeyboardInterrupt:
-            return None, "Query cancelled by user."
+        if json_data:
+            return json_data, None
+        else:
+            return None, "Got empty response from '{}'.".format(url)
 
 
 register(Url)

--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -137,9 +137,6 @@ class Vertica(BaseSQLQueryRunner):
                 error = "No data was returned."
 
             cursor.close()
-        except KeyboardInterrupt:
-            error = "Query cancelled by user."
-            json_data = None
         finally:
             if connection:
                 connection.close()

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -286,11 +286,12 @@ def serialize_job(job):
     status = STATUSES[job_status]
     query_result_id = None
 
-    if isinstance(job.result, Exception):
+    if job.is_cancelled:
+        error = "Query cancelled by user."
+        status = 4
+    elif isinstance(job.result, Exception):
         error = str(job.result)
         status = 4
-    elif job.is_cancelled:
-        error = "Query execution cancelled."
     else:
         error = ""
         query_result_id = job.result

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -4,7 +4,7 @@ import signal
 import time
 from rq import Worker as BaseWorker, Queue as BaseQueue, get_current_job
 from rq.utils import utcnow
-from rq.timeouts import UnixSignalDeathPenalty, HorseMonitorTimeoutException, JobTimeoutException
+from rq.timeouts import UnixSignalDeathPenalty, HorseMonitorTimeoutException
 from rq.job import Job as BaseJob, JobStatus
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
After moving query executions to RQ, job timeouts resulted in `JobTimeoutException` being raised. Since some query runners perform cleanup when executions are being cancelled by users, the same cleanup should be performed when jobs time out. (i.e. cancel the database query).

While going through the different query runners, I've noticed that query cancellation code is very repetitive, and sometimes just unnecessary and only returns a "Query cancelled by user." error message. I've modified these to raise the exception and have the serializer handle that automatically.

One caveat is that previously, when cancelling a query, the user would see "Query cancelled by user", and now it will also include an "Error running query" prefix.

![image](https://user-images.githubusercontent.com/289488/75196838-72597480-5765-11ea-8d25-89f102497164.png)

This is due to me reusing the error status code for the serialized job, we could easily work around this by introducing a "cancelled" status call ("failed" doesn't feel right).

## Related Tickets & Documents
#4307 #4629 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
