### PR TITLE
Fix there's no publish button on mobile query page

### DIFF
--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -70,7 +70,7 @@ export default function QueryPageHeader({
   tagsExtra,
   onChange,
 }) {
-  const isMobile = !useMedia({ minWidth: 768 });
+  const isDesktop = useMedia({ minWidth: 768 });
   const queryFlags = useQueryFlags(query, dataSource);
   const updateName = useRenameQuery(query, onChange);
   const updateTags = useUpdateQueryTags(query, onChange);
@@ -110,7 +110,7 @@ export default function QueryPageHeader({
           },
           publish: {
             isAvailable:
-              isMobile && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit,
+              !isDesktop && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit,
             title: "Publish",
             onClick: publishQuery,
           },
@@ -138,7 +138,7 @@ export default function QueryPageHeader({
       duplicateQuery,
       archiveQuery,
       openPermissionsEditorDialog,
-      isMobile,
+      isDesktop,
       publishQuery,
       unpublishQuery,
       openApiKeyDialog,
@@ -170,7 +170,7 @@ export default function QueryPageHeader({
       </div>
       <div className="header-actions">
         {headerExtra}
-        {!isMobile && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
+        {isDesktop && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
           <Button className="m-r-5" onClick={publishQuery}>
             <i className="fa fa-paper-plane m-r-5" /> Publish
           </Button>

--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -158,7 +158,7 @@ export default function QueryPageHeader({
       <div className="header-actions">
         {headerExtra}
         {queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
-          <Button className="hidden-xs m-r-5" onClick={publishQuery}>
+          <Button className="m-r-5" onClick={publishQuery}>
             <i className="fa fa-paper-plane m-r-5" /> Publish
           </Button>
         )}

--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -5,6 +5,7 @@ import Button from "antd/lib/button";
 import Dropdown from "antd/lib/dropdown";
 import Menu from "antd/lib/menu";
 import Icon from "antd/lib/icon";
+import useMedia from "use-media";
 import EditInPlace from "@/components/EditInPlace";
 import FavoritesControl from "@/components/FavoritesControl";
 import { QueryTagsControl } from "@/components/tags-control/TagsControl";
@@ -68,8 +69,8 @@ export default function QueryPageHeader({
   headerExtra,
   tagsExtra,
   onChange,
-  onRefresh,
 }) {
+  const isMobile = !useMedia({ minWidth: 768 });
   const queryFlags = useQueryFlags(query, dataSource);
   const updateName = useRenameQuery(query, onChange);
   const updateTags = useUpdateQueryTags(query, onChange);
@@ -107,6 +108,12 @@ export default function QueryPageHeader({
             title: "Manage Permissions",
             onClick: openPermissionsEditorDialog,
           },
+          publish: {
+            isAvailable:
+              isMobile && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit,
+            title: "Publish",
+            onClick: publishQuery,
+          },
           unpublish: {
             isAvailable: !queryFlags.isNew && queryFlags.canEdit && !queryFlags.isDraft,
             title: "Unpublish",
@@ -122,13 +129,19 @@ export default function QueryPageHeader({
         },
       ]),
     [
-      queryFlags,
-      archiveQuery,
-      unpublishQuery,
-      openApiKeyDialog,
-      openPermissionsEditorDialog,
+      queryFlags.isNew,
+      queryFlags.canFork,
+      queryFlags.canEdit,
+      queryFlags.isArchived,
+      queryFlags.isDraft,
       isDuplicating,
       duplicateQuery,
+      archiveQuery,
+      openPermissionsEditorDialog,
+      isMobile,
+      publishQuery,
+      unpublishQuery,
+      openApiKeyDialog,
     ]
   );
 
@@ -157,7 +170,7 @@ export default function QueryPageHeader({
       </div>
       <div className="header-actions">
         {headerExtra}
-        {queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
+        {!isMobile && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
           <Button className="m-r-5" onClick={publishQuery}>
             <i className="fa fa-paper-plane m-r-5" /> Publish
           </Button>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
Reported by @susodapop, the Publish Button was removed during the Query Page migration since there was too many buttons and it was breaking the width layout. But since #4663 the buttons wrap in a new row, so we can fit the Publish button back.

If you think there are too many buttons on mobile version it's also possible to move the Publish button to the dropdown.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Query View**
| Before | After |
| --------- | ------ |
| ![Screen Shot 2020-03-29 at 12 57 39](https://user-images.githubusercontent.com/3356951/77853857-e4860480-71bc-11ea-8987-8110c1ae4e74.png)  | ![Screen Shot 2020-03-29 at 12 55 23](https://user-images.githubusercontent.com/3356951/77853829-ab4d9480-71bc-11ea-915e-5f54375aa13b.png) |

**Query Source**
| Before | After |
| --------- | ------ |
| ![Screen Shot 2020-03-29 at 12 57 20](https://user-images.githubusercontent.com/3356951/77853852-d89a4280-71bc-11ea-91b3-a7946260457c.png)  | ![Screen Shot 2020-03-29 at 12 56 34](https://user-images.githubusercontent.com/3356951/77853844-c6200900-71bc-11ea-81ec-0816064200cd.png) |