### PR TITLE
Removing PIP cache from the built image, 300MB size reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,10 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+# Disalbe PIP Cache and Version Check
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_NO_CACHE_DIR=1
+
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.
 COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

Removed **pip cache** from built image, and resulted in around 300Mb of image size reduction.
See image below for screenshot.


![image](https://user-images.githubusercontent.com/655051/78089983-9d924c00-7414-11ea-91f0-837935e4bf03.png)
