### PR TITLE
Upgrade Plotly

### DIFF
--- a/client/app/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/client/app/visualizations/chart/plotly/applyLayoutFixes.js
@@ -36,6 +36,7 @@ export default function applyLayoutFixes(plotlyElement, layout, updatePlot) {
     // half of plot container's height - legend will have max height equal to
     // plot height), re-render plot again and offset legend to the space under
     // the plot.
+    // Related issue: https://github.com/plotly/plotly.js/issues/1199
     layout.legend = {
       orientation: "h",
       // locate legend inside of plot area - otherwise plotly will preserve

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
@@ -18,7 +18,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "boxmode": "group",
       "boxgroupgap": 0.50,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
@@ -15,7 +15,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
@@ -15,7 +15,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
@@ -19,7 +19,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "boxmode": "group",
       "boxgroupgap": 0.50,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
@@ -18,7 +18,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "xaxis": {
         "automargin": true,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
@@ -15,7 +15,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
@@ -15,7 +15,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
@@ -19,7 +19,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "xaxis": {
         "automargin": true,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
@@ -19,7 +19,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": false,
       "barmode": "relative",
       "xaxis": {

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
@@ -19,7 +19,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": false,
       "xaxis": {
         "automargin": true,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
@@ -16,7 +16,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
@@ -12,7 +12,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
@@ -15,7 +15,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "annotations": [
         {

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
@@ -12,7 +12,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
@@ -10,7 +10,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
@@ -13,7 +13,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "annotations": []
     }

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
@@ -10,7 +10,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
@@ -13,7 +13,7 @@
       "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
       "width": 400,
       "height": 300,
-      "autosize": true,
+      "autosize": false,
       "showlegend": true,
       "annotations": [
         {

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
@@ -10,7 +10,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
+      "margin": { "l": 10, "r": 10, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
+++ b/client/app/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
@@ -10,7 +10,7 @@
   },
   "output": {
     "layout": {
-      "margin": { "l": 10, "r": 10, "b": 10, "t": 25, "pad": 4 },
+      "margin": { "l": 5, "r": 5, "b": 5, "t": 20, "pad": 4 },
       "width": 400,
       "height": 300,
       "autosize": false,

--- a/client/app/visualizations/chart/plotly/prepareLayout.js
+++ b/client/app/visualizations/chart/plotly/prepareLayout.js
@@ -121,7 +121,7 @@ export default function prepareLayout(element, options, data) {
     margin: { l: 10, r: 10, b: 10, t: 25, pad: 4 },
     width: Math.floor(element.offsetWidth),
     height: Math.floor(element.offsetHeight),
-    autosize: true,
+    autosize: false,
     showlegend: has(options, "legend") ? options.legend.enabled : true,
   };
 

--- a/client/app/visualizations/chart/plotly/prepareLayout.js
+++ b/client/app/visualizations/chart/plotly/prepareLayout.js
@@ -118,7 +118,7 @@ function prepareBoxLayout(layout, options, data) {
 
 export default function prepareLayout(element, options, data) {
   const layout = {
-    margin: { l: 5, r: 5, b: 5, t: 20, pad: 4 },
+    margin: { l: 10, r: 10, b: 5, t: 20, pad: 4 },
     width: Math.floor(element.offsetWidth),
     height: Math.floor(element.offsetHeight),
     autosize: false,

--- a/client/app/visualizations/chart/plotly/prepareLayout.js
+++ b/client/app/visualizations/chart/plotly/prepareLayout.js
@@ -118,7 +118,7 @@ function prepareBoxLayout(layout, options, data) {
 
 export default function prepareLayout(element, options, data) {
   const layout = {
-    margin: { l: 10, r: 10, b: 10, t: 25, pad: 4 },
+    margin: { l: 5, r: 5, b: 5, t: 20, pad: 4 },
     width: Math.floor(element.offsetWidth),
     height: Math.floor(element.offsetHeight),
     autosize: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,6 @@
         "turntable-camera-controller": "^3.0.0"
       }
     },
-    "3d-view-controls": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/3d-view-controls/-/3d-view-controls-2.2.2.tgz",
-      "integrity": "sha512-WL0u3PN41lEx/4qvKqV6bJlweUYoW18FXMshW/qHb41AVdZxDReLoJNGYsI7x6jf9bYelEF62BJPQmO7yEnG2w==",
-      "requires": {
-        "3d-view": "^2.0.0",
-        "has-passive-events": "^1.0.0",
-        "mouse-change": "^1.1.1",
-        "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.0.2",
-        "right-now": "^1.0.0"
-      }
-    },
     "@ant-design/colors": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.1.0.tgz",
@@ -974,10 +961,28 @@
         "wgs84": "0.0.0"
       }
     },
-    "@mapbox/gl-matrix": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz",
-      "integrity": "sha1-5RJqq01kw2uBx6l9CuDd3eV3PSs="
+    "@mapbox/geojson-rewind": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
+      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
+      "requires": {
+        "@mapbox/geojson-area": "0.2.2",
+        "concat-stream": "~1.6.0",
+        "minimist": "^1.2.5",
+        "sharkdown": "^0.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
+      }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
     },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
@@ -993,11 +998,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "@mapbox/shelf-pack": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.2.0.tgz",
-      "integrity": "sha512-dyQxe6ukILV6qaEvxoKCIwhblgRjYp1ZGlClo4xvfbmxzFO5LYu7Tnrg2AZrRgN7VsSragsGcNjzUe9kCdKHYQ=="
     },
     "@mapbox/tiny-sdf": {
       "version": "1.1.1",
@@ -1023,13 +1023,64 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@plotly/d3-sankey": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.5.1.tgz",
-      "integrity": "sha512-uMToNGexOSLG0hBm+uAzElfFW0Pt2utgJ//puL5nuerNnPnRTTe3Un7XFVcWqRhvXEViF00Xq/8wGoA8i8eZJA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
       "requires": {
         "d3-array": "1",
         "d3-collection": "1",
-        "d3-interpolate": "1"
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "requires": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@turf/area": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
+      "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
+      }
+    },
+    "@turf/bbox": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
+      "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
+      }
+    },
+    "@turf/centroid": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.0.2.tgz",
+      "integrity": "sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+    },
+    "@turf/meta": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "requires": {
+        "@turf/helpers": "6.x"
       }
     },
     "@types/eslint-visitor-keys": {
@@ -1398,7 +1449,8 @@
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -1668,6 +1720,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
@@ -1675,7 +1728,8 @@
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
         }
       }
     },
@@ -2390,9 +2444,9 @@
       "dev": true
     },
     "binary-search-bounds": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-      "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
+      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
     },
     "bit-twiddle": {
       "version": "1.0.2",
@@ -2588,111 +2642,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "brfs": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
-      "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
-      "requires": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "requires": {
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-          "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "object-inspect": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
-        },
-        "quote-stream": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-          "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
-          "requires": {
-            "buffer-equal": "0.0.1",
-            "minimist": "^1.1.3",
-            "through2": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "static-module": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
-          "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
-          "requires": {
-            "concat-stream": "~1.6.0",
-            "convert-source-map": "^1.5.1",
-            "duplexer2": "~0.1.4",
-            "escodegen": "~1.9.0",
-            "falafel": "^2.1.0",
-            "has": "^1.0.1",
-            "magic-string": "^0.22.4",
-            "merge-source-map": "1.0.4",
-            "object-inspect": "~1.4.0",
-            "quote-stream": "~1.0.2",
-            "readable-stream": "~2.3.3",
-            "shallow-copy": "~0.0.1",
-            "static-eval": "^2.0.0",
-            "through2": "~2.0.3"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -2829,43 +2778,48 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
-        },
-        "magic-string": {
-          "version": "0.25.6",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
-          "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==",
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
         },
         "regenerate-unicode-properties": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-          "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+          "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
           "requires": {
             "regenerate": "^1.4.0"
           }
         },
         "regexpu-core": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
-          "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+          "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
           "requires": {
             "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.1.0",
-            "regjsgen": "^0.5.0",
-            "regjsparser": "^0.6.0",
+            "regenerate-unicode-properties": "^8.2.0",
+            "regjsgen": "^0.5.1",
+            "regjsparser": "^0.6.4",
             "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.1.0"
+            "unicode-match-property-value-ecmascript": "^1.2.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+          "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
+        },
+        "regjsparser": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+          "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+          "requires": {
+            "jsesc": "~0.5.0"
           }
         },
         "unicode-match-property-value-ecmascript": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-          "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+          "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
         }
       }
     },
