### PR TITLE
Use memoized query result data

### DIFF
--- a/client/app/components/visualizations/EditVisualizationDialog.jsx
+++ b/client/app/components/visualizations/EditVisualizationDialog.jsx
@@ -9,7 +9,7 @@ import Filters, { filterData } from "@/components/Filters";
 import notification from "@/services/notification";
 import Visualization from "@/services/visualization";
 import recordEvent from "@/services/recordEvent";
-import { useQueryResultData } from "@/lib/getQueryResultData";
+import useQueryResultData from "@/lib/useQueryResultData";
 import {
   registeredVisualizations,
   getDefaultVisualization,

--- a/client/app/components/visualizations/EditVisualizationDialog.jsx
+++ b/client/app/components/visualizations/EditVisualizationDialog.jsx
@@ -9,7 +9,7 @@ import Filters, { filterData } from "@/components/Filters";
 import notification from "@/services/notification";
 import Visualization from "@/services/visualization";
 import recordEvent from "@/services/recordEvent";
-import getQueryResultData from "@/lib/getQueryResultData";
+import { useQueryResultData } from "@/lib/getQueryResultData";
 import {
   registeredVisualizations,
   getDefaultVisualization,
@@ -71,7 +71,7 @@ function EditVisualizationDialog({ dialog, visualization, query, queryResult }) 
 
   const isNew = !visualization;
 
-  const data = getQueryResultData(queryResult);
+  const data = useQueryResultData(queryResult);
   const [filters, setFilters] = useState(data.filters);
 
   const filteredData = useMemo(

--- a/client/app/components/visualizations/VisualizationRenderer.jsx
+++ b/client/app/components/visualizations/VisualizationRenderer.jsx
@@ -1,7 +1,7 @@
 import { map, find } from "lodash";
 import React, { useState, useMemo, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import getQueryResultData from "@/lib/getQueryResultData";
+import { useQueryResultData } from "@/lib/getQueryResultData";
 import Filters, { FiltersType, filterData } from "@/components/Filters";
 import { VisualizationType } from "@redash/viz/lib";
 import { Renderer } from "@/components/visualizations/visualizationComponents";
@@ -25,7 +25,7 @@ function combineFilters(localFilters, globalFilters) {
 }
 
 export default function VisualizationRenderer(props) {
-  const data = useMemo(() => getQueryResultData(props.queryResult), [props.queryResult]);
+  const data = useQueryResultData(props.queryResult);
   const [filters, setFilters] = useState(data.filters);
   const filtersRef = useRef();
   filtersRef.current = filters;

--- a/client/app/components/visualizations/VisualizationRenderer.jsx
+++ b/client/app/components/visualizations/VisualizationRenderer.jsx
@@ -1,7 +1,7 @@
 import { map, find } from "lodash";
 import React, { useState, useMemo, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import { useQueryResultData } from "@/lib/getQueryResultData";
+import useQueryResultData from "@/lib/useQueryResultData";
 import Filters, { FiltersType, filterData } from "@/components/Filters";
 import { VisualizationType } from "@redash/viz/lib";
 import { Renderer } from "@/components/visualizations/visualizationComponents";

--- a/client/app/lib/getQueryResultData.js
+++ b/client/app/lib/getQueryResultData.js
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
 import { get, invoke } from "lodash";
 
-export default function getQueryResultData(queryResult) {
+export function getQueryResultData(queryResult) {
   return {
     status: invoke(queryResult, "getStatus") || null,
     columns: invoke(queryResult, "getColumns") || [],
@@ -13,4 +14,8 @@ export default function getQueryResultData(queryResult) {
     runtime: invoke(queryResult, "getRuntime") || null,
     metadata: get(queryResult, "query_result.data.metadata", {}),
   };
+}
+
+export function useQueryResultData(queryResult) {
+  return useMemo(() => getQueryResultData(queryResult), [queryResult]);
 }

--- a/client/app/lib/useQueryResultData.js
+++ b/client/app/lib/useQueryResultData.js
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { get, invoke } from "lodash";
 
-export function getQueryResultData(queryResult) {
+function getQueryResultData(queryResult, queryResultStatus = null) {
   return {
-    status: invoke(queryResult, "getStatus") || null,
+    status: queryResultStatus || invoke(queryResult, "getStatus") || null,
     columns: invoke(queryResult, "getColumns") || [],
     rows: invoke(queryResult, "getData") || [],
     filters: invoke(queryResult, "getFilters") || [],
@@ -16,6 +16,8 @@ export function getQueryResultData(queryResult) {
   };
 }
 
-export function useQueryResultData(queryResult) {
-  return useMemo(() => getQueryResultData(queryResult), [queryResult]);
+export default function useQueryResultData(queryResult) {
+  // make sure it re-executes when queryResult status changes
+  const queryResultStatus = invoke(queryResult, "getStatus");
+  return useMemo(() => getQueryResultData(queryResult, queryResultStatus), [queryResult, queryResultStatus]);
 }

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -27,7 +27,7 @@ import useQuery from "./hooks/useQuery";
 import useVisualizationTabHandler from "./hooks/useVisualizationTabHandler";
 import useAutocompleteFlags from "./hooks/useAutocompleteFlags";
 import useQueryExecute from "./hooks/useQueryExecute";
-import { useQueryResultData } from "@/lib/getQueryResultData";
+import useQueryResultData from "@/lib/useQueryResultData";
 import useQueryDataSources from "./hooks/useQueryDataSources";
 import useDataSourceSchema from "./hooks/useDataSourceSchema";
 import useQueryFlags from "./hooks/useQueryFlags";

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -27,7 +27,7 @@ import useQuery from "./hooks/useQuery";
 import useVisualizationTabHandler from "./hooks/useVisualizationTabHandler";
 import useAutocompleteFlags from "./hooks/useAutocompleteFlags";
 import useQueryExecute from "./hooks/useQueryExecute";
-import getQueryResultData from "@/lib/getQueryResultData";
+import { useQueryResultData } from "@/lib/getQueryResultData";
 import useQueryDataSources from "./hooks/useQueryDataSources";
 import useDataSourceSchema from "./hooks/useDataSourceSchema";
 import useQueryFlags from "./hooks/useQueryFlags";
@@ -73,7 +73,7 @@ function QuerySource(props) {
     loadedInitialResults,
   } = useQueryExecute(query);
 
-  const queryResultData = getQueryResultData(queryResult);
+  const queryResultData = useQueryResultData(queryResult);
 
   const editorRef = useRef(null);
   const [autocompleteAvailable, autocompleteEnabled, toggleAutocomplete] = useAutocompleteFlags(schema);

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -11,7 +11,7 @@ import Parameters from "@/components/Parameters";
 
 import DataSource from "@/services/data-source";
 import { ExecutionStatus } from "@/services/query-result";
-import { useQueryResultData } from "@/lib/getQueryResultData";
+import useQueryResultData from "@/lib/useQueryResultData";
 
 import QueryPageHeader from "./components/QueryPageHeader";
 import QueryVisualizationTabs from "./components/QueryVisualizationTabs";

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -11,7 +11,7 @@ import Parameters from "@/components/Parameters";
 
 import DataSource from "@/services/data-source";
 import { ExecutionStatus } from "@/services/query-result";
-import getQueryResultData from "@/lib/getQueryResultData";
+import { useQueryResultData } from "@/lib/getQueryResultData";
 
 import QueryPageHeader from "./components/QueryPageHeader";
 import QueryVisualizationTabs from "./components/QueryVisualizationTabs";
@@ -56,7 +56,7 @@ function QueryView(props) {
     updatedAt,
   } = useQueryExecute(query);
 
-  const queryResultData = getQueryResultData(queryResult);
+  const queryResultData = useQueryResultData(queryResult);
 
   const updateQueryDescription = useUpdateQueryDescription(query, setQuery);
   const editSchedule = useEditScheduleDialog(query, setQuery);

--- a/client/app/pages/queries/components/QueryExecutionMetadata.jsx
+++ b/client/app/pages/queries/components/QueryExecutionMetadata.jsx
@@ -5,7 +5,7 @@ import useAddToDashboardDialog from "../hooks/useAddToDashboardDialog";
 import useEmbedDialog from "../hooks/useEmbedDialog";
 import QueryControlDropdown from "@/components/EditVisualizationButton/QueryControlDropdown";
 import EditVisualizationButton from "@/components/EditVisualizationButton";
-import { useQueryResultData } from "@/lib/getQueryResultData";
+import useQueryResultData from "@/lib/useQueryResultData";
 import { durationHumanize, pluralize, prettySize } from "@/lib/utils";
 
 import "./QueryExecutionMetadata.less";

--- a/client/app/pages/queries/components/QueryExecutionMetadata.jsx
+++ b/client/app/pages/queries/components/QueryExecutionMetadata.jsx
@@ -5,7 +5,7 @@ import useAddToDashboardDialog from "../hooks/useAddToDashboardDialog";
 import useEmbedDialog from "../hooks/useEmbedDialog";
 import QueryControlDropdown from "@/components/EditVisualizationButton/QueryControlDropdown";
 import EditVisualizationButton from "@/components/EditVisualizationButton";
-import getQueryResultData from "@/lib/getQueryResultData";
+import { useQueryResultData } from "@/lib/getQueryResultData";
 import { durationHumanize, pluralize, prettySize } from "@/lib/utils";
 
 import "./QueryExecutionMetadata.less";
@@ -19,7 +19,7 @@ export default function QueryExecutionMetadata({
   onEditVisualization,
   extraActions,
 }) {
-  const queryResultData = getQueryResultData(queryResult);
+  const queryResultData = useQueryResultData(queryResult);
   const openAddToDashboardDialog = useAddToDashboardDialog(query);
   const openEmbedDialog = useEmbedDialog(query);
   return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
Reported by @kravets-levko, in a few places we use the `getQueryResultData` without `useMemo`. The problem is that it recreates the object every time the component re-renders, unnecessarily updating everything that depends on this data.

In my understanding the `queryResult` object shouldn't be mutated, so _ideally_ this shouldn't cause any issues. I want to confirm from Cypress + some manual tests, but from code it seemed ok.

## Related Tickets & Documents
#4915 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--