### PR TITLE
Add plus between tags to clarify how they are used

### DIFF
--- a/client/app/assets/less/redash/tags-control.less
+++ b/client/app/assets/less/redash/tags-control.less
@@ -10,6 +10,10 @@
     display: inline-block;
   }
 
+  .tag-separator {
+    margin: 4px 3px 0 0;
+  }
+
   &.disabled {
     opacity: 0.4;
   }

--- a/client/app/components/NoTaggedObjectsFound.jsx
+++ b/client/app/components/NoTaggedObjectsFound.jsx
@@ -7,7 +7,7 @@ export default function NoTaggedObjectsFound({ objectType, tags }) {
   return (
     <BigMessage icon="fa-tags">
       No {objectType} found tagged with&nbsp;
-      <TagsControl className="inline-tags-control" tags={Array.from(tags)} />.
+      <TagsControl className="inline-tags-control" tags={Array.from(tags)} tagSeparator={"+"} />.
     </BigMessage>
   );
 }

--- a/client/app/components/tags-control/TagsControl.jsx
+++ b/client/app/components/tags-control/TagsControl.jsx
@@ -12,6 +12,7 @@ export class TagsControl extends React.Component {
     onEdit: PropTypes.func,
     className: PropTypes.string,
     tagsExtra: PropTypes.node,
+    tagSeparator: PropTypes.node,
     children: PropTypes.node,
   };
 
@@ -22,6 +23,7 @@ export class TagsControl extends React.Component {
     onEdit: () => {},
     className: "",
     tagsExtra: null,
+    tagSeparator: null,
     children: null,
   };
 
@@ -49,13 +51,17 @@ export class TagsControl extends React.Component {
   }
 
   render() {
+    const { tags, tagSeparator } = this.props;
     return (
       <div className={"tags-control " + this.props.className} data-test="TagsControl">
         {this.props.children}
-        {map(this.props.tags, tag => (
-          <span className="label label-tag" key={tag} title={tag} data-test="TagLabel">
-            {tag}
-          </span>
+        {map(tags, (tag, i) => (
+          <React.Fragment key={tag}>
+            {tagSeparator && i > 0 && <span className="tag-separator">{tagSeparator}</span>}
+            <span className="label label-tag" key={tag} title={tag} data-test="TagLabel">
+              {tag}
+            </span>
+          </React.Fragment>
         ))}
         {this.props.canEdit && this.renderEditButton()}
         {this.props.tagsExtra}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

As stated in #4628 , this PR adds a '+' between tags in the case of no results to clarify how they are being used.

## Related Tickets & Documents

Closes #4628

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

How the tags look after this change (both with and without the separator):

![Captura de Pantalla 2020-07-01 a la(s) 2 42 16 p  m](https://user-images.githubusercontent.com/144447/86289866-0aeb7f80-bbb2-11ea-9fec-ec9b06f5a59e.png)
![Captura de Pantalla 2020-07-01 a la(s) 2 42 45 p  m](https://user-images.githubusercontent.com/144447/86289868-0b841600-bbb2-11ea-9182-51bd55544682.png)
![Captura de Pantalla 2020-07-01 a la(s) 3 46 08 p  m](https://user-images.githubusercontent.com/144447/86289869-0c1cac80-bbb2-11ea-98f9-c5fe961ed8b7.png)

