### PR TITLE
Don't immediately remove notifications from notification trays

### DIFF
--- a/client/app/services/notifications.js
+++ b/client/app/services/notifications.js
@@ -33,9 +33,6 @@ function showNotification(title, content) {
     body: content,
     icon: redashIconUrl,
   });
-  setTimeout(() => {
-    notification.close();
-  }, 3000);
   notification.onclick = function onClick() {
     window.focus();
     this.close();


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [x] Other

## Description

Let the notifications go into browser/OS notification trays so users can click on them from there if they miss the initial notification. Modern browsers generally use OS notifications so the user is in control of the notification at the OS level.

[Example of how users can adjust the timeout on macOS](https://osxdaily.com/2014/01/29/change-notifications-banner-time-mac-os-x/)

The current 3s delay is almost unusuable… I can rarely get my mouse to that part of the screen in time.
