### PR TITLE
Make sure queries have options and parameters

### DIFF
--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -5,6 +5,7 @@ import { axios } from "@/services/axios";
 import {
   zipObject,
   isEmpty,
+  isArray,
   map,
   filter,
   includes,
@@ -45,6 +46,14 @@ function collectParams(parts) {
 export class Query {
   constructor(query) {
     extend(this, query);
+
+    if (!has(this, "options")) {
+      this.options = {};
+    }
+
+    if (!isArray(this.options.parameters)) {
+      this.options.parameters = [];
+    }
   }
 
   isNew() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
**Bug**
Queries without `parameters` in their `options` break Public Dashboards.

Example: [Dashboard](http://redash-preview.netlify.com/dashboard/test-publish)/[Public Dashboard](http://redash-preview.netlify.com/public/dashboards/1z3XwLDXGVtFR8IUGfXOjegGQGTAoKQn48A4lliM?org_slug=default)

**Cause**

It's straightforward to understand that we rely on that Array for the Parameters functions to work. However, two questions intrigued me: "Why it fails only with Public Dashboards?" and  "Why it started happening only now?"

So, the answers:
Previously what "guaranteed" that queries would have the parameters array before executing functions was this line:
https://github.com/getredash/redash/blob/3df1a86d66942ddf969a3c9f097883f9e9fc8eb1/client/app/services/query.js#L240

On #4736 we removed the check for an existing query text that, specifically for Public Dashboards (don't have a query text), would also prevent parameters from being updated. Moving the line I mentioned a few lines above would also fix the problem, but I preferred to make sure queries had that from the constructor.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--