### PR TITLE
Fix dashboard root container height bug on Safari

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/index.less
+++ b/client/app/components/ApplicationArea/ApplicationLayout/index.less
@@ -7,7 +7,7 @@ body #application-root {
   flex-direction: row;
   justify-content: stretch;
   padding-bottom: 0 !important;
-  height: 100vh;
+  min-height: 100vh;
 
   .application-layout-side-menu {
     height: 100vh;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Both on mobile Safari as well as desktop Safari, the dashboard controls overlap with the dashboard content:

![image](https://user-images.githubusercontent.com/768011/85994530-c6db5d80-b9ac-11ea-9b41-35a706a92f59.png)

The reason for this is that the `application-root` container on Safari is limited to the viewport height. Chrome ignores the `height: 100vh` and just pushes beyond that, but webkit limits the height and this has all sorts of consequences.

The fix should address that and still get the desired effect of having 100vh as the minimum height.
