### PR TITLE
Navbar: show correct settings link for non-admin users

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -1,10 +1,12 @@
+import { first } from "lodash";
 import React, { useState } from "react";
 import Button from "antd/lib/button";
 import Menu from "antd/lib/menu";
 import Icon from "antd/lib/icon";
 import HelpTrigger from "@/components/HelpTrigger";
-import { Auth, currentUser } from "@/services/auth";
 import CreateDashboardDialog from "@/components/dashboards/CreateDashboardDialog";
+import { Auth, currentUser } from "@/services/auth";
+import settingsMenu from "@/services/settingsMenu";
 import logoUrl from "@/assets/images/redash_icon_small.png";
 
 import VersionInfo from "./VersionInfo";
@@ -25,6 +27,8 @@ function NavbarSection({ inlineCollapsed, children, ...props }) {
 
 export default function DesktopNavbar() {
   const [collapsed, setCollapsed] = useState(true);
+
+  const firstSettingsTab = first(settingsMenu.getAvailableItems());
 
   return (
     <div className="desktop-navbar">
@@ -106,9 +110,9 @@ export default function DesktopNavbar() {
             <span>Help</span>
           </HelpTrigger>
         </Menu.Item>
-        {currentUser.isAdmin && (
+        {firstSettingsTab && (
           <Menu.Item key="settings">
-            <a href="data_sources">
+            <a href={firstSettingsTab.path}>
               <Icon type="setting" />
               <span>Settings</span>
             </a>

--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -112,7 +112,7 @@ export default function DesktopNavbar() {
         </Menu.Item>
         {firstSettingsTab && (
           <Menu.Item key="settings">
-            <a href={firstSettingsTab.path}>
+            <a href={firstSettingsTab.path} data-test="SettingsLink">
               <Icon type="setting" />
               <span>Settings</span>
             </a>

--- a/client/app/components/ApplicationArea/ApplicationLayout/MobileNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/MobileNavbar.jsx
@@ -1,15 +1,19 @@
+import { first } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
-import logoUrl from "@/assets/images/redash_icon_small.png";
+import Button from "antd/lib/button";
+import Icon from "antd/lib/icon";
 import Dropdown from "antd/lib/dropdown";
 import Menu from "antd/lib/menu";
 import { Auth, currentUser } from "@/services/auth";
-import Button from "antd/lib/button";
-import Icon from "antd/lib/icon";
+import settingsMenu from "@/services/settingsMenu";
+import logoUrl from "@/assets/images/redash_icon_small.png";
 
 import "./MobileNavbar.less";
 
 export default function MobileNavbar({ getPopupContainer }) {
+  const firstSettingsTab = first(settingsMenu.getAvailableItems());
+
   return (
     <div className="mobile-navbar">
       <div className="mobile-navbar-logo">
@@ -43,9 +47,9 @@ export default function MobileNavbar({ getPopupContainer }) {
                 <a href="users/me">Edit Profile</a>
               </Menu.Item>
               <Menu.Divider />
-              {currentUser.isAdmin && (
+              {firstSettingsTab && (
                 <Menu.Item key="settings">
-                  <a href="data_sources">Settings</a>
+                  <a href={firstSettingsTab.path}>Settings</a>
                 </Menu.Item>
               )}
               {currentUser.hasPermission("super_admin") && (

--- a/client/app/components/SettingsWrapper.jsx
+++ b/client/app/components/SettingsWrapper.jsx
@@ -17,15 +17,13 @@ function wrapSettingsTab(options, WrappedComponent) {
           <PageHeader title="Settings" />
           <div className="bg-white tiled">
             <Menu selectedKeys={[activeItem && activeItem.title]} selectable={false} mode="horizontal">
-              {settingsMenu.items
-                .filter(item => item.isAvailable())
-                .map(item => (
-                  <Menu.Item key={item.title}>
-                    <a href={item.path} data-test="SettingsScreenItem">
-                      {item.title}
-                    </a>
-                  </Menu.Item>
-                ))}
+              {settingsMenu.getAvailableItems().map(item => (
+                <Menu.Item key={item.title}>
+                  <a href={item.path} data-test="SettingsScreenItem">
+                    {item.title}
+                  </a>
+                </Menu.Item>
+              ))}
             </Menu>
             <div className="p-15">
               <div>

--- a/client/app/services/settingsMenu.js
+++ b/client/app/services/settingsMenu.js
@@ -1,4 +1,4 @@
-import { isFunction, extend, omit, sortBy, find } from "lodash";
+import { isFunction, extend, omit, sortBy, find, filter } from "lodash";
 import { stripBase } from "@/components/ApplicationArea/Router";
 import { currentUser } from "@/services/auth";
 
@@ -27,6 +27,10 @@ class SettingsMenu {
   add(item) {
     this.items.push(new SettingsMenuItem(item));
     this.items = sortBy(this.items, "order");
+  }
+
+  getAvailableItems() {
+    return filter(this.items, item => item.isAvailable());
   }
 
   getActiveItem(path) {

--- a/client/cypress/integration/settings/settings_tabs_spec.js
+++ b/client/cypress/integration/settings/settings_tabs_spec.js
@@ -22,22 +22,38 @@ describe("Settings Tabs", () => {
 
   describe("For admin user", () => {
     beforeEach(() => {
-      cy.logout().then(() => cy.login());
+      cy.logout();
+      cy.login();
+      cy.visit("/");
     });
 
-    it("shows available tabs", () => {
-      cy.visit("/users");
+    it("settings link should lead to Data Sources settings", () => {
+      cy.getByTestId("SettingsLink")
+        .should("exist")
+        .should("have.attr", "href", "data_sources");
+    });
+
+    it("all tabs should be available", () => {
+      cy.getByTestId("SettingsLink").click();
       expectSettingsTabsToBe([...userTabs, ...adminTabs]);
     });
   });
 
   describe("For regular user", () => {
     beforeEach(() => {
-      cy.logout().then(() => cy.login(regularUser.email, regularUser.password));
+      cy.logout();
+      cy.login(regularUser.email, regularUser.password);
+      cy.visit("/");
     });
 
-    it("shows available tabs", () => {
-      cy.visit("/users");
+    it("settings link should lead to Users settings", () => {
+      cy.getByTestId("SettingsLink")
+        .should("exist")
+        .should("have.attr", "href", "users");
+    });
+
+    it("limited set of settings tabs should be available", () => {
+      cy.getByTestId("SettingsLink").click();
       expectSettingsTabsToBe(userTabs);
     });
   });

--- a/client/cypress/integration/settings/settings_tabs_spec.js
+++ b/client/cypress/integration/settings/settings_tabs_spec.js
@@ -1,14 +1,11 @@
 import { createUser } from "../../support/redash-api";
 
 describe("Settings Tabs", () => {
-  before(() => {
-    cy.login();
-    createUser({
-      name: "Example User",
-      email: "user@redash.io",
-      password: "password",
-    });
-  });
+  const regularUser = {
+    name: "Example User",
+    email: "user@redash.io",
+    password: "password",
+  };
 
   const userTabs = ["Users", "Groups", "Query Snippets", "Account"];
   const adminTabs = ["Data Sources", "Alert Destinations", "Settings"];
@@ -19,16 +16,29 @@ describe("Settings Tabs", () => {
       expect(listedPages).to.have.members(expectedTabs);
     });
 
-  it("shows all tabs for admins", () => {
-    cy.visit("/users");
-    expectSettingsTabsToBe([...userTabs, ...adminTabs]);
+  before(() => {
+    cy.login().then(() => createUser(regularUser));
   });
 
-  it("hides unavailable tabs for users", () => {
-    cy.logout()
-      .then(() => cy.login("user@redash.io", "password"))
-      .then(() => cy.visit("/users"));
+  describe("For admin user", () => {
+    beforeEach(() => {
+      cy.logout().then(() => cy.login());
+    });
 
-    expectSettingsTabsToBe(userTabs);
+    it("shows available tabs", () => {
+      cy.visit("/users");
+      expectSettingsTabsToBe([...userTabs, ...adminTabs]);
+    });
+  });
+
+  describe("For regular user", () => {
+    beforeEach(() => {
+      cy.logout().then(() => cy.login(regularUser.email, regularUser.password));
+    });
+
+    it("shows available tabs", () => {
+      cy.visit("/users");
+      expectSettingsTabsToBe(userTabs);
+    });
   });
 });

--- a/client/cypress/support/redash-api/index.js
+++ b/client/cypress/support/redash-api/index.js
@@ -103,7 +103,7 @@ export function createUser({ name, email, password }) {
   return cy
     .request({
       method: "POST",
-      url: "api/users",
+      url: "api/users?no_invite=yes",
       body: { name, email },
       failOnStatusCode: false,
     })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Other

## Description

Non-admin users still have an access to some settings pages, but settings item in navbar was hidden for them. This PR makes settings item available for all users, but it will lead to first available settings page for that user.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
