### PR TITLE
Fix param added with empty query ignores options

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -223,7 +223,7 @@ class Parameters {
   }
 
   updateParameters(update) {
-    if (this.query.query && this.query.query === this.cachedQueryText) {
+    if (this.query.query === this.cachedQueryText) {
       const parameters = this.query.options.parameters;
       const hasUnprocessedParameters = find(parameters, p => !(p instanceof Parameter));
       if (hasUnprocessedParameters) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
This one was a bit hard to find :sweat_smile:. From what I understood on this code:
https://github.com/getredash/redash/blob/a682265e1396cf46b7baf8cc593239b6129c5662/client/app/services/query.js#L226-L235

It exists to determine when to skip parameters sync (query text with actual parameters list in query object). Since parameters are added in a context of inequality between the cachedQuery and the query text, the idea is to keep those parameters in there until the query text is modified (what wasn't happening for an empty query text)


## Related Tickets & Documents
Fixes #4723 
and #4146 is the one that triggered this context to be possible

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--