### PR TITLE
Skip building frontend when APP_ENV=dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,13 @@ jobs:
     environment:
       COMPOSE_FILE: .circleci/docker-compose.circle.yml
       COMPOSE_PROJECT_NAME: redash
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      DOCKER_BUILDKIT: 1
     docker:
-      - image: circleci/buildpack-deps:xenial
+      - image: circleci/buildpack-deps:focal
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 18.09.3
       - checkout
       - run:
           name: Build Docker Images
@@ -82,13 +85,16 @@ jobs:
     environment:
       COMPOSE_FILE: .circleci/docker-compose.cypress.yml
       COMPOSE_PROJECT_NAME: cypress
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      DOCKER_BUILDKIT: 1
       PERCY_TOKEN_ENCODED: ZGRiY2ZmZDQ0OTdjMzM5ZWE0ZGQzNTZiOWNkMDRjOTk4Zjg0ZjMxMWRmMDZiM2RjOTYxNDZhOGExMjI4ZDE3MA==
       CYPRESS_PROJECT_ID_ENCODED: OTI0Y2th
       CYPRESS_RECORD_KEY_ENCODED: YzA1OTIxMTUtYTA1Yy00NzQ2LWEyMDMtZmZjMDgwZGI2ODgx
     docker:
       - image: circleci/node:12
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 18.09.3
       - checkout
       - run:
           name: Install npm dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,20 +40,28 @@ jobs:
             docker-compose up -d
             sleep 10
       - run:
+          name: Build Front End Assets for some testcases # TODO: Fix testcases and remove this step
+          command: |
+            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            npm ci
+            npm run build
+            docker cp ./client/dist $(docker-compose ps -q redash):/app/client/
+      - run:
           name: Create Test Database
-          command: docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;"
+          command: docker-compose exec postgres psql -U postgres -c "create database tests;"
       - run:
           name: List Enabled Query Runners
-          command: docker-compose run --rm redash manage ds list_types
+          command: docker-compose exec redash /app/bin/docker-entrypoint manage ds list_types
       - run:
           name: Run Tests
-          command: docker-compose run --name tests redash tests --junitxml=junit.xml --cov-report xml --cov=redash --cov-config .coveragerc tests/
+          command: docker-compose exec redash /app/bin/docker-entrypoint tests --junitxml=junit.xml --cov-report xml --cov=redash --cov-config .coveragerc tests/
       - run:
           name: Copy Test Results
           command: |
             mkdir -p /tmp/test-results/unit-tests
-            docker cp tests:/app/coverage.xml ./coverage.xml
-            docker cp tests:/app/junit.xml /tmp/test-results/unit-tests/results.xml
+            docker cp $(docker-compose ps -q redash):/app/coverage.xml ./coverage.xml
+            docker cp $(docker-compose ps -q redash):/app/junit.xml /tmp/test-results/unit-tests/results.xml
           when: always
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/docker-compose.circle.yml
+++ b/.circleci/docker-compose.circle.yml
@@ -1,7 +1,10 @@
 version: '3'
 services:
   redash:
-    build: ../
+    build:
+      context: ../
+      args:
+        APP_ENV: dev
     command: manage version
     depends_on:
       - postgres

--- a/.circleci/docker-compose.circle.yml
+++ b/.circleci/docker-compose.circle.yml
@@ -5,7 +5,6 @@ services:
       context: ../
       args:
         APP_ENV: dev
-    command: manage version
     depends_on:
       - postgres
       - redis

--- a/.circleci/docker_build
+++ b/.circleci/docker_build
@@ -6,11 +6,11 @@ docker login -u $DOCKER_USER -p $DOCKER_PASS
 
 if [ $CIRCLE_BRANCH = master ] || [ $CIRCLE_BRANCH = preview-image ]
 then
-    docker build -t redash/redash:preview -t redash/preview:$VERSION_TAG .
+    DOCKER_BUILDKIT=1 docker build -t redash/redash:preview -t redash/preview:$VERSION_TAG .
     docker push redash/redash:preview
     docker push redash/preview:$VERSION_TAG
 else
-    docker build -t redash/redash:$VERSION_TAG .
+    DOCKER_BUILDKIT=1 docker build -t redash/redash:$VERSION_TAG .
     docker push redash/redash:$VERSION_TAG
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: compose_build up test_db create_database clean down bundle tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
 
 compose_build:
