### PR TITLE
Fix dashboard not showing results while refreshing

### DIFF
--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -238,8 +238,8 @@ class VisualizationWidget extends React.Component {
   };
 
   renderVisualization() {
-    const { isLoading, widget, filters } = this.props;
-    const widgetQueryResult = !isLoading && widget.getQueryResult();
+    const { widget, filters } = this.props;
+    const widgetQueryResult = widget.getQueryResult();
     const widgetStatus = widgetQueryResult && widgetQueryResult.getStatus();
     switch (widgetStatus) {
       case "failed":


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Since #4734 whenever you refresh a widget it shows the big spinner and hide old results. This PR remove the by mistaken added `isLoading` check.

## Related Tickets & Documents
#4734 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![dashboard-refresh-widgets](https://user-images.githubusercontent.com/3356951/80554062-58752180-89a2-11ea-8dd2-9020c8fb90cb.gif)
