### PR TITLE
Snowflake: use different method of showing columns if no schema specified in db name

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -129,7 +129,7 @@ class Snowflake(BaseQueryRunner):
         return '.' in self.configuration.get('database')
 
     def get_schema(self, get_stats=False):
-        if self._database_name_with_schema():
+        if self._database_name_includes_schema():
             query = "SHOW COLUMNS"
         else:
             query = "SHOW COLUMNS IN DATABASE"

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -123,10 +123,18 @@ class Snowflake(BaseQueryRunner):
             cursor.close()
             connection.close()
 
-        return data, error
+        return data, error    
+    
+    def _database_name_with_schema(self):
+        return '.' in self.configuration.get('database')
 
     def get_schema(self, get_stats=False):
-        results, error = self._run_query_without_warehouse("SHOW COLUMNS")
+        if self._database_name_with_schema():
+            query = "SHOW COLUMNS"
+        else:
+            query = "SHOW COLUMNS IN DATABASE"
+
+        results, error = self._run_query_without_warehouse(query)
 
         if error is not None:
             raise Exception("Failed getting schema.")

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -125,7 +125,7 @@ class Snowflake(BaseQueryRunner):
 
         return data, error    
     
-    def _database_name_with_schema(self):
+    def _database_name_includes_schema(self):
         return '.' in self.configuration.get('database')
 
     def get_schema(self, get_stats=False):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

The change done in #4634 breaks fetching schema when database name doesn't include schema name. This one fixes it.