### PR TITLE
Change visualization editor scroll to internal divs

### DIFF
--- a/client/app/visualizations/components/EditVisualizationDialog.jsx
+++ b/client/app/visualizations/components/EditVisualizationDialog.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import Modal from "antd/lib/modal";
 import Select from "antd/lib/select";
 import Input from "antd/lib/input";
-import * as Grid from "antd/lib/grid";
 import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 import ErrorBoundary, { ErrorMessage } from "@/components/ErrorBoundary";
 import Filters, { filterData } from "@/components/Filters";
@@ -14,6 +13,8 @@ import recordEvent from "@/services/recordEvent";
 import getQueryResultData from "@/lib/getQueryResultData";
 import { VisualizationType } from "@/visualizations/prop-types";
 import registeredVisualizations, { getDefaultVisualization, newVisualization } from "@/visualizations";
+
+import "./EditVisualizationDialog.less";
 
 function updateQueryVisualizations(query, visualization) {
   const index = findIndex(query.visualizations, v => v.id === visualization.id);
@@ -157,8 +158,8 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
       onOk={save}
       onCancel={dismiss}
       wrapProps={{ "data-test": "EditVisualizationDialog" }}>
-      <Grid.Row gutter={24}>
-        <Grid.Col span={24} md={10}>
+      <div className="edit-visualization-dialog">
+        <div className="visualization-settings">
           <div className="m-b-15">
             <label htmlFor="visualization-type">Visualization Type</label>
             <Select
@@ -188,8 +189,8 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
           <div data-test="VisualizationEditor">
             <Editor data={data} options={options} visualizationName={name} onOptionsChange={onOptionsChanged} />
           </div>
-        </Grid.Col>
-        <Grid.Col span={24} md={14}>
+        </div>
+        <div className="visualization-preview">
           <label htmlFor="visualization-preview" className="invisible hidden-xs">
             Preview
           </label>
@@ -207,8 +208,8 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
               />
             </ErrorBoundary>
           </div>
-        </Grid.Col>
-      </Grid.Row>
+        </div>
+      </div>
     </Modal>
   );
 }

--- a/client/app/visualizations/components/EditVisualizationDialog.less
+++ b/client/app/visualizations/components/EditVisualizationDialog.less
@@ -4,13 +4,13 @@
     height: 100%;
 
     .visualization-settings {
-      padding: 0px 12px;
+      padding-right: 12px;
       width: 40%;
       overflow: auto;
     }
 
     .visualization-preview {
-      padding: 0px 12px;
+      padding-left: 12px;
       width: 60%;
       overflow: auto;
     }

--- a/client/app/visualizations/components/EditVisualizationDialog.less
+++ b/client/app/visualizations/components/EditVisualizationDialog.less
@@ -1,0 +1,18 @@
+@media (min-width: 992px) {
+  .edit-visualization-dialog {
+    display: flex;
+    height: 100%;
+
+    .visualization-settings {
+      padding: 0px 12px;
+      width: 40%;
+      overflow: auto;
+    }
+
+    .visualization-preview {
+      padding: 0px 12px;
+      width: 60%;
+      overflow: auto;
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This one annoys me every time I configure a Visualization Editor with several settings:

**Before**
![vis-editor-scrollbar-before](https://user-images.githubusercontent.com/3356951/75371818-38dc5280-58a6-11ea-9655-575c6131370f.gif)

**After**
![vis-editor-scrollbar-after](https://user-images.githubusercontent.com/3356951/75371848-44c81480-58a6-11ea-8690-bc9987453fdd.gif)

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Gifs Above
No mobile changes