### PR TITLE
Refine DynamicComponent API

### DIFF
--- a/client/app/components/BeaconConsent.jsx
+++ b/client/app/components/BeaconConsent.jsx
@@ -37,7 +37,7 @@ function BeaconConsent() {
   };
 
   return (
-    <DynamicComponent name="BeaconConsent">
+    <DynamicComponent.BeaconConsent>
       <div className="m-t-10 tiled">
         <Card
           title={
@@ -71,7 +71,7 @@ function BeaconConsent() {
           </div>
         </Card>
       </div>
-    </DynamicComponent>
+    </DynamicComponent.BeaconConsent>
   );
 }
 

--- a/client/app/components/DynamicComponent.jsx
+++ b/client/app/components/DynamicComponent.jsx
@@ -1,50 +1,65 @@
-import { isFunction, isString } from "lodash";
-import React from "react";
-import PropTypes from "prop-types";
+import { isFunction, each } from "lodash";
+import React, { useState, useEffect } from "react";
 
-const componentsRegistry = new Map();
-const activeInstances = new Set();
+// Introduce new dynamic components here; use `null` for default representation (display children)
+const dynamicComponents = {
+  HomeExtra: null,
+  BeaconConsent: null,
+  BeaconConsentSetting: null,
+  UsersListExtra: null,
+  DataSourcesListExtra: null,
+  CreateDashboardDialogExtra: null,
+  HelpDrawerExtraContent: null,
+};
 
-export function registerComponent(name, component) {
-  if (isString(name) && name !== "") {
-    componentsRegistry.set(name, isFunction(component) ? component : null);
-    // Refresh active DynamicComponent instances which use this component
-    activeInstances.forEach(dynamicComponent => {
-      if (dynamicComponent.props.name === name) {
-        dynamicComponent.forceUpdate();
+// Overriding dynamic components is simple: just assign a value to one of the fields above, e.g.:
+//
+// import DynamicComponent from "@/components/DynamicComponent";
+// DynamicComponent.HomeExtra = CustomHomeExtraComponent;
+
+const updateListeners = new Set();
+
+// Patch components registry: convert each entry to getter + setter
+each(dynamicComponents, (Component, name, target) => {
+  function DynamicComponent({ children, ...props }) {
+    // use state to force update component when underlying component has changed
+    const [RealComponent, setRealComponent] = useState(() => Component);
+
+    // listen for changes and re-render when needed
+    useEffect(() => {
+      function update(changedComponentName) {
+        if (changedComponentName === name) {
+          setRealComponent(() => Component);
+        }
       }
-    });
+
+      updateListeners.add(update);
+      return () => {
+        updateListeners.delete(update);
+      };
+    }, []);
+
+    return RealComponent ? <RealComponent {...props}>{children}</RealComponent> : children;
   }
-}
 
-export function unregisterComponent(name) {
-  registerComponent(name, null);
-}
-
-export default class DynamicComponent extends React.Component {
-  static propTypes = {
-    name: PropTypes.string.isRequired,
-    children: PropTypes.node,
-  };
-
-  static defaultProps = {
+  DynamicComponent.defaultProps = {
     children: null,
   };
 
-  componentDidMount() {
-    activeInstances.add(this);
-  }
+  DynamicComponent.displayName = `DynamicComponent<${name}>`;
 
-  componentWillUnmount() {
-    activeInstances.delete(this);
-  }
+  Object.defineProperty(target, name, {
+    configurable: false,
+    enumerable: true,
+    get: () => DynamicComponent,
+    set: newComponent => {
+      Component = isFunction(newComponent) ? newComponent : null;
+      updateListeners.forEach(fn => fn(name)); // notify mounted components that underlying component has changed
+    },
+  });
+});
 
-  render() {
-    const { name, children, ...props } = this.props;
-    const RealComponent = componentsRegistry.get(name);
-    if (!RealComponent) {
-      return children;
-    }
-    return <RealComponent {...props}>{children}</RealComponent>;
-  }
-}
+// prevent it from adding components not defined explicitly above ^
+Object.freeze(dynamicComponents);
+
+export default dynamicComponents;

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -210,7 +210,7 @@ export default class HelpTrigger extends React.Component {
           </div>
 
           {/* extra content */}
-          <DynamicComponent name="HelpDrawerExtraContent" onLeave={this.closeDrawer} openPageUrl={this.loadIframe} />
+          <DynamicComponent.HelpDrawerExtraContent onLeave={this.closeDrawer} openPageUrl={this.loadIframe} />
         </Drawer>
       </React.Fragment>
     );

--- a/client/app/components/dashboards/CreateDashboardDialog.jsx
+++ b/client/app/components/dashboards/CreateDashboardDialog.jsx
@@ -54,7 +54,7 @@ function CreateDashboardDialog({ dialog }) {
       wrapProps={{
         "data-test": "CreateDashboardDialog",
       }}>
-      <DynamicComponent name="CreateDashboardDialogExtra" disabled={!isCreateDashboardEnabled}>
+      <DynamicComponent.CreateDashboardDialogExtra disabled={!isCreateDashboardEnabled}>
         <Input
           defaultValue={name}
           onChange={handleNameChange}
@@ -63,7 +63,7 @@ function CreateDashboardDialog({ dialog }) {
           disabled={saveInProgress}
           autoFocus
         />
-      </DynamicComponent>
+      </DynamicComponent.CreateDashboardDialogExtra>
     </Modal>
   );
 }

--- a/client/app/pages/data-sources/DataSourcesList.jsx
+++ b/client/app/pages/data-sources/DataSourcesList.jsx
@@ -136,7 +136,7 @@ class DataSourcesList extends React.Component {
             <i className="fa fa-plus m-r-5" />
             New Data Source
           </Button>
-          <DynamicComponent name="DataSourcesListExtra" />
+          <DynamicComponent.DataSourcesListExtra />
         </div>
         {this.state.loading ? <LoadingState className="" /> : this.renderDataSources()}
       </div>

--- a/client/app/pages/home/Home.jsx
+++ b/client/app/pages/home/Home.jsx
@@ -167,7 +167,7 @@ function Home() {
           showInviteStep
           onboardingMode
         />
-        <DynamicComponent name="HomeExtra" />
+        <DynamicComponent.HomeExtra />
         <DashboardAndQueryFavoritesList />
         <BeaconConsent />
       </div>

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -200,7 +200,7 @@ class OrganizationSettings extends React.Component {
             Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
           </Checkbox>
         </Form.Item>
-        <DynamicComponent name="BeaconConsentSetting">
+        <DynamicComponent.BeaconConsentSetting>
           <Form.Item
             label={
               <>
@@ -214,7 +214,7 @@ class OrganizationSettings extends React.Component {
               Help Redash improve by automatically sending anonymous usage data
             </Checkbox>
           </Form.Item>
-        </DynamicComponent>
+        </DynamicComponent.BeaconConsentSetting>
       </React.Fragment>
     );
   }

--- a/client/app/pages/users/UsersList.jsx
+++ b/client/app/pages/users/UsersList.jsx
@@ -197,7 +197,7 @@ class UsersList extends React.Component {
           <i className="fa fa-plus m-r-5" />
           New User
         </Button>
-        <DynamicComponent name="UsersListExtra" />
+        <DynamicComponent.UsersListExtra />
       </div>
     );
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

I had few concerns regarding existing DynamicComponent API: using `name` property for choosing component by key was typo-prone and shadowed `name` prop itself (rest props are passed to underlying component). Using separate function to register components was also not that perfect.

This proposal changes DynamicComponent API to allow direct access to dynamic components by their identifier using dot notation (e.g. `<DynamicComponent.HomeExtra ...>`). ~~All dynamic components should be explicitly defined now, so no any possibility to register arbitrary component or render non-existing component (it will trigger error in console - fail-fast).~~ Also, same way is used for registering (overriding) components: `DynamicComponent.HomeExtra = CustomHomeExtraComponent`