### PR TITLE
Dashboard Performance: HtmlContent improvements

### DIFF
--- a/client/app/components/HtmlContent.jsx
+++ b/client/app/components/HtmlContent.jsx
@@ -2,14 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import { sanitize } from "dompurify";
 
-export default function HtmlContent({ children, ...props }) {
+const HtmlContent = React.memo(function HtmlContent({ children, ...props }) {
   return (
     <div
       {...props}
       dangerouslySetInnerHTML={{ __html: sanitize(children) }} // eslint-disable-line react/no-danger
     />
   );
-}
+});
 
 HtmlContent.propTypes = {
   children: PropTypes.string,
@@ -18,3 +18,5 @@ HtmlContent.propTypes = {
 HtmlContent.defaultProps = {
   children: "",
 };
+
+export default HtmlContent;

--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -94,9 +94,11 @@ function VisualizationWidgetHeader({ widget, refreshStartedAt, parameters, onPar
           <p>
             <QueryLink query={widget.getQuery()} visualization={widget.visualization} readOnly={!canViewQuery} />
           </p>
-          <HtmlContent className="text-muted markdown query--description">
-            {markdown.toHTML(widget.getQuery().description || "")}
-          </HtmlContent>
+          {!isEmpty(widget.getQuery().description) && (
+            <HtmlContent className="text-muted markdown query--description">
+              {markdown.toHTML(widget.getQuery().description || "")}
+            </HtmlContent>
+          )}
         </div>
       </div>
       {!isEmpty(parameters) && (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
Second PR for #4714, basically all widgets had this component rendered unnecessarily (also it could be memoized as its props should always return the same component). Although the `sanitize` function is kinda of performant, I believe it scales with the number of renders and widgets.

**Individual improvement (based on master)**
| Dashboard | master | This PR | % of improvement |
| --------------- | --------- | ---------- | ------------------------- |
| Sales Dashboard | 3599 ms | 2859 ms |  20% |
| Dashboard for testing React migration | 42505 ms | 37854 ms | 10% | 

_(The performance analysis were run with the same time for each dashboard twice (with the least value selected) to make sure results more reliable.)_

The Scripting time I'm noting actually varies considerably, but when there's an actual improvement, the minimum value you can get diminishes, so it's been the best benchmark I've found so far. It just makes it a bit more difficult to measure dashboards with low avg scripting time (< 3s).

## Related Tickets & Documents
#4714 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--