### PR TITLE
Fix: auto hide Plotly Modebar

### DIFF
--- a/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
+++ b/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
@@ -36,7 +36,7 @@ export default function PlotlyChart({ options, data }) {
           displaylogo: false,
         };
         
-        if (!visualizationsSettings.hidePlotlyModeBar) {
+        if (visualizationsSettings.hidePlotlyModeBar) {
           plotlyOptions.displayModeBar = false;
         }
 

--- a/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
+++ b/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
@@ -34,8 +34,11 @@ export default function PlotlyChart({ options, data }) {
         const plotlyOptions = {
           showLink: false,
           displaylogo: false,
-          displayModeBar: !visualizationsSettings.hidePlotlyModeBar,
         };
+        
+        if (!visualizationsSettings.hidePlotlyModeBar) {
+          plotlyOptions.displayModeBar = false;
+        }
 
         const chartData = getChartData(data.rows, options);
         const plotlyData = prepareData(chartData, options);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

#4644 introduced a change to previous behavior: if the modebar is enabled it will always be visible instead of autohiding as before. This PR reverts the behavior to the old one.