### PR TITLE
Fix Destination not returning custom error message

### DIFF
--- a/client/app/components/ApplicationArea/ErrorMessage.jsx
+++ b/client/app/components/ApplicationArea/ErrorMessage.jsx
@@ -21,7 +21,11 @@ export function getErrorMessage(
   if (isObject(error)) {
     // HTTP errors
     if (error.isAxiosError && isObject(error.response)) {
-      return getErrorMessageByStatus(error.response.status, get(error, "response.data.message", defaultMessage));
+      const errorData = get(error, "response.data", {});
+
+      // handle cases where the message is an object as { "message": msg } or { "error": msg }
+      const errorMessage = errorData.message || errorData.error || defaultMessage;
+      return getErrorMessageByStatus(error.response.status, errorMessage);
     }
     // Router errors
     if (error.status) {

--- a/client/app/components/ApplicationArea/ErrorMessage.jsx
+++ b/client/app/components/ApplicationArea/ErrorMessage.jsx
@@ -25,6 +25,10 @@ export function getErrorMessage(error) {
     if (error.status) {
       return getErrorMessageByStatus(error.status, message);
     }
+    // Other Error instances
+    if (error.message) {
+      return error.message;
+    }
   }
   return message;
 }

--- a/client/app/components/ApplicationArea/ErrorMessage.jsx
+++ b/client/app/components/ApplicationArea/ErrorMessage.jsx
@@ -14,23 +14,25 @@ function getErrorMessageByStatus(status, defaultMessage) {
   }
 }
 
-export function getErrorMessage(error) {
-  const message = "It seems like we encountered an error. Try refreshing this page or contact your administrator.";
+export function getErrorMessage(
+  error,
+  defaultMessage = "It seems like we encountered an error. Try refreshing this page or contact your administrator."
+) {
   if (isObject(error)) {
     // HTTP errors
     if (error.isAxiosError && isObject(error.response)) {
-      return getErrorMessageByStatus(error.response.status, get(error, "response.data.message", message));
+      return getErrorMessageByStatus(error.response.status, get(error, "response.data.message", defaultMessage));
     }
     // Router errors
     if (error.status) {
-      return getErrorMessageByStatus(error.status, message);
+      return getErrorMessageByStatus(error.status, defaultMessage);
     }
     // Other Error instances
     if (error.message) {
       return error.message;
     }
   }
-  return message;
+  return defaultMessage;
 }
 
 export default function ErrorMessage({ error }) {

--- a/client/app/components/CreateSourceDialog.jsx
+++ b/client/app/components/CreateSourceDialog.jsx
@@ -67,7 +67,7 @@ class CreateSourceDialog extends React.Component {
         })
         .catch(error => {
           this.setState({ savingSource: false, currentStep: StepEnum.CONFIGURE_IT });
-          errorCallback(getErrorMessage(error));
+          errorCallback(getErrorMessage(error, "Failed saving."));
         });
     }
   };

--- a/client/app/components/CreateSourceDialog.jsx
+++ b/client/app/components/CreateSourceDialog.jsx
@@ -67,7 +67,7 @@ class CreateSourceDialog extends React.Component {
         })
         .catch(error => {
           this.setState({ savingSource: false, currentStep: StepEnum.CONFIGURE_IT });
-          errorCallback(getErrorMessage(error.message));
+          errorCallback(getErrorMessage(error));
         });
     }
   };

--- a/client/app/pages/destinations/DestinationsList.jsx
+++ b/client/app/pages/destinations/DestinationsList.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Button from "antd/lib/button";
-import { isEmpty, isString, find, get, reject } from "lodash";
+import { isEmpty, reject } from "lodash";
 import Destination, { IMG_ROOT } from "@/services/destination";
 import { policy } from "@/services/policy";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";

--- a/client/app/pages/destinations/DestinationsList.jsx
+++ b/client/app/pages/destinations/DestinationsList.jsx
@@ -57,16 +57,11 @@ class DestinationsList extends React.Component {
     const target = { options: {}, type: selectedType.type };
     helper.updateTargetWithValues(target, values);
 
-    return Destination.create(target)
-      .then(destination => {
-        this.setState({ loading: true });
-        Destination.query().then(destinations => this.setState({ destinations, loading: false }));
-        return destination;
-      })
-      .catch(error => {
-        const message = find([get(error, "response.data.message"), get(error, "message"), "Failed saving."], isString);
-        return Promise.reject(new Error(message));
-      });
+    return Destination.create(target).then(destination => {
+      this.setState({ loading: true });
+      Destination.query().then(destinations => this.setState({ destinations, loading: false }));
+      return destination;
+    });
   };
 
   showCreateSourceDialog = () => {

--- a/client/cypress/integration/destination/create_destination_spec.js
+++ b/client/cypress/integration/destination/create_destination_spec.js
@@ -1,10 +1,12 @@
+import { createDestination } from "../../support/redash-api";
+
 describe("Create Destination", () => {
   beforeEach(() => {
     cy.login();
-    cy.visit("/destinations/new");
   });
 
   it("renders the page and takes a screenshot", function() {
+    cy.visit("/destinations/new");
     cy.server();
     cy.route("api/destinations/types").as("DestinationTypesRequest");
 
@@ -20,5 +22,21 @@ describe("Create Destination", () => {
     cy.getByTestId("CreateSourceDialog").should("contain", "Email");
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.percySnapshot("Create Destination - Types");
+  });
+
+  it("shows a custom error message when destination name is already taken", () => {
+    createDestination("Slack Destination", "slack").then(() => {
+      cy.visit("/destinations/new");
+
+      cy.getByTestId("SearchSource").type("Slack");
+      cy.getByTestId("CreateSourceDialog")
+        .contains("Slack")
+        .click();
+
+      cy.getByTestId("Name").type("Slack Destination");
+      cy.getByTestId("CreateSourceButton").click();
+
+      cy.contains("Alert Destination with the name Slack Destination already exists.");
+    });
   });
 });

--- a/client/cypress/support/redash-api/index.js
+++ b/client/cypress/support/redash-api/index.js
@@ -130,6 +130,15 @@ export function createUser({ name, email, password }) {
     });
 }
 
+export function createDestination(name, type, options = {}) {
+  return cy.request({
+    method: "POST",
+    url: "api/destinations",
+    body: { name, type, options },
+    failOnStatusCode: false,
+  });
+}
+
 export function getDestinations() {
   return cy.request("GET", "api/destinations").then(({ body }) => body);
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
**Bug**
Creating a destination with an existing name wouldn't return its custom message.

**Solution**
Just returned the full error, so it's handled by `getErrorMessage` later.

Extra: Updated `getErrorMessage` to allow `new Error("Custom message")` that we already use along the way.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--