### PR TITLE
Add timeout configuration to gunicorn workers

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -32,7 +32,7 @@ server() {
   # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
   MAX_REQUESTS=${MAX_REQUESTS:-1000}
   MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} --timeout ${REDASH_WEB_WORKERS_TIMEOUT:-30} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER
 }
 
 create_db() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Currently, we are not able to configure the timeout of gunicorn worker when running Redash with docker. With this PR, an environment variable `REDASH_WEB_WORKERS_TIMEOUT` can be added into `env` file to configure the timeout of gunicorn.

## Related Tickets & Documents
