### PR TITLE
Catch QueryResultError on widget load

### DIFF
--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -103,7 +103,7 @@ function useDashboard(dashboardData) {
         if (error instanceof QueryResultError) {
           return;
         }
-        return error;
+        return Promise.reject(error);
       })
       .finally(() => setDashboard(currentDashboard => extend({}, currentDashboard)));
   }, []);

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -5,6 +5,7 @@ import location from "@/services/location";
 import { Dashboard, collectDashboardFilters } from "@/services/dashboard";
 import { currentUser } from "@/services/auth";
 import recordEvent from "@/services/recordEvent";
+import { QueryResultError } from "@/services/query";
 import AddWidgetDialog from "@/components/dashboards/AddWidgetDialog";
 import TextboxDialog from "@/components/dashboards/TextboxDialog";
 import PermissionsEditorDialog from "@/components/PermissionsEditorDialog";
@@ -95,7 +96,16 @@ function useDashboard(dashboardData) {
   const loadWidget = useCallback((widget, forceRefresh = false) => {
     widget.getParametersDefs(); // Force widget to read parameters values from URL
     setDashboard(currentDashboard => extend({}, currentDashboard));
-    return widget.load(forceRefresh).finally(() => setDashboard(currentDashboard => extend({}, currentDashboard)));
+    return widget
+      .load(forceRefresh)
+      .catch(error => {
+        // QueryResultErrors are expected
+        if (error instanceof QueryResultError) {
+          return;
+        }
+        return error;
+      })
+      .finally(() => setDashboard(currentDashboard => extend({}, currentDashboard)));
   }, []);
 
   const refreshWidget = useCallback(widget => loadWidget(widget, true), [loadWidget]);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
QueryResultErrors are expected from widget loading, so it shouldn't be left unhandled.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--