### PR TITLE
Sankey diagram should occupy all available area (not just the left part)

### DIFF
--- a/client/app/visualizations/sankey/d3sankey.js
+++ b/client/app/visualizations/sankey/d3sankey.js
@@ -168,11 +168,11 @@ function Sankey() {
 
     function resolveCollisions() {
       nodesByBreadth.forEach(nodes => {
-        let node,
-          dy,
-          y0 = 0,
-          n = nodes.length,
-          i;
+        const n = nodes.length;
+        let node;
+        let dy;
+        let y0 = 0;
+        let i;
 
         // Push any overlapping nodes down.
         nodes.sort(ascendingDepth);

--- a/client/app/visualizations/sankey/d3sankey.js
+++ b/client/app/visualizations/sankey/d3sankey.js
@@ -84,6 +84,7 @@ function Sankey() {
 
     //
     moveSinksRight(x);
+    x = d3.max(nodes, n => n.x); // get new maximum x value
     scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
   }
 

--- a/client/app/visualizations/sankey/d3sankey.js
+++ b/client/app/visualizations/sankey/d3sankey.js
@@ -87,14 +87,6 @@ function Sankey() {
     scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
   }
 
-  function moveSourcesRight() {
-    nodes.forEach(node => {
-      if (!node.targetLinks.length) {
-        node.x = d3.min(node.sourceLinks, d => d.target.x) - 1;
-      }
-    });
-  }
-
   function computeNodeDepths(iterations) {
     const nodesByBreadth = d3
       .nest()
@@ -130,39 +122,6 @@ function Sankey() {
             node.y += (y - center(node)) * alpha;
           }
         });
-      });
-    }
-
-    function resolveCollisions() {
-      nodesByBreadth.forEach(nodes => {
-        const n = nodes.length;
-        let node;
-        let dy;
-        let y0 = 0;
-        let i;
-
-        // Push any overlapping nodes down.
-        nodes.sort(ascendingDepth);
-        for (i = 0; i < n; ++i) {
-          node = nodes[i];
-          dy = y0 - node.y;
-          if (dy > 0) node.y += dy;
-          y0 = node.y + node.dy + nodePadding;
-        }
-
-        // If the bottommost node goes outside the bounds, push it back up.
-        dy = y0 - nodePadding - size[1];
-        if (dy > 0) {
-          y0 = node.y -= dy;
-
-          // Push any overlapping nodes back up.
-          for (i = n - 2; i >= 0; --i) {
-            node = nodes[i];
-            dy = node.y + node.dy + nodePadding - y0;
-            if (dy > 0) node.y -= dy;
-            y0 = node.y;
-          }
-        }
       });
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Due to a bug in `d3-sankey` it was using wrong count of columns to compute column width, therefore not using all available area to build graph.

## Related Tickets & Documents

Closes getredash/redash#4763

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:

![image](https://user-images.githubusercontent.com/12139186/78059770-1f419580-7393-11ea-927c-1ec96f3995d2.png)

After:

![image](https://user-images.githubusercontent.com/12139186/78059732-0df88900-7393-11ea-94a5-85b0070209d3.png)
