### PR TITLE
Fix: front-end error when parse python float nan

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -70,7 +70,13 @@ def generate_token(length):
 
 class JSONEncoder(simplejson.JSONEncoder):
     """Adapter for `simplejson.dumps`."""
-
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        # Float value nan or inf in Python should be render to None or null in json.
+        # Using ignore_nan = False will make Python render nan as NaN, leading to parse error in front-end
+        self.ignore_nan = True
+    
     def default(self, o):
         # Some SQLAlchemy collections are lazy.
         if isinstance(o, Query):

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -71,11 +71,6 @@ def generate_token(length):
 class JSONEncoder(simplejson.JSONEncoder):
     """Adapter for `simplejson.dumps`."""
     
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        # Float value nan or inf in Python should be render to None or null in json.
-        # Using ignore_nan = False will make Python render nan as NaN, leading to parse error in front-end
-        self.ignore_nan = True
     
     def default(self, o):
         # Some SQLAlchemy collections are lazy.
@@ -120,6 +115,9 @@ def json_dumps(data, *args, **kwargs):
     simplejson.dumps function."""
     kwargs.setdefault("cls", JSONEncoder)
     kwargs.setdefault("encoding", None)
+    # Float value nan or inf in Python should be render to None or null in json.
+    # Using ignore_nan = False will make Python render nan as NaN, leading to parse error in front-end
+    kwargs.setdefault('ignore_nan', True)
     return simplejson.dumps(data, *args, **kwargs)
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Change simplejson encoder `ignore_nan` to `True` to overcome json parse issue in front-end when data returned has float `nan` value in it

## Related Tickets & Documents
https://github.com/getredash/redash/issues/4902

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