@@ -2895,11 +2849,6 @@
           "dev": true
         }
       }
-    },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -3065,13 +3014,6 @@
         "binary-search-bounds": "^2.0.3",
         "robust-in-sphere": "^1.1.3",
         "robust-orientation": "^1.1.3"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
       }
     },
     "cell-orientation": {
@@ -3710,6 +3652,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -4282,6 +4225,11 @@
         "d3-timer": "1"
       }
     },
+    "d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
     "d3-interpolate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
@@ -4290,10 +4238,23 @@
         "d3-color": "1"
       }
     },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
     "d3-quadtree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
       "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
     },
     "d3-timer": {
       "version": "1.0.10",
@@ -4891,6 +4852,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
       "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404="
+    },
+    "elementary-circuits-directed-graph": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.2.0.tgz",
+      "integrity": "sha512-eOQofnrNqebPtC29PvyNMGUBdMrIw5i8nOoC/2VOlSF84tf5+ZXnRkIk7TgdT22jFXK68CC7aA881KRmNYf/Pg==",
+      "requires": {
+        "strongly-connected-components": "^1.0.1"
+      }
     },
     "elliptic": {
       "version": "6.4.1",
@@ -6211,6 +6180,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
       "requires": {
         "is-extendable": "^0.1.0"
       }
@@ -6300,14 +6270,26 @@
       "dev": true
     },
     "falafel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
