### PR TITLE
Fix Multi-Filters: "select all" makes table view unscrollable

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -112,6 +112,14 @@ body.fixed-layout {
   }
 }
 
+// Don't let filters take all visualization space on query fixed layout
+.query-fixed-layout {
+  .filters-wrapper {
+    max-height: 40%;
+    overflow: auto;
+  }
+}
+
 .page-header--new {
   .query-tags,
   .query-tags__mobile {

--- a/client/app/components/Filters.jsx
+++ b/client/app/components/Filters.jsx
@@ -102,7 +102,9 @@ function Filters({ filters, onChange }) {
                     allowClear={filter.multiple}
                     optionFilterProp="children"
                     showSearch
-                    maxTagCount={5}
+                    maxTagCount={3}
+                    maxTagTextLength={10}
+                    maxTagPlaceholder={num => `+${num.length} more`}
                     onChange={values => onChange(filter, values)}>
                     {!filter.multiple && options}
                     {filter.multiple && [

--- a/client/app/components/Filters.jsx
+++ b/client/app/components/Filters.jsx
@@ -102,6 +102,7 @@ function Filters({ filters, onChange }) {
                     allowClear={filter.multiple}
                     optionFilterProp="children"
                     showSearch
+                    maxTagCount={5}
                     onChange={values => onChange(filter, values)}>
                     {!filter.multiple && options}
                     {filter.multiple && [

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -39,8 +39,9 @@ function QueryView(props) {
   const queryFlags = useQueryFlags(query, dataSource);
   const [parameters, areParametersDirty, updateParametersDirtyFlag] = useQueryParameters(query);
   const [selectedVisualization, setSelectedVisualization] = useVisualizationTabHandler(query.visualizations);
-  const isMobile = !useMedia({ minWidth: 768 });
-  const [fullscreen, toggleFullscreen] = useFullscreenHandler(!isMobile);
+  const isDesktop = useMedia({ minWidth: 768 });
+  const isFixedLayout = useMedia({ minHeight: 500 }) && isDesktop;
+  const [fullscreen, toggleFullscreen] = useFullscreenHandler(isDesktop);
   const [addingDescription, setAddingDescription] = useState(false);
 
   const {
@@ -85,7 +86,11 @@ function QueryView(props) {
   }, [query.data_source_id]);
 
   return (
-    <div className={cx("query-page-wrapper", { "query-view-fullscreen": fullscreen, "query-fixed-layout": !isMobile })}>
+    <div
+      className={cx("query-page-wrapper", {
+        "query-view-fullscreen": fullscreen,
+        "query-fixed-layout": isFixedLayout,
+      })}>
       <div className="container">
         <QueryPageHeader
           query={query}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
This PR holds 3 changes to improve experience with multi-filters on the query pages:
1. Introduce `max-height: 40%` to the filters area, this way it creates a scroll rather than taking the whole space visualizations have;
2. On Query View Page, also check for height > 500px to determine if the page will have a fixed layout. This way pages with small height areas won't have the fixed layout;
3. Add `maxTagCount` of 5, it was a number to have +- 2 lines in each multi-filter, but LMK if you have other suggestions.

## Related Tickets & Documents
Fixes #4772 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![multi-filters-select-all](https://user-images.githubusercontent.com/3356951/78619705-6bd61680-7854-11ea-8f8b-5f97a76c5c2e.gif)
