### PR TITLE
Athena: Make s3_staging_dir an option

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -83,7 +83,7 @@ class Athena(BaseQueryRunner):
                     "default": 5,
                 },
             },
-            "required": ["region", "s3_staging_dir"],
+            "required": ["region"],
             "extra_options": ["glue", "cost_per_tb"],
             "order": [
                 "region",
@@ -216,7 +216,7 @@ class Athena(BaseQueryRunner):
 
     def run_query(self, query, user):
         cursor = pyathena.connect(
-            s3_staging_dir=self.configuration["s3_staging_dir"],
+            s3_staging_dir=self.configuration.get("s3_staging_dir", None),
             schema_name=self.configuration.get("schema", "default"),
             encryption_option=self.configuration.get("encryption_option", None),
             kms_key=self.configuration.get("kms_key", None),

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -20,7 +20,7 @@ cassandra-driver==3.21.0
 memsql==3.0.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
-PyAthena>=1.5.0
+PyAthena>=1.10.7
 pymapd==0.19.0
 qds-sdk>=1.9.6
 ibm-db>=2.0.9


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
If you use a workgroup with output_location set, you can omit the s3_staging_dir setting.

The following is a quote from the [boto3 document](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/athena.html#Athena.Client.start_query_execution).
> To run the query, you must specify the query results location using one of the ways: either for individual queries using either this setting (client-side), or in the workgroup, using WorkGroupConfiguration .

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/5929819/82819199-f218eb80-9eda-11ea-83b2-d14bc02edded.png)

We tested that a test connection succeeds even when s3_staging_dir is empty.
