### PR TITLE
Pin @percy/agent version and update Cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "prettier --write 'client/app/**/*.{js,jsx}' 'client/cypress/**/*.js'",
     "test": "TZ=Africa/Khartoum jest",
     "test:watch": "jest --watch",
-    "cypress:install": "npm install --no-save cypress@~4.1.0 @percy/cypress@^2.2.0 atob@2.1.2",
+    "cypress:install": "npm install --no-save cypress@~4.5.0 @percy/agent@0.26.2 @percy/cypress@^2.2.0 atob@2.1.2",
     "cypress": "node client/cypress/cypress.js",
     "preinstall": "(cd viz-lib && npm ci && npm run build:babel)"
   },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
Looks like Cypress on CircleCI started to fail after an update in [@percy/agent](https://github.com/percy/percy-agent) from yesterday. For now I'm temporarily pinning the version, but we will need to revisit it later.

(Cypress update has nothing to do with it, but I took the opportunity since I was there)

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--
