### PR TITLE
Add 12 column layout option for all dashboards

### DIFF
--- a/client/app/components/dashboards/dashboard-grid.less
+++ b/client/app/components/dashboards/dashboard-grid.less
@@ -54,6 +54,12 @@
       background-size: calc((100vw - 15px) / 6) 5px;
       background-position: -7px 1px;
     }
+
+    &[columns-count="12"] {
+      &::before {
+        background-size: calc((100vw - 15px) / 12) 5px;
+      }
+    }
   }
 
   .widget-auto-height-enabled {

--- a/client/app/config/dashboard-grid-options.js
+++ b/client/app/config/dashboard-grid-options.js
@@ -1,3 +1,17 @@
+export const dashboard12ColGridOptions = {
+  columns: 12, // grid columns count
+  rowHeight: 50, // grid row height (incl. bottom padding)
+  margins: 15, // widget margins
+  mobileBreakPoint: 800,
+  // defaults for widgets
+  defaultSizeX: 4,
+  defaultSizeY: 3,
+  minSizeX: 1,
+  maxSizeX: 12,
+  minSizeY: 1,
+  maxSizeY: 1000,
+};
+
 export default {
   columns: 6, // grid columns count
   rowHeight: 50, // grid row height (incl. bottom padding)
@@ -7,7 +21,7 @@ export default {
   defaultSizeX: 3,
   defaultSizeY: 3,
   minSizeX: 1,
-  maxSizeX: 6,
+  maxSizeX: 12, // you cannot go above 6 in the UI anyway
   minSizeY: 1,
   maxSizeY: 1000,
 };

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -23,6 +23,11 @@ function DashboardSettings({ dashboardOptions }) {
         onChange={({ target }) => updateDashboard({ dashboard_filters_enabled: target.checked })}>
         Use Dashboard Level Filters
       </Checkbox>
+      <Checkbox
+        checked={!!dashboard.use_12_column_layout}
+        onChange={({ target }) => updateDashboard({ use_12_column_layout: target.checked })}>
+        Use 12-column layout
+      </Checkbox>
     </div>
   );
 }

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -199,7 +199,7 @@ function useDashboard(dashboardData) {
   // reload dashboard when filter option changes
   useEffect(() => {
     loadDashboard();
-  }, [dashboard.dashboard_filters_enabled]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dashboard.dashboard_filters_enabled, dashboard.use_12_column_layout]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     dashboard,

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -79,7 +79,7 @@ function prepareWidgetsForDashboard(widgets) {
 }
 
 function calculateNewWidgetPosition(existingWidgets, newWidget, use12Cols) {
-  const [gridOptions, xAxisMultiplier] = use12Cols ? [dashboard12ColGridOptions, 2] : [dashboardGridOptions, 1];
+  const gridOptions = use12Cols ? dashboard12ColGridOptions : dashboardGridOptions;
   const width = _.extend({ sizeX: gridOptions.defaultSizeX }, _.extend({}, newWidget.options).position).sizeX;
 
   // Find first free row for each column

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -18,7 +18,7 @@ function calculatePositionOptions(widget) {
 
   const visualizationOptions = {
     autoHeight: false,
-    sizeX: Math.round(dashboardGridOptions.columns / 2) * 2,
+    sizeX: Math.round(dashboardGridOptions.columns / 2),
     sizeY: dashboardGridOptions.defaultSizeY,
     minSizeX: dashboardGridOptions.minSizeX,
     maxSizeX: dashboardGridOptions.maxSizeX,

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -18,7 +18,7 @@ function calculatePositionOptions(widget) {
 
   const visualizationOptions = {
     autoHeight: false,
-    sizeX: Math.round(dashboardGridOptions.columns / 2),
+    sizeX: Math.round(dashboardGridOptions.columns / 2) * 2,
     sizeY: dashboardGridOptions.defaultSizeY,
     minSizeX: dashboardGridOptions.minSizeX,
     maxSizeX: dashboardGridOptions.maxSizeX,

--- a/migrations/versions/dedeb4b35ab8_add_use_12_column_layout.py
+++ b/migrations/versions/dedeb4b35ab8_add_use_12_column_layout.py
@@ -1,0 +1,29 @@
+"""add use_12_column_layout
+
+Revision ID: dedeb4b35ab8
+Revises: e5c7a4e2df4d
+Create Date: 2020-04-18 18:20:00.333654
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "dedeb4b35ab8"
+down_revision = "e5c7a4e2df4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "dashboards",
+        sa.Column(
+            "use_12_column_layout", sa.Boolean(), nullable=False, server_default=False
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("dashboards", "use_12_column_layout")

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -128,6 +128,7 @@ class DashboardResource(BaseResource):
         :>json string updated_at: ISO format timestamp for last dashboard modification
         :>json number version: Revision number of dashboard
         :>json boolean dashboard_filters_enabled: Whether filters are enabled or not
+        :>json booleann use_12_column_layout: Whether to use 12-column layout or not
         :>json boolean is_archived: Whether this dashboard has been removed from the index or not
         :>json boolean is_draft: Whether this dashboard is a draft or not.
         :>json array layout: Array of arrays containing widget IDs, corresponding to the rows and columns the widgets are displayed in
@@ -199,6 +200,7 @@ class DashboardResource(BaseResource):
                 "is_draft",
                 "is_archived",
                 "dashboard_filters_enabled",
+                "use_12_column_layout"
             ),
         )
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1067,6 +1067,7 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
     # layout is no longer used, but kept so we know how to render old dashboards.
     layout = Column(db.Text)
     dashboard_filters_enabled = Column(db.Boolean, default=False)
+    use_12_column_layout = Column(db.Boolean, default=False)
     is_archived = Column(db.Boolean, default=False, index=True)
     is_draft = Column(db.Boolean, default=True, index=True)
     widgets = db.relationship("Widget", backref="dashboard", lazy="dynamic")

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -55,7 +55,7 @@ def public_widget(widget):
 def public_dashboard(dashboard):
     dashboard_dict = project(
         serialize_dashboard(dashboard, with_favorite_state=False),
-        ("name", "layout", "dashboard_filters_enabled", "updated_at", "created_at"),
+        ("name", "layout", "dashboard_filters_enabled", "use_12_column_layout", "updated_at", "created_at"),
     )
 
     widget_list = (
@@ -252,6 +252,7 @@ def serialize_dashboard(obj, with_widgets=False, user=None, with_favorite_state=
         "user": obj.user.to_dict(),
         "layout": layout,
         "dashboard_filters_enabled": obj.dashboard_filters_enabled,
+        "use_12_column_layout": obj.use_12_column_layout,
         "widgets": widgets,
         "is_archived": obj.is_archived,
         "is_draft": obj.is_draft,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Feature

## Description
#### Reasoning
For more than a year of using Redash in my company and for personal projects one thing perplexed me: why there are only 6 columns available for widgets to be placed on a dashboard. Looking at other solutions (Grafana, Metabase, Superset, Shiny) all of them have more columns in the layout (12+). The number 12 is a great setting for any dashboard: it divides by 2, 3, 4 and 6, whereas 6 has only the 2 and 3 options. The handiness of dividing the layout into 4 even columns is apparent when using Counter or any other "small" widgets. See examples in the screenshots section.

Overall, the feature allows for a more fluid developer and consumer experience, while not forcing anyone to adopt the feature and not breaking old dashboards.

#### Implementation
* The old 6-column layout is used by default;
* New "Use 12 columns layout" checkbox in the dashboard editor – it switches the grid options used for the dashboard and updates the dashboard in the database: column dashboards.use_12_column layout (bool);
* When the checkbox is checked, background CSS grid changes accordingly;
* When the checkbox is unchecked, react-grid automatically smooshes all the widgets of width 7+.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![ezgif com-optimize](https://user-images.githubusercontent.com/52893451/79643679-ca808600-81ac-11ea-92f9-3586d1d6f61e.gif)
![image](https://user-images.githubusercontent.com/52893451/79643204-8d1af900-81aa-11ea-8323-ce88a5ff9aeb.png)
![image](https://user-images.githubusercontent.com/52893451/79643734-04518c80-81ad-11ea-94f8-6be912f5c6f1.png)
