### PR TITLE
Avoid purging operational queues

### DIFF
--- a/redash/worker.py
+++ b/redash/worker.py
@@ -17,13 +17,16 @@ from redash import (
 from redash.tasks.worker import Queue as RedashQueue
 
 
-default_queues = ["scheduled_queries", "queries", "periodic", "emails", "default", "schemas"]
+default_operational_queues = ["periodic", "emails", "default", "schemas"]
+default_query_queues = ["scheduled_queries", "queries"]
+default_queues = default_operational_queues + default_query_queues
 
 
 class StatsdRecordingJobDecorator(rq_job):  # noqa
     """
     RQ Job Decorator mixin that uses our Queue class to ensure metrics are accurately incremented in Statsd
     """
+
     queue_class = RedashQueue
 
 

--- a/redash/worker.py
+++ b/redash/worker.py
@@ -17,8 +17,8 @@ from redash import (
 from redash.tasks.worker import Queue as RedashQueue
 
 
-default_operational_queues = ["periodic", "emails", "default", "schemas"]
-default_query_queues = ["scheduled_queries", "queries"]
+default_operational_queues = ["periodic", "emails", "default"]
+default_query_queues = ["scheduled_queries", "queries", "schemas"]
 default_queues = default_operational_queues + default_query_queues
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The `purge_failed_jobs` job helps keep Redis memory consumption low by purging jobs that failed over a week ago. The bulk of these jobs are due to query execution failures.

However, the job purges _all_ queues, including "operational" queues (such as the `periodic` queue) which could affect system availability. This PR will force `purge_failed_jobs` to skip operational queues and handle query execution queues only.