### PR TITLE
Chart with a horizontal legend sometimes doesn't render properly

### DIFF
--- a/client/app/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/client/app/visualizations/chart/plotly/applyLayoutFixes.js
@@ -25,6 +25,10 @@ export default function applyLayoutFixes(plotlyElement, layout, updatePlot) {
   );
 
   if (layout.width <= 600) {
+    // Save current `layout.height` value because `updatePlot().then(...)` handler may be called multiple
+    // times within single update, and since the handler mutates `layout` object - it may lead to bugs
+    const layoutHeight = layout.height;
+
     // change legend orientation to horizontal; plotly has a bug with this
     // legend alignment - it does not preserve enough space under the plot;
     // so we'll hack this: update plot (it will re-render legend), compute
@@ -71,7 +75,7 @@ export default function applyLayoutFixes(plotlyElement, layout, updatePlot) {
         //    plot; if legend is too large, plotly will reduce it's height and
         //    show a scrollbar; in this case, height of plot === height of legend,
         //    so we can split container's height half by half between them.
-        layout.height = Math.floor(Math.max(layout.height / 2, layout.height - (bounds.bottom - bounds.top)));
+        layout.height = Math.floor(Math.max(layoutHeight / 2, layoutHeight - (bounds.bottom - bounds.top)));
         // offset the legend
         legend.style[transformName] = "translate(0, " + layout.height + "px)";
         updatePlot(plotlyElement, pick(layout, ["height"]));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Chart (with a lot of legend items - ?) on a small screens (when legend is below the plot) sometimes was rendered very small and didn't fit its container.

The bug was in the code that computes layout for horizontal legend - `updatePlot()` result handler is called multiple times and on each turn mutates `layout` object. It was using dimensions computed on previous turn and each time decreased plot height.

## Related Tickets & Documents

https://github.com/getredash/redash/pull/4670#issuecomment-590234928

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before/After:

![image](https://user-images.githubusercontent.com/12139186/75239315-22ad9400-57cb-11ea-89db-e36fb9141b77.png)
![image](https://user-images.githubusercontent.com/12139186/75239260-11fd1e00-57cb-11ea-9124-eeced60fbca6.png)
