### PR TITLE
Show explicit user name instead of avatar in lists.

### DIFF
--- a/client/app/pages/alerts/AlertsList.jsx
+++ b/client/app/pages/alerts/AlertsList.jsx
@@ -46,6 +46,7 @@ class AlertsList extends React.Component {
         field: "name",
       }
     ),
+    Columns.custom((text, item) => item.user.name, { title: "Created By" }),
     Columns.custom.sortable(
       (text, alert) => (
         <div>
@@ -59,7 +60,6 @@ class AlertsList extends React.Component {
       }
     ),
     Columns.timeAgo.sortable({ title: "Last Updated At", field: "updated_at", className: "text-nowrap", width: "1%" }),
-    Columns.avatar({ field: "user", className: "p-l-0 p-r-0" }, name => `Created by ${name}`),
     Columns.dateTime.sortable({ title: "Created At", field: "created_at", className: "text-nowrap", width: "1%" }),
   ];
 

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -61,7 +61,7 @@ class DashboardList extends React.Component {
         width: null,
       }
     ),
-    Columns.avatar({ field: "user", className: "p-l-0 p-r-0" }, name => `Created by ${name}`),
+    Columns.custom((text, item) => item.user.name, { title: "Created By" }),
     Columns.dateTime.sortable({
       title: "Created At",
       field: "created_at",

--- a/client/app/pages/dashboards/components/DashboardHeader.jsx
+++ b/client/app/pages/dashboards/components/DashboardHeader.jsx
@@ -41,7 +41,9 @@ function DashboardPageTitle({ dashboardOptions }) {
             ignoreBlanks
           />
         </h3>
-        <img src={dashboard.user.profile_image_url} className="profile-image" alt={dashboard.user.name} />
+        <Tooltip title={dashboard.user.name} placement="bottom">
+          <img src={dashboard.user.profile_image_url} className="profile-image" alt={dashboard.user.name} />
+        </Tooltip>
       </div>
       <DashboardTagsControl
         tags={dashboard.tags}

--- a/client/app/pages/queries-list/QueriesList.jsx
+++ b/client/app/pages/queries-list/QueriesList.jsx
@@ -77,12 +77,11 @@ class QueriesList extends React.Component {
         width: null,
       }
     ),
-    Columns.avatar({ field: "user", className: "p-l-0 p-r-0" }, name => `Created by ${name}`),
+    Columns.custom((text, item) => item.user.name, { title: "Created By" }),
     Columns.dateTime.sortable({ title: "Created At", field: "created_at" }),
-    Columns.duration.sortable({ title: "Runtime", field: "runtime" }),
     Columns.dateTime.sortable({ title: "Last Executed At", field: "retrieved_at", orderByField: "executed_at" }),
     Columns.custom.sortable((text, item) => <SchedulePhrase schedule={item.schedule} isNew={item.isNew()} />, {
-      title: "Update Schedule",
+      title: "Refresh Schedule",
       field: "schedule",
     }),
   ];


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

In several places in the application we show only the user avatar instead of their name. In large organizations that don't use avatars this leads to long lists with random icons instead of names.

* Updated all lists (queries, dashboards, alerts) to show explicit user name. 
* On the dashboard page showing the user name when hovering over the user avatar.

There is probably a better UX to be achieved by moving the user name to a second line below the object name, but compared to the effort this seemed like a quick win.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

| Before | After |
| ------ | ------ |
| ![Queries List](https://user-images.githubusercontent.com/71468/80196598-4d2e9880-8626-11ea-83e7-f278613be42d.png) | ![After: Queries List](https://user-images.githubusercontent.com/71468/80196772-7c450a00-8626-11ea-9d46-1a03bb49084c.png) |
| ![Dashboards List](https://user-images.githubusercontent.com/71468/80196649-5ddf0e80-8626-11ea-93c6-523b3d0af92f.png) | ![After: Dashboards List](https://user-images.githubusercontent.com/71468/80196919-a5659a80-8626-11ea-83c8-655c1649b382.png) |
| ![Alerts List](https://user-images.githubusercontent.com/71468/80196698-69cad080-8626-11ea-871a-50fef170f377.png) | ![After: Alerts List](https://user-images.githubusercontent.com/71468/80196989-ba422e00-8626-11ea-818c-9796ccf83ae2.png) |
| | ![Dashboard Page](https://user-images.githubusercontent.com/71468/80197056-cded9480-8626-11ea-926a-ef71ec3db484.png) |


