### PR TITLE
Compare strings containing numbers as alert values

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -909,18 +909,25 @@ OPERATORS = {
 
 
 def next_state(op, value, threshold):
-    if isinstance(value, numbers.Number) and not isinstance(value, bool):
-        try:
-            threshold = float(threshold)
-        except ValueError:
-            return Alert.UNKNOWN_STATE
-    # If it's a boolean cast to string and lower case, because upper cased
-    # boolean value is Python specific and most likely will be confusing to
-    # users.
-    elif isinstance(value, bool):
+    if isinstance(value, bool):
+        # If it's a boolean cast to string and lower case, because upper cased
+        # boolean value is Python specific and most likely will be confusing to
+        # users.
         value = str(value).lower()
     else:
-        value = str(value)
+        try:
+            value = float(value)
+            value_is_number = True
+        except ValueError:
+            value_is_number = isinstance(value, numbers.Number)
+
+        if value_is_number:
+            try:
+                threshold = float(threshold)
+            except ValueError:
+                return Alert.UNKNOWN_STATE
+        else:
+            value = str(value)
 
     if op(value, threshold):
         new_state = Alert.TRIGGERED_STATE

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -81,6 +81,7 @@ class TestNextState(TestCase):
         self.assertEqual(
             Alert.TRIGGERED_STATE, next_state(OPERATORS.get("=="), 1, "1.0")
         )
+        self.assertEqual(Alert.TRIGGERED_STATE, next_state(OPERATORS.get(">"), "5", 1))
 
     def test_numeric_value_and_plain_string(self):
         self.assertEqual(
@@ -88,7 +89,7 @@ class TestNextState(TestCase):
         )
 
     def test_non_numeric_value(self):
-        self.assertEqual(Alert.OK_STATE, next_state(OPERATORS.get("=="), "1", "1.0"))
+        self.assertEqual(Alert.OK_STATE, next_state(OPERATORS.get("=="), "string", "1.0"))
 
     def test_string_value(self):
         self.assertEqual(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
As described in #4561, alert triggers might be off when alert thresholds and values are strings (`"600" > "5000"` is `True`), so in this PR, when the alert `value` is a string which contains a number, both `value` and `threshold` will be converted to a float for the comparison.

## Related Tickets & Documents

Closes #4561 .