-      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
+      "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
       "requires": {
-        "acorn": "^5.0.0",
+        "acorn": "^7.1.1",
         "foreach": "^2.0.5",
-        "isarray": "0.0.1",
+        "isarray": "^2.0.1",
         "object-keys": "^1.0.6"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "fast-deep-equal": {
@@ -6440,6 +6422,13 @@
       "requires": {
         "binary-search-bounds": "^1.0.0",
         "cubic-hermite": "^1.0.0"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "finalhandler": {
@@ -6610,15 +6599,6 @@
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "requires": {
         "css-font": "^1.0.0"
-      }
-    },
-    "font-atlas-sdf": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/font-atlas-sdf/-/font-atlas-sdf-1.3.3.tgz",
-      "integrity": "sha512-GxUpcdkdoHgC3UrpMuA7JmG1Ty/MY0BhfmV8r7ZSv3bkqBY5vmRIjcj7Pg8iqj20B03vlU6fUhdpyIgEo/Z35w==",
-      "requires": {
-        "optical-properties": "^1.0.0",
-        "tiny-sdf": "^1.0.2"
       }
     },
     "font-awesome": {
@@ -7264,17 +7244,6 @@
       "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
       "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
     },
-    "geojson-rewind": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.1.tgz",
-      "integrity": "sha1-IiQHl8hHzC8MHTE+SqDJFa+n8p0=",
-      "requires": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "1.2.0",
-        "sharkdown": "^0.1.0"
-      }
-    },
     "geojson-vt": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
@@ -7351,66 +7320,6 @@
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
         "vectorize-text": "^3.2.1"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-buffer": {
