### PR TITLE
Use total_seconds to find stale jobs

### DIFF
--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -84,7 +84,7 @@ def purge_failed_jobs():
                     stale_jobs.append(failed_job)
                 elif (
                     datetime.utcnow() - failed_job.ended_at
-                ).seconds > settings.JOB_DEFAULT_FAILURE_TTL:
+                ).total_seconds() > settings.JOB_DEFAULT_FAILURE_TTL:
                     stale_jobs.append(failed_job)
 
             for stale_job in stale_jobs:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Seems that deletion of stale failed jobs didn't work if the job ran in intervals larger than a day.