### PR TITLE
Textbox: confirm close if text was changed

### DIFF
--- a/client/app/components/dashboards/TextboxDialog.jsx
+++ b/client/app/components/dashboards/TextboxDialog.jsx
@@ -44,11 +44,10 @@ function TextboxDialog({ dialog, isNew, ...props }) {
     const originalText = props.text;
     if (text !== originalText) {
       Modal.confirm({
-        title: "Confirm action",
-        content: "Closing this dialog will discard all changes you've made. Are you sure?",
+        title: "Quit editing?",
+        content: "Changes you made so far will not be saved. Are you sure?",
         okText: "Yes, discard changes",
         okType: "danger",
-        cancelText: "No, get me back",
         onOk: () => dialog.dismiss(),
         maskClosable: true,
         autoFocusButton: null,

--- a/client/app/components/dashboards/TextboxDialog.jsx
+++ b/client/app/components/dashboards/TextboxDialog.jsx
@@ -46,7 +46,7 @@ function TextboxDialog({ dialog, isNew, ...props }) {
       Modal.confirm({
         title: "Quit editing?",
         content: "Changes you made so far will not be saved. Are you sure?",
-        okText: "Yes, discard changes",
+        okText: "Yes, quit",
         okType: "danger",
         onOk: () => dialog.dismiss(),
         maskClosable: true,

--- a/client/app/components/dashboards/TextboxDialog.jsx
+++ b/client/app/components/dashboards/TextboxDialog.jsx
@@ -40,11 +40,31 @@ function TextboxDialog({ dialog, isNew, ...props }) {
     });
   }, [dialog, isNew, text]);
 
+  const confirmDialogDismiss = useCallback(() => {
+    const originalText = props.text;
+    if (text !== originalText) {
+      Modal.confirm({
+        title: "Confirm action",
+        content: "Closing this dialog will discard all changes you've made. Are you sure?",
+        okText: "Yes, discard changes",
+        okType: "danger",
+        cancelText: "No, get me back",
+        onOk: () => dialog.dismiss(),
+        maskClosable: true,
+        autoFocusButton: null,
+        style: { top: 170 },
+      });
+    } else {
+      dialog.dismiss();
+    }
+  }, [dialog, text, props.text]);
+
   return (
     <Modal
       {...dialog.props}
       title={isNew ? "Add Textbox" : "Edit Textbox"}
       onOk={saveWidget}
+      onCancel={confirmDialogDismiss}
       okText={isNew ? "Add to Dashboard" : "Save"}
       width={500}
       wrapProps={{ "data-test": "TextboxDialog" }}>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

When adding or editing a textbox it's very easy to accidentally close the dialog and lose all changes (by clicking outside of dialog). This PR solves this issue by showing a confirmation dialog when trying to close a textbox dialog with changes.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/12139186/86013072-6a695400-ba27-11ea-855a-02f9d88cfae7.png)
