### PR TITLE
 When resizing chart to a certain size it errors out

### DIFF
--- a/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
+++ b/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
@@ -1,4 +1,4 @@
-import { isArray, isObject } from "lodash";
+import { isArray, isString, isObject, startsWith } from "lodash";
 import React, { useState, useEffect, useContext } from "react";
 import useMedia from "use-media";
 import { ErrorBoundaryContext } from "@/components/ErrorBoundary";
@@ -13,6 +13,11 @@ function catchErrors(func, errorHandler) {
     try {
       return func(...args);
     } catch (error) {
+      // This error happens only when chart width is 20px and looks that
+      // it's safe to just ignore it: 1px less or more and chart will get fixed.
+      if (isString(error) && startsWith(error, "ax.dtick error")) {
+        return;
+      }
       errorHandler.handleError(error);
     }
   };

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -113,8 +113,9 @@ function placeLegendAuto(plotlyElement, layout, updatePlot) {
 
 export default function applyLayoutFixes(plotlyElement, layout, options, updatePlot) {
   // update layout size to plot container
-  layout.width = Math.floor(plotlyElement.offsetWidth);
-  layout.height = Math.floor(plotlyElement.offsetHeight);
+  // plot size should be at least 5x5px
+  layout.width = Math.max(5, Math.floor(plotlyElement.offsetWidth));
+  layout.height = Math.max(5, Math.floor(plotlyElement.offsetHeight));
 
   if (options.legend.enabled) {
     switch (options.legend.placement) {

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.js
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.js
@@ -119,8 +119,9 @@ function prepareBoxLayout(layout, options, data) {
 export default function prepareLayout(element, options, data) {
   const layout = {
     margin: { l: 10, r: 10, b: 5, t: 20, pad: 4 },
-    width: Math.floor(element.offsetWidth),
-    height: Math.floor(element.offsetHeight),
+    // plot size should be at least 5x5px
+    width: Math.max(5, Math.floor(element.offsetWidth)),
+    height: Math.max(5, Math.floor(element.offsetHeight)),
     autosize: false,
     showlegend: has(options, "legend") ? options.legend.enabled : true,
   };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

I managed to reproduce this bug for two cases:

1. when width = 20px and height > 0: Plotly throws a string error `"ax.dtick error: Infinity"`. Looks that it's safe to just ignore this error as it happens at very specific size which is almost impossible to get from UI. Also, in this case Plotly will build plot partially.
2. when width <= 3 or height <= 4 (weird numbers, but generally it's zero-size container): Plotly fails to build plot at all. I decided to set minimal width and height for plot to 5px. I also don't know how to get this case using UI, I reproduced it setting container size from WebTools.

## Related Tickets & Documents

Fixes getredash/redash#4692
