### PR TITLE
Dashboard Search bug fix

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1084,7 +1084,7 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
     def all(cls, org, group_ids, user_id):
         query = (
             Dashboard.query.options(
-                subqueryload(Dashboard.user).load_only("_profile_image_url", "name")
+                joinedload(Dashboard.user).load_only("_profile_image_url", "name")
             )
             .outerjoin(Widget)
             .outerjoin(Visualization)

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -98,6 +98,7 @@ class Presto(BaseQueryRunner):
             port=self.configuration.get("port", 8080),
             protocol=self.configuration.get("protocol", "http"),
             username=self.configuration.get("username", "redash"),
+            source='redash',
             password=(self.configuration.get("password") or None),
             catalog=self.configuration.get("catalog", "hive"),
             schema=self.configuration.get("schema", "default"),

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -98,7 +98,6 @@ class Presto(BaseQueryRunner):
             port=self.configuration.get("port", 8080),
             protocol=self.configuration.get("protocol", "http"),
             username=self.configuration.get("username", "redash"),
-            source='redash',
             password=(self.configuration.get("password") or None),
             catalog=self.configuration.get("catalog", "hive"),
             schema=self.configuration.get("schema", "default"),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] ~Feature~
- [x] Bug Fix

## Description
* Move Dashboard off `subqueryload()` loader in all() method due to inconsistent results bug in SQLAlchemy when leveraging distinct within a subqueryload call through paginate.
* ~Added source argument for the Presto query runner to specify `redash` so that queries coming from Re:Dash are reported as coming `redash` within Presto.~

## Related Tickets & Documents
#4803 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A
