### PR TITLE
Remove "context" prop from visualizations

### DIFF
--- a/client/app/visualizations/components/EditVisualizationDialog.jsx
+++ b/client/app/visualizations/components/EditVisualizationDialog.jsx
@@ -1,4 +1,4 @@
-import { isEqual, extend, map, sortBy, findIndex, filter, pick } from "lodash";
+import { isEqual, extend, map, sortBy, findIndex, filter, pick, omit } from "lodash";
 import React, { useState, useMemo, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import Modal from "antd/lib/modal";
@@ -125,7 +125,16 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
 
   function save() {
     setSaveInProgress(true);
-    const visualizationData = extend(newVisualization(type), visualization, { name, options, query_id: query.id });
+    let visualizationOptions = options;
+    if (type === "TABLE") {
+      visualizationOptions = omit(visualizationOptions, ["paginationSize"]);
+    }
+
+    const visualizationData = extend(newVisualization(type), visualization, {
+      name,
+      options: visualizationOptions,
+      query_id: query.id,
+    });
     saveVisualization(visualizationData).then(savedVisualization => {
       updateQueryVisualizations(query, savedVisualization);
       dialog.close(savedVisualization);

--- a/client/app/visualizations/components/VisualizationRenderer.jsx
+++ b/client/app/visualizations/components/VisualizationRenderer.jsx
@@ -57,11 +57,17 @@ export default function VisualizationRenderer(props) {
   const { showFilters, visualization } = props;
   const { Renderer, getOptions } = registeredVisualizations[visualization.type];
 
+  let options = getOptions(visualization.options, data);
+
+  // define pagination size based on context for Table visualization
+  if (visualization.type === "TABLE") {
+    options.paginationSize = props.context === "widget" ? "small" : "default";
+  }
+
   // Avoid unnecessary updates (which may be expensive or cause issues with
   // internal state of some visualizations like Table) - compare options deeply
   // and use saved reference if nothing changed
   // More details: https://github.com/getredash/redash/pull/3963#discussion_r306935810
-  let options = getOptions(visualization.options, data);
   if (isEqual(lastOptions.current, options)) {
     options = lastOptions.current;
   }
@@ -85,7 +91,6 @@ export default function VisualizationRenderer(props) {
             options={options}
             data={filteredData}
             visualizationName={visualization.name}
-            context={props.context}
           />
         </div>
       </ErrorBoundary>

--- a/client/app/visualizations/prop-types.js
+++ b/client/app/visualizations/prop-types.js
@@ -20,7 +20,6 @@ export const RendererPropTypes = {
   data: Data.isRequired,
   options: VisualizationOptions.isRequired,
   onOptionsChange: PropTypes.func, // (newOptions) => void
-  context: PropTypes.oneOf(["query", "widget"]).isRequired,
 };
 
 // For each visualization's editor

--- a/client/app/visualizations/table/Renderer.jsx
+++ b/client/app/visualizations/table/Renderer.jsx
@@ -1,4 +1,4 @@
-import { filter, map, initial, last, reduce } from "lodash";
+import { filter, map, get, initial, last, reduce } from "lodash";
 import React, { useMemo, useState, useRef, useCallback, useEffect } from "react";
 import Table from "antd/lib/table";
 import Input from "antd/lib/input";
@@ -120,7 +120,7 @@ export default function Renderer({ options, data, context }) {
         columns={tableColumns}
         dataSource={preparedRows}
         pagination={{
-          size: context === "widget" ? "small" : "",
+          size: get(options, "paginationSize", ""),
           position: "bottom",
           pageSize: options.itemsPerPage,
           hideOnSinglePage: true,

--- a/client/app/visualizations/table/getOptions.js
+++ b/client/app/visualizations/table/getOptions.js
@@ -4,6 +4,7 @@ import { clientConfig } from "@/services/auth";
 
 const DEFAULT_OPTIONS = {
   itemsPerPage: 25,
+  paginationSize: "default", // not editable through Editor
 };
 
 function getColumnContentAlignment(type) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

Use a Table visualization option instead (it was the only lib that used that prop)

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--