### PR TITLE
Update Query Page shortcuts for MacOS

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -291,7 +291,7 @@ function QuerySource(props) {
                       }
                       executeButtonProps={{
                         disabled: !queryFlags.canExecute || isQueryExecuting || areParametersDirty,
-                        shortcut: "mod+enter, alt+enter",
+                        shortcut: "mod+enter, alt+enter, ctrl+enter",
                         onClick: doExecuteQuery,
                         text: (
                           <span className="hidden-xs">{selectedText === null ? "Execute" : "Execute Selected"}</span>

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -101,7 +101,7 @@ function QueryView(props) {
             <QueryViewButton
               className="m-r-5"
               type="primary"
-              shortcut="mod+enter, alt+enter"
+              shortcut="mod+enter, alt+enter, ctrl+enter"
               disabled={!queryFlags.canExecute || isExecuting || areParametersDirty}
               onClick={doExecuteQuery}>
               Refresh

--- a/client/app/services/KeyboardShortcuts.js
+++ b/client/app/services/KeyboardShortcuts.js
@@ -3,10 +3,12 @@ import Mousetrap from "mousetrap";
 import "mousetrap/plugins/global-bind/mousetrap-global-bind";
 
 const modKey = /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "Cmd" : "Ctrl";
+const altKey = /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "Option" : "Alt";
 
 export function humanReadableShortcut(shortcut, limit = Infinity) {
   const modifiers = {
     mod: upperFirst(modKey),
+    alt: upperFirst(altKey),
   };
 
   shortcut = toLower(toString(shortcut));
@@ -29,6 +31,7 @@ function onShortcut(event, shortcut) {
 
 const KeyboardShortcuts = {
   modKey,
+  altKey,
 
   bind: keymap => {
     each(keymap, (fn, key) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
- Add `Ctrl + Enter`;
- Show `Option + Key` when in Mac

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--