### PR TITLE
Fix broken custom JS visualization settings

### DIFF
--- a/client/app/components/visualizations/visualizationComponents.jsx
+++ b/client/app/components/visualizations/visualizationComponents.jsx
@@ -28,7 +28,7 @@ function wrapComponentWithSettings(WrappedComponent) {
         "floatFormat",
         "booleanValues",
         "tableCellMaxJSONSize",
-        "allowCustomJSVisualization",
+        "allowCustomJSVisualizations",
         "hidePlotlyModeBar",
       ]),
     });

--- a/viz-lib/src/visualizations/visualizationsSettings.js
+++ b/viz-lib/src/visualizations/visualizationsSettings.js
@@ -40,7 +40,7 @@ export const visualizationsSettings = {
   floatFormat: "0,0.00",
   booleanValues: ["false", "true"],
   tableCellMaxJSONSize: 50000,
-  allowCustomJSVisualization: false,
+  allowCustomJSVisualizations: false,
   hidePlotlyModeBar: false,
   choroplethAvailableMaps: {},
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

The setting to allow custom JS visualizations was broken because of a typo and not getting passed through to the visualization components, therefore never showing the "Custom" option in the chart type selector or rendering widgets correctly.
