### PR TITLE
Add/Edit Tags dialog does not set focus on tags input

### DIFF
--- a/client/app/components/tags-control/EditTagsDialog.jsx
+++ b/client/app/components/tags-control/EditTagsDialog.jsx
@@ -9,6 +9,16 @@ function EditTagsDialog({ dialog, tags, getAvailableTags }) {
   const [availableTags, setAvailableTags] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [values, setValues] = useState(() => uniq(map(tags, trim))); // lazy evaluate
+  const [selectRef, setSelectRef] = useState(null);
+
+  // Select is initially disabled, so autoFocus prop cannot make it focused.
+  // Solution is to pass focus to the select when available tags are loaded and
+  // select becomes enabled.
+  useEffect(() => {
+    if (selectRef && !isLoading) {
+      selectRef.focus();
+    }
+  }, [selectRef, isLoading]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -31,12 +41,12 @@ function EditTagsDialog({ dialog, tags, getAvailableTags }) {
       className="shortModal"
       wrapProps={{ "data-test": "EditTagsDialog" }}>
       <Select
+        ref={setSelectRef}
         mode="tags"
         className="w-100"
         placeholder="Add some tags..."
         defaultValue={values}
         onChange={v => setValues(compact(map(v, trim)))}
-        autoFocus
         disabled={isLoading}
         loading={isLoading}>
         {map(availableTags, tag => (

--- a/client/app/components/tags-control/EditTagsDialog.jsx
+++ b/client/app/components/tags-control/EditTagsDialog.jsx
@@ -1,66 +1,60 @@
 import { map, trim, uniq, compact } from "lodash";
-import React from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import Select from "antd/lib/select";
 import Modal from "antd/lib/modal";
 import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 
-class EditTagsDialog extends React.Component {
-  static propTypes = {
-    dialog: DialogPropType.isRequired,
-    tags: PropTypes.arrayOf(PropTypes.string),
-    getAvailableTags: PropTypes.func.isRequired,
-  };
+function EditTagsDialog({ dialog, tags, getAvailableTags }) {
+  const [availableTags, setAvailableTags] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [values, setValues] = useState(() => uniq(map(tags, trim))); // lazy evaluate
 
-  static defaultProps = {
-    tags: [],
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      loading: true,
-      availableTags: [],
-      result: uniq(map(this.props.tags, trim)),
-    };
-  }
-
-  componentDidMount() {
-    this.props.getAvailableTags().then(availableTags => {
-      this.setState({
-        loading: false,
-        availableTags: uniq(compact(map(availableTags, trim))),
-      });
+  useEffect(() => {
+    let isCancelled = false;
+    getAvailableTags().then(availableTags => {
+      if (!isCancelled) {
+        setAvailableTags(uniq(compact(map(availableTags, trim))));
+        setIsLoading(false);
+      }
     });
-  }
+    return () => {
+      isCancelled = true;
+    };
+  }, [getAvailableTags]);
 
-  render() {
-    const { dialog } = this.props;
-    const { loading, availableTags, result } = this.state;
-    return (
-      <Modal
-        {...dialog.props}
-        onOk={() => dialog.close(result)}
-        title="Add/Edit Tags"
-        className="shortModal"
-        wrapProps={{ "data-test": "EditTagsDialog" }}>
-        <Select
-          mode="tags"
-          className="w-100"
-          placeholder="Add some tags..."
-          defaultValue={result}
-          onChange={values => this.setState({ result: compact(map(values, trim)) })}
-          autoFocus
-          disabled={loading}
-          loading={loading}>
-          {map(availableTags, tag => (
-            <Select.Option key={tag}>{tag}</Select.Option>
-          ))}
-        </Select>
-      </Modal>
-    );
-  }
+  return (
+    <Modal
+      {...dialog.props}
+      onOk={() => dialog.close(values)}
+      title="Add/Edit Tags"
+      className="shortModal"
+      wrapProps={{ "data-test": "EditTagsDialog" }}>
+      <Select
+        mode="tags"
+        className="w-100"
+        placeholder="Add some tags..."
+        defaultValue={values}
+        onChange={v => setValues(compact(map(v, trim)))}
+        autoFocus
+        disabled={isLoading}
+        loading={isLoading}>
+        {map(availableTags, tag => (
+          <Select.Option key={tag}>{tag}</Select.Option>
+        ))}
+      </Select>
+    </Modal>
+  );
 }
+
+EditTagsDialog.propTypes = {
+  dialog: DialogPropType.isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string),
+  getAvailableTags: PropTypes.func.isRequired,
+};
+
+EditTagsDialog.defaultProps = {
+  tags: [],
+};
 
 export default wrapDialog(EditTagsDialog);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

I took an opportunity and converted the dialog to function component and fixed cleanup (it didn't cancel a request on destroy). The actual fix is https://github.com/getredash/redash/pull/4979/commits/9ad3ba1a7381cde95505395bb5f9bcabacda3f58.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
