### PR TITLE
Send stack trace to Sentry when refresh_queries fails to enqueue

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -663,7 +663,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
                 message = "Could not determine if query %d is outdated due to %s. The schedule for this query has been disabled." % (query.id, repr(e))
                 logging.info(message)
-                sentry.capture_message(message)
+                sentry.capture_exception(type(e)(message).with_traceback(e.__traceback__))
 
         return list(outdated_queries.values())
 

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -90,7 +90,7 @@ def refresh_queries():
         except Exception as e:
             message = "Could not enqueue query %d due to %s" % (query.id, repr(e))
             logging.info(message)
-            sentry.capture_message(message)
+            sentry.capture_exception(type(e)(message).with_traceback(e.__traceback__))
 
     status = {
         "outdated_queries_count": len(enqueued),

--- a/redash/utils/sentry.py
+++ b/redash/utils/sentry.py
@@ -36,4 +36,4 @@ def init():
         )
 
 
-capture_message = iffy(lambda _: settings.SENTRY_DSN, sentry_sdk.capture_message)
+capture_exception = iffy(lambda _: settings.SENTRY_DSN, sentry_sdk.capture_exception)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When `refresh_queries` fails to enqueue a certain query (or determine its schedule), a message is sent to Sentry. That message contains the exception type and message, but does not include the stack trace. This PR replaces Sentry's `capture_message` with `capture_exception` to enable the stack trace to be sent as well.