### PR TITLE
Refactor Organization Settings and add extension points to it

### DIFF
--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -1,25 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { isEmpty, join, get } from "lodash";
+import { get } from "lodash";
 
-import Alert from "antd/lib/alert";
 import Button from "antd/lib/button";
 import Form from "antd/lib/form";
-import Input from "antd/lib/input";
-import Select from "antd/lib/select";
-import Checkbox from "antd/lib/checkbox";
-import Tooltip from "antd/lib/tooltip";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
 import LoadingState from "@/components/items-list/components/LoadingState";
 
 import { clientConfig } from "@/services/auth";
 import recordEvent from "@/services/recordEvent";
 import OrgSettings from "@/services/organizationSettings";
-import HelpTrigger from "@/components/HelpTrigger";
 import wrapSettingsTab from "@/components/SettingsWrapper";
-import DynamicComponent from "@/components/DynamicComponent";
 
-const Option = Select.Option;
+import GeneralSettings from "./components/GeneralSettings";
+import AuthSettings from "./components/AuthSettings";
 
 class OrganizationSettings extends React.Component {
   static propTypes = {
@@ -75,188 +69,6 @@ class OrganizationSettings extends React.Component {
     );
   };
 
-  renderGoogleLoginOptions() {
-    const { formValues } = this.state;
-    return (
-      <React.Fragment>
-        <h4>Google Login</h4>
-        <Form.Item label="Allowed Google Apps Domains">
-          <Select
-            mode="tags"
-            value={formValues.auth_google_apps_domains}
-            onChange={value => this.handleChange("auth_google_apps_domains", value)}
-          />
-          {!isEmpty(formValues.auth_google_apps_domains) && (
-            <Alert
-              message={
-                <p>
-                  Any user registered with a <strong>{join(formValues.auth_google_apps_domains, ", ")}</strong> Google
-                  Apps account will be able to login. If they don{"'"}t have an existing user, a new user will be
-                  created and join the <strong>Default</strong> group.
-                </p>
-              }
-              className="m-t-15"
-            />
-          )}
-        </Form.Item>
-      </React.Fragment>
-    );
-  }
-
-  renderSAMLOptions() {
-    const { formValues } = this.state;
-    return (
-      <React.Fragment>
-        <h4>SAML</h4>
-        <Form.Item>
-          <Checkbox
-            name="auth_saml_enabled"
-            checked={formValues.auth_saml_enabled}
-            onChange={e => this.handleChange("auth_saml_enabled", e.target.checked)}>
-            SAML Enabled
-          </Checkbox>
-        </Form.Item>
-        {formValues.auth_saml_enabled && (
-          <div>
-            <Form.Item label="SAML Metadata URL">
-              <Input
-                value={formValues.auth_saml_metadata_url}
-                onChange={e => this.handleChange("auth_saml_metadata_url", e.target.value)}
-              />
-            </Form.Item>
-            <Form.Item label="SAML Entity ID">
-              <Input
-                value={formValues.auth_saml_entity_id}
-                onChange={e => this.handleChange("auth_saml_entity_id", e.target.value)}
-              />
-            </Form.Item>
-            <Form.Item label="SAML NameID Format">
-              <Input
-                value={formValues.auth_saml_nameid_format}
-                onChange={e => this.handleChange("auth_saml_nameid_format", e.target.value)}
-              />
-            </Form.Item>
-          </div>
-        )}
-      </React.Fragment>
-    );
-  }
-
-  renderGeneralSettings() {
-    const { formValues } = this.state;
-    return (
-      <React.Fragment>
-        <h3 className="m-t-0">General</h3>
-        <hr />
-        <Form.Item label="Date Format">
-          <Select
-            value={formValues.date_format}
-            onChange={value => this.handleChange("date_format", value)}
-            data-test="DateFormatSelect">
-            {clientConfig.dateFormatList.map(dateFormat => (
-              <Option key={dateFormat}>{dateFormat}</Option>
-            ))}
-          </Select>
-        </Form.Item>
-        <Form.Item label="Time Format">
-          <Select
-            value={formValues.time_format}
-            onChange={value => this.handleChange("time_format", value)}
-            data-test="TimeFormatSelect">
-            {clientConfig.timeFormatList.map(timeFormat => (
-              <Option key={timeFormat}>{timeFormat}</Option>
-            ))}
-          </Select>
-        </Form.Item>
-        <Form.Item label="Chart Visualization">
-          <Checkbox
-            name="hide_plotly_mode_bar"
-            checked={formValues.hide_plotly_mode_bar}
-            onChange={e => this.handleChange("hide_plotly_mode_bar", e.target.checked)}>
-            Hide Plotly mode bar
-          </Checkbox>
-        </Form.Item>
-        <Form.Item label="Feature Flags">
-          <Checkbox
-            name="feature_show_permissions_control"
-            checked={formValues.feature_show_permissions_control}
-            onChange={e => this.handleChange("feature_show_permissions_control", e.target.checked)}>
-            Enable experimental multiple owners support
-          </Checkbox>
-        </Form.Item>
-        <Form.Item>
-          <Checkbox
-            name="send_email_on_failed_scheduled_queries"
-            checked={formValues.send_email_on_failed_scheduled_queries}
-            onChange={e => this.handleChange("send_email_on_failed_scheduled_queries", e.target.checked)}>
-            Email query owners when scheduled queries fail
-          </Checkbox>
-        </Form.Item>
-        <Form.Item>
-          <Checkbox
-            name="multi_byte_search_enabled"
-            checked={formValues.multi_byte_search_enabled}
-            onChange={e => this.handleChange("multi_byte_search_enabled", e.target.checked)}>
-            Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
-          </Checkbox>
-        </Form.Item>
-        <DynamicComponent name="BeaconConsentSetting">
-          <Form.Item
-            label={
-              <>
-                Anonymous Usage Data Sharing <HelpTrigger type="USAGE_DATA_SHARING" />
-              </>
-            }>
-            <Checkbox
-              name="beacon_consent"
-              checked={formValues.beacon_consent}
-              onChange={e => this.handleChange("beacon_consent", e.target.checked)}>
-              Help Redash improve by automatically sending anonymous usage data
-            </Checkbox>
-          </Form.Item>
-        </DynamicComponent>
-      </React.Fragment>
-    );
-  }
-
-  renderAuthSettings() {
-    const { settings, formValues } = this.state;
-    return (
-      <React.Fragment>
-        <h3 className="m-t-0">
-          Authentication <HelpTrigger type="AUTHENTICATION_OPTIONS" />
-        </h3>
-        <hr />
-        {!settings.auth_password_login_enabled && (
-          <Alert
-            message="Password based login is currently disabled and users will
-            be able to login only with the enabled SSO options."
-            type="warning"
-            className="m-t-15 m-b-15"
-          />
-        )}
-        <Form.Item>
-          <Checkbox
-            checked={formValues.auth_password_login_enabled}
-            disabled={this.disablePasswordLoginToggle()}
-            onChange={e => this.handleChange("auth_password_login_enabled", e.target.checked)}>
-            <Tooltip
-              title={
-                this.disablePasswordLoginToggle()
-                  ? "Password login can be disabled only if another login method is enabled."
-                  : null
-              }
-              placement="right">
-              Password Login Enabled
-            </Tooltip>
-          </Checkbox>
-        </Form.Item>
-        {clientConfig.googleLoginEnabled && this.renderGoogleLoginOptions()}
-        {this.renderSAMLOptions()}
-      </React.Fragment>
-    );
-  }
-
   render() {
     const { loading, submitting } = this.state;
     return (
@@ -266,8 +78,16 @@ class OrganizationSettings extends React.Component {
             <LoadingState className="" />
           ) : (
             <Form layout="vertical" onSubmit={this.handleSubmit}>
-              {this.renderGeneralSettings()}
-              {this.renderAuthSettings()}
+              <GeneralSettings
+                settings={this.state.settings}
+                values={this.state.formValues}
+                onChange={this.handleChange}
+              />
+              <AuthSettings
+                settings={this.state.settings}
+                values={this.state.formValues}
+                onChange={this.handleChange}
+              />
               <Button className="w-100" type="primary" htmlType="submit" loading={submitting}>
                 Save
               </Button>

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -7,7 +7,6 @@ import Form from "antd/lib/form";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
 import LoadingState from "@/components/items-list/components/LoadingState";
 
-import { clientConfig } from "@/services/auth";
 import recordEvent from "@/services/recordEvent";
 import OrgSettings from "@/services/organizationSettings";
 import wrapSettingsTab from "@/components/SettingsWrapper";
@@ -41,9 +40,6 @@ class OrganizationSettings extends React.Component {
       .catch(error => this.props.onError(error));
   }
 
-  disablePasswordLoginToggle = () =>
-    !(clientConfig.googleLoginEnabled || clientConfig.ldapLoginEnabled || this.state.formValues.auth_saml_enabled);
-
   handleSubmit = e => {
     e.preventDefault();
     if (!this.state.submitting) {
@@ -58,15 +54,8 @@ class OrganizationSettings extends React.Component {
     }
   };
 
-  handleChange = (name, value) => {
-    this.setState(
-      prevState => ({ formValues: Object.assign(prevState.formValues, { [name]: value }) }),
-      () => {
-        if (this.disablePasswordLoginToggle() && !this.state.formValues.auth_password_login_enabled) {
-          this.handleChange("auth_password_login_enabled", true);
-        }
-      }
-    );
+  handleChange = changes => {
+    this.setState(prevState => ({ formValues: { ...prevState.formValues, ...changes } }));
   };
 
   render() {

--- a/client/app/pages/settings/OrganizationSettings.jsx
+++ b/client/app/pages/settings/OrganizationSettings.jsx
@@ -48,12 +48,9 @@ function OrganizationSettings({ onError }) {
     };
   }, []);
 
-  const handleChange = useCallback(
-    changes => {
-      setCurrentValues({ ...currentValues, ...changes });
-    },
-    [currentValues]
-  );
+  const handleChange = useCallback(changes => {
+    setCurrentValues(currentValues => ({ ...currentValues, ...changes }));
+  }, []);
 
   const handleSubmit = useCallback(
     event => {

--- a/client/app/pages/settings/components/AuthSettings/GoogleLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/GoogleLoginSettings.jsx
@@ -1,0 +1,42 @@
+import { isEmpty, join } from "lodash";
+import React from "react";
+import Form from "antd/lib/form";
+import Select from "antd/lib/select";
+import Alert from "antd/lib/alert";
+import { clientConfig } from "@/services/auth";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+
+export default function GoogleLoginSettings({ values, onChange }) {
+  if (!clientConfig.googleLoginEnabled) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <h4>Google Login</h4>
+      <Form.Item label="Allowed Google Apps Domains">
+        <Select
+          mode="tags"
+          value={values.auth_google_apps_domains}
+          onChange={value => onChange("auth_google_apps_domains", value)}
+        />
+        {!isEmpty(values.auth_google_apps_domains) && (
+          <Alert
+            message={
+              <p>
+                Any user registered with a <strong>{join(values.auth_google_apps_domains, ", ")}</strong> Google Apps
+                account will be able to login. If they don't have an existing user, a new user will be created and join
+                the <strong>Default</strong> group.
+              </p>
+            }
+            className="m-t-15"
+          />
+        )}
+      </Form.Item>
+    </React.Fragment>
+  );
+}
+
+GoogleLoginSettings.propTypes = SettingsEditorPropTypes;
+
+GoogleLoginSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/AuthSettings/GoogleLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/GoogleLoginSettings.jsx
@@ -18,7 +18,7 @@ export default function GoogleLoginSettings({ values, onChange }) {
         <Select
           mode="tags"
           value={values.auth_google_apps_domains}
-          onChange={value => onChange("auth_google_apps_domains", value)}
+          onChange={value => onChange({ auth_google_apps_domains: value })}
         />
         {!isEmpty(values.auth_google_apps_domains) && (
           <Alert

--- a/client/app/pages/settings/components/AuthSettings/GoogleLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/GoogleLoginSettings.jsx
@@ -3,16 +3,19 @@ import React from "react";
 import Form from "antd/lib/form";
 import Select from "antd/lib/select";
 import Alert from "antd/lib/alert";
+import DynamicComponent from "@/components/DynamicComponent";
 import { clientConfig } from "@/services/auth";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
-export default function GoogleLoginSettings({ values, onChange }) {
+export default function GoogleLoginSettings(props) {
+  const { values, onChange } = props;
+
   if (!clientConfig.googleLoginEnabled) {
     return null;
   }
 
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.GoogleLoginSettings" {...props}>
       <h4>Google Login</h4>
       <Form.Item label="Allowed Google Apps Domains">
         <Select
@@ -33,7 +36,7 @@ export default function GoogleLoginSettings({ values, onChange }) {
           />
         )}
       </Form.Item>
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Alert from "antd/lib/alert";
+import Form from "antd/lib/form";
+import Checkbox from "antd/lib/checkbox";
+import Tooltip from "antd/lib/tooltip";
+import { clientConfig } from "@/services/auth";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+
+export default function PasswordLoginSettings({ settings, values, onChange }) {
+  const isTheOnlyAuthMethod =
+    !clientConfig.googleLoginEnabled && !clientConfig.ldapLoginEnabled && !values.auth_saml_enabled;
+
+  return (
+    <React.Fragment>
+      {!settings.auth_password_login_enabled && (
+        <Alert
+          message="Password based login is currently disabled and users will
+            be able to login only with the enabled SSO options."
+          type="warning"
+          className="m-t-15 m-b-15"
+        />
+      )}
+      <Form.Item>
+        <Checkbox
+          checked={values.auth_password_login_enabled}
+          disabled={isTheOnlyAuthMethod}
+          onChange={e => onChange("auth_password_login_enabled", e.target.checked)}>
+          <Tooltip
+            title={
+              isTheOnlyAuthMethod ? "Password login can be disabled only if another login method is enabled." : null
+            }
+            placement="right">
+            Password Login Enabled
+          </Tooltip>
+        </Checkbox>
+      </Form.Item>
+    </React.Fragment>
+  );
+}
+
+PasswordLoginSettings.propTypes = SettingsEditorPropTypes;
+
+PasswordLoginSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
@@ -24,7 +24,7 @@ export default function PasswordLoginSettings({ settings, values, onChange }) {
         <Checkbox
           checked={values.auth_password_login_enabled}
           disabled={isTheOnlyAuthMethod}
-          onChange={e => onChange("auth_password_login_enabled", e.target.checked)}>
+          onChange={e => onChange({ auth_password_login_enabled: e.target.checked })}>
           <Tooltip
             title={
               isTheOnlyAuthMethod ? "Password login can be disabled only if another login method is enabled." : null

--- a/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
@@ -3,15 +3,18 @@ import Alert from "antd/lib/alert";
 import Form from "antd/lib/form";
 import Checkbox from "antd/lib/checkbox";
 import Tooltip from "antd/lib/tooltip";
+import DynamicComponent from "@/components/DynamicComponent";
 import { clientConfig } from "@/services/auth";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
-export default function PasswordLoginSettings({ settings, values, onChange }) {
+export default function PasswordLoginSettings(props) {
+  const { settings, values, onChange } = props;
+
   const isTheOnlyAuthMethod =
     !clientConfig.googleLoginEnabled && !clientConfig.ldapLoginEnabled && !values.auth_saml_enabled;
 
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.PasswordLoginSettings" {...props}>
       {!settings.auth_password_login_enabled && (
         <Alert
           message="Password based login is currently disabled and users will
@@ -34,7 +37,7 @@ export default function PasswordLoginSettings({ settings, values, onChange }) {
           </Tooltip>
         </Checkbox>
       </Form.Item>
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/pages/settings/components/AuthSettings/SAMLSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/SAMLSettings.jsx
@@ -12,7 +12,7 @@ export default function SAMLSettings({ values, onChange }) {
         <Checkbox
           name="auth_saml_enabled"
           checked={values.auth_saml_enabled}
-          onChange={e => onChange("auth_saml_enabled", e.target.checked)}>
+          onChange={e => onChange({ auth_saml_enabled: e.target.checked })}>
           SAML Enabled
         </Checkbox>
       </Form.Item>
@@ -21,16 +21,19 @@ export default function SAMLSettings({ values, onChange }) {
           <Form.Item label="SAML Metadata URL">
             <Input
               value={values.auth_saml_metadata_url}
-              onChange={e => onChange("auth_saml_metadata_url", e.target.value)}
+              onChange={e => onChange({ auth_saml_metadata_url: e.target.value })}
             />
           </Form.Item>
           <Form.Item label="SAML Entity ID">
-            <Input value={values.auth_saml_entity_id} onChange={e => onChange("auth_saml_entity_id", e.target.value)} />
+            <Input
+              value={values.auth_saml_entity_id}
+              onChange={e => onChange({ auth_saml_entity_id: e.target.value })}
+            />
           </Form.Item>
           <Form.Item label="SAML NameID Format">
             <Input
               value={values.auth_saml_nameid_format}
-              onChange={e => onChange("auth_saml_nameid_format", e.target.value)}
+              onChange={e => onChange({ auth_saml_nameid_format: e.target.value })}
             />
           </Form.Item>
         </div>

--- a/client/app/pages/settings/components/AuthSettings/SAMLSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/SAMLSettings.jsx
@@ -2,11 +2,14 @@ import React from "react";
 import Form from "antd/lib/form";
 import Checkbox from "antd/lib/checkbox";
 import Input from "antd/lib/input";
+import DynamicComponent from "@/components/DynamicComponent";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
-export default function SAMLSettings({ values, onChange }) {
+export default function SAMLSettings(props) {
+  const { values, onChange } = props;
+
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.SAMLSettings" {...props}>
       <h4>SAML</h4>
       <Form.Item>
         <Checkbox
@@ -38,7 +41,7 @@ export default function SAMLSettings({ values, onChange }) {
           </Form.Item>
         </div>
       )}
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/pages/settings/components/AuthSettings/SAMLSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/SAMLSettings.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import Form from "antd/lib/form";
+import Checkbox from "antd/lib/checkbox";
+import Input from "antd/lib/input";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+
+export default function SAMLSettings({ values, onChange }) {
+  return (
+    <React.Fragment>
+      <h4>SAML</h4>
+      <Form.Item>
+        <Checkbox
+          name="auth_saml_enabled"
+          checked={values.auth_saml_enabled}
+          onChange={e => onChange("auth_saml_enabled", e.target.checked)}>
+          SAML Enabled
+        </Checkbox>
+      </Form.Item>
+      {values.auth_saml_enabled && (
+        <div>
+          <Form.Item label="SAML Metadata URL">
+            <Input
+              value={values.auth_saml_metadata_url}
+              onChange={e => onChange("auth_saml_metadata_url", e.target.value)}
+            />
+          </Form.Item>
+          <Form.Item label="SAML Entity ID">
+            <Input value={values.auth_saml_entity_id} onChange={e => onChange("auth_saml_entity_id", e.target.value)} />
+          </Form.Item>
+          <Form.Item label="SAML NameID Format">
+            <Input
+              value={values.auth_saml_nameid_format}
+              onChange={e => onChange("auth_saml_nameid_format", e.target.value)}
+            />
+          </Form.Item>
+        </div>
+      )}
+    </React.Fragment>
+  );
+}
+
+SAMLSettings.propTypes = SettingsEditorPropTypes;
+
+SAMLSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/AuthSettings/index.jsx
+++ b/client/app/pages/settings/components/AuthSettings/index.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import HelpTrigger from "@/components/HelpTrigger";
+import DynamicComponent from "@/components/DynamicComponent";
 import { clientConfig } from "@/services/auth";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
@@ -23,7 +24,7 @@ export default function AuthSettings(props) {
   );
 
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.AuthSettings" {...props}>
       <h3 className="m-t-0">
         Authentication <HelpTrigger type="AUTHENTICATION_OPTIONS" />
       </h3>
@@ -31,7 +32,7 @@ export default function AuthSettings(props) {
       <PasswordLoginSettings {...props} onChange={handleChange} />
       <GoogleLoginSettings {...props} onChange={handleChange} />
       <SAMLSettings {...props} onChange={handleChange} />
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/pages/settings/components/AuthSettings/index.jsx
+++ b/client/app/pages/settings/components/AuthSettings/index.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import HelpTrigger from "@/components/HelpTrigger";
+
+import PasswordLoginSettings from "./PasswordLoginSettings";
+import GoogleLoginSettings from "./GoogleLoginSettings";
+import SAMLSettings from "./SAMLSettings";
+
+export default function AuthSettings(props) {
+  return (
+    <React.Fragment>
+      <h3 className="m-t-0">
+        Authentication <HelpTrigger type="AUTHENTICATION_OPTIONS" />
+      </h3>
+      <hr />
+      <PasswordLoginSettings {...props} />
+      <GoogleLoginSettings {...props} />
+      <SAMLSettings {...props} />
+    </React.Fragment>
+  );
+}

--- a/client/app/pages/settings/components/AuthSettings/index.jsx
+++ b/client/app/pages/settings/components/AuthSettings/index.jsx
@@ -1,20 +1,39 @@
-import React from "react";
+import React, { useCallback } from "react";
 import HelpTrigger from "@/components/HelpTrigger";
+import { clientConfig } from "@/services/auth";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
 import PasswordLoginSettings from "./PasswordLoginSettings";
 import GoogleLoginSettings from "./GoogleLoginSettings";
 import SAMLSettings from "./SAMLSettings";
 
 export default function AuthSettings(props) {
+  const { values, onChange } = props;
+  const handleChange = useCallback(
+    changes => {
+      const allSettings = { ...values, ...changes };
+      const allAuthMethodsDisabled =
+        !clientConfig.googleLoginEnabled && !clientConfig.ldapLoginEnabled && !allSettings.auth_saml_enabled;
+      if (allAuthMethodsDisabled) {
+        changes = { ...changes, auth_password_login_enabled: true };
+      }
+      onChange(changes);
+    },
+    [values, onChange]
+  );
+
   return (
     <React.Fragment>
       <h3 className="m-t-0">
         Authentication <HelpTrigger type="AUTHENTICATION_OPTIONS" />
       </h3>
       <hr />
-      <PasswordLoginSettings {...props} />
-      <GoogleLoginSettings {...props} />
-      <SAMLSettings {...props} />
+      <PasswordLoginSettings {...props} onChange={handleChange} />
+      <GoogleLoginSettings {...props} onChange={handleChange} />
+      <SAMLSettings {...props} onChange={handleChange} />
     </React.Fragment>
   );
 }
+
+AuthSettings.propTypes = SettingsEditorPropTypes;
+AuthSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/GeneralSettings/BeaconConsentSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/BeaconConsentSettings.jsx
@@ -17,7 +17,7 @@ export default function BeaconConsentSettings({ values, onChange }) {
         <Checkbox
           name="beacon_consent"
           checked={values.beacon_consent}
-          onChange={e => onChange("beacon_consent", e.target.checked)}>
+          onChange={e => onChange({ beacon_consent: e.target.checked })}>
           Help Redash improve by automatically sending anonymous usage data
         </Checkbox>
       </Form.Item>

--- a/client/app/pages/settings/components/GeneralSettings/BeaconConsentSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/BeaconConsentSettings.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Form from "antd/lib/form";
+import HelpTrigger from "@/components/HelpTrigger";
+import Checkbox from "antd/lib/checkbox";
+import DynamicComponent from "@/components/DynamicComponent";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+
+export default function BeaconConsentSettings({ values, onChange }) {
+  return (
+    <DynamicComponent name="BeaconConsentSetting">
+      <Form.Item
+        label={
+          <>
+            Anonymous Usage Data Sharing <HelpTrigger type="USAGE_DATA_SHARING" />
+          </>
+        }>
+        <Checkbox
+          name="beacon_consent"
+          checked={values.beacon_consent}
+          onChange={e => onChange("beacon_consent", e.target.checked)}>
+          Help Redash improve by automatically sending anonymous usage data
+        </Checkbox>
+      </Form.Item>
+    </DynamicComponent>
+  );
+}
+
+BeaconConsentSettings.propTypes = SettingsEditorPropTypes;
+
+BeaconConsentSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/GeneralSettings/BeaconConsentSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/BeaconConsentSettings.jsx
@@ -5,9 +5,11 @@ import Checkbox from "antd/lib/checkbox";
 import DynamicComponent from "@/components/DynamicComponent";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
-export default function BeaconConsentSettings({ values, onChange }) {
+export default function BeaconConsentSettings(props) {
+  const { values, onChange } = props;
+
   return (
-    <DynamicComponent name="BeaconConsentSetting">
+    <DynamicComponent name="OrganizationSettings.BeaconConsentSettings" {...props}>
       <Form.Item
         label={
           <>

--- a/client/app/pages/settings/components/GeneralSettings/FeatureFlagsSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FeatureFlagsSettings.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import Checkbox from "antd/lib/checkbox";
 import Form from "antd/lib/form";
+import DynamicComponent from "@/components/DynamicComponent";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
-export default function FeaturesSettings({ values, onChange }) {
+export default function FeatureFlagsSettings(props) {
+  const { values, onChange } = props;
+
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.FeatureFlagsSettings" {...props}>
       <Form.Item label="Feature Flags">
         <Checkbox
           name="feature_show_permissions_control"
@@ -30,10 +33,10 @@ export default function FeaturesSettings({ values, onChange }) {
           Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
         </Checkbox>
       </Form.Item>
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 
-FeaturesSettings.propTypes = SettingsEditorPropTypes;
+FeatureFlagsSettings.propTypes = SettingsEditorPropTypes;
 
-FeaturesSettings.defaultProps = SettingsEditorDefaultProps;
+FeatureFlagsSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/GeneralSettings/FeaturesSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FeaturesSettings.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import Checkbox from "antd/lib/checkbox";
+import Form from "antd/lib/form";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+
+export default function FeaturesSettings({ values, onChange }) {
+  return (
+    <React.Fragment>
+      <Form.Item label="Feature Flags">
+        <Checkbox
+          name="feature_show_permissions_control"
+          checked={values.feature_show_permissions_control}
+          onChange={e => onChange("feature_show_permissions_control", e.target.checked)}>
+          Enable experimental multiple owners support
+        </Checkbox>
+      </Form.Item>
+      <Form.Item>
+        <Checkbox
+          name="send_email_on_failed_scheduled_queries"
+          checked={values.send_email_on_failed_scheduled_queries}
+          onChange={e => onChange("send_email_on_failed_scheduled_queries", e.target.checked)}>
+          Email query owners when scheduled queries fail
+        </Checkbox>
+      </Form.Item>
+      <Form.Item>
+        <Checkbox
+          name="multi_byte_search_enabled"
+          checked={values.multi_byte_search_enabled}
+          onChange={e => onChange("multi_byte_search_enabled", e.target.checked)}>
+          Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
+        </Checkbox>
+      </Form.Item>
+    </React.Fragment>
+  );
+}
+
+FeaturesSettings.propTypes = SettingsEditorPropTypes;
+
+FeaturesSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/GeneralSettings/FeaturesSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FeaturesSettings.jsx
@@ -10,7 +10,7 @@ export default function FeaturesSettings({ values, onChange }) {
         <Checkbox
           name="feature_show_permissions_control"
           checked={values.feature_show_permissions_control}
-          onChange={e => onChange("feature_show_permissions_control", e.target.checked)}>
+          onChange={e => onChange({ feature_show_permissions_control: e.target.checked })}>
           Enable experimental multiple owners support
         </Checkbox>
       </Form.Item>
@@ -18,7 +18,7 @@ export default function FeaturesSettings({ values, onChange }) {
         <Checkbox
           name="send_email_on_failed_scheduled_queries"
           checked={values.send_email_on_failed_scheduled_queries}
-          onChange={e => onChange("send_email_on_failed_scheduled_queries", e.target.checked)}>
+          onChange={e => onChange({ send_email_on_failed_scheduled_queries: e.target.checked })}>
           Email query owners when scheduled queries fail
         </Checkbox>
       </Form.Item>
@@ -26,7 +26,7 @@ export default function FeaturesSettings({ values, onChange }) {
         <Checkbox
           name="multi_byte_search_enabled"
           checked={values.multi_byte_search_enabled}
-          onChange={e => onChange("multi_byte_search_enabled", e.target.checked)}>
+          onChange={e => onChange({ multi_byte_search_enabled: e.target.checked })}>
           Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
         </Checkbox>
       </Form.Item>

--- a/client/app/pages/settings/components/GeneralSettings/FormatSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FormatSettings.jsx
@@ -10,7 +10,7 @@ export default function FormatSettings({ values, onChange }) {
       <Form.Item label="Date Format">
         <Select
           value={values.date_format}
-          onChange={value => onChange("date_format", value)}
+          onChange={value => onChange({ date_format: value })}
           data-test="DateFormatSelect">
           {clientConfig.dateFormatList.map(dateFormat => (
             <Select.Option key={dateFormat}>{dateFormat}</Select.Option>
@@ -20,7 +20,7 @@ export default function FormatSettings({ values, onChange }) {
       <Form.Item label="Time Format">
         <Select
           value={values.time_format}
-          onChange={value => onChange("time_format", value)}
+          onChange={value => onChange({ time_format: value })}
           data-test="TimeFormatSelect">
           {clientConfig.timeFormatList.map(timeFormat => (
             <Select.Option key={timeFormat}>{timeFormat}</Select.Option>

--- a/client/app/pages/settings/components/GeneralSettings/FormatSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FormatSettings.jsx
@@ -2,11 +2,14 @@ import React from "react";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 import Form from "antd/lib/form";
 import Select from "antd/lib/select";
+import DynamicComponent from "@/components/DynamicComponent";
 import { clientConfig } from "@/services/auth";
 
-export default function FormatSettings({ values, onChange }) {
+export default function FormatSettings(props) {
+  const { values, onChange } = props;
+
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.FormatSettings" {...props}>
       <Form.Item label="Date Format">
         <Select
           value={values.date_format}
@@ -27,7 +30,7 @@ export default function FormatSettings({ values, onChange }) {
           ))}
         </Select>
       </Form.Item>
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/pages/settings/components/GeneralSettings/FormatSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FormatSettings.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+import Form from "antd/lib/form";
+import Select from "antd/lib/select";
+import { clientConfig } from "@/services/auth";
+
+export default function FormatSettings({ values, onChange }) {
+  return (
+    <React.Fragment>
+      <Form.Item label="Date Format">
+        <Select
+          value={values.date_format}
+          onChange={value => onChange("date_format", value)}
+          data-test="DateFormatSelect">
+          {clientConfig.dateFormatList.map(dateFormat => (
+            <Select.Option key={dateFormat}>{dateFormat}</Select.Option>
+          ))}
+        </Select>
+      </Form.Item>
+      <Form.Item label="Time Format">
+        <Select
+          value={values.time_format}
+          onChange={value => onChange("time_format", value)}
+          data-test="TimeFormatSelect">
+          {clientConfig.timeFormatList.map(timeFormat => (
+            <Select.Option key={timeFormat}>{timeFormat}</Select.Option>
+          ))}
+        </Select>
+      </Form.Item>
+    </React.Fragment>
+  );
+}
+
+FormatSettings.propTypes = SettingsEditorPropTypes;
+
+FormatSettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/GeneralSettings/PlotlySettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/PlotlySettings.jsx
@@ -10,7 +10,7 @@ export default function PlotlySettings({ values, onChange }) {
         <Checkbox
           name="hide_plotly_mode_bar"
           checked={values.hide_plotly_mode_bar}
-          onChange={e => onChange("hide_plotly_mode_bar", e.target.checked)}>
+          onChange={e => onChange({ hide_plotly_mode_bar: e.target.checked })}>
           Hide Plotly mode bar
         </Checkbox>
       </Form.Item>

--- a/client/app/pages/settings/components/GeneralSettings/PlotlySettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/PlotlySettings.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Checkbox from "antd/lib/checkbox";
+import Form from "antd/lib/form";
+import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
+
+export default function PlotlySettings({ values, onChange }) {
+  return (
+    <React.Fragment>
+      <Form.Item label="Chart Visualization">
+        <Checkbox
+          name="hide_plotly_mode_bar"
+          checked={values.hide_plotly_mode_bar}
+          onChange={e => onChange("hide_plotly_mode_bar", e.target.checked)}>
+          Hide Plotly mode bar
+        </Checkbox>
+      </Form.Item>
+    </React.Fragment>
+  );
+}
+
+PlotlySettings.propTypes = SettingsEditorPropTypes;
+
+PlotlySettings.defaultProps = SettingsEditorDefaultProps;

--- a/client/app/pages/settings/components/GeneralSettings/PlotlySettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/PlotlySettings.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import Checkbox from "antd/lib/checkbox";
 import Form from "antd/lib/form";
+import DynamicComponent from "@/components/DynamicComponent";
 import { SettingsEditorPropTypes, SettingsEditorDefaultProps } from "../prop-types";
 
-export default function PlotlySettings({ values, onChange }) {
+export default function PlotlySettings(props) {
+  const { values, onChange } = props;
+
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.PlotlySettings" {...props}>
       <Form.Item label="Chart Visualization">
         <Checkbox
           name="hide_plotly_mode_bar"
@@ -14,7 +17,7 @@ export default function PlotlySettings({ values, onChange }) {
           Hide Plotly mode bar
         </Checkbox>
       </Form.Item>
-    </React.Fragment>
+    </DynamicComponent>
   );
 }
 

--- a/client/app/pages/settings/components/GeneralSettings/index.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/index.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import FormatSettings from "./FormatSettings";
+import PlotlySettings from "./PlotlySettings";
+import FeaturesSettings from "./FeaturesSettings";
+import BeaconConsentSettings from "./BeaconConsentSettings";
+
+export default function GeneralSettings(props) {
+  return (
+    <React.Fragment>
+      <h3 className="m-t-0">General</h3>
+      <hr />
+      <FormatSettings {...props} />
+      <PlotlySettings {...props} />
+      <FeaturesSettings {...props} />
+      <BeaconConsentSettings {...props} />
+    </React.Fragment>
+  );
+}

--- a/client/app/pages/settings/components/GeneralSettings/index.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/index.jsx
@@ -1,19 +1,20 @@
 import React from "react";
+import DynamicComponent from "@/components/DynamicComponent";
 
 import FormatSettings from "./FormatSettings";
 import PlotlySettings from "./PlotlySettings";
-import FeaturesSettings from "./FeaturesSettings";
+import FeatureFlagsSettings from "./FeatureFlagsSettings";
 import BeaconConsentSettings from "./BeaconConsentSettings";
 
 export default function GeneralSettings(props) {
   return (
-    <React.Fragment>
+    <DynamicComponent name="OrganizationSettings.GeneralSettings" {...props}>
       <h3 className="m-t-0">General</h3>
       <hr />
       <FormatSettings {...props} />
       <PlotlySettings {...props} />
-      <FeaturesSettings {...props} />
+      <FeatureFlagsSettings {...props} />
       <BeaconConsentSettings {...props} />
-    </React.Fragment>
+    </DynamicComponent>
   );
 }

--- a/client/app/pages/settings/components/prop-types.js
+++ b/client/app/pages/settings/components/prop-types.js
@@ -1,0 +1,13 @@
+import PropTypes from "prop-types";
+
+export const SettingsEditorPropTypes = {
+  settings: PropTypes.object,
+  values: PropTypes.object,
+  onChange: PropTypes.func, // (key, value) => void
+};
+
+export const SettingsEditorDefaultProps = {
+  settings: {},
+  values: {},
+  onChange: () => {},
+};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Other

## Description

Refactor Organization Settings page: split it into smaller components and add extension points (`<DynamicComponent>`s). For easier understanding, I split all changes into few commits, each contains some logically isolated part of changes.

**Important note**: Dynamic component `BeaconConsentSetting` renamed to `OrganizationSettings.BeaconConsentSettings` for consistency with other similar blocks.
