### PR TITLE
Fix parameter spec flaky test

### DIFF
--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -184,7 +184,7 @@ describe("Parameter", () => {
 
       it("should show a 'No options available' message when you click", () => {
         cy.getByTestId("ParameterName-test-parameter")
-          .find(".ant-select-selection")
+          .find(".ant-select:not(.ant-select-disabled) .ant-select-selection")
           .click();
 
         cy.contains("li.ant-select-dropdown-menu-item", "No options available");


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
We got a flaky test since #4707, this was also addressed in #4757, but no reason to postpone its fix.

Cypress click doesn't have an effect when the Select is disabled, it should be able to identify when a Select is disabled, but it's a bit trickier since Antd's Select is not just a Select (it has some other divs for styling). This PR changes it to make sure a non-disabled select is clicked.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--