### PR TITLE
Reduce number of queries used to load the dashboards list

### DIFF
--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -110,7 +110,7 @@ class DashboardListResource(BaseResource):
         )
         models.db.session.add(dashboard)
         models.db.session.commit()
-        return DashboardSerializer(dashboard)
+        return DashboardSerializer(dashboard).serialize()
 
 
 class DashboardResource(BaseResource):
@@ -154,7 +154,7 @@ class DashboardResource(BaseResource):
         )
         response = DashboardSerializer(
             dashboard, with_widgets=True, user=self.current_user
-        )
+        ).serialize()
 
         api_key = models.ApiKey.get_by_object(dashboard)
         if api_key:
@@ -222,7 +222,7 @@ class DashboardResource(BaseResource):
 
         result = DashboardSerializer(
             dashboard, with_widgets=True, user=self.current_user
-        )
+        ).serialize()
 
         self.record_event(
             {"action": "edit", "object_id": dashboard.id, "object_type": "dashboard"}
@@ -245,7 +245,9 @@ class DashboardResource(BaseResource):
         dashboard.is_archived = True
         dashboard.record_changes(changed_by=self.current_user)
         models.db.session.add(dashboard)
-        d = DashboardSerializer(dashboard, with_widgets=True, user=self.current_user)
+        d = DashboardSerializer(
+            dashboard, with_widgets=True, user=self.current_user
+        ).serialize()
         models.db.session.commit()
 
         self.record_event(

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -18,7 +18,6 @@ from redash.permissions import (
 )
 from redash.security import csp_allows_embeding
 from redash.serializers import (
-    serialize_dashboard,
     DashboardSerializer,
     public_dashboard,
 )
@@ -111,7 +110,7 @@ class DashboardListResource(BaseResource):
         )
         models.db.session.add(dashboard)
         models.db.session.commit()
-        return serialize_dashboard(dashboard)
+        return DashboardSerializer(dashboard)
 
 
 class DashboardResource(BaseResource):
@@ -153,7 +152,7 @@ class DashboardResource(BaseResource):
         dashboard = get_object_or_404(
             models.Dashboard.get_by_slug_and_org, dashboard_slug, self.current_org
         )
-        response = serialize_dashboard(
+        response = DashboardSerializer(
             dashboard, with_widgets=True, user=self.current_user
         )
 
@@ -221,7 +220,7 @@ class DashboardResource(BaseResource):
         except StaleDataError:
             abort(409)
 
-        result = serialize_dashboard(
+        result = DashboardSerializer(
             dashboard, with_widgets=True, user=self.current_user
         )
 
@@ -246,7 +245,7 @@ class DashboardResource(BaseResource):
         dashboard.is_archived = True
         dashboard.record_changes(changed_by=self.current_user)
         models.db.session.add(dashboard)
-        d = serialize_dashboard(dashboard, with_widgets=True, user=self.current_user)
+        d = DashboardSerializer(dashboard, with_widgets=True, user=self.current_user)
         models.db.session.commit()
 
         self.record_event(

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -661,9 +661,14 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 query.schedule["disabled"] = True
                 db.session.commit()
 
-                message = "Could not determine if query %d is outdated due to %s. The schedule for this query has been disabled." % (query.id, repr(e))
+                message = (
+                    "Could not determine if query %d is outdated due to %s. The schedule for this query has been disabled."
+                    % (query.id, repr(e))
+                )
                 logging.info(message)
-                sentry.capture_exception(type(e)(message).with_traceback(e.__traceback__))
+                sentry.capture_exception(
+                    type(e)(message).with_traceback(e.__traceback__)
+                )
 
         return list(outdated_queries.values())
 
@@ -1084,7 +1089,9 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
     def all(cls, org, group_ids, user_id):
         query = (
             Dashboard.query.options(
-                joinedload(Dashboard.user).load_only("_profile_image_url", "name")
+                joinedload(Dashboard.user).load_only(
+                    "id", "name", "_profile_image_url", "email"
+                )
             )
             .outerjoin(Widget)
             .outerjoin(Visualization)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

Reduced the number of queries used to load dashboards list:

1. Make sure all required user object fields are loaded in first query (otherwise number of fields X number of dashboards is issued 😱).
2. Use a single query to load favorites status for all the dashboards together.

## Related Tickets & Documents

#4804 