### PR TITLE
Add support for Presto User Impersonation

### DIFF
--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -45,6 +45,10 @@ class Presto(BaseQueryRunner):
                 "schema": {"type": "string"},
                 "catalog": {"type": "string"},
                 "username": {"type": "string"},
+                "user_impersonation": {
+                    "type": "boolean",
+                    "title": "Enable User Impersonation",
+                },
                 "password": {"type": "string"},
             },
             "order": [
@@ -52,6 +56,7 @@ class Presto(BaseQueryRunner):
                 "protocol",
                 "port",
                 "username",
+                "user_impersonation",
                 "password",
                 "schema",
                 "catalog",
@@ -93,11 +98,17 @@ class Presto(BaseQueryRunner):
         return list(schema.values())
 
     def run_query(self, query, user):
+        enable_user_impersonation = self.configuration.get("user_impersonation")
+        principle_username = None
+        if enable_user_impersonation and user is not None:
+            principle_username = user.email.split('@')[0]
+
         connection = presto.connect(
             host=self.configuration.get("host", ""),
             port=self.configuration.get("port", 8080),
             protocol=self.configuration.get("protocol", "http"),
             username=self.configuration.get("username", "redash"),
+            principle_username=principle_username,
             password=(self.configuration.get("password") or None),
             catalog=self.configuration.get("catalog", "hive"),
             schema=self.configuration.get("schema", "default"),

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -99,16 +99,16 @@ class Presto(BaseQueryRunner):
 
     def run_query(self, query, user):
         enable_user_impersonation = self.configuration.get("user_impersonation")
-        principle_username = None
+        principal_username = None
         if enable_user_impersonation and user is not None:
-            principle_username = user.email.split('@')[0]
+            principal_username = user.email.split('@')[0]
 
         connection = presto.connect(
             host=self.configuration.get("host", ""),
             port=self.configuration.get("port", 8080),
             protocol=self.configuration.get("protocol", "http"),
             username=self.configuration.get("username", "redash"),
-            principle_username=principle_username,
+            principal_username=principal_username,
             password=(self.configuration.get("password") or None),
             catalog=self.configuration.get("catalog", "hive"),
             schema=self.configuration.get("schema", "default"),

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -4,7 +4,7 @@ impyla==0.16.0
 influxdb==5.2.3
 mysqlclient==1.3.14
 oauth2client==4.1.3
-pyhive==0.6.2
+pyhive==0.6.3 # TODO: This needs to be updated to match the version that this fix is included in. Should not be merged until then.
 pymongo[tls,srv]==3.9.0
 vertica-python==0.9.5
 td-client==1.0.0

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -4,7 +4,7 @@ impyla==0.16.0
 influxdb==5.2.3
 mysqlclient==1.3.14
 oauth2client==4.1.3
-pyhive==0.6.1
+pyhive==0.6.2
 pymongo[tls,srv]==3.9.0
 vertica-python==0.9.5
 td-client==1.0.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description
The newest version of PyHive now supports enabling User Impersonation for Presto. This allows you to configure an authentication user for the Presto Configuration, but still execute the actual queries in Presto as the user logged into Re:Dash. This is a critical component to be able to have user level authorization in Presto, while also communicating over the SSL interface which requires authentication.

In order to leverage this setting. you must have User Impersonation configured in Presto. This is the documentation for doing so: https://docs.starburstdata.com/latest/security/impersonation.html

Upgrading PyHive to 0.6.2 to gain access to the new User Impersonation code. 

## Related Tickets & Documents
https://docs.starburstdata.com/latest/security/impersonation.html
https://github.com/dropbox/PyHive/pull/309