### PR TITLE
Prevent IDOR on group members for admins outside the group

### DIFF
--- a/redash/handlers/groups.py
+++ b/redash/handlers/groups.py
@@ -105,7 +105,7 @@ class GroupMemberListResource(BaseResource):
     def get(self, group_id):
         if not (
             self.current_user.has_permission("admin")
-            or int(group_id) in self.current_user.group_ids
+            and int(group_id) in self.current_user.group_ids
         ):
             abort(403)
 

--- a/tests/handlers/test_groups.py
+++ b/tests/handlers/test_groups.py
@@ -138,3 +138,29 @@ class TestGroupResourceGet(BaseTestCase):
             "get", "/api/groups/{}".format(self.factory.admin_group.id)
         )
         self.assertEqual(rv.status_code, 403)
+
+
+class TestGroupMemberListResourceGet(BaseTestCase):
+    def test_returns_group_members(self):
+        group = self.factory.create_group()
+        user = self.factory.create_admin()
+        user.group_ids.append(group.id)
+        db.session.flush()
+
+        rv = self.make_request(
+            "get", "/api/groups/{}/members".format(group.id), user=user,
+        )
+        self.assertEqual(rv.status_code, 200)
+
+    def test_doesnt_return_group_members_if_user_not_admin_of_group(self):
+        group = self.factory.create_group()
+        user = self.factory.create_admin()
+        user.group_ids.append(group.id)
+
+        other_group = self.factory.create_group()
+        db.session.flush()
+
+        rv = self.make_request(
+            "get", "/api/groups/{}/members".format(other_group.id), user=user
+        )
+        self.assertEqual(rv.status_code, 403)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
> The group members endpoint in the REST API checks for administrator rights, so it can’t be used by regular users. But it isn’t checking that the user making the request actually has permission to access the group’s membership information. Since the group IDs are incremental for the whole Redash environment, without distinction between organizations, admins in one organization can enumerate all the groups in other organizations and their users, accessing their emails and full names.

Logic operators 🤯