### PR TITLE
Datasource Exasol: support encryption setting

### DIFF
--- a/redash/query_runner/exasol.py
+++ b/redash/query_runner/exasol.py
@@ -66,9 +66,10 @@ class Exasol(BaseQueryRunner):
                 "password": {"type": "string"},
                 "host": {"type": "string"},
                 "port": {"type": "number", "default": 8563},
+                "encrypted": {"type": "boolean", "title": "Enable SSL Encryption"},
             },
             "required": ["host", "port", "user", "password"],
-            "order": ["host", "port", "user", "password"],
+            "order": ["host", "port", "user", "password", "encrypted"],
             "secret": ["password"],
         }
 
@@ -81,6 +82,7 @@ class Exasol(BaseQueryRunner):
             dsn=exahost,
             user=self.configuration.get("user", None),
             password=self.configuration.get("password", None),
+            encryption=self.configuration.get("encrypted", True),
             compression=True,
             json_lib="rapidjson",
             fetch_mapper=_exasol_type_mapper,

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -32,6 +32,6 @@ phoenixdb==0.7
 certifi>=2019.9.11
 pydgraph==2.0.2
 azure-kusto-data==0.0.35
-pyexasol==0.9.1
+pyexasol==0.12.0
 python-rapidjson==0.8.0
 pyodbc==4.0.28


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Other

## Description
This adds support to toggle SSL Encryption for connections to Exasol
See also https://github.com/badoo/pyexasol/blob/master/docs/ENCRYPTION.md
