### PR TITLE
Accept invitation through password resets

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -84,7 +84,7 @@ def render_token_login_page(template, org_slug, token, invite):
             flash("Password length is too short (<6).")
             status_code = 400
         else:
-            if invite:
+            if invite or user.is_invitation_pending:
                 user.is_invitation_pending = False
             user.hash_password(request.form["password"])
             models.db.session.add(user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

As described in #4813, some users have their `is_invitation_pending` flag set to `True`, but they are clearly active users.

This situation happens when users are invited, but instead of following the invitation link, they request a password reset. Following a successful password reset, they are logged in, but their `is_invitation_pending` flag remains as `True` forever.

## Related Tickets & Documents
#4813