### PR TITLE
Show helpful error message when detached data source queried

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -62,6 +62,9 @@ error_messages = {
 
 
 def run_query(query, parameters, data_source, query_id, max_age=0):
+    if data_source is None:
+        return error_response("The data source for this query no longer exists.")
+        
     if data_source.paused:
         if data_source.pause_reason:
             message = "{} is paused ({}). Please try later.".format(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
When a data source is deleted, its queries can still be accessed at the /queries/{id} route. If a user tries to execute one of these queries, they get an unspecified 500 error. This change shows a more helpful message indicating the cause of the problem. 

## Related Tickets & Documents
Resolves #4608

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
