### PR TITLE
DOMPurify by default removes 'target' attribute

### DIFF
--- a/client/app/components/HtmlContent.jsx
+++ b/client/app/components/HtmlContent.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { sanitize } from "dompurify";
+import sanitize from "@/services/sanitize";
 
 export default function HtmlContent({ children, ...props }) {
   return (

--- a/client/app/services/sanitize.js
+++ b/client/app/services/sanitize.js
@@ -1,0 +1,21 @@
+import { isString } from "lodash";
+import DOMPurify from "dompurify";
+
+DOMPurify.setConfig({
+  ADD_ATTR: ["target"],
+});
+
+DOMPurify.addHook("afterSanitizeAttributes", function(node) {
+  // Fix elements with `target` attribute:
+  // - allow only `target="_blank"
+  // - add `rel="noopener noreferrer"` to prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+
+  const target = node.getAttribute("target");
+  if (isString(target) && target.toLowerCase() === "_blank") {
+    node.setAttribute("rel", "noopener noreferrer");
+  } else {
+    node.removeAttribute("target");
+  }
+});
+
+export default DOMPurify.sanitize;

--- a/client/app/services/user.js
+++ b/client/app/services/user.js
@@ -1,5 +1,5 @@
 import { isString, get, find } from "lodash";
-import { sanitize } from "dompurify";
+import sanitize from "@/services/sanitize";
 import { axios } from "@/services/axios";
 import notification from "@/services/notification";
 import { clientConfig } from "@/services/auth";

--- a/client/app/visualizations/choropleth/Renderer/initChoropleth.js
+++ b/client/app/visualizations/choropleth/Renderer/initChoropleth.js
@@ -1,12 +1,12 @@
 import { isFunction, isObject, isArray, map } from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
-import { sanitize } from "dompurify";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet-fullscreen";
 import "leaflet-fullscreen/dist/leaflet.fullscreen.css";
 import { formatSimpleTemplate } from "@/lib/value-format";
+import sanitize from "@/services/sanitize";
 import resizeObserver from "@/services/resizeObserver";
 import {
   createNumberFormatter,

--- a/client/app/visualizations/map/initMap.js
+++ b/client/app/visualizations/map/initMap.js
@@ -1,6 +1,5 @@
 import { isFunction, each, map, toString, clone } from "lodash";
 import chroma from "chroma-js";
-import { sanitize } from "dompurify";
 import L from "leaflet";
 import "leaflet.markercluster";
 import "leaflet/dist/leaflet.css";
@@ -14,6 +13,7 @@ import markerShadow from "leaflet/dist/images/marker-shadow.png";
 import "leaflet-fullscreen";
 import "leaflet-fullscreen/dist/leaflet.fullscreen.css";
 import { formatSimpleTemplate } from "@/lib/value-format";
+import sanitize from "@/services/sanitize";
 import resizeObserver from "@/services/resizeObserver";
 import chooseTextColorForBackground from "@/lib/chooseTextColorForBackground";
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

DOMPurify by default removes 'target' attribute. This PR allows to use `target="_blank"` and also adds `rel="noopener noreferrer"` to such links (see comment in code)

## Related Tickets & Documents

getredash/redash#4728
