### PR TITLE
Use npm ci instead of npm install in CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p /tmp/test-results/eslint
-      - run: npm install
+      - run: npm ci
       - run: npm run lint:ci
       - store_test_results:
           path: /tmp/test-results
@@ -72,7 +72,7 @@ jobs:
       - checkout
       - run: sudo apt install python3-pip
       - run: sudo pip3 install -r requirements_bundles.txt
-      - run: npm install
+      - run: npm ci
       - run: npm run bundle
       - run: npm test
       - run: npm run lint
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Install npm dependencies
           command: |
-            npm install
+            npm ci
       - run:
           name: Setup Redash server
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12 as frontend-builder
 
 WORKDIR /frontend
 COPY package.json package-lock.json /frontend/
-RUN npm install
+RUN npm ci
 
 COPY client /frontend/client
 COPY webpack.config.js /frontend/
@@ -39,7 +39,7 @@ RUN apt-get update && \
     default-libmysqlclient-dev \
     freetds-dev \
     libsasl2-dev && \
-  # MSSQL ODBC Driver:  
+  # MSSQL ODBC Driver:
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
   curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
   apt-get update && \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ backend-unit-tests: up test_db
 	docker-compose run --rm --name tests server tests
 
 frontend-unit-tests: bundle
-	npm install
+	npm ci
 	npm run bundle
 	npm test
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base    = "client"
   publish = "client/dist"
-  command = "npm install && npm run build"
+  command = "npm ci && npm run build"
 
 [[redirects]]
   from = "/api/*"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

`npm install` _may_ install newer versions of packages, while `npm ci` will perfectly restore dependencies using `package-lock.json`. Using `npm ci` is recommended for CI scripts