### PR TITLE
Dashboard Performance: Memoize widgets

### DIFF
--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -33,6 +33,53 @@ const WidgetType = PropTypes.shape({
 const SINGLE = "single-column";
 const MULTI = "multi-column";
 
+const DashboardWidget = React.memo(
+  function DashboardWidget({
+    widget,
+    dashboard,
+    onLoadWidget,
+    onRefreshWidget,
+    onRemoveWidget,
+    onParameterMappingsChange,
+    canEdit,
+    isPublic,
+    isLoading,
+    filters,
+  }) {
+    const { type } = widget;
+    const onLoad = () => onLoadWidget(widget);
+    const onRefresh = () => onRefreshWidget(widget);
+    const onDelete = () => onRemoveWidget(widget.id);
+
+    if (type === WidgetTypeEnum.VISUALIZATION) {
+      return (
+        <VisualizationWidget
+          widget={widget}
+          dashboard={dashboard}
+          filters={filters}
+          canEdit={canEdit}
+          isPublic={isPublic}
+          isLoading={isLoading}
+          onLoad={onLoad}
+          onRefresh={onRefresh}
+          onDelete={onDelete}
+          onParameterMappingsChange={onParameterMappingsChange}
+        />
+      );
+    }
+    if (type === WidgetTypeEnum.TEXTBOX) {
+      return <TextboxWidget widget={widget} canEdit={canEdit} isPublic={isPublic} onDelete={onDelete} />;
+    }
+    return <RestrictedWidget widget={widget} />;
+  },
+  (prevProps, nextProps) =>
+    prevProps.widget === nextProps.widget &&
+    prevProps.canEdit === nextProps.canEdit &&
+    prevProps.isPublic === nextProps.isPublic &&
+    prevProps.isLoading === nextProps.isLoading &&
+    prevProps.filters === nextProps.filters
+);
+
 class DashboardGrid extends React.Component {
   static propTypes = {
     isEditing: PropTypes.bool.isRequired,
@@ -203,38 +250,29 @@ class DashboardGrid extends React.Component {
           onLayoutChange={this.onLayoutChange}
           onBreakpointChange={this.onBreakpointChange}
           breakpoints={{ [MULTI]: cfg.mobileBreakPoint, [SINGLE]: 0 }}>
-          {widgets.map(widget => {
-            const widgetProps = {
-              widget,
-              filters,
-              isPublic,
-              canEdit: dashboard.canEdit(),
-              onDelete: () => onRemoveWidget(widget.id),
-            };
-            const { type } = widget;
-            return (
-              <div
-                key={widget.id}
-                data-grid={DashboardGrid.normalizeFrom(widget)}
-                data-widgetid={widget.id}
-                data-test={`WidgetId${widget.id}`}
-                className={cx("dashboard-widget-wrapper", {
-                  "widget-auto-height-enabled": this.autoHeightCtrl.exists(widget.id),
-                })}>
-                {type === WidgetTypeEnum.VISUALIZATION && (
-                  <VisualizationWidget
-                    {...widgetProps}
-                    dashboard={dashboard}
-                    onLoad={() => onLoadWidget(widget)}
-                    onRefresh={() => onRefreshWidget(widget)}
-                    onParameterMappingsChange={onParameterMappingsChange}
-                  />
-                )}
-                {type === WidgetTypeEnum.TEXTBOX && <TextboxWidget {...widgetProps} />}
-                {type === WidgetTypeEnum.RESTRICTED && <RestrictedWidget widget={widget} />}
-              </div>
-            );
-          })}
+          {widgets.map(widget => (
+            <div
+              key={widget.id}
+              data-grid={DashboardGrid.normalizeFrom(widget)}
+              data-widgetid={widget.id}
+              data-test={`WidgetId${widget.id}`}
+              className={cx("dashboard-widget-wrapper", {
+                "widget-auto-height-enabled": this.autoHeightCtrl.exists(widget.id),
+              })}>
+              <DashboardWidget
+                dashboard={dashboard}
+                widget={widget}
+                filters={filters}
+                isPublic={isPublic}
+                isLoading={widget.loading}
+                canEdit={dashboard.canEdit()}
+                onLoadWidget={onLoadWidget}
+                onRefreshWidget={onRefreshWidget}
+                onRemoveWidget={onRemoveWidget}
+                onParameterMappingsChange={onParameterMappingsChange}
+              />
+            </div>
+          ))}
         </ResponsiveGridLayout>
       </div>
     );

--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -187,6 +187,7 @@ class VisualizationWidget extends React.Component {
     dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
     filters: FiltersType,
     isPublic: PropTypes.bool,
+    isLoading: PropTypes.bool,
     canEdit: PropTypes.bool,
     onLoad: PropTypes.func,
     onRefresh: PropTypes.func,
@@ -197,6 +198,7 @@ class VisualizationWidget extends React.Component {
   static defaultProps = {
     filters: [],
     isPublic: false,
+    isLoading: false,
     canEdit: false,
     onLoad: () => {},
     onRefresh: () => {},
@@ -236,8 +238,8 @@ class VisualizationWidget extends React.Component {
   };
 
   renderVisualization() {
-    const { widget, filters } = this.props;
-    const widgetQueryResult = widget.getQueryResult();
+    const { isLoading, widget, filters } = this.props;
+    const widgetQueryResult = !isLoading && widget.getQueryResult();
     const widgetStatus = widgetQueryResult && widgetQueryResult.getStatus();
     switch (widgetStatus) {
       case "failed":
@@ -273,10 +275,10 @@ class VisualizationWidget extends React.Component {
   }
 
   render() {
-    const { widget, isPublic, canEdit, onRefresh } = this.props;
+    const { widget, isLoading, isPublic, canEdit, onRefresh } = this.props;
     const { localParameters } = this.state;
     const widgetQueryResult = widget.getQueryResult();
-    const isRefreshing = widget.loading && !!(widgetQueryResult && widgetQueryResult.getStatus());
+    const isRefreshing = isLoading && !!(widgetQueryResult && widgetQueryResult.getStatus());
 
     return (
       <Widget


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
The idea of this PR is to handle this:
| Before | After |
| --------- | ------ |
| ![Screenshot from 2020-03-13 14-41-20](https://user-images.githubusercontent.com/3356951/76645919-ba83df80-6538-11ea-97c7-c748793e01db.png)  |  ![Screenshot from 2020-03-13 14-22-40](https://user-images.githubusercontent.com/3356951/76645734-56f9b200-6538-11ea-80d3-fc52040c954b.png) |

Basically, whenever a widget updates it updates the Dashboard and all children components get re-rendered. This PR memoizes widgets and only update them when one of their props change (need to test a bit more to make sure it does not blow anything). While I also wanted to memoize the base child from ReactGridLayout and avoid the whole grid item to re-render, I couldn't find a working way to do that.

For smaller dashboards I didn't see a relevant difference in the scripting time, but for the React Migration dashboard it did shave off extra 2 seconds in the Scripting Time (14s to 12s avg, tested with #4724, #4726 and this PR changes together).

## Related Tickets & Documents
#4714 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--
