### PR TITLE
Fix visualizations with filters not showing selected values

### DIFF
--- a/client/app/components/visualizations/VisualizationRenderer.jsx
+++ b/client/app/components/visualizations/VisualizationRenderer.jsx
@@ -2,7 +2,6 @@ import { map, find } from "lodash";
 import React, { useState, useMemo, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import getQueryResultData from "@/lib/getQueryResultData";
-import { getColumnCleanName } from "@/services/query-result";
 import Filters, { FiltersType, filterData } from "@/components/Filters";
 import { VisualizationType } from "@/visualizations/prop-types";
 import { Renderer } from "@/components/visualizations/visualizationComponents";
@@ -43,17 +42,12 @@ export default function VisualizationRenderer(props) {
     setFilters(combineFilters(filtersRef.current, props.filters));
   }, [props.filters]);
 
-  const cleanColumnNames = useMemo(
-    () => map(data.columns, col => ({ ...col, name: getColumnCleanName(col.friendly_name) })),
-    [data.columns]
-  );
-
   const filteredData = useMemo(
     () => ({
-      columns: cleanColumnNames,
+      columns: data.columns,
       rows: filterData(data.rows, filters),
     }),
-    [cleanColumnNames, data.rows, filters]
+    [data, filters]
   );
 
   const { showFilters, visualization } = props;

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -39,10 +39,6 @@ function getColumnNameWithoutType(column) {
   return parts[0];
 }
 
-export function getColumnCleanName(column) {
-  return getColumnNameWithoutType(column);
-}
-
 function getColumnFriendlyName(column) {
   return getColumnNameWithoutType(column).replace(/(?:^|\s)\S/g, a => a.toUpperCase());
 }
@@ -252,10 +248,6 @@ class QueryResult {
     }
 
     return this.columnNames;
-  }
-
-  getColumnCleanNames() {
-    return this.getColumnNames().map(col => getColumnCleanName(col));
   }
 
   getColumnFriendlyNames() {

--- a/client/app/visualizations/table/getOptions.js
+++ b/client/app/visualizations/table/getOptions.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { getColumnCleanName } from "@/services/query-result";
 import { visualizationsSettings } from "@/visualizations/visualizationsSettings";
 
 const DEFAULT_OPTIONS = {
@@ -25,7 +26,7 @@ function getDefaultColumnsOptions(columns) {
     displayAs: displayAs[col.type] || "string",
     visible: true,
     order: 100000 + index,
-    title: col.name,
+    title: getColumnCleanName(col.name),
     allowSearch: false,
     alignContent: getColumnContentAlignment(col.type),
     // `string` cell options

--- a/client/app/visualizations/table/getOptions.js
+++ b/client/app/visualizations/table/getOptions.js
@@ -1,11 +1,34 @@
 import _ from "lodash";
-import { getColumnCleanName } from "@/services/query-result";
 import { visualizationsSettings } from "@/visualizations/visualizationsSettings";
 
 const DEFAULT_OPTIONS = {
   itemsPerPage: 25,
   paginationSize: "default", // not editable through Editor
 };
+
+const filterTypes = ["filter", "multi-filter", "multiFilter"];
+
+function getColumnNameWithoutType(column) {
+  let typeSplit;
+  if (column.indexOf("::") !== -1) {
+    typeSplit = "::";
+  } else if (column.indexOf("__") !== -1) {
+    typeSplit = "__";
+  } else {
+    return column;
+  }
+
+  const parts = column.split(typeSplit);
+  if (parts[0] === "" && parts.length === 2) {
+    return parts[1];
+  }
+
+  if (!_.includes(filterTypes, parts[1])) {
+    return column;
+  }
+
+  return parts[0];
+}
 
 function getColumnContentAlignment(type) {
   return ["integer", "float", "boolean", "date", "datetime"].indexOf(type) >= 0 ? "right" : "left";
@@ -26,7 +49,7 @@ function getDefaultColumnsOptions(columns) {
     displayAs: displayAs[col.type] || "string",
     visible: true,
     order: 100000 + index,
-    title: getColumnCleanName(col.name),
+    title: getColumnNameWithoutType(col.name),
     allowSearch: false,
     alignContent: getColumnContentAlignment(col.type),
     // `string` cell options


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
This PR moves the getColumnCleanName back to the table visualization, fixing an introduced bug.

I still want to work on a more definitive solution to handle the column names for all visualizations, but I realized it was not worth it to postpone the fix. As I reintroduced a dependency to the Table Visualization, I'll handle that later on #4837.

Note: #4757 contains a set of general tests for Filters, I'll merge it as soon as this fix arrives (currently it fails in CI due to the bug).

## Related Tickets & Documents
Fixes #4853 
Bug introduced in #4793 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--