### PR TITLE
Fix wrong Sentry exception messages on invalid parameters

### DIFF
--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -130,11 +130,7 @@ class ParameterizedQuery(object):
             key for (key, value) in parameters.items() if not self._valid(key, value)
         ]
         if invalid_parameter_names:
-            raise InvalidParameterError(
-                "The following parameter values are incompatible with their definitions: {}".format(
-                    ", ".join(invalid_parameter_names)
-                )
-            )
+            raise InvalidParameterError(invalid_parameter_names)
         else:
             self.parameters.update(parameters)
             self.query = mustache_render(
@@ -201,7 +197,12 @@ class ParameterizedQuery(object):
 
 
 class InvalidParameterError(Exception):
-    pass
+    def __init__(self, parameters):
+        parameter_names = ", ".join(parameters)
+        message = "The following parameter values are incompatible with their definitions: {}".format(
+            parameter_names
+        )
+        super(InvalidParameterError, self).__init__(message)
 
 
 class QueryDetachedFromDataSourceError(Exception):

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -130,7 +130,11 @@ class ParameterizedQuery(object):
             key for (key, value) in parameters.items() if not self._valid(key, value)
         ]
         if invalid_parameter_names:
-            raise InvalidParameterError(invalid_parameter_names)
+            raise InvalidParameterError(
+                "The following parameter values are incompatible with their definitions: {}".format(
+                    ", ".join(invalid_parameter_names)
+                )
+            )
         else:
             self.parameters.update(parameters)
             self.query = mustache_render(
@@ -197,12 +201,7 @@ class ParameterizedQuery(object):
 
 
 class InvalidParameterError(Exception):
-    def __init__(self, parameters):
-        parameter_names = ", ".join(parameters)
-        message = "The following parameter values are incompatible with their definitions: {}".format(
-            parameter_names
-        )
-        super(InvalidParameterError, self).__init__(message)
+    pass
 
 
 class QueryDetachedFromDataSourceError(Exception):

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -71,6 +71,10 @@ def _apply_default_parameters(query):
         return query.query_text
 
 
+class RefreshQueriesError(Exception):
+    pass
+
+
 def refresh_queries():
     logger.info("Refreshing queries...")
     enqueued = []
@@ -90,7 +94,8 @@ def refresh_queries():
         except Exception as e:
             message = "Could not enqueue query %d due to %s" % (query.id, repr(e))
             logging.info(message)
-            sentry.capture_exception(type(e)(message).with_traceback(e.__traceback__))
+            error = RefreshQueriesError(message).with_traceback(e.__traceback__)
+            sentry.capture_exception(error)
 
     status = {
         "outdated_queries_count": len(enqueued),
@@ -196,4 +201,3 @@ def refresh_schemas():
         u"task=refresh_schemas state=finish total_runtime=%.2f",
         time.time() - global_start_time,
     )
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Following #4780 `refresh_queries` reports any queries it fails to refresh and provides the underlying exception details and stack trace. For `InvalidParameterError`, these would result in this:

```
The following parameter values are incompatible with their definitions: C, o, u, l, d,  , n, o, t,  , e, n, q, u, e, u, e,  , q, u, e, r, y,  , 1, 2, 3,  , d, u, e,  , t, o,  , I, n, v, a, l, i, d, P, a, r, a, m, e, t, e, r, E, r, r, o, r, (, ', T, h, e,  , f, o, l, l, o, w, i, n, g,  , p, a, r, a, m, e, t, e, r,  , v, a, l, u, e, s,  , a, r, e,  , i, n, c, o, m, p, a, t, i, b, l, e,  , w, i, t, h,  , t, h, e, i, r,  , d, e, f, i, n, i, t, i, o, n, s, :,  , O, h, , N, o, ', )
```

This is a result of custom message construction done in `InvalidParameterError`'s initializer, which kinda makes no sense to me right now.

## Related Tickets & Documents
#4780 