-	docker-compose build
+	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
 
 up:
-	docker-compose up -d --build
+	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up -d
 
 test_db:
 	@for i in `seq 1 5`; do \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ version: '3.2'
 # For a production example please refer to getredash/setup repository on GitHub.
 services:
   server:
-    build: .
+    build:
+      context: .
+      args:
+        APP_ENV: dev
     command: dev_server
     depends_on:
       - postgres
@@ -22,7 +25,10 @@ services:
       REDASH_MAIL_DEFAULT_SENDER: redash@example.com
       REDASH_MAIL_SERVER: email
   scheduler:
-    build: .
+    build:
+      context: .
+      args:
+        APP_ENV: dev
     command: dev_scheduler
     volumes:
       - type: bind
@@ -35,7 +41,10 @@ services:
       REDASH_MAIL_DEFAULT_SENDER: redash@example.com
       REDASH_MAIL_SERVER: email
   worker:
-    build: .
+    build:
+      context: .
+      args:
+        APP_ENV: dev
     command: dev_worker
     volumes:
       - type: bind


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Skip building frontend materials when APP_ENV=dev with BuildKit

```
$ make compose_build
COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
redis uses an image, skipping
postgres uses an image, skipping
email uses an image, skipping
WARNING: Native build is an experimental feature and could change at any time
Building server
[+] Building 325.0s (17/17) FINISHED                                                                                                                                    
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 35B                                                                                                                                   0.0s
 => [internal] load build definition from Dockerfile                                                                                                               0.0s
 => => transferring dockerfile: 2.62kB                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/python:3.7-slim                                                                                                 0.0s
 => CACHED [server 1/6] FROM docker.io/library/python:3.7-slim                                                                                                     0.0s
 => CACHED https://databricks.com/wp-content/uploads/2.6.10.1010-2/SimbaSparkODBC-2.6.10.1010-2-Debian-64bit.zip                                                   0.0s
 => [internal] load build context                                                                                                                                  0.3s
 => => transferring context: 94.95kB                                                                                                                               0.2s
 => [server 2/6] RUN useradd --create-home redash                                                                                                                  0.5s
 => [server 3/6] RUN apt-get update &&   apt-get install -y     curl     gnupg     build-essential     pwgen     libffi-dev     sudo     git-core     wget     l  55.5s
 => [server 4/6] ADD https://databricks.com/wp-content/uploads/2.6.10.1010-2/SimbaSparkODBC-2.6.10.1010-2-Debian-64bit.zip /tmp/simba_odbc.zip                     0.1s 
 => [server 5/6] RUN unzip /tmp/simba_odbc.zip -d /tmp/   && dpkg -i /tmp/SimbaSparkODBC-2.6.10.1010-2-Debian-64bit/simbaspark_2.6.10.1010-2_amd64.deb   && echo   1.2s 
 => [server 6/6] WORKDIR /app                                                                                                                                      0.0s 
 => [dev-server 1/4] COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./                                                0.1s 
 => [dev-server 2/4] RUN pip install -r requirements.txt -r requirements_dev.txt                                                                                 109.3s
 => [dev-server 3/4] RUN if [ "x$skip_ds_deps" = "x" ] ; then pip install -r requirements_all_ds.txt ; else echo "Skipping pip install -r requirements_all_ds.t  147.3s
 => [dev-server 4/4] COPY . /app                                                                                                                                   0.5s
 => [stage-4 1/1] RUN chown -R redash /app                                                                                                                         4.3s
 => exporting to image                                                                                                                                             6.0s
 => => exporting layers                                                                                                                                            6.0s
 => => writing image sha256:b74dea256833205521af4536f5b1e003839a0a62b4c887a12eabc070d02f81cf                                                                       0.0s
 => => naming to docker.io/library/redash_server                                                                                                                   0.0s
Successfully built b74dea256833205521af4536f5b1e003839a0a62b4c887a12eabc070d02f81cf
```

Requirements:
docker 18.09.3+
docker-compose 1.25.1+

⚠️  You can build redash without BuildKit. But the build may be slower without BuildKit because Docker tries to build both dev and prod steps in Dockerfile.

## Related Tickets & Documents
Yet another #4292 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
