### PR TITLE
Move data source/destination deprecated handling to frontend

### DIFF
--- a/client/app/components/CreateSourceDialog.jsx
+++ b/client/app/components/CreateSourceDialog.jsx
@@ -124,7 +124,12 @@ class CreateSourceDialog extends React.Component {
     const { imageFolder } = this.props;
     return (
       <List.Item className="p-l-10 p-r-10 clickable" onClick={() => this.selectType(item)}>
-        <PreviewCard title={item.name} imageUrl={`${imageFolder}/${item.type}.png`} roundedImage={false}>
+        <PreviewCard
+          title={item.name}
+          imageUrl={`${imageFolder}/${item.type}.png`}
+          roundedImage={false}
+          data-test="PreviewItem"
+          data-test-type={item.type}>
           <i className="fa fa-angle-double-right" />
         </PreviewCard>
       </List.Item>

--- a/client/app/pages/data-sources/DataSourcesList.jsx
+++ b/client/app/pages/data-sources/DataSourcesList.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Button from "antd/lib/button";
-import { isEmpty } from "lodash";
+import { isEmpty, reject } from "lodash";
 import DataSource, { IMG_ROOT } from "@/services/data-source";
 import { policy } from "@/services/policy";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
@@ -77,7 +77,7 @@ class DataSourcesList extends React.Component {
   showCreateSourceDialog = () => {
     recordEvent("view", "page", "data_sources/new");
     this.newDataSourceDialog = CreateSourceDialog.showModal({
-      types: this.state.dataSourceTypes,
+      types: reject(this.state.dataSourceTypes, "deprecated"),
       sourceType: "Data Source",
       imageFolder: IMG_ROOT,
       helpTriggerPrefix: "DS_",

--- a/client/app/pages/destinations/DestinationsList.jsx
+++ b/client/app/pages/destinations/DestinationsList.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Button from "antd/lib/button";
-import { isEmpty, isString, find, get } from "lodash";
+import { isEmpty, isString, find, get, reject } from "lodash";
 import Destination, { IMG_ROOT } from "@/services/destination";
 import { policy } from "@/services/policy";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
@@ -71,7 +71,7 @@ class DestinationsList extends React.Component {
 
   showCreateSourceDialog = () => {
     CreateSourceDialog.showModal({
-      types: this.state.destinationTypes,
+      types: reject(this.state.destinationTypes, "deprecated"),
       sourceType: "Alert Destination",
       imageFolder: IMG_ROOT,
       onCreate: this.createDestination,

--- a/client/cypress/integration/data-source/create_data_source_spec.js
+++ b/client/cypress/integration/data-source/create_data_source_spec.js
@@ -4,7 +4,19 @@ describe("Create Data Source", () => {
     cy.visit("/data_sources/new");
   });
 
-  it("renders the page and takes a screenshot", () => {
+  it("renders the page and takes a screenshot", function() {
+    cy.server();
+    cy.route("api/data_sources/types").as("DataSourceTypesRequest");
+
+    cy.wait("@DataSourceTypesRequest")
+      .then(({ response }) => response.body.filter(type => type.deprecated))
+      .then(deprecatedTypes => deprecatedTypes.map(type => type.type))
+      .as("deprecatedTypes");
+
+    cy.getByTestId("PreviewItem")
+      .then($previewItems => Cypress.$.map($previewItems, item => Cypress.$(item).attr("data-test-type")))
+      .then(availableTypes => expect(availableTypes).not.to.contain.members(this.deprecatedTypes));
+
     cy.getByTestId("CreateSourceDialog").should("contain", "PostgreSQL");
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.percySnapshot("Create Data Source - Types");

--- a/client/cypress/integration/destination/create_destination_spec.js
+++ b/client/cypress/integration/destination/create_destination_spec.js
@@ -4,7 +4,19 @@ describe("Create Destination", () => {
     cy.visit("/destinations/new");
   });
 
-  it("renders the page and takes a screenshot", () => {
+  it("renders the page and takes a screenshot", function() {
+    cy.server();
+    cy.route("api/destinations/types").as("DestinationTypesRequest");
+
+    cy.wait("@DestinationTypesRequest")
+      .then(({ response }) => response.body.filter(type => type.deprecated))
+      .then(deprecatedTypes => deprecatedTypes.map(type => type.type))
+      .as("deprecatedTypes");
+
+    cy.getByTestId("PreviewItem")
+      .then($previewItems => Cypress.$.map($previewItems, item => Cypress.$(item).attr("data-test-type")))
+      .then(availableTypes => expect(availableTypes).not.to.contain.members(this.deprecatedTypes));
+
     cy.getByTestId("CreateSourceDialog").should("contain", "Email");
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.percySnapshot("Create Destination - Types");

--- a/redash/destinations/__init__.py
+++ b/redash/destinations/__init__.py
@@ -41,6 +41,7 @@ class BaseDestination(object):
             "type": cls.type(),
             "icon": cls.icon(),
             "configuration_schema": cls.configuration_schema(),
+            **({ "deprecated": True } if cls.deprecated else {})
         }
 
 

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -25,12 +25,7 @@ from redash.utils.configuration import ConfigurationContainer, ValidationError
 class DataSourceTypeListResource(BaseResource):
     @require_admin
     def get(self):
-        available_query_runners = [
-            q for q in query_runners.values() if not q.deprecated
-        ]
-        return [
-            q.to_dict() for q in sorted(available_query_runners, key=lambda q: q.name())
-        ]
+        return [q.to_dict() for q in sorted(query_runners.values(), key=lambda q: q.name())]
 
 
 class DataSourceResource(BaseResource):

--- a/redash/handlers/destinations.py
+++ b/redash/handlers/destinations.py
@@ -15,8 +15,7 @@ from redash.utils.configuration import ConfigurationContainer, ValidationError
 class DestinationTypeListResource(BaseResource):
     @require_admin
     def get(self):
-        available_destinations = [q for q in destinations.values() if not q.deprecated]
-        return [q.to_dict() for q in available_destinations]
+        return [q.to_dict() for q in destinations.values()]
 
 
 class DestinationResource(BaseResource):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -127,6 +127,7 @@ class BaseQueryRunner(object):
             "name": cls.name(),
             "type": cls.type(),
             "configuration_schema": cls.configuration_schema(),
+            **({ "deprecated": True } if cls.deprecated else {})
         }
 
 

--- a/tests/handlers/test_data_sources.py
+++ b/tests/handlers/test_data_sources.py
@@ -49,14 +49,6 @@ class DataSourceTypesTest(BaseTestCase):
         rv = self.make_request("get", "/api/data_sources/types", user=admin)
         self.assertEqual(rv.status_code, 200)
 
-    def test_does_not_show_deprecated_types(self):
-        admin = self.factory.create_admin()
-        with patch.object(PostgreSQL, "deprecated", return_value=True):
-            rv = self.make_request("get", "/api/data_sources/types", user=admin)
-
-        types = [datasource_type["type"] for datasource_type in rv.json]
-        self.assertNotIn("pg", types)
-
     def test_returns_403_for_non_admin(self):
         rv = self.make_request("get", "/api/data_sources/types")
         self.assertEqual(rv.status_code, 403)

--- a/tests/handlers/test_destinations.py
+++ b/tests/handlers/test_destinations.py
@@ -97,13 +97,3 @@ class TestDestinationResource(BaseTestCase):
         d = NotificationDestination.query.get(d.id)
         self.assertEqual(d.name, data["name"])
         self.assertEqual(d.options["url"], data["options"]["url"])
-
-
-class DestinationTypesTest(BaseTestCase):
-    def test_does_not_show_deprecated_types(self):
-        admin = self.factory.create_admin()
-        with patch.object(Slack, "deprecated", return_value=True):
-            rv = self.make_request("get", "/api/destinations/types", user=admin)
-
-        types = [destination_type["type"] for destination_type in rv.json]
-        self.assertNotIn("slack", types)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Move #3972 logic to the frontend and add cypress assertions for that

One possible extra is to add a _Deprecated_  note on the title of data sources/destinations.


## Related Tickets & Documents
Fixes #4746

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--