### PR TITLE
Run queries through ad-hoc SSH tunnels

### DIFF
--- a/client/app/pages/queries/hooks/useDataSourceSchema.js
+++ b/client/app/pages/queries/hooks/useDataSourceSchema.js
@@ -1,7 +1,7 @@
 import { reduce } from "lodash";
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { axios } from "@/services/axios";
-import DataSource from "@/services/data-source";
+import DataSource, { SCHEMA_NOT_SUPPORTED } from "@/services/data-source";
 import notification from "@/services/notification";
 
 function sleep(ms) {
@@ -20,6 +20,8 @@ function getSchema(dataSource, refresh = undefined) {
           return fetchSchemaFromJob(data);
         } else if (data.job.status === 3) {
           return data.job.result;
+        } else if (data.job.status === 4 && data.job.error.code === SCHEMA_NOT_SUPPORTED) {
+          return [];
         } else {
           return Promise.reject(new Error(data.job.error));
         }

--- a/client/app/pages/queries/hooks/useDataSourceSchema.js
+++ b/client/app/pages/queries/hooks/useDataSourceSchema.js
@@ -1,22 +1,35 @@
 import { reduce } from "lodash";
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
-import DataSource, { SCHEMA_NOT_SUPPORTED } from "@/services/data-source";
+import { axios } from "@/services/axios";
+import DataSource from "@/services/data-source";
 import notification from "@/services/notification";
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 function getSchema(dataSource, refresh = undefined) {
   if (!dataSource) {
     return Promise.resolve([]);
   }
 
-  return DataSource.fetchSchema(dataSource, refresh)
-    .then(data => {
-      if (data.schema) {
-        return data.schema;
-      } else if (data.error.code === SCHEMA_NOT_SUPPORTED) {
-        return [];
-      }
-      return Promise.reject(new Error("Schema refresh failed."));
+  const fetchSchemaFromJob = (data) => {
+    return sleep(1000).then(() => {
+      return axios.get(`api/jobs/${data.job.id}`).then(data => {
+        if (data.job.status < 3) {
+          return fetchSchemaFromJob(data);
+        }
+        else if (data.job.status === 3) {
+          return data.job.result;
+        } else {
+          return Promise.reject(new Error(data.job.error));
+        }
+      })
     })
+  };
+
+  return DataSource.fetchSchema(dataSource, refresh)
+    .then(fetchSchemaFromJob)
     .catch(() => {
       notification.error("Schema refresh failed.", "Please try again later.");
       return Promise.resolve([]);

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -1,7 +1,5 @@
 import { axios } from "@/services/axios";
 
-export const SCHEMA_NOT_SUPPORTED = 1;
-export const SCHEMA_LOAD_ERROR = 2;
 export const IMG_ROOT = "/static/images/db-logos";
 
 const DataSource = {

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -1,5 +1,7 @@
 import { axios } from "@/services/axios";
 
+export const SCHEMA_NOT_SUPPORTED = 1;
+export const SCHEMA_LOAD_ERROR = 2;
 export const IMG_ROOT = "/static/images/db-logos";
 
 const DataSource = {

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -21,13 +21,16 @@ from redash.query_runner import (
 )
 from redash.utils import filter_none
 from redash.utils.configuration import ConfigurationContainer, ValidationError
-from redash.tasks.general import test_connection
+from redash.tasks.general import test_connection, get_schema
+from redash.serializers import serialize_job
 
 
 class DataSourceTypeListResource(BaseResource):
     @require_admin
     def get(self):
-        return [q.to_dict() for q in sorted(query_runners.values(), key=lambda q: q.name())]
+        return [
+            q.to_dict() for q in sorted(query_runners.values(), key=lambda q: q.name())
+        ]
 
 
 class DataSourceResource(BaseResource):
@@ -184,19 +187,9 @@ class DataSourceSchemaResource(BaseResource):
         require_access(data_source, self.current_user, view_only)
         refresh = request.args.get("refresh") is not None
 
-        response = {}
+        job = get_schema.delay(data_source.id, refresh)
 
-        try:
-            response["schema"] = data_source.get_schema(refresh)
-        except NotSupported:
-            response["error"] = {
-                "code": 1,
-                "message": "Data source type does not support retrieving schema",
-            }
-        except Exception:
-            response["error"] = {"code": 2, "message": "Error retrieving schema."}
-
-        return response
+        return serialize_job(job)
 
 
 class DataSourcePauseResource(BaseResource):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -362,15 +362,15 @@ def with_ssh_tunnel(query_runner, details):
                 )
             except Exception as error:
                 raise type(error)("SSH tunnel: {}".format(str(error)))
-            else:
-                with stack:
-                    try:
-                        query_runner.host, query_runner.port = server.local_bind_address
-                        result = f(*args, **kwargs)
-                    finally:
-                        query_runner.host, query_runner.port = remote_host, remote_port
 
-                    return result
+            with stack:
+                try:
+                    query_runner.host, query_runner.port = server.local_bind_address
+                    result = f(*args, **kwargs)
+                finally:
+                    query_runner.host, query_runner.port = remote_host, remote_port
+
+                return result
 
         return wrapper
 

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -75,6 +75,12 @@ class BaseQueryRunner(object):
 
     @property
     def host(self):
+        """Returns this query runner's configured host.
+        This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
+
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
+        """
         if "host" in self.configuration:
             return self.configuration["host"]
         else:
@@ -82,6 +88,12 @@ class BaseQueryRunner(object):
 
     @host.setter
     def host(self, host):
+        """Sets this query runner's configured host.
+        This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
+
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
+        """
         if "host" in self.configuration:
             self.configuration["host"] = host
         else:
@@ -89,6 +101,12 @@ class BaseQueryRunner(object):
 
     @property
     def port(self):
+        """Returns this query runner's configured port.
+        This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
+
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
+        """
         if "port" in self.configuration:
             return self.configuration["port"]
         else:
@@ -96,6 +114,12 @@ class BaseQueryRunner(object):
 
     @port.setter
     def port(self, port):
+        """Sets this query runner's configured port.
+        This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
+
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
+        """
         if "port" in self.configuration:
             self.configuration["port"] = port
         else:
@@ -158,7 +182,7 @@ class BaseQueryRunner(object):
             "name": cls.name(),
             "type": cls.type(),
             "configuration_schema": cls.configuration_schema(),
-            **({ "deprecated": True } if cls.deprecated else {})
+            **({"deprecated": True} if cls.deprecated else {}),
         }
 
 

--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from urllib.parse import urlparse
 
 import requests
 
@@ -41,6 +42,30 @@ class ClickHouse(BaseSQLQueryRunner):
     @classmethod
     def type(cls):
         return "clickhouse"
+
+    @property
+    def _url(self):
+        return urlparse(self.configuration["url"])
+
+    @_url.setter
+    def _url(self, url):
+        self.configuration["url"] = url.geturl()
+
+    @property
+    def host(self):
+        return self._url.hostname
+
+    @host.setter
+    def host(self, host):
+        self._url = self._url._replace(netloc="{}:{}".format(host, self._url.port))
+
+    @property
+    def port(self):
+        return self._url.port
+
+    @port.setter
+    def port(self, port):
+        self._url = self._url._replace(netloc="{}:{}".format(self._url.hostname, port))
 
     def _get_tables(self, schema):
         query = "SELECT database, table, name FROM system.columns WHERE database NOT IN ('system')"

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -292,6 +292,9 @@ def serialize_job(job):
     elif isinstance(job.result, Exception):
         error = str(job.result)
         status = 4
+    elif isinstance(job.result, dict) and "error" in job.result:
+        error = job.result["error"]
+        status = 4
     else:
         error = ""
         result = query_result_id = job.result

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -284,7 +284,7 @@ def serialize_job(job):
         updated_at = 0
 
     status = STATUSES[job_status]
-    query_result_id = None
+    result = query_result_id = None
 
     if job.is_cancelled:
         error = "Query cancelled by user."
@@ -294,7 +294,7 @@ def serialize_job(job):
         status = 4
     else:
         error = ""
-        query_result_id = job.result
+        result = query_result_id = job.result
 
     return {
         "job": {
@@ -302,6 +302,7 @@ def serialize_job(job):
             "updated_at": updated_at,
             "status": status,
             "error": error,
+            "result": result,
             "query_result_id": query_result_id,
         }
     }

--- a/redash/settings/dynamic_settings.py
+++ b/redash/settings/dynamic_settings.py
@@ -25,3 +25,15 @@ def periodic_jobs():
 # This provides the ability to override the way we store QueryResult's data column.
 # Reference implementation: redash.models.DBPersistence
 QueryResultPersistence = None
+
+
+def ssh_tunnel_auth():
+    """
+    To enable data source connections via SSH tunnels, provide your SSH authentication
+    pkey here. Return a string pointing at your **private** key's path (which will be used
+    to extract the public key), or a `paramiko.pkey.PKey` instance holding your **public** key.
+    """
+    return {
+        # 'ssh_pkey': 'path_to_private_key', # or instance of `paramiko.pkey.PKey`
+        # 'ssh_private_key_password': 'optional_passphrase_of_private_key',
+    }

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -82,9 +82,14 @@ def get_schema(data_source_id, refresh):
         data_source = models.DataSource.get_by_id(data_source_id)
         return data_source.query_runner.get_schema(refresh)
     except NotSupported:
-        return []
-    except Exception as e:
-        return e
+        return {
+            "error": {
+                "code": 1,
+                "message": "Data source type does not support retrieving schema",
+            }
+        }
+    except Exception:
+        return {"error": {"code": 2, "message": "Error retrieving schema."}}
 
 
 def sync_user_details():

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -63,6 +63,17 @@ def send_mail(to, subject, html, text):
         logger.exception("Failed sending message: %s", message.subject)
 
 
+@job("queries", timeout=30, ttl=90)
+def test_connection(data_source_id):
+    try:
+        data_source = models.DataSource.get_by_id(data_source_id)
+        data_source.query_runner.test_connection()
+    except Exception as e:
+        return e
+    else:
+        return True
+
+
 def sync_user_details():
     users.sync_last_active_at()
 

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -80,7 +80,7 @@ def test_connection(data_source_id):
 def get_schema(data_source_id, refresh):
     try:
         data_source = models.DataSource.get_by_id(data_source_id)
-        return data_source.query_runner.get_schema(refresh)
+        return data_source.get_schema(refresh)
     except NotSupported:
         return {
             "error": {

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -76,7 +76,7 @@ def test_connection(data_source_id):
         return True
 
 
-@job("schemas", queue_class=Queue, at_front=True, timeout=30, ttl=90)
+@job("schemas", queue_class=Queue, at_front=True, timeout=300, ttl=90)
 def get_schema(data_source_id, refresh):
     try:
         data_source = models.DataSource.get_by_id(data_source_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ maxminddb-geolite2==2018.703
 pypd==1.1.0
 disposable-email-domains>=0.0.52
 gevent==1.4.0
+sshtunnel==0.1.5
 supervisor==4.1.0
 supervisor_checks==0.8.1
 werkzeug==0.16.1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Redash requires network access to the data sources it needs to query, but sometime these data sources aren't publicly available. A way around this is using [SSH tunnels](https://www.ssh.com/ssh/tunneling/example), which can be setup manually outside Redash, but can also be setup automatically before a connection is made, and closed automatically after they are no longer required.

This PR sets up ad-hoc SSH tunnels for data sources if they have a `ssh_tunnel` dict in their options, which must include an `ssh_host` and `ssh_username` of the bastion server to connect through.

In order to enable SSH tunnels, `dynamic_settings.ssh_tunnel_auth()` must be implemented to allow the Redash instance to authenticate with the bastion server(s).

# Related Issues

#2013