### PR TITLE
Plotly Charts: use .legend to determine legends size

### DIFF
--- a/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
+++ b/viz-lib/src/visualizations/chart/Renderer/PlotlyChart.jsx
@@ -35,7 +35,7 @@ export default function PlotlyChart({ options, data }) {
           showLink: false,
           displaylogo: false,
         };
-        
+
         if (visualizationsSettings.hidePlotlyModeBar) {
           plotlyOptions.displayModeBar = false;
         }

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -117,5 +117,7 @@ export default function applyLayoutFixes(plotlyElement, layout, options, updateP
         break;
       // no default
     }
+  } else {
+    updatePlot(plotlyElement, pick(layout, ["width", "height"]));
   }
 }

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -76,18 +76,8 @@ function placeLegendBelowPlot(plotlyElement, layout, updatePlot) {
     if (legend) {
       // compute real height of legend - items may be split into few columnns,
       // also scrollbar may be shown
-      const bounds = reduce(
-        legend.querySelectorAll(".traces"),
-        (result, node) => {
-          const b = node.getBoundingClientRect();
-          result = result || b;
-          return {
-            top: Math.min(result.top, b.top),
-            bottom: Math.max(result.bottom, b.bottom),
-          };
-        },
-        null
-      );
+      const bounds = legend.querySelector(".bg").getBoundingClientRect();
+
       // here we have two values:
       // 1. height of plot container excluding height of legend items;
       //    it may be any value between 0 and plot container's height;

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -1,25 +1,6 @@
-import { find, pick, reduce } from "lodash";
+import { pick } from "lodash";
 
-function fixLegendContainer(plotlyElement) {
-  const legend = plotlyElement.querySelector(".legend");
-  if (legend) {
-    let node = legend.parentNode;
-    while (node) {
-      if (node.tagName.toLowerCase() === "svg") {
-        node.style.overflow = "visible";
-        break;
-      }
-      node = node.parentNode;
-    }
-  }
-}
-
-function placeLegendNextToPlot(plotlyElement, layout, updatePlot) {
-  const transformName = find(
-    ["transform", "WebkitTransform", "MozTransform", "MsTransform", "OTransform"],
-    prop => prop in plotlyElement.style
-  );
-
+function placeLegendNextToPlot(layout) {
   layout.legend = {
     orientation: "v",
     // vertical legend will be rendered properly, so just place it to the right
@@ -29,75 +10,20 @@ function placeLegendNextToPlot(plotlyElement, layout, updatePlot) {
     xanchor: "left",
     yanchor: "top",
   };
-
-  const legend = plotlyElement.querySelector(".legend");
-  if (legend) {
-    legend.style[transformName] = null;
-  }
-
-  updatePlot(plotlyElement, pick(layout, ["width", "height", "legend"]));
 }
 
-function placeLegendBelowPlot(plotlyElement, layout, updatePlot) {
-  const transformName = find(
-    ["transform", "WebkitTransform", "MozTransform", "MsTransform", "OTransform"],
-    prop => prop in plotlyElement.style
-  );
-
-  // Save current `layout.height` value because `updatePlot().then(...)` handler may be called multiple
-  // times within single update, and since the handler mutates `layout` object - it may lead to bugs
-  const layoutHeight = layout.height;
-
-  // change legend orientation to horizontal; plotly has a bug with this
-  // legend alignment - it does not preserve enough space under the plot;
-  // so we'll hack this: update plot (it will re-render legend), compute
-  // legend height, reduce plot size by legend height (but not less than
-  // half of plot container's height - legend will have max height equal to
-  // plot height), re-render plot again and offset legend to the space under
-  // the plot.
-  // Related issue: https://github.com/plotly/plotly.js/issues/1199
+function placeLegendBelowPlot(layout) {
   layout.legend = {
     orientation: "h",
-    // locate legend inside of plot area - otherwise plotly will preserve
-    // some amount of space under the plot; also this will limit legend height
-    // to plot's height
-    y: 0,
-    x: 0,
-    xanchor: "left",
-    yanchor: "bottom",
+    y: -0.2,
   };
-
-  // set `overflow: visible` to svg containing legend because later we will
-  // position legend outside of it
-  fixLegendContainer(plotlyElement);
-
-  updatePlot(plotlyElement, pick(layout, ["width", "height", "legend"])).then(() => {
-    const legend = plotlyElement.querySelector(".legend"); // eslint-disable-line no-shadow
-    if (legend) {
-      // compute real height of legend - items may be split into few columnns,
-      // also scrollbar may be shown
-      const bounds = legend.querySelector(".bg").getBoundingClientRect();
-
-      // here we have two values:
-      // 1. height of plot container excluding height of legend items;
-      //    it may be any value between 0 and plot container's height;
-      // 2. half of plot containers height. Legend cannot be larger than
-      //    plot; if legend is too large, plotly will reduce it's height and
-      //    show a scrollbar; in this case, height of plot === height of legend,
-      //    so we can split container's height half by half between them.
-      layout.height = Math.floor(Math.max(layoutHeight / 2, layoutHeight - (bounds.bottom - bounds.top)));
-      // offset the legend
-      legend.style[transformName] = "translate(0, " + layout.height + "px)";
-      updatePlot(plotlyElement, pick(layout, ["height"]));
-    }
-  });
 }
 
-function placeLegendAuto(plotlyElement, layout, updatePlot) {
+function placeLegendAuto(layout) {
   if (layout.width <= 600) {
-    placeLegendBelowPlot(plotlyElement, layout, updatePlot);
+    placeLegendBelowPlot(layout);
   } else {
-    placeLegendNextToPlot(plotlyElement, layout, updatePlot);
+    placeLegendNextToPlot(layout);
   }
 }
 
@@ -110,12 +36,14 @@ export default function applyLayoutFixes(plotlyElement, layout, options, updateP
   if (options.legend.enabled) {
     switch (options.legend.placement) {
       case "auto":
-        placeLegendAuto(plotlyElement, layout, updatePlot);
+        placeLegendAuto(layout);
         break;
       case "below":
-        placeLegendBelowPlot(plotlyElement, layout, updatePlot);
+        placeLegendBelowPlot(layout);
         break;
       // no default
     }
   }
+
+  updatePlot(plotlyElement, pick(layout, ["width", "height", "legend"]));
 }

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -1,6 +1,25 @@
-import { pick } from "lodash";
+import { find, pick, reduce } from "lodash";
 
-function placeLegendNextToPlot(layout) {
+function fixLegendContainer(plotlyElement) {
+  const legend = plotlyElement.querySelector(".legend");
+  if (legend) {
+    let node = legend.parentNode;
+    while (node) {
+      if (node.tagName.toLowerCase() === "svg") {
+        node.style.overflow = "visible";
+        break;
+      }
+      node = node.parentNode;
+    }
+  }
+}
+
+function placeLegendNextToPlot(plotlyElement, layout, updatePlot) {
+  const transformName = find(
+    ["transform", "WebkitTransform", "MozTransform", "MsTransform", "OTransform"],
+    prop => prop in plotlyElement.style
+  );
+
   layout.legend = {
     orientation: "v",
     // vertical legend will be rendered properly, so just place it to the right
@@ -10,20 +29,75 @@ function placeLegendNextToPlot(layout) {
     xanchor: "left",
     yanchor: "top",
   };
+
+  const legend = plotlyElement.querySelector(".legend");
+  if (legend) {
+    legend.style[transformName] = null;
+  }
+
+  updatePlot(plotlyElement, pick(layout, ["width", "height", "legend"]));
 }
 
-function placeLegendBelowPlot(layout) {
+function placeLegendBelowPlot(plotlyElement, layout, updatePlot) {
+  const transformName = find(
+    ["transform", "WebkitTransform", "MozTransform", "MsTransform", "OTransform"],
+    prop => prop in plotlyElement.style
+  );
+
+  // Save current `layout.height` value because `updatePlot().then(...)` handler may be called multiple
+  // times within single update, and since the handler mutates `layout` object - it may lead to bugs
+  const layoutHeight = layout.height;
+
+  // change legend orientation to horizontal; plotly has a bug with this
+  // legend alignment - it does not preserve enough space under the plot;
+  // so we'll hack this: update plot (it will re-render legend), compute
+  // legend height, reduce plot size by legend height (but not less than
+  // half of plot container's height - legend will have max height equal to
+  // plot height), re-render plot again and offset legend to the space under
+  // the plot.
+  // Related issue: https://github.com/plotly/plotly.js/issues/1199
   layout.legend = {
     orientation: "h",
-    y: -0.2,
+    // locate legend inside of plot area - otherwise plotly will preserve
+    // some amount of space under the plot; also this will limit legend height
+    // to plot's height
+    y: 0,
+    x: 0,
+    xanchor: "left",
+    yanchor: "bottom",
   };
+
+  // set `overflow: visible` to svg containing legend because later we will
+  // position legend outside of it
+  fixLegendContainer(plotlyElement);
+
+  updatePlot(plotlyElement, pick(layout, ["width", "height", "legend"])).then(() => {
+    const legend = plotlyElement.querySelector(".legend"); // eslint-disable-line no-shadow
+    if (legend) {
+      // compute real height of legend - items may be split into few columnns,
+      // also scrollbar may be shown
+      const bounds = legend.querySelector(".bg").getBoundingClientRect();
+
+      // here we have two values:
+      // 1. height of plot container excluding height of legend items;
+      //    it may be any value between 0 and plot container's height;
+      // 2. half of plot containers height. Legend cannot be larger than
+      //    plot; if legend is too large, plotly will reduce it's height and
+      //    show a scrollbar; in this case, height of plot === height of legend,
+      //    so we can split container's height half by half between them.
+      layout.height = Math.floor(Math.max(layoutHeight / 2, layoutHeight - (bounds.bottom - bounds.top)));
+      // offset the legend
+      legend.style[transformName] = "translate(0, " + layout.height + "px)";
+      updatePlot(plotlyElement, pick(layout, ["height"]));
+    }
+  });
 }
 
-function placeLegendAuto(layout) {
+function placeLegendAuto(plotlyElement, layout, updatePlot) {
   if (layout.width <= 600) {
-    placeLegendBelowPlot(layout);
+    placeLegendBelowPlot(plotlyElement, layout, updatePlot);
   } else {
-    placeLegendNextToPlot(layout);
+    placeLegendNextToPlot(plotlyElement, layout, updatePlot);
   }
 }
 
@@ -36,14 +110,12 @@ export default function applyLayoutFixes(plotlyElement, layout, options, updateP
   if (options.legend.enabled) {
     switch (options.legend.placement) {
       case "auto":
-        placeLegendAuto(layout);
+        placeLegendAuto(plotlyElement, layout, updatePlot);
         break;
       case "below":
-        placeLegendBelowPlot(layout);
+        placeLegendBelowPlot(plotlyElement, layout, updatePlot);
         break;
       // no default
     }
   }
-
-  updatePlot(plotlyElement, pick(layout, ["width", "height", "legend"]));
 }

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -76,7 +76,7 @@ function placeLegendBelowPlot(plotlyElement, layout, updatePlot) {
     if (legend) {
       // compute real height of legend - items may be split into few columnns,
       // also scrollbar may be shown
-      const bounds = legend.querySelector(".bg").getBoundingClientRect();
+      const bounds = legend.getBoundingClientRect();
 
       // here we have two values:
       // 1. height of plot container excluding height of legend items;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
**The bug** ([Preview](https://redash-preview.netlify.app/queries/373#647))

<img width="541" alt="Screen Shot 2020-06-02 at 16 10 07" src="https://user-images.githubusercontent.com/3356951/83559832-9a3a4000-a4eb-11ea-81c6-44c134067031.png">

Currently Charts that have legends moved to the bottom can "cut" part of their text.

**With this fix** ([Preview](https://deploy-preview-4935--redash-preview.netlify.app/queries/373#647))

<img width="465" alt="Screen Shot 2020-06-02 at 16 14 17" src="https://user-images.githubusercontent.com/3356951/83560161-277d9480-a4ec-11ea-8f43-23c91b17f8d0.png">


## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
See description ☝️ 