### PR TITLE
feature: add ability to make the restriction of api calls to private addresses optional

### DIFF
--- a/redash/query_runner/json_ds.py
+++ b/redash/query_runner/json_ds.py
@@ -5,6 +5,7 @@ import ipaddress
 import datetime
 from urllib.parse import urlparse
 from funcy import compact, project
+from redash import settings
 from redash.utils import json_dumps
 from redash.query_runner import (
     BaseHTTPQueryRunner,
@@ -170,7 +171,7 @@ class JSON(BaseHTTPQueryRunner):
         if "url" not in query:
             raise QueryParseError("Query must include 'url' option.")
 
-        if is_private_address(query["url"]):
+        if is_private_address(query["url"]) and settings.ENFORCE_PRIVATE_ADDRESS_BLOCK:
             raise Exception("Can't query private addresses.")
 
         method = query.get("method", "get")

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -76,7 +76,7 @@ ENFORCE_HTTPS_PERMANENT = parse_boolean(
 ENFORCE_FILE_SAVE = parse_boolean(os.environ.get("REDASH_ENFORCE_FILE_SAVE", "true"))
 
 # Whether api calls using the json query runner will block private addresses
-ENFORCE_PRIVATE_ADDRESS_BLOCK = parse_boolean(os.envrion.get("REDASH_ENFORE_PRIVATE_IP_BLOCK", "true"))
+ENFORCE_PRIVATE_ADDRESS_BLOCK = parse_boolean(os.environ.get("REDASH_ENFORE_PRIVATE_IP_BLOCK", "true"))
 
 # Whether to use secure cookies by default.
 COOKIES_SECURE = parse_boolean(

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -75,6 +75,9 @@ ENFORCE_HTTPS_PERMANENT = parse_boolean(
 # Whether file downloads are enforced or not.
 ENFORCE_FILE_SAVE = parse_boolean(os.environ.get("REDASH_ENFORCE_FILE_SAVE", "true"))
 
+# Whether api calls using the json query runner will block private addresses
+ENFORCE_PRIVATE_ADDRESS_BLOCK = parse_boolean(os.envrion.get("REDASH_ENFORE_PRIVATE_IP_BLOCK", "true"))
+
 # Whether to use secure cookies by default.
 COOKIES_SECURE = parse_boolean(
     os.environ.get("REDASH_COOKIES_SECURE", str(ENFORCE_HTTPS))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -76,7 +76,7 @@ ENFORCE_HTTPS_PERMANENT = parse_boolean(
 ENFORCE_FILE_SAVE = parse_boolean(os.environ.get("REDASH_ENFORCE_FILE_SAVE", "true"))
 
 # Whether api calls using the json query runner will block private addresses
-ENFORCE_PRIVATE_ADDRESS_BLOCK = parse_boolean(os.environ.get("REDASH_ENFORE_PRIVATE_IP_BLOCK", "true"))
+ENFORCE_PRIVATE_ADDRESS_BLOCK = parse_boolean(os.environ.get("REDASH_ENFORCE_PRIVATE_IP_BLOCK", "true"))
 
 # Whether to use secure cookies by default.
 COOKIES_SECURE = parse_boolean(


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Add configuration item to make the restriction on private address optional

## Related Tickets & Documents
https://github.com/getredash/redash/issues/4193
https://discuss.redash.io/t/error-running-query-cant-query-private-addresses/4568

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
