### PR TITLE
Install puppeteer with unsafe perm to avoid cypress flaky

### DIFF
--- a/.circleci/Dockerfile.cypress
+++ b/.circleci/Dockerfile.cypress
@@ -4,7 +4,7 @@ ENV APP /usr/src/app
 WORKDIR $APP
 
 COPY package.json $APP/package.json
-RUN npm run cypress:install > /dev/null
+RUN npm install puppeteer --unsafe-perm=true && npm run cypress:install > /dev/null
 
 COPY client/cypress $APP/client/cypress
 COPY cypress.json $APP/cypress.json


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
Following [this](https://support.circleci.com/hc/en-us/articles/360044577411-ERROR-Failed-to-download-Chromium-r686378-)

Running some tests to make sure it worked.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