@@ -7440,66 +7349,6 @@
         "glsl-specular-cook-torrance": "^2.0.1",
         "glslify": "^7.0.0",
         "ndarray": "^1.0.18"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-constants": {
@@ -7521,71 +7370,6 @@
         "iota-array": "^1.0.0",
         "ndarray": "^1.0.18",
         "surface-nets": "^1.0.2"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-error3d": {
@@ -7598,66 +7382,6 @@
         "gl-vao": "^1.3.0",
         "glsl-out-of-range": "^1.0.4",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-fbo": {
@@ -7690,71 +7414,6 @@
         "glslify": "^7.0.0",
         "iota-array": "^1.0.0",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-line3d": {
@@ -7770,71 +7429,6 @@
         "glsl-out-of-range": "^1.0.4",
         "glslify": "^7.0.0",
         "ndarray": "^1.0.18"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-mat2": {
@@ -7851,6 +7445,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
       "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
+    },
+    "gl-matrix": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.2.1.tgz",
+      "integrity": "sha512-YYVO8jUSf6+SakL4AJmx9Jc7zAZhkJQ+WhdtX3VQe5PJdCOX6/ybY4x1vk+h94ePnjRn6uml68+QxTAJneUpvA=="
     },
     "gl-matrix-invert": {
       "version": "1.0.0",
@@ -7882,66 +7481,6 @@
         "polytope-closest-point": "^1.0.0",
         "simplicial-complex-contour": "^1.0.0",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-plot2d": {
@@ -7956,150 +7495,29 @@
         "glsl-inverse": "^1.0.0",
         "glslify": "^7.0.0",
         "text-cache": "^4.2.1"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-plot3d": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-1.6.3.tgz",
-      "integrity": "sha512-/pQAJHDrYgbwTYygXn1aErwRX6KDb2WwJAFaRBjr4xOoSC/flC5VI/1LyQFuQwNlxExx58gAm88aMkWwi8sdiQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.4.tgz",
+      "integrity": "sha512-R/V4hSrE2sFD+Xls7D6qCOlWCRmqtUff0sKbeFJdI91HfFzPJPiy9Pqa/Jh2UsvdmwkkSQPNDcBvLd6TvhRC/g==",
       "requires": {
-        "3d-view-controls": "^2.2.2",
+        "3d-view": "^2.0.0",
         "a-big-triangle": "^1.0.3",
-        "gl-axes3d": "^1.4.4",
+        "gl-axes3d": "^1.5.2",
         "gl-fbo": "^2.0.5",
         "gl-mat4": "^1.2.0",
         "gl-select-static": "^2.0.4",
         "gl-shader": "^4.2.1",
-        "gl-spikes3d": "^1.0.8",
+        "gl-spikes3d": "^1.0.9",
         "glslify": "^7.0.0",
-        "is-mobile": "^2.0.0",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.0",
         "mouse-change": "^1.4.0",
-        "ndarray": "^1.0.18"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.18",
+        "right-now": "^1.0.0"
       }
     },
     "gl-pointcloud2d": {
@@ -8111,66 +7529,6 @@
         "gl-shader": "^4.2.1",
         "glslify": "^7.0.0",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-quat": {
@@ -8197,66 +7555,6 @@
         "is-string-blank": "^1.0.1",
         "typedarray-pool": "^1.0.2",
         "vectorize-text": "^3.2.1"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-select-box": {
@@ -8267,66 +7565,6 @@
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.0.5",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-select-static": {
@@ -8364,66 +7602,6 @@
         "gl-shader": "^4.2.1",
         "gl-vao": "^1.3.0",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-state": {
@@ -8446,72 +7624,12 @@
         "glsl-out-of-range": "^1.0.4",
         "glsl-specular-cook-torrance": "^2.0.1",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-surface3d": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.4.6.tgz",
-      "integrity": "sha512-aItWQTNUX3JJc6i2FbXX82ljPZgDV3kXzkzANcBGoAnKwRpJw12WcMKKTL4sOCs9BW+3sx6BhR0P5+2zh5Scfw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.5.1.tgz",
+      "integrity": "sha512-wE9tMHlAL5ZBluXpdVwxhBiPv7J9HwEBc5tVHFDP6TJkvhvf2RTDkCPDOPP5wCSLAFATImbzgwgoNM30/ghDTw==",
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "bit-twiddle": "^1.0.2",
@@ -8532,71 +7650,6 @@
         "ndarray-scratch": "^1.1.1",
         "surface-nets": "^1.0.2",
         "typedarray-pool": "^1.0.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-text": {
@@ -8891,9 +7944,9 @@
       }
     },
     "glslify": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/glslify/-/glslify-6.4.1.tgz",
-      "integrity": "sha512-YDQ1Lei4Mj0TjJqjbf/llIJ1c10vsUTf6OQZ9N058PnVwOmIZyTmtr5Pgh9i99nxvP4M4sRWA5+IucQuOUnV5w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
+      "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
       "requires": {
         "bl": "^1.0.0",
         "concat-stream": "^1.5.2",
@@ -8908,7 +7961,6 @@
         "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
         "static-eval": "^2.0.0",
-        "tape": "^4.6.0",
         "through2": "^2.0.1",
         "xtend": "^4.0.0"
       },
@@ -8987,24 +8039,6 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
-    "gray-matter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
-      "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.10.0",
-        "kind-of": "^5.0.2",
-        "strip-bom-string": "^1.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
     },
     "grid-index": {
       "version": "1.1.0",
@@ -9825,6 +8859,13 @@
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
       "requires": {
         "binary-search-bounds": "^1.0.0"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "invariant": {
@@ -9980,7 +9021,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -10838,6 +9880,7 @@
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
       "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10846,7 +9889,8 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
         }
       }
     },
