### PR TITLE
Fix HelpTrigger in header not working

### DIFF
--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -108,8 +108,8 @@ export default class HelpTrigger extends React.Component {
   };
 
   getUrl = () => {
-    const [pagePath] = get(TYPES, this.props.type, []);
-    return pagePath ? DOMAIN + HELP_PATH + pagePath : this.props.href;
+    const helpTriggerType = get(TYPES, this.props.type);
+    return helpTriggerType ? DOMAIN + HELP_PATH + helpTriggerType[0] : this.props.href;
   };
 
   openDrawer = () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Turns out the header `pagePath` points to and empty string, which as it's also falsy, it was considered as "there is no url for this type". Changed the check to be made in the object instead to fix that.

## Related Tickets & Documents
Fixes #4886 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![help-trigger-fix](https://user-images.githubusercontent.com/3356951/81702437-a9285800-9441-11ea-8a47-4df4ddf00246.gif)
