### PR TITLE
Add column description to table viz

### DIFF
--- a/client/app/visualizations/table/Editor/ColumnEditor.jsx
+++ b/client/app/visualizations/table/Editor/ColumnEditor.jsx
@@ -47,6 +47,14 @@ export default function ColumnEditor({ column, onChange }) {
       </Section>
 
       <Section>
+        <Input
+          label="Description"
+          defaultValue={column.description}
+          onChange={event => handleChangeDebounced({ description: event.target.value })}
+        />
+      </Section>
+
+      <Section>
         <Select
           label="Display as:"
           data-test={`Table.Column.${column.name}.DisplayAs`}

--- a/client/app/visualizations/table/utils.js
+++ b/client/app/visualizations/table/utils.js
@@ -64,16 +64,18 @@ export function prepareColumns(columns, searchInput, orderBy, onOrderByChange) {
       align: column.alignContent,
       title: (
         <React.Fragment>
-          <div className="table-visualization-heading" data-sort-column-index={sortColumnIndex}>
-            {column.description && (
-              <Tooltip placement="top" title={column.description} className="p-r-5">
+          {column.description && (
+            <Tooltip placement="top" title={column.description} className="p-r-5">
+              <div className="table-visualization-heading">
                 <i className="fa fa-info-circle" aria-hidden="true"></i>
-              </Tooltip>
-            )}
-            <Tooltip placement="top" title={column.title}>
-              {column.title}
+              </div>
             </Tooltip>
-          </div>
+          )}
+          <Tooltip placement="top" title={column.title}>
+            <div className="table-visualization-heading" data-sort-column-index={sortColumnIndex}>
+              {column.title}
+            </div>
+          </Tooltip>
           <span className="ant-table-column-sorter">
             <div className="ant-table-column-sorter-inner ant-table-column-sorter-inner-full">
               <Icon

--- a/client/app/visualizations/table/utils.js
+++ b/client/app/visualizations/table/utils.js
@@ -64,11 +64,16 @@ export function prepareColumns(columns, searchInput, orderBy, onOrderByChange) {
       align: column.alignContent,
       title: (
         <React.Fragment>
-          <Tooltip placement="top" title={column.title}>
-            <div className="table-visualization-heading" data-sort-column-index={sortColumnIndex}>
+          <div className="table-visualization-heading" data-sort-column-index={sortColumnIndex}>
+            {column.description && (
+              <Tooltip placement="top" title={column.description} className="p-r-5">
+                <i className="fa fa-info-circle" aria-hidden="true"></i>
+              </Tooltip>
+            )}
+            <Tooltip placement="top" title={column.title}>
               {column.title}
-            </div>
-          </Tooltip>
+            </Tooltip>
+          </div>
           <span className="ant-table-column-sorter">
             <div className="ant-table-column-sorter-inner ant-table-column-sorter-inner-full">
               <Icon


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

This adds the ability to add a description to a column in a table visualization. The description will appear on hover (or click on mobile).

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Visualization Editor:

![Screen Shot 2020-04-24 at 5 53 55 PM](https://user-images.githubusercontent.com/71468/80226186-b4fbd800-8654-11ea-8c28-bcdc1ec9408c.png)

Renderer:

![Screen Shot 2020-04-24 at 5 55 15 PM](https://user-images.githubusercontent.com/71468/80226242-c9d86b80-8654-11ea-8eda-3ad959801c0d.png)