@@ -10988,9 +10032,9 @@
       }
     },
     "kdbush": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz",
-      "integrity": "sha1-PL0D6d6tnA9vZszblkUOXOzGQOA="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "killable": {
       "version": "1.0.1",
@@ -11349,11 +10393,11 @@
       }
     },
     "magic-string": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
       "requires": {
-        "vlq": "^0.2.2"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -11423,78 +10467,39 @@
       }
     },
     "mapbox-gl": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.45.0.tgz",
-      "integrity": "sha1-r3HMgk8NflHM1cUF6q5BG8CRDM0=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.2.tgz",
+      "integrity": "sha512-6Ro7GbTMWxcbc836m6rbBNkesgTncbE1yXWeuHlr89esSqaItKr0+ntOu8rZie3fv+GtitkbODysXzIGCA7G+w==",
       "requires": {
-        "@mapbox/gl-matrix": "^0.0.1",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.1",
-        "@mapbox/mapbox-gl-supported": "^1.3.1",
+        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.4.0",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/shelf-pack": "^3.1.0",
         "@mapbox/tiny-sdf": "^1.1.0",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.0.0",
-        "brfs": "^1.4.4",
+        "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.3",
-        "geojson-rewind": "^0.3.0",
-        "geojson-vt": "^3.1.0",
-        "gray-matter": "^3.0.8",
-        "grid-index": "^1.0.0",
+        "earcut": "^2.1.5",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.0.0",
+        "grid-index": "^1.1.0",
         "minimist": "0.0.8",
+        "murmurhash-js": "^1.0.0",
         "pbf": "^3.0.5",
-        "quickselect": "^1.0.0",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "shuffle-seed": "^1.1.6",
-        "sort-object": "^0.3.2",
-        "supercluster": "^2.3.0",
-        "through2": "^2.0.3",
-        "tinyqueue": "^1.1.0",
-        "vt-pbf": "^3.0.1"
+        "supercluster": "^6.0.1",
+        "tinyqueue": "^2.0.0",
+        "vt-pbf": "^3.1.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
         }
       }
     },
@@ -11568,6 +10573,13 @@
         "gl-mat4": "^1.1.2",
         "gl-vec3": "^1.0.3",
         "mat4-interpolate": "^1.0.3"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "md5.js": {
@@ -11618,21 +10630,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
-    },
-    "merge-source-map": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-      "requires": {
-        "source-map": "^0.5.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
     },
     "merge-stream": {
       "version": "1.0.1",
@@ -12703,11 +11700,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "optical-properties": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/optical-properties/-/optical-properties-1.0.0.tgz",
-      "integrity": "sha512-XnBQYbIIzDVr7U3L7d3xyAEqp1W+HTkqmw/G4L/Ae/+dq57bT1jqW2uDwV0wCUzO8gsTDIZhGQsGrMb17VSkEA=="
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -13174,65 +12166,70 @@
       }
     },
     "plotly.js": {
-      "version": "1.43.2",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.43.2.tgz",
-      "integrity": "sha512-f4X/i3HXxB0leZOm4mQWD97AD6s22sESqQGQBS39nyfN5Dfb5bNQvmowgKc0F8IUB0gf4xPOrJ/4UIPIfeIPNA==",
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.52.3.tgz",
+      "integrity": "sha512-7szNqbVuhqn4ZgaTpJ9h4+9PzjoXJnSdzjnY5QwHddp/j0xu5kpHCGvkg+WmeF3brK3y8qwEHF/MIFBBa7i0ng==",
       "requires": {
-        "3d-view": "^2.0.0",
-        "@plotly/d3-sankey": "^0.5.1",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@turf/area": "^6.0.1",
+        "@turf/bbox": "^6.0.1",
+        "@turf/centroid": "^6.0.2",
         "alpha-shape": "^1.0.0",
-        "array-range": "^1.0.1",
         "canvas-fit": "^1.5.0",
-        "color-normalize": "^1.3.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
         "convex-hull": "^1.0.3",
         "country-regex": "^1.1.0",
         "d3": "^3.5.12",
         "d3-force": "^1.0.6",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^1.4.0",
         "delaunay-triangulate": "^1.1.6",
         "es6-promise": "^3.0.2",
-        "fast-isnumeric": "^1.1.2",
-        "font-atlas-sdf": "^1.3.3",
-        "gl-cone3d": "^1.2.1",
-        "gl-contour2d": "^1.1.4",
-        "gl-error3d": "^1.0.9",
-        "gl-heatmap2d": "^1.0.4",
-        "gl-line3d": "^1.1.6",
+        "fast-isnumeric": "^1.1.3",
+        "gl-cone3d": "^1.5.1",
+        "gl-contour2d": "^1.1.6",
+        "gl-error3d": "^1.0.15",
+        "gl-heatmap2d": "^1.0.5",
+        "gl-line3d": "1.2.0",
         "gl-mat4": "^1.2.0",
-        "gl-mesh3d": "^2.0.2",
-        "gl-plot2d": "^1.4.0",
-        "gl-plot3d": "^1.6.1",
-        "gl-pointcloud2d": "^1.0.1",
-        "gl-scatter3d": "^1.1.2",
-        "gl-select-box": "^1.0.2",
-        "gl-spikes2d": "^1.0.1",
-        "gl-streamtube3d": "^1.1.1",
-        "gl-surface3d": "^1.4.0",
-        "gl-text": "^1.1.6",
-        "glslify": "^6.3.1",
+        "gl-mesh3d": "^2.3.0",
+        "gl-plot2d": "^1.4.3",
+        "gl-plot3d": "^2.4.4",
+        "gl-pointcloud2d": "^1.0.2",
+        "gl-scatter3d": "^1.2.2",
+        "gl-select-box": "^1.0.3",
+        "gl-spikes2d": "^1.0.2",
+        "gl-streamtube3d": "^1.4.0",
+        "gl-surface3d": "^1.4.6",
+        "gl-text": "^1.1.8",
+        "glslify": "^7.0.0",
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
-        "mapbox-gl": "0.45.0",
+        "is-mobile": "^2.2.0",
+        "mapbox-gl": "1.3.2",
         "matrix-camera-controller": "^2.1.3",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.0.2",
+        "mouse-wheel": "^1.2.0",
         "ndarray": "^1.0.18",
         "ndarray-fill": "^1.0.2",
         "ndarray-homography": "^1.0.0",
-        "point-cluster": "^3.1.4",
+        "point-cluster": "^3.1.8",
         "polybooljs": "^1.2.0",
         "regl": "^1.3.11",
-        "regl-error2d": "^2.0.5",
-        "regl-line2d": "^3.0.12",
-        "regl-scatter2d": "^3.1.2",
-        "regl-splom": "^1.0.5",
+        "regl-error2d": "^2.0.8",
+        "regl-line2d": "^3.0.15",
+        "regl-scatter2d": "^3.1.7",
+        "regl-splom": "^1.0.8",
         "right-now": "^1.0.0",
         "robust-orientation": "^1.1.3",
-        "sane-topojson": "^2.0.0",
+        "sane-topojson": "^4.0.0",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
         "svg-path-sdf": "^1.1.3",
-        "tinycolor2": "^1.3.0",
+        "tinycolor2": "^1.4.1",
         "topojson-client": "^2.1.0",
         "webgl-context": "^2.2.0",
         "world-calendars": "^1.0.3"
@@ -13261,13 +12258,6 @@
         "math-log2": "^1.0.1",
         "parse-rect": "^1.2.0",
         "pick-by-alias": "^1.2.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
       }
     },
     "point-in-big-polygon": {
@@ -13279,6 +12269,13 @@
         "interval-tree-1d": "^1.0.1",
         "robust-orientation": "^1.1.3",
         "slab-decomposition": "^1.0.1"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "polybooljs": {
@@ -13782,6 +12779,11 @@
         "uniqs": "^2.0.0"
       }
     },
+    "potpack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -14026,9 +13028,9 @@
       "dev": true
     },
     "quickselect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "quote-stream": {
       "version": "0.0.0",
@@ -15072,9 +14074,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -15170,20 +14172,22 @@
     "regjsgen": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       }
     },
     "regl": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.13.tgz",
-      "integrity": "sha512-TTiCabJbbUykCL4otjqOvKqDFJhvJOT7xB51JxcDeSHGrEJl1zz4RthPcoOogqfuR3ECN4Te790DfHCXzli5WQ=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.4.2.tgz",
+      "integrity": "sha512-wc/kE6kGmGfQk3G9f1Pai4TZ0K1pWxkD1Jeaj6CxJwEiB1jwHgEpqD84G2t7F0DmNXfQh7IUnoG1opxoONJ7Xg=="
     },
     "regl-error2d": {
       "version": "2.0.8",
@@ -15217,66 +14221,6 @@
         "parse-rect": "^1.2.0",
         "pick-by-alias": "^1.2.0",
         "to-float32": "^1.0.1"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "regl-scatter2d": {
@@ -15300,66 +14244,6 @@
         "point-cluster": "^3.1.8",
         "to-float32": "^1.0.1",
         "update-diff": "^1.1.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "regl-splom": {
@@ -15804,9 +14688,9 @@
       }
     },
     "sane-topojson": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-2.0.0.tgz",
-      "integrity": "sha1-QOJXNqKMTM6qojP0W7hjc6J4W4Q="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-4.0.0.tgz",
+      "integrity": "sha512-bJILrpBboQfabG3BNnHI2hZl52pbt80BE09u4WhnrmzuF2JbMKZdl62G5glXskJ46p+gxE2IzOwGj/awR4g8AA=="
     },
     "sax": {
       "version": "1.2.4",
@@ -15833,11 +14717,6 @@
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
       }
