### PR TITLE
Cancel BigQuery Queries

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -335,14 +335,11 @@ class BigQuery(BaseQueryRunner):
                 error = e.content
         except (KeyboardInterrupt, InterruptException, JobTimeoutException):
             if self.current_job_id:
-                response_kind = None
-                while response_kind != "bigquery#jobCancelResponse":
-                    response_kind = jobs.cancel(
-                        projectId=self._get_project_id(),
-                        jobId=self.current_job_id,
-                        location=self._get_location(),
-                    ).execute()["kind"]
-                    time.sleep(1)
+                self._get_bigquery_service().jobs().cancel(
+                    projectId=self._get_project_id(),
+                    jobId=self.current_job_id,
+                    location=self._get_location(),
+                ).execute()
 
             raise
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When a user requests to cancel a BigQuery query, or when the Redash time limit is reached, the underlying job in BigQuery continues to run until completion. This PR cancels the underlying BigQuery job in these situations.

## Related Tickets & Documents
#4681 