### PR TITLE
Set POSTGRES_HOST_AUTH_METHOD environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       - "15432:5432"
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
   email:
     image: djfarrelly/maildev
     ports:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes #4739. Runs the postgres container with the environment variable `POSTGRES_HOST_AUTH_METHOD` set to the value `trust`.

Setting this environment variable is not recommended by the image maintainers, but results in a postgres container that operates in much the same way that it did before the change was introduced. It is also backwards-compatible with older copies of the `postgres:9.5-alpine` image, which will simply ignore the environment variable.

## Related Tickets & Documents

* Redash Bug Report: #4739 
* Redash forum topic: https://discuss.redash.io/t/unable-to-create-docker-based-development-environment/5595/8
* https://github.com/docker-library/postgres/pull/658
* https://github.com/docker-library/postgres/issues/681 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A