### PR TITLE
Fix: table viz crashing when search is enabled

### DIFF
--- a/viz-lib/src/visualizations/table/Renderer.jsx
+++ b/viz-lib/src/visualizations/table/Renderer.jsx
@@ -103,7 +103,7 @@ export default function Renderer({ options, data, context }) {
     // so let's use this "hack" for better performance.
     if (searchInputRef.current) {
       // pass value and fake event-like object
-      searchInputRef.current.input.setValue("", { target: { value: "" } });
+      searchInputRef.current.input.setValue("");
     }
     setOrderBy([]);
   }, [options.columns, data.columns, searchInputRef]);

--- a/viz-lib/src/visualizations/table/Renderer.jsx
+++ b/viz-lib/src/visualizations/table/Renderer.jsx
@@ -1,5 +1,5 @@
 import { filter, map, get, initial, last, reduce } from "lodash";
-import React, { useMemo, useState, useRef, useCallback, useEffect } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import Table from "antd/lib/table";
 import Input from "antd/lib/input";
@@ -52,33 +52,7 @@ function SearchInputInfoIcon({ searchColumns }) {
   );
 }
 
-// Some explanation why this weird solution with `clearCallbackRef` is used.
-// When visualization options are editing, renderer may re-create table columns quite often.
-// Search input is one of table columns, and it does not depend on options.
-// We could just render it once and then leave it for React, but there is a feature
-// that needs access to Search input's value: when SOME options or data columns change - search
-// input should reset. If we'll use managed input's state in renderer itself - it will create
-// dependency that will update table columns on every character typed in input.
-// Therefore we use this pattern: input manages its state itself, and provides a callback to
-// clear value when needed. It's still weird, but at least will not break with new Ant version.
-
-function SearchInput({ searchColumns, clearCallbackRef, ...props }) {
-  const [currentValue, setCurrentValue] = useState(props.defaultValue);
-
-  useEffect(() => {
-    setCurrentValue(props.value);
-  }, [props.value]);
-
-  const onChange = useCallback(
-    event => {
-      setCurrentValue(event.target.value);
-      props.onChange(event.target.value);
-    },
-    [props.onChange]
-  );
-
-  clearCallbackRef.current = useCallback(() => setCurrentValue(""), []);
-
+function SearchInput({ searchColumns, ...props }) {
   if (searchColumns.length <= 0) {
     return null;
   }
@@ -87,8 +61,6 @@ function SearchInput({ searchColumns, clearCallbackRef, ...props }) {
   return (
     <Input.Search
       {...props}
-      value={currentValue}
-      onChange={onChange}
       placeholder={`Search ${getSearchColumns(searchColumns, { limit: searchColumnsLimit }).join("")}...`}
       suffix={searchColumns.length > searchColumnsLimit ? <SearchInputInfoIcon searchColumns={searchColumns} /> : null}
     />
@@ -96,12 +68,10 @@ function SearchInput({ searchColumns, clearCallbackRef, ...props }) {
 }
 
 SearchInput.propTypes = {
-  clearCallbackRef: PropTypes.object,
   onChange: PropTypes.func,
 };
 
 SearchInput.defaultProps = {
-  clearCallbackRef: {},
   onChange: () => {},
 };
 
@@ -111,16 +81,10 @@ export default function Renderer({ options, data }) {
 
   const searchColumns = useMemo(() => filter(options.columns, "allowSearch"), [options.columns]);
 
-  const clearSearchInputCallbackRef = useRef();
-
   const tableColumns = useMemo(() => {
     const searchInput =
       searchColumns.length > 0 ? (
-        <SearchInput
-          searchColumns={searchColumns}
-          clearCallbackRef={clearSearchInputCallbackRef}
-          onChange={setSearchTerm}
-        />
+        <SearchInput searchColumns={searchColumns} onChange={event => setSearchTerm(event.target.value)} />
       ) : null;
     return prepareColumns(options.columns, searchInput, orderBy, newOrderBy => {
       setOrderBy(newOrderBy);
@@ -136,13 +100,8 @@ export default function Renderer({ options, data }) {
     orderBy,
   ]);
 
-  // If data or config columns change - reset sorting and search
+  // If data or config columns change - reset sorting
   useEffect(() => {
-    setSearchTerm("");
-    // Clear search input
-    if (clearSearchInputCallbackRef.current) {
-      clearSearchInputCallbackRef.current();
-    }
     setOrderBy([]);
   }, [options.columns, data.columns]);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Feature

## Description

I managed to reproduce this only on a private deployment of Redash and locally, but it doesn't happen on redash-preview. Might be due to a recent change in Ant library?

It looks like the second argument of setValue is a callback that is being passed to setState. By passing an object there, we trigger the following error:

> Invalid argument passed as callback. Expected a function. Instead received: [object Object]

Removing the second argument fixes this and seems not to affect functionality.

#### Update (by @kravets-levko)

After out discussion with @arikfr we decided that search input shouldn't clear when data changes, and filter should stay applied. I decided to not open a new PR and added fix to this one, but kept original PR description for better context.