### PR TITLE
Set the schema item title attribute correctly.

### DIFF
--- a/client/app/pages/queries/components/SchemaBrowser.jsx
+++ b/client/app/pages/queries/components/SchemaBrowser.jsx
@@ -36,7 +36,7 @@ function SchemaItem({ item, expanded, onToggle, onSelect, ...props }) {
       <div className="table-name" onClick={onToggle}>
         <i className="fa fa-table m-r-5" />
         <strong>
-          <span title="{{table.name}}">{item.name}</span>
+          <span title={item.name}>{item.name}</span>
           {!isNil(item.size) && <span> ({item.size})</span>}
         </strong>
         <i


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This looks like an oversight in the React conversion since the title shows up as `{{table.name}}`.