### PR TITLE
Use Antd Descriptions on Details visualization

### DIFF
--- a/client/app/assets/less/ant.less
+++ b/client/app/assets/less/ant.less
@@ -1,33 +1,33 @@
-@import '~antd/lib/style/core/iconfont';
-@import '~antd/lib/style/core/motion';
-@import '~antd/lib/alert/style/index';
-@import '~antd/lib/input/style/index';
-@import '~antd/lib/input-number/style/index';
-@import '~antd/lib/date-picker/style/index';
-@import '~antd/lib/modal/style/index';
-@import '~antd/lib/tooltip/style/index';
-@import '~antd/lib/select/style/index';
-@import '~antd/lib/checkbox/style/index';
-@import '~antd/lib/upload/style/index';
-@import '~antd/lib/form/style/index';
-@import '~antd/lib/button/style/index';
-@import '~antd/lib/radio/style/index';
-@import '~antd/lib/time-picker/style/index';
-@import '~antd/lib/pagination/style/index';
-@import '~antd/lib/table/style/index';
-@import '~antd/lib/popover/style/index';
-@import '~antd/lib/icon/style/index';
-@import '~antd/lib/tag/style/index';
-@import '~antd/lib/grid/style/index';
-@import '~antd/lib/switch/style/index';
-@import '~antd/lib/empty/style/index';
-@import '~antd/lib/drawer/style/index';
-@import '~antd/lib/card/style/index';
-@import '~antd/lib/steps/style/index';
-@import '~antd/lib/divider/style/index';
-@import '~antd/lib/dropdown/style/index';
-@import '~antd/lib/menu/style/index';
-@import '~antd/lib/list/style/index';
+@import "~antd/lib/style/core/iconfont";
+@import "~antd/lib/style/core/motion";
+@import "~antd/lib/alert/style/index";
+@import "~antd/lib/input/style/index";
+@import "~antd/lib/input-number/style/index";
+@import "~antd/lib/date-picker/style/index";
+@import "~antd/lib/modal/style/index";
+@import "~antd/lib/tooltip/style/index";
+@import "~antd/lib/select/style/index";
+@import "~antd/lib/checkbox/style/index";
+@import "~antd/lib/upload/style/index";
+@import "~antd/lib/form/style/index";
+@import "~antd/lib/button/style/index";
+@import "~antd/lib/radio/style/index";
+@import "~antd/lib/time-picker/style/index";
+@import "~antd/lib/pagination/style/index";
+@import "~antd/lib/table/style/index";
+@import "~antd/lib/popover/style/index";
+@import "~antd/lib/icon/style/index";
+@import "~antd/lib/tag/style/index";
+@import "~antd/lib/grid/style/index";
+@import "~antd/lib/switch/style/index";
+@import "~antd/lib/empty/style/index";
+@import "~antd/lib/drawer/style/index";
+@import "~antd/lib/card/style/index";
+@import "~antd/lib/steps/style/index";
+@import "~antd/lib/divider/style/index";
+@import "~antd/lib/dropdown/style/index";
+@import "~antd/lib/menu/style/index";
+@import "~antd/lib/list/style/index";
 @import "~antd/lib/badge/style/index";
 @import "~antd/lib/card/style/index";
 @import "~antd/lib/spin/style/index";
@@ -36,7 +36,8 @@
 @import "~antd/lib/collapse/style/index";
 @import "~antd/lib/progress/style/index";
 @import "~antd/lib/typography/style/index";
-@import 'inc/ant-variables';
+@import "~antd/lib/descriptions/style/index";
+@import "inc/ant-variables";
 
 // Increase z-indexes to avoid conflicts with some other libraries (e.g. Plotly)
 @zindex-modal: 2000;
@@ -237,11 +238,11 @@
   &-item {
     // custom rule
     &.selected {
-      background-color: #F6F8F9;
+      background-color: #f6f8f9;
     }
 
     &.disabled {
-      background-color: fade(#F6F8F9, 40%);
+      background-color: fade(#f6f8f9, 40%);
 
       & > * {
         opacity: 0.4;
@@ -367,7 +368,7 @@
     top: auto !important;
     bottom: 8px;
 
-     // makes the icon white instead of see-through
+    // makes the icon white instead of see-through
     & svg {
       background: white;
       border-radius: 50%;
@@ -394,7 +395,7 @@
 }
 
 // overrides for checkbox
-@checkbox-prefix-cls: ~'@{ant-prefix}-checkbox';
+@checkbox-prefix-cls: ~"@{ant-prefix}-checkbox";
 
 .@{checkbox-prefix-cls}-wrapper + span,
 .@{checkbox-prefix-cls} + span {

--- a/viz-lib/src/visualizations/details/DetailsRenderer.jsx
+++ b/viz-lib/src/visualizations/details/DetailsRenderer.jsx
@@ -3,9 +3,8 @@ import { map, mapValues, keyBy } from "lodash";
 import moment from "moment";
 import { RendererPropTypes } from "@/visualizations/prop-types";
 import { visualizationsSettings } from "@/visualizations/visualizationsSettings";
+import Descriptions from "antd/lib/descriptions";
 import Pagination from "antd/lib/pagination";
-
-import "./details.less";
 
 function renderValue(value, type) {
   const formats = {
@@ -37,16 +36,13 @@ export default function DetailsRenderer({ data }) {
 
   return (
     <div>
-      <table className="table table-bordered details-viz">
-        <tbody>
-          {map(columns, key => (
-            <tr key={key}>
-              <th>{key}</th>
-              <td>{renderValue(row[key], types[key])}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <Descriptions size="small" column={1} bordered>
+        {map(columns, key => (
+          <Descriptions.Item key={key} label={key}>
+            {renderValue(row[key], types[key])}
+          </Descriptions.Item>
+        ))}
+      </Descriptions>
       {data.rows.length > 1 && (
         <div className="paginator-container">
           <Pagination current={page + 1} defaultPageSize={1} total={data.rows.length} onChange={p => setPage(p - 1)} />

--- a/viz-lib/src/visualizations/details/DetailsRenderer.jsx
+++ b/viz-lib/src/visualizations/details/DetailsRenderer.jsx
@@ -6,6 +6,8 @@ import { visualizationsSettings } from "@/visualizations/visualizationsSettings"
 import Descriptions from "antd/lib/descriptions";
 import Pagination from "antd/lib/pagination";
 
+import "./details.less";
+
 function renderValue(value, type) {
   const formats = {
     date: visualizationsSettings.dateFormat,
@@ -36,7 +38,7 @@ export default function DetailsRenderer({ data }) {
 
   return (
     <div>
-      <Descriptions size="small" column={1} bordered>
+      <Descriptions className="details-viz" size="small" column={1} bordered>
         {map(columns, key => (
           <Descriptions.Item key={key} label={key}>
             {renderValue(row[key], types[key])}

--- a/viz-lib/src/visualizations/details/DetailsRenderer.jsx
+++ b/viz-lib/src/visualizations/details/DetailsRenderer.jsx
@@ -37,8 +37,8 @@ export default function DetailsRenderer({ data }) {
   const row = data.rows[page];
 
   return (
-    <div>
-      <Descriptions className="details-viz" size="small" column={1} bordered>
+    <div className="details-viz">
+      <Descriptions size="small" column={1} bordered>
         {map(columns, key => (
           <Descriptions.Item key={key} label={key}>
             {renderValue(row[key], types[key])}

--- a/viz-lib/src/visualizations/details/details.less
+++ b/viz-lib/src/visualizations/details/details.less
@@ -1,5 +1,0 @@
-.details-viz th {
-  width: 1px;
-  white-space: nowrap;
-  background-color: rgba(102, 136, 153, 0.03) !important;
-}

--- a/viz-lib/src/visualizations/details/details.less
+++ b/viz-lib/src/visualizations/details/details.less
@@ -1,0 +1,4 @@
+.details-viz .ant-descriptions-item-label {
+  width: 1px;
+  white-space: nowrap;
+}

--- a/viz-lib/src/visualizations/details/details.less
+++ b/viz-lib/src/visualizations/details/details.less
@@ -1,4 +1,10 @@
-.details-viz .ant-descriptions-item-label {
-  width: 1px;
-  white-space: nowrap;
+.details-viz {
+  .ant-descriptions-item-label {
+    width: 1px;
+    white-space: nowrap;
+  }
+
+  .paginator-container {
+    margin-top: 10px;
+  }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description
This updates the Details Visualization to use Antd [Descriptions](https://3x.ant.design/components/descriptions/) component.

This removes dependency on "table" css styles.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**
<img width="1771" alt="Screen Shot 2020-05-24 at 15 56 52" src="https://user-images.githubusercontent.com/3356951/82762417-4aff5b80-9dd7-11ea-910a-b8b78e383edb.png">

**After**
<img width="1769" alt="Screen Shot 2020-05-24 at 16 05 31" src="https://user-images.githubusercontent.com/3356951/82762636-82bad300-9dd8-11ea-9bdc-1d623e3567fd.png">
