### PR TITLE
Counter: Only autoselect existing columns in data

### DIFF
--- a/client/app/visualizations/counter/Editor/CounterValueOptions.jsx
+++ b/client/app/visualizations/counter/Editor/CounterValueOptions.jsx
@@ -1,4 +1,4 @@
-import { isNil, get, map, includes } from "lodash";
+import { get, map, includes } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { Section, InputNumber, Input, Select, Checkbox, ContextHelp } from "@/components/visualizations/editor";
@@ -52,7 +52,14 @@ export default function CounterValueOptions({ disabled, counterTypes, options, d
             disabled={disabled}
             allowClear
             placeholder="Select column..."
-            defaultValue={isNil(options.column) ? undefined : options.column}
+            defaultValue={
+              includes(
+                map(data.columns, col => col.name),
+                options.column
+              )
+                ? options.column
+                : undefined
+            }
             onChange={column => onChange({ column: column || null })}>
             {map(data.columns, col => (
               <Select.Option key={col.name} data-test={`Counter.ColumnName.${col.name}`}>

--- a/client/app/visualizations/counter/Editor/CounterValueOptions.jsx
+++ b/client/app/visualizations/counter/Editor/CounterValueOptions.jsx
@@ -1,4 +1,4 @@
-import { get, map, includes } from "lodash";
+import { isNil, get, map, includes } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { Section, InputNumber, Input, Select, Checkbox, ContextHelp } from "@/components/visualizations/editor";
@@ -52,14 +52,7 @@ export default function CounterValueOptions({ disabled, counterTypes, options, d
             disabled={disabled}
             allowClear
             placeholder="Select column..."
-            defaultValue={
-              includes(
-                map(data.columns, col => col.name),
-                options.column
-              )
-                ? options.column
-                : undefined
-            }
+            defaultValue={isNil(options.column) ? undefined : options.column}
             onChange={column => onChange({ column: column || null })}>
             {map(data.columns, col => (
               <Select.Option key={col.name} data-test={`Counter.ColumnName.${col.name}`}>

--- a/client/app/visualizations/counter/Editor/GeneralSettings.test.jsx
+++ b/client/app/visualizations/counter/Editor/GeneralSettings.test.jsx
@@ -10,17 +10,19 @@ function findByTestID(wrapper, testId) {
 }
 
 function mount(options, done) {
-  options = getOptions(options);
+  const data = {
+    columns: [
+      { name: "a", type: "number" },
+      { name: "b", type: "number" },
+    ],
+    rows: [{ a: 123, b: 987 }],
+  };
+
+  options = getOptions(options, data);
   return enzyme.mount(
     <GeneralSettings
       visualizationName="Test"
-      data={{
-        columns: [
-          { name: "a", type: "number" },
-          { name: "b", type: "number" },
-        ],
-        rows: [{ a: 123, b: 987 }],
-      }}
+      data={data}
       options={options}
       onOptionsChange={changedOptions => {
         expect(changedOptions).toMatchSnapshot();

--- a/client/app/visualizations/counter/Editor/PrimaryValueSettings.test.jsx
+++ b/client/app/visualizations/counter/Editor/PrimaryValueSettings.test.jsx
@@ -10,17 +10,19 @@ function findByTestID(wrapper, testId) {
 }
 
 function mount(options, done) {
-  options = getOptions(options);
+  const data = {
+    columns: [
+      { name: "a", type: "number" },
+      { name: "b", type: "number" },
+    ],
+    rows: [{ a: 123, b: 987 }],
+  };
+
+  options = getOptions(options, data);
   return enzyme.mount(
     <PrimaryValueSettings
       visualizationName="Test"
-      data={{
-        columns: [
-          { name: "a", type: "number" },
-          { name: "b", type: "number" },
-        ],
-        rows: [{ a: 123, b: 987 }],
-      }}
+      data={data}
       options={options}
       onOptionsChange={changedOptions => {
         expect(changedOptions).toMatchSnapshot();

--- a/client/app/visualizations/counter/Editor/SecondaryValueSettings.test.jsx
+++ b/client/app/visualizations/counter/Editor/SecondaryValueSettings.test.jsx
@@ -10,17 +10,19 @@ function findByTestID(wrapper, testId) {
 }
 
 function mount(options, done) {
-  options = getOptions(options);
+  const data = {
+    columns: [
+      { name: "a", type: "number" },
+      { name: "b", type: "number" },
+    ],
+    rows: [{ a: 123, b: 987 }],
+  };
+
+  options = getOptions(options, data);
   return enzyme.mount(
     <SecondaryValueSettings
       visualizationName="Test"
-      data={{
-        columns: [
-          { name: "a", type: "number" },
-          { name: "b", type: "number" },
-        ],
-        rows: [{ a: 123, b: 987 }],
-      }}
+      data={data}
       options={options}
       onOptionsChange={changedOptions => {
         expect(changedOptions).toMatchSnapshot();

--- a/client/app/visualizations/counter/Renderer.test.jsx
+++ b/client/app/visualizations/counter/Renderer.test.jsx
@@ -5,25 +5,20 @@ import getOptions from "./getOptions";
 import Renderer from "./Renderer";
 
 function mount(options) {
-  options = getOptions(options);
-  return enzyme.mount(
-    <Renderer
-      visualizationName="Test"
-      data={{
-        columns: [
-          { name: "city", type: "string" },
-          { name: "population", type: "number" },
-        ],
-        rows: [
-          { city: "New York City", population: 18604000 },
-          { city: "Shanghai", population: 24484000 },
-          { city: "Tokyo", population: 38140000 },
-        ],
-      }}
-      options={options}
-      context="query"
-    />
-  );
+  const data = {
+    columns: [
+      { name: "city", type: "string" },
+      { name: "population", type: "number" },
+    ],
+    rows: [
+      { city: "New York City", population: 18604000 },
+      { city: "Shanghai", population: 24484000 },
+      { city: "Tokyo", population: 38140000 },
+    ],
+  };
+
+  options = getOptions(options, data);
+  return enzyme.mount(<Renderer visualizationName="Test" data={data} options={options} context="query" />);
 }
 
 describe("Visualizations -> Counter -> Renderer", () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
Don't autoselect "counter" column when creating a Counter. Basically this only selects a default column value in the UI when it exists in data.

## Related Tickets & Documents
#4727 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--