### PR TITLE
Fix: show size of actually used Redash database

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -40,7 +40,7 @@ def get_db_sizes():
             "Query Results Size",
             "select pg_total_relation_size('query_results') as size from (select 1) as a",
         ],
-        ["Redash DB Size", "select pg_database_size('postgres') as size"],
+        ["Redash DB Size", "select pg_database_size(current_database()) as size"],
     ]
     for query_name, query in queries:
         result = db.session.execute(query).first()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

System status dashboard currently shows a size of `postgres` database, which is a default database name, but it can be changed in Redash settings. If non-default database name is used dashboard shows a wrong size. This change fixes the size shown in a dashboard for non-default database name by using `current_database()` instead of hard-coded database name.