### PR TITLE
Change visualizations build to be on postinstall instead of preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:watch": "jest --watch",
     "cypress:install": "npm install --no-save cypress@~4.5.0 @percy/agent@0.26.2 @percy/cypress@^2.2.0 atob@2.1.2",
     "cypress": "node client/cypress/cypress.js",
-    "postinstall": "(cd viz-lib && npm ci)"
+    "postinstall": "(cd viz-lib && npm ci && npm run build:babel)"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:watch": "jest --watch",
     "cypress:install": "npm install --no-save cypress@~4.5.0 @percy/agent@0.26.2 @percy/cypress@^2.2.0 atob@2.1.2",
     "cypress": "node client/cypress/cypress.js",
-    "preinstall": "(cd viz-lib && npm ci && npm run build:babel)"
+    "postinstall": "(cd viz-lib && npm ci)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This updates the `preinstall` script to be a `postinstall` instead. While there shouldn't be much difference, at some situations I had a problem in which running `npm install` for the Redash repo would remove existent `node_modules` installed for the visualizations lib. Making it necessary to run `npm install` on the sub-package afterwards.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--