### PR TITLE
Add additional statsd metrics for worker/scheduler

### DIFF
--- a/redash/cli/rq.py
+++ b/redash/cli/rq.py
@@ -18,6 +18,7 @@ from redash.tasks import (
     schedule_periodic_jobs,
     periodic_job_definitions,
 )
+from redash.worker import default_queues
 
 manager = AppGroup(help="RQ management commands.")
 
@@ -38,7 +39,7 @@ def worker(queues):
     configure_mappers()
 
     if not queues:
-        queues = ["scheduled_queries", "queries", "periodic", "emails", "default", "schemas"]
+        queues = default_queues
 
     with Connection(rq_redis_connection):
         w = Worker(queues, log_job_description=False, job_monitoring_interval=5)

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -101,7 +101,6 @@ def enqueue_query(
                 )
 
                 logger.info("[%s] Created new job: %s", query_hash, job.id)
-                statsd_client.incr("rq.jobs.created.{}".format(queue_name))
                 pipe.set(
                     _job_lock_id(query_hash, data_source.id),
                     job.id,

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -7,7 +7,7 @@ from rq.job import JobStatus
 from rq.timeouts import JobTimeoutException
 from rq.exceptions import NoSuchJobError
 
-from redash import models, redis_connection, settings, statsd_client
+from redash import models, redis_connection, settings
 from redash.query_runner import InterruptException
 from redash.tasks.worker import Queue, Job
 from redash.tasks.alerts import check_alerts_for_query

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -7,7 +7,7 @@ from rq.job import JobStatus
 from rq.timeouts import JobTimeoutException
 from rq.exceptions import NoSuchJobError
 
-from redash import models, redis_connection, settings
+from redash import models, redis_connection, settings, statsd_client
 from redash.query_runner import InterruptException
 from redash.tasks.worker import Queue, Job
 from redash.tasks.alerts import check_alerts_for_query
@@ -101,6 +101,7 @@ def enqueue_query(
                 )
 
                 logger.info("[%s] Created new job: %s", query_hash, job.id)
+                statsd_client.incr("rq.jobs.created.{}".format(queue_name))
                 pipe.set(
                     _job_lock_id(query_hash, data_source.id),
                     job.id,

--- a/redash/tasks/schedule.py
+++ b/redash/tasks/schedule.py
@@ -17,6 +17,7 @@ from redash.tasks import (
     purge_failed_jobs,
     version_check,
     send_aggregated_errors,
+    Queue
 )
 
 logger = logging.getLogger(__name__)
@@ -24,12 +25,9 @@ logger = logging.getLogger(__name__)
 
 class StatsdRecordingScheduler(Scheduler):
     """
-    RQ Scheduler Mixin that overrides `enqueue_job` to increment/modify metrics via Statsd
+    RQ Scheduler Mixin that uses Redash's custom RQ Queue class to increment/modify metrics via Statsd
     """
-
-    def enqueue_job(self, job):
-        super().enqueue_job(job)
-        statsd_client.incr("rq.jobs.created.{}".format(self.queue_name))
+    queue_class = Queue
 
 
 rq_scheduler = StatsdRecordingScheduler(

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -28,15 +28,8 @@ class StatsdRecordingQueue(BaseQueue):
     RQ Queue Mixin that overrides `enqueue_call` to increment metrics via Statsd
     """
 
-    def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
-                     result_ttl=None, ttl=None, failure_ttl=None,
-                     description=None, depends_on=None, job_id=None,
-                     at_front=False, meta=None):
-        job = super().enqueue_call(
-            func, args, kwargs, timeout,
-            result_ttl, ttl, failure_ttl, description,
-            depends_on, job_id, at_front, meta
-        )
+    def enqueue_job(self, *args, **kwargs):
+        job = super().enqueue_job(*args, **kwargs)
         statsd_client.incr("rq.jobs.created.{}".format(self.name))
         return job
 

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -2,6 +2,7 @@ import errno
 import os
 import signal
 import time
+from redash import statsd_client
 from rq import Worker as BaseWorker, Queue as BaseQueue, get_current_job
 from rq.utils import utcnow
 from rq.timeouts import UnixSignalDeathPenalty, HorseMonitorTimeoutException
@@ -24,6 +25,24 @@ class CancellableJob(BaseJob):
 
 class CancellableQueue(BaseQueue):
     job_class = CancellableJob
+
+
+class StatsdRecordingWorker(BaseWorker):
+    """
+    RQ Worker Mixin that overrides `execute_job` to increment/modify metrics via Statsd
+    """
+
+    def execute_job(self, job, queue):
+        statsd_client.incr("rq.jobs.running.{}".format(queue.name))
+        statsd_client.incr("rq.jobs.started.{}".format(queue.name))
+        try:
+            super().execute_job(job, queue)
+        finally:
+            statsd_client.decr("rq.jobs.running.{}".format(queue.name))
+            if job.get_status() == JobStatus.FINISHED:
+                statsd_client.incr("rq.jobs.finished.{}".format(queue.name))
+            else:
+                statsd_client.incr("rq.jobs.failed.{}".format(queue.name))
 
 
 class HardLimitingWorker(BaseWorker):
@@ -130,6 +149,10 @@ class HardLimitingWorker(BaseWorker):
             )
 
 
+class RedashWorker(StatsdRecordingWorker, HardLimitingWorker):
+    pass
+
+
 Job = CancellableJob
 Queue = CancellableQueue
-Worker = HardLimitingWorker
+Worker = RedashWorker

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -14,8 +14,20 @@ from redash import (
     redis_connection,
     rq_redis_connection,
 )
+from redash.tasks.worker import Queue as RedashQueue
 
-job = partial(rq_job, connection=rq_redis_connection)
+
+default_queues = ["scheduled_queries", "queries", "periodic", "emails", "default", "schemas"]
+
+
+class StatsdRecordingJobDecorator(rq_job):  # noqa
+    """
+    RQ Job Decorator mixin that uses our Queue class to ensure metrics are accurately incremented in Statsd
+    """
+    queue_class = RedashQueue
+
+
+job = partial(StatsdRecordingJobDecorator, connection=rq_redis_connection)
 
 
 class CurrentJobFilter(logging.Filter):

--- a/tests/metrics/test_database.py
+++ b/tests/metrics/test_database.py
@@ -4,6 +4,6 @@ from tests import BaseTestCase
 
 @patch("statsd.StatsClient.timing")
 class TestDatabaseMetrics(BaseTestCase):
-    def test_flask_request_records_statsd_metrics(self, timing):
-        self.client.get("/ping")
-        timing.assert_called_once_with("requests.redash_ping.get", ANY)
+    def test_db_request_records_statsd_metrics(self, timing):
+        self.factory.create_query()
+        timing.assert_called_with("db.changes.insert", ANY)

--- a/tests/metrics/test_database.py
+++ b/tests/metrics/test_database.py
@@ -1,0 +1,9 @@
+from mock import patch, ANY
+from tests import BaseTestCase
+
+
+@patch("statsd.StatsClient.timing")
+class TestDatabaseMetrics(BaseTestCase):
+    def test_flask_request_records_statsd_metrics(self, timing):
+        self.client.get("/ping")
+        timing.assert_called_once_with("requests.redash_ping.get", ANY)

--- a/tests/metrics/test_request.py
+++ b/tests/metrics/test_request.py
@@ -6,4 +6,4 @@ from tests import BaseTestCase
 class TestRequestMetrics(BaseTestCase):
     def test_flask_request_records_statsd_metrics(self, timing):
         self.factory.create_query()
-        timing.assert_called_once_with("db.queries.Insert", ANY)
+        timing.assert_called_with("db.queries.Insert", ANY)

--- a/tests/metrics/test_request.py
+++ b/tests/metrics/test_request.py
@@ -1,0 +1,9 @@
+from mock import patch, ANY
+from tests import BaseTestCase
+
+
+@patch("statsd.StatsClient.timing")
+class TestRequestMetrics(BaseTestCase):
+    def test_flask_request_records_statsd_metrics(self, timing):
+        self.factory.create_query()
+        timing.assert_called_once_with("db.queries.Insert", ANY)

--- a/tests/metrics/test_request.py
+++ b/tests/metrics/test_request.py
@@ -5,5 +5,5 @@ from tests import BaseTestCase
 @patch("statsd.StatsClient.timing")
 class TestRequestMetrics(BaseTestCase):
     def test_flask_request_records_statsd_metrics(self, timing):
-        self.factory.create_query()
-        timing.assert_called_with("db.queries.Insert", ANY)
+        self.client.get("/ping")
+        timing.assert_called_once_with("requests.redash_ping.get", ANY)

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import uuid
 
-from mock import patch, Mock
+from mock import patch, Mock, call
 
 from rq import Connection
 from rq.exceptions import NoSuchJobError
@@ -34,10 +34,11 @@ def create_job(*args, **kwargs):
     return Job(connection=rq_redis_connection)
 
 
+@patch("statsd.StatsClient.incr")
 @patch("redash.tasks.queries.execution.Job.fetch", side_effect=fetch_job)
 @patch("redash.tasks.queries.execution.Queue.enqueue", side_effect=create_job)
 class TestEnqueueTask(BaseTestCase):
-    def test_multiple_enqueue_of_same_query(self, enqueue, _):
+    def test_multiple_enqueue_of_same_query(self, enqueue, _, incr):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -67,8 +68,9 @@ class TestEnqueueTask(BaseTestCase):
             )
 
         self.assertEqual(1, enqueue.call_count)
+        incr.assert_called_once_with("rq.jobs.created.scheduled_queries")
 
-    def test_multiple_enqueue_of_expired_job(self, enqueue, fetch_job):
+    def test_multiple_enqueue_of_expired_job(self, enqueue, fetch_job, incr):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -94,9 +96,10 @@ class TestEnqueueTask(BaseTestCase):
             )
 
         self.assertEqual(2, enqueue.call_count)
+        incr.assert_has_calls([call("rq.jobs.created.scheduled_queries")] * 2)
 
     @patch("redash.settings.dynamic_settings.query_time_limit", return_value=60)
-    def test_limits_query_time(self, _, enqueue, __):
+    def test_limits_query_time(self, _, enqueue, __, ___):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -112,7 +115,7 @@ class TestEnqueueTask(BaseTestCase):
         _, kwargs = enqueue.call_args
         self.assertEqual(60, kwargs.get("job_timeout"))
 
-    def test_multiple_enqueue_of_different_query(self, enqueue, _):
+    def test_multiple_enqueue_of_different_query(self, enqueue, _, incr):
         query = self.factory.create_query()
 
         with Connection(rq_redis_connection):
@@ -142,6 +145,7 @@ class TestEnqueueTask(BaseTestCase):
             )
 
         self.assertEqual(3, enqueue.call_count)
+        incr.assert_has_calls([call("rq.jobs.created.queries")] * 3)
 
 
 @patch("redash.tasks.queries.execution.get_current_job", side_effect=fetch_job)

--- a/tests/tasks/test_worker.py
+++ b/tests/tasks/test_worker.py
@@ -1,0 +1,66 @@
+from mock import patch, call, ANY
+from tests import BaseTestCase
+from rq import Connection
+from rq.job import JobStatus
+from redash.tasks import Worker
+from redash import rq_redis_connection
+
+from tests import BaseTestCase
+from redash import redis_connection, rq_redis_connection, models
+from redash.tasks.queries.execution import (
+    enqueue_query,
+)
+
+
+@patch("statsd.StatsClient.incr")
+class TestWorkerMetrics(BaseTestCase):
+    def test_worker_records_success_metrics(self, incr):
+        query = self.factory.create_query()
+
+        with Connection(rq_redis_connection):
+            enqueue_query(
+                query.query_text,
+                query.data_source,
+                query.user_id,
+                False,
+                None,
+                {"Username": "Patrick", "Query ID": query.id},
+            )
+
+            Worker(["queries"]).work(max_jobs=1)
+
+        calls = [
+            call("rq.jobs.running.queries"),
+            call("rq.jobs.started.queries"),
+            call("rq.jobs.running.queries", -1, 1),
+            call("rq.jobs.finished.queries")
+        ]
+        incr.assert_has_calls(calls)
+
+    @patch("rq.Worker.execute_job")
+    def test_worker_records_failure_metrics(self, _, incr):
+        """
+        Force superclass execute_job to do nothing and set status to JobStatus.Failed to simulate query failure
+        """
+        query = self.factory.create_query()
+
+        with Connection(rq_redis_connection):
+            job = enqueue_query(
+                query.query_text,
+                query.data_source,
+                query.user_id,
+                False,
+                None,
+                {"Username": "Patrick", "Query ID": query.id},
+            )
+            job.set_status(JobStatus.FAILED)
+
+            Worker(["queries"]).work(max_jobs=1)
+
+        calls = [
+            call("rq.jobs.running.queries"),
+            call("rq.jobs.started.queries"),
+            call("rq.jobs.running.queries", -1, 1),
+            call("rq.jobs.failed.queries")
+        ]
+        incr.assert_has_calls(calls)

--- a/tests/tasks/test_worker.py
+++ b/tests/tasks/test_worker.py
@@ -1,19 +1,24 @@
-from mock import patch, call, ANY
-from tests import BaseTestCase
+from mock import patch, call
 from rq import Connection
 from rq.job import JobStatus
 from redash.tasks import Worker
-from redash import rq_redis_connection
 
 from tests import BaseTestCase
-from redash import redis_connection, rq_redis_connection, models
+from redash import rq_redis_connection
+from redash.tasks.worker import Queue
 from redash.tasks.queries.execution import (
     enqueue_query,
 )
+from redash.worker import job, default_queues
 
 
 @patch("statsd.StatsClient.incr")
 class TestWorkerMetrics(BaseTestCase):
+    def tearDown(self):
+        with Connection(rq_redis_connection):
+            for queue_name in default_queues:
+                Queue(queue_name).empty()
+
     def test_worker_records_success_metrics(self, incr):
         query = self.factory.create_query()
 
@@ -64,3 +69,34 @@ class TestWorkerMetrics(BaseTestCase):
             call("rq.jobs.failed.queries")
         ]
         incr.assert_has_calls(calls)
+
+
+@patch("statsd.StatsClient.incr")
+class TestQueueMetrics(BaseTestCase):
+    def tearDown(self):
+        with Connection(rq_redis_connection):
+            for queue_name in default_queues:
+                Queue(queue_name).empty()
+
+    def test_enqueue_query_records_created_metric(self, incr):
+        query = self.factory.create_query()
+
+        with Connection(rq_redis_connection):
+            enqueue_query(
+                query.query_text,
+                query.data_source,
+                query.user_id,
+                False,
+                None,
+                {"Username": "Patrick", "Query ID": query.id},
+            )
+
+        incr.assert_called_with("rq.jobs.created.queries")
+
+    def test_job_delay_records_created_metric(self, incr):
+        @job("default", timeout=300)
+        def foo():
+            pass
+
+        foo.delay()
+        incr.assert_called_with("rq.jobs.created.default")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Adds additional statsd metrics for created, started, running (in-flight), and finished/failed jobs on RQ workers, and adds some rudimentary tests for existing flask and database metrics.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
