### PR TITLE
Delete locks for cancelled queries

### DIFF
--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -45,20 +45,26 @@ def enqueue_query(
             if job_id:
                 logger.info("[%s] Found existing job: %s", query_hash, job_id)
                 job_complete = None
+                job_cancelled = None
 
                 try:
                     job = Job.fetch(job_id)
                     job_exists = True
                     status = job.get_status()
                     job_complete = status in [JobStatus.FINISHED, JobStatus.FAILED]
+                    job_cancelled = job.is_cancelled
 
                     if job_complete:
                         message = "job found is complete (%s)" % status
+                    elif job_cancelled:
+                        message = "job found has ben cancelled"
                 except NoSuchJobError:
                     message = "job found has expired"
                     job_exists = False
 
-                if job_complete or not job_exists:
+                lock_is_irrelevant = job_complete or job_cancelled or not job_exists
+
+                if lock_is_irrelevant:
                     logger.info("[%s] %s, removing lock", query_hash, message)
                     redis_connection.delete(_job_lock_id(query_hash, data_source.id))
                     job = None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When a user cancels a job, it gets marked for cancellation immediately, but it may take up to 5 seconds for the job to actually gets cancelled (5 seconds is the interval set for the work horse monitor). If a user tries to re-execute the query during these 5 seconds, `enqueue_query` will still see this query as execution and will refuse to enqueue it again.

This PR will treat cancelled jobs as irrelevant (like complete or expired jobs) and will allow executing them.