-    },
-    "seedrandom": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
-      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA=="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -16046,14 +14925,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "shuffle-seed": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/shuffle-seed/-/shuffle-seed-1.1.6.tgz",
-      "integrity": "sha1-UzwSaDurO0+j6HUfxOViFGdEJgs=",
-      "requires": {
-        "seedrandom": "^2.4.2"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -16138,6 +15009,13 @@
         "binary-search-bounds": "^1.0.0",
         "functional-red-black-tree": "^1.0.0",
         "robust-orientation": "^1.1.3"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "slash": {
@@ -16306,16 +15184,6 @@
         }
       }
     },
-    "sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
-    },
-    "sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
-    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -16323,15 +15191,6 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
-      }
-    },
-    "sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "requires": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
       }
     },
     "sortablejs": {
@@ -16580,9 +15439,9 @@
       "dev": true
     },
     "static-eval": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.3.tgz",
-      "integrity": "sha512-zsxDGucfAh8T339sSKgpFbvg15Fms2IVaJGC+jqp0bVsxhcpM+iMeAI8weNo8dmf4OblgifTBUoyk1vGVtYw2w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.5.tgz",
+      "integrity": "sha512-nNbV6LbGtMBgv7e9LFkt5JV8RVlRsyJrphfAt9tOtBBW/SfnzZDf2KnS72an8e434A+9e/BmJuTxeGPvrAK7KA==",
       "requires": {
         "escodegen": "^1.11.1"
       }
@@ -16973,11 +15832,6 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
-    "strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -16996,11 +15850,11 @@
       "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
     },
     "supercluster": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-2.3.0.tgz",
-      "integrity": "sha1-h6tWCBu+qaHXJN9TUe6ejDry9Is=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
       "requires": {
-        "kdbush": "^1.0.1"
+        "kdbush": "^3.0.0"
       }
     },
     "superscript-text": {
@@ -17168,9 +16022,9 @@
       }
     },
     "tape": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
-      "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.2.tgz",
+      "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
       "requires": {
         "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
@@ -17183,7 +16037,7 @@
         "is-regex": "~1.0.5",
         "minimist": "~1.2.0",
         "object-inspect": "~1.7.0",
-        "resolve": "~1.14.2",
+        "resolve": "~1.15.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.2.1",
         "through": "~2.3.8"
@@ -17203,9 +16057,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -17277,9 +16131,9 @@
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "resolve": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -17531,11 +16385,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
       "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
-    "tiny-sdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-sdf/-/tiny-sdf-1.0.2.tgz",
-      "integrity": "sha1-KOdphcRMTlhMS2fY7N2bM6HKwow="
-    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -17547,9 +16396,9 @@
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -18341,11 +17190,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "vm-browserify": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mustache": "^2.3.0",
     "numeral": "^2.0.6",
     "pace-progress": "git+https://github.com/getredash/pace.git",
-    "plotly.js": "1.43.2",
+    "plotly.js": "1.52.3",
     "prop-types": "^15.6.1",
     "query-string": "^6.9.0",
     "react": "^16.8.3",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Upgrade Plotly to latest version to use new features (like `offsetgroup` needed for getredash/redash#4150) also for smoother upgrades in future.

I tested Chart visualization a lot after upgrade and didn't notice anything critical. Seems Plotly now computes auto-margins in a different way - I adjusted margins on our side to keep it as close as possible to previous version. Also, it changed legend styles a bit (see screenshots before/after) - unfortunately, I didn't find a good fix:

![image](https://user-images.githubusercontent.com/12139186/77939832-6ad73f00-72c0-11ea-8e91-bfdc0a0d70de.png)
![image](https://user-images.githubusercontent.com/12139186/77939858-74f93d80-72c0-11ea-88c7-6cad23890e0b.png)

## Related Tickets & Documents

getredash/redash#4150
