### PR TITLE
Fixed Clickhouse column name encoding problem

### DIFF
--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -68,7 +68,7 @@ class ClickHouse(BaseSQLQueryRunner):
             verify = self.configuration.get("verify", True)
             r = requests.post(
                 url,
-                data=data,
+                data=data.encode("utf-8","ignore"),
                 stream=stream,
                 timeout=self.configuration.get("timeout", 30),
                 params={


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Fix column name error from Clickhouse when alias column name contains non 'latin-1' characters.

## Related Tickets & Documents

Fixes #4677.
