### PR TITLE
Use lambda on options for destinations factory

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -153,7 +153,7 @@ destination_factory = ModelFactory(
     user=user_factory.create,
     name=Sequence("Destination {}"),
     type="slack",
-    options=ConfigurationContainer.from_json('{"url": "https://www.slack.com"}'),
+    options=lambda: ConfigurationContainer.from_json('{"url": "https://www.slack.com"}'),
 )
 
 alert_subscription_factory = ModelFactory(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
This is one of the differences I found while comparing with the `data_sources` tests and trying to figure out the flakyness reason for the `test_destinations`. I'm not 100% sure this fixes the problem, but it did pass on CI a few times with no problems.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--