### PR TITLE
Table Viz: show 500 records option

### DIFF
--- a/client/app/visualizations/table/Editor/GridSettings.jsx
+++ b/client/app/visualizations/table/Editor/GridSettings.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Section, Select } from "@/components/visualizations/editor";
 import { EditorPropTypes } from "@/visualizations/prop-types";
 
-const ALLOWED_ITEM_PER_PAGE = [5, 10, 15, 20, 25, 50, 100, 150, 200, 250];
+const ALLOWED_ITEM_PER_PAGE = [5, 10, 15, 20, 25, 50, 100, 150, 200, 250, 500];
 
 export default function GridSettings({ options, onOptionsChange }) {
   return (


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [X] Feature


## Description

This PR adds `500` to the `ALLOWED_ITEMS_PER_PAGE` constant in `GridSettings.jsx`. Users are currently limited to showing 250 records per page. This change ups the limit to 500.


## Related Tickets & Documents

https://github.com/redashlabs/product/issues/52

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before

#### Desktop
![before](https://user-images.githubusercontent.com/17067911/78254366-6a56c800-74bb-11ea-863f-7f20780be622.png)

#### Mobile

![before_mobile](https://user-images.githubusercontent.com/17067911/78256508-3df07b00-74be-11ea-86ef-d4639207479f.png)


### After

#### Desktop

![after](https://user-images.githubusercontent.com/17067911/78254385-6fb41280-74bb-11ea-8a69-1f13e0c27724.png)

#### Mobile

![after_mobile](https://user-images.githubusercontent.com/17067911/78256524-46e14c80-74be-11ea-8523-eaedfd94c251.png)


