### PR TITLE
Add support for PyHive source argument with Presto

### DIFF
--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -46,6 +46,7 @@ class Presto(BaseQueryRunner):
                 "catalog": {"type": "string"},
                 "username": {"type": "string"},
                 "password": {"type": "string"},
+                "source": {"type": "string", "default": "redash"},
             },
             "order": [
                 "host",
@@ -53,6 +54,7 @@ class Presto(BaseQueryRunner):
                 "port",
                 "username",
                 "password",
+                "source",
                 "schema",
                 "catalog",
             ],
@@ -99,6 +101,7 @@ class Presto(BaseQueryRunner):
             protocol=self.configuration.get("protocol", "http"),
             username=self.configuration.get("username", "redash"),
             password=(self.configuration.get("password") or None),
+            source=self.configuration.get("source", "redash"),
             catalog=self.configuration.get("catalog", "hive"),
             schema=self.configuration.get("schema", "default"),
         )


### PR DESCRIPTION
##  What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description
Add ability to define the source field for PyHive to inform Presto where the query is coming from. Defaults to `redash`, can be changed to better suit the environment.

## Related Tickets & Documents
https://github.com/dropbox/PyHive/blob/master/pyhive/presto.py#L98
