### PR TITLE
Update requirements_bundles versions and comment

### DIFF
--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # Make a directory for extensions and set it as an environment variable
 # to be picked up by webpack.
-extensions_relative_path = Path('client', 'app', 'extensions')
+extensions_relative_path = Path("client", "app", "extensions")
 extensions_directory = Path(__file__).parent.parent / extensions_relative_path
 
 if not extensions_directory.exists():
@@ -94,9 +94,9 @@ def load_bundles():
 
 bundles = load_bundles().items()
 if bundles:
-    print('Number of extension bundles found: {}'.format(len(bundles)))
+    print("Number of extension bundles found: {}".format(len(bundles)))
 else:
-    print('No extension bundles found.')
+    print("No extension bundles found.")
 
 for bundle_name, paths in bundles:
     # Shortcut in case not paths were found for the bundle

--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,5 +4,5 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata>=0.19  # remove when on 3.8
-importlib_resources==1.0.2  # remove when on 3.7
+importlib-metadata>=1.6  # remove when on 3.8
+importlib_resources==1.5  # remove when on 3.9


### PR DESCRIPTION
- [x] Refactor

## Description

The `importlib_resources` library is now tracking Python 3.9. The version and comment have been updated. This also updates the `importlib_metadata` version.

Use black formatting on bin/bundle-extensions.