### PR TITLE
Allow GET from non-admins on data source resource

### DIFF
--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -9,6 +9,7 @@ import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSess
 import EditInPlace from "@/components/EditInPlace";
 import Parameters from "@/components/Parameters";
 
+import DataSource from "@/services/data-source";
 import { ExecutionStatus } from "@/services/query-result";
 import useQueryResultData from "@/lib/useQueryResultData";
 
@@ -22,7 +23,6 @@ import QueryExecutionMetadata from "./components/QueryExecutionMetadata";
 
 import useVisualizationTabHandler from "./hooks/useVisualizationTabHandler";
 import useQueryExecute from "./hooks/useQueryExecute";
-import useQueryDataSources from "./hooks/useQueryDataSources";
 import useUpdateQueryDescription from "./hooks/useUpdateQueryDescription";
 import useQueryFlags from "./hooks/useQueryFlags";
 import useQueryParameters from "./hooks/useQueryParameters";
@@ -35,7 +35,7 @@ import "./QueryView.less";
 
 function QueryView(props) {
   const [query, setQuery] = useState(props.query);
-  const { dataSource } = useQueryDataSources(query);
+  const [dataSource, setDataSource] = useState();
   const queryFlags = useQueryFlags(query, dataSource);
   const [parameters, areParametersDirty, updateParametersDirtyFlag] = useQueryParameters(query);
   const [selectedVisualization, setSelectedVisualization] = useVisualizationTabHandler(query.visualizations);
@@ -80,6 +80,10 @@ function QueryView(props) {
   useEffect(() => {
     document.title = query.name;
   }, [query.name]);
+
+  useEffect(() => {
+    DataSource.get({ id: query.data_source_id }).then(setDataSource);
+  }, [query.data_source_id]);
 
   return (
     <div

--- a/client/app/pages/queries/components/QueryMetadata.jsx
+++ b/client/app/pages/queries/components/QueryMetadata.jsx
@@ -1,4 +1,4 @@
-import { isFunction } from "lodash";
+import { isFunction, has } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
@@ -41,7 +41,7 @@ export default function QueryMetadata({ query, dataSource, layout, onEditSchedul
         </div>
       </div>
       <div className="query-metadata-space" />
-      {dataSource && (
+      {has(dataSource, "name") && has(dataSource, "type") && (
         <div className="query-metadata-item">
           Data Source:
           <img src={`${IMG_ROOT}/${dataSource.type}.png`} width="20" alt={dataSource.type} />
@@ -88,8 +88,8 @@ QueryMetadata.propTypes = {
     schedule: PropTypes.object,
   }).isRequired,
   dataSource: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
+    type: PropTypes.string,
+    name: PropTypes.string,
   }),
   onEditSchedule: PropTypes.func,
 };

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -39,11 +39,13 @@ class DataSourceResource(BaseResource):
             models.DataSource.get_by_id_and_org, data_source_id, self.current_org
         )
         require_access(data_source, self.current_user, view_only)
-        ds = (
-            data_source.to_dict(all=self.current_user.has_permission("admin"))
-            if self.current_user.has_permission("list_data_sources")
-            else {}
-        )
+
+        ds = {}
+        if self.current_user.has_permission("list_data_sources"):
+            # if it's a non-admin, limit the information
+            ds = data_source.to_dict(all=self.current_user.has_permission("admin"))
+
+        # add view_only info, required for frontend permissions
         ds["view_only"] = all(
             project(data_source.groups, self.current_user.group_ids).values()
         )

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -39,7 +39,11 @@ class DataSourceResource(BaseResource):
             models.DataSource.get_by_id_and_org, data_source_id, self.current_org
         )
         require_access(data_source, self.current_user, view_only)
-        ds = data_source.to_dict(all=self.current_user.has_permission("admin"))
+        ds = (
+            data_source.to_dict(all=self.current_user.has_permission("admin"))
+            if self.current_user.has_permission("list_data_sources")
+            else {}
+        )
         ds["view_only"] = all(
             project(data_source.groups, self.current_user.group_ids).values()
         )

--- a/tests/handlers/test_data_sources.py
+++ b/tests/handlers/test_data_sources.py
@@ -54,6 +54,45 @@ class DataSourceTypesTest(BaseTestCase):
         self.assertEqual(rv.status_code, 403)
 
 
+class TestDataSourceResourceGet(BaseTestCase):
+    def setUp(self):
+        super(TestDataSourceResourceGet, self).setUp()
+        self.path = "/api/data_sources/{}".format(self.factory.data_source.id)
+
+    def test_returns_all_data_for_admins(self):
+        admin = self.factory.create_admin()
+        rv = self.make_request("get", self.path, user=admin)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn("view_only", rv.json)
+        self.assertIn("options", rv.json)
+
+    def test_returns_only_view_only_for_users_without_list_permissions(self):
+        group = self.factory.create_group(permissions=[])
+        data_source = self.factory.create_data_source(group=group, view_only=True)
+        user = self.factory.create_user(group_ids=[group.id])
+
+        rv = self.make_request(
+            "get", "/api/data_sources/{}".format(data_source.id), user=user
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json, {"view_only": True})
+
+    def test_returns_limited_data_for_non_admin_in_the_default_group(self):
+        user = self.factory.create_user()
+        self.assertTrue(user.has_permission("list_data_sources"))
+
+        rv = self.make_request("get", self.path, user=user)
+        self.assertEqual(rv.status_code, 200)
+        self.assertNotIn("options", rv.json)
+        self.assertIn("view_only", rv.json)
+
+    def test_returns_403_for_non_admin_in_group_without_permission(self):
+        group = self.factory.create_group()
+        user = self.factory.create_user(group_ids=[group.id])
+        rv = self.make_request("get", self.path, user=user)
+        self.assertEqual(rv.status_code, 403)
+
+
 class TestDataSourceResourcePost(BaseTestCase):
     def setUp(self):
         super(TestDataSourceResourcePost, self).setUp()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description
This allows requests from non-admin users that have at least "view_only" permissions on the DS. Also adds the `view_only` information and limit the result information when the user is non-admin.

Reverts #4927 as with this the specific route can be used.

Reasoning: it removes the need for the "list_data_sources" permission when accessing the View Query page.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--