### PR TITLE
Fork button disabled on View Query page for non-admin users

### DIFF
--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -9,7 +9,6 @@ import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSess
 import EditInPlace from "@/components/EditInPlace";
 import Parameters from "@/components/Parameters";
 
-import DataSource from "@/services/data-source";
 import { ExecutionStatus } from "@/services/query-result";
 import useQueryResultData from "@/lib/useQueryResultData";
 
@@ -23,6 +22,7 @@ import QueryExecutionMetadata from "./components/QueryExecutionMetadata";
 
 import useVisualizationTabHandler from "./hooks/useVisualizationTabHandler";
 import useQueryExecute from "./hooks/useQueryExecute";
+import useQueryDataSources from "./hooks/useQueryDataSources";
 import useUpdateQueryDescription from "./hooks/useUpdateQueryDescription";
 import useQueryFlags from "./hooks/useQueryFlags";
 import useQueryParameters from "./hooks/useQueryParameters";
@@ -35,7 +35,7 @@ import "./QueryView.less";
 
 function QueryView(props) {
   const [query, setQuery] = useState(props.query);
-  const [dataSource, setDataSource] = useState();
+  const { dataSource } = useQueryDataSources(query);
   const queryFlags = useQueryFlags(query, dataSource);
   const [parameters, areParametersDirty, updateParametersDirtyFlag] = useQueryParameters(query);
   const [selectedVisualization, setSelectedVisualization] = useVisualizationTabHandler(query.visualizations);
@@ -80,10 +80,6 @@ function QueryView(props) {
   useEffect(() => {
     document.title = query.name;
   }, [query.name]);
-
-  useEffect(() => {
-    DataSource.get({ id: query.data_source_id }).then(setDataSource);
-  }, [query.data_source_id]);
 
   return (
     <div


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

In Angular version it worked because both View and Source pages shared a lot of code and both were loading all datasources. When migrating to React, we decided to optimize View page and load only single data source, but in this case non-admin users cannot access that API. This fix changes things to work as in Angular version (load all data sources and pick only one). While I think its better to update API, this fix shouldn't cause problems because 1) it already worked this way for a long time; 2) dashboard list returns really small amount of data.

See also a discussion in getredash/redash#4923

## Related Tickets & Documents

Fixes getredash/redash#4923
