### PR TITLE
POLP: new datasource always add to admin group

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -150,7 +150,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
     def create_with_group(cls, *args, **kwargs):
         data_source = cls(*args, **kwargs)
         data_source_group = DataSourceGroup(
-            data_source=data_source, group=data_source.org.default_group
+            data_source=data_source, group=data_source.org.admin_group
         )
         db.session.add_all([data_source, data_source_group])
         return data_source


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
from the principle of least privilege (POLP), it is nicer new data source didn't add to "default" group. We can add to "admin" group instead

## Related Tickets & Documents
https://discuss.redash.io/t/prevent-new-connections-being-added-to-default-group/4791
https://discuss.redash.io/t/new-data-source-always-gets-added-to-default-group/6006

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
