### PR TITLE
Allow to change order of legend items

### DIFF
--- a/viz-lib/src/visualizations/chart/Editor/GeneralSettings.jsx
+++ b/viz-lib/src/visualizations/chart/Editor/GeneralSettings.jsx
@@ -173,23 +173,42 @@ export default function GeneralSettings({ options, data, onOptionsChange }) {
       )}
 
       {!includes(["custom", "heatmap"], options.globalSeriesType) && (
-        <Section>
-          <Select
-            label="Legend Placement"
-            data-test="Chart.LegendPlacement"
-            value={options.legend.enabled ? options.legend.placement : "hidden"}
-            onChange={handleLegendPlacementChange}>
-            <Select.Option value="hidden" data-test="Chart.LegendPlacement.HideLegend">
-              Hide legend
-            </Select.Option>
-            <Select.Option value="auto" data-test="Chart.LegendPlacement.Auto">
-              Right
-            </Select.Option>
-            <Select.Option value="below" data-test="Chart.LegendPlacement.Below">
-              Bottom
-            </Select.Option>
-          </Select>
-        </Section>
+        <React.Fragment>
+          <Section>
+            <Select
+              label="Legend Placement"
+              data-test="Chart.LegendPlacement"
+              value={options.legend.enabled ? options.legend.placement : "hidden"}
+              onChange={handleLegendPlacementChange}>
+              <Select.Option value="hidden" data-test="Chart.LegendPlacement.HideLegend">
+                Hide legend
+              </Select.Option>
+              <Select.Option value="auto" data-test="Chart.LegendPlacement.Auto">
+                Right
+              </Select.Option>
+              <Select.Option value="below" data-test="Chart.LegendPlacement.Below">
+                Bottom
+              </Select.Option>
+            </Select>
+          </Section>
+
+          {options.legend.enabled && (
+            <Section>
+              <Select
+                label="Legend Items Order"
+                data-test="Chart.LegendItemsOrder"
+                value={options.legend.traceorder}
+                onChange={traceorder => onOptionsChange({ legend: { traceorder } })}>
+                <Select.Option value="normal" data-test="Chart.LegendItemsOrder.Normal">
+                  Normal
+                </Select.Option>
+                <Select.Option value="reversed" data-test="Chart.LegendItemsOrder.Reversed">
+                  Reversed
+                </Select.Option>
+              </Select>
+            </Section>
+          )}
+        </React.Fragment>
       )}
 
       {includes(["box"], options.globalSeriesType) && (

--- a/viz-lib/src/visualizations/chart/getOptions.js
+++ b/viz-lib/src/visualizations/chart/getOptions.js
@@ -4,7 +4,7 @@ import { visualizationsSettings } from "@/visualizations/visualizationsSettings"
 const DEFAULT_OPTIONS = {
   globalSeriesType: "column",
   sortX: true,
-  legend: { enabled: true, placement: "auto" },
+  legend: { enabled: true, placement: "auto", traceorder: "normal" },
   yAxis: [{ type: "linear" }, { type: "linear", opposite: true }],
   xAxis: { type: "-", labels: { enabled: true } },
   error_y: { type: "data", visible: true },

--- a/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
+++ b/viz-lib/src/visualizations/chart/plotly/applyLayoutFixes.js
@@ -1,4 +1,4 @@
-import { find, pick, reduce } from "lodash";
+import { find, pick, extend } from "lodash";
 
 function fixLegendContainer(plotlyElement) {
   const legend = plotlyElement.querySelector(".legend");
@@ -20,7 +20,7 @@ function placeLegendNextToPlot(plotlyElement, layout, updatePlot) {
     prop => prop in plotlyElement.style
   );
 
-  layout.legend = {
+  layout.legend = extend({}, layout.legend, {
     orientation: "v",
     // vertical legend will be rendered properly, so just place it to the right
     // side of plot
@@ -28,7 +28,7 @@ function placeLegendNextToPlot(plotlyElement, layout, updatePlot) {
     x: 1,
     xanchor: "left",
     yanchor: "top",
-  };
+  });
 
   const legend = plotlyElement.querySelector(".legend");
   if (legend) {
@@ -56,7 +56,7 @@ function placeLegendBelowPlot(plotlyElement, layout, updatePlot) {
   // plot height), re-render plot again and offset legend to the space under
   // the plot.
   // Related issue: https://github.com/plotly/plotly.js/issues/1199
-  layout.legend = {
+  layout.legend = extend({}, layout.legend, {
     orientation: "h",
     // locate legend inside of plot area - otherwise plotly will preserve
     // some amount of space under the plot; also this will limit legend height
@@ -65,7 +65,7 @@ function placeLegendBelowPlot(plotlyElement, layout, updatePlot) {
     x: 0,
     xanchor: "left",
     yanchor: "bottom",
-  };
+  });
 
   // set `overflow: visible` to svg containing legend because later we will
   // position legend outside of it

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
@@ -3,15 +3,13 @@
     "options": {
       "globalSeriesType": "box",
       "xAxis": { "type": "-", "labels": { "enabled": true } },
-      "yAxis": [
-        { "type": "linear" },
-        { "type": "linear", "opposite": true }
-      ],
-      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } }
+      "yAxis": [{ "type": "linear" }, { "type": "linear", "opposite": true }],
+      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } },
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" }
-    ]
+    "series": [{ "name": "a" }]
   },
   "output": {
     "layout": {
@@ -20,8 +18,11 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "boxmode": "group",
-      "boxgroupgap": 0.50,
+      "boxgroupgap": 0.5,
       "xaxis": {
         "automargin": true,
         "showticklabels": true,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
@@ -3,16 +3,13 @@
     "options": {
       "globalSeriesType": "box",
       "xAxis": { "type": "-", "labels": { "enabled": true } },
-      "yAxis": [
-        { "type": "linear" },
-        { "type": "linear", "opposite": true }
-      ],
-      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } }
+      "yAxis": [{ "type": "linear" }, { "type": "linear", "opposite": true }],
+      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } },
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" },
-      { "name": "b", "yaxis": "y2" }
-    ]
+    "series": [{ "name": "a" }, { "name": "b", "yaxis": "y2" }]
   },
   "output": {
     "layout": {
@@ -21,8 +18,11 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "boxmode": "group",
-      "boxgroupgap": 0.50,
+      "boxgroupgap": 0.5,
       "xaxis": {
         "automargin": true,
         "showticklabels": true,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
@@ -3,15 +3,13 @@
     "options": {
       "globalSeriesType": "column",
       "xAxis": { "type": "-", "labels": { "enabled": true } },
-      "yAxis": [
-        { "type": "linear" },
-        { "type": "linear", "opposite": true }
-      ],
-      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } }
+      "yAxis": [{ "type": "linear" }, { "type": "linear", "opposite": true }],
+      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } },
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" }
-    ]
+    "series": [{ "name": "a" }]
   },
   "output": {
     "layout": {
@@ -20,6 +18,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "xaxis": {
         "automargin": true,
         "showticklabels": true,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
@@ -3,16 +3,13 @@
     "options": {
       "globalSeriesType": "column",
       "xAxis": { "type": "-", "labels": { "enabled": true } },
-      "yAxis": [
-        { "type": "linear" },
-        { "type": "linear", "opposite": true }
-      ],
-      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } }
+      "yAxis": [{ "type": "linear" }, { "type": "linear", "opposite": true }],
+      "series": { "stacking": null, "error_y": { "type": "data", "visible": true } },
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" },
-      { "name": "b", "yaxis": "y2" }
-    ]
+    "series": [{ "name": "a" }, { "name": "b", "yaxis": "y2" }]
   },
   "output": {
     "layout": {
@@ -21,6 +18,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "xaxis": {
         "automargin": true,
         "showticklabels": true,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
@@ -2,17 +2,12 @@
   "input": {
     "options": {
       "globalSeriesType": "column",
-      "legend": { "enabled": false },
+      "legend": { "enabled": false, "traceorder": "normal" },
       "xAxis": { "type": "-", "labels": { "enabled": true } },
-      "yAxis": [
-        { "type": "linear" },
-        { "type": "linear", "opposite": true }
-      ],
+      "yAxis": [{ "type": "linear" }, { "type": "linear", "opposite": true }],
       "series": { "stacking": "stack", "error_y": { "type": "data", "visible": true } }
     },
-    "series": [
-      { "name": "a" }
-    ]
+    "series": [{ "name": "a" }]
   },
   "output": {
     "layout": {
@@ -21,6 +16,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": false,
+      "legend": {
+        "traceorder": "normal"
+      },
       "barmode": "relative",
       "xaxis": {
         "automargin": true,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
@@ -2,17 +2,12 @@
   "input": {
     "options": {
       "globalSeriesType": "column",
-      "legend": { "enabled": false },
+      "legend": { "enabled": false, "traceorder": "normal" },
       "xAxis": { "type": "-", "labels": { "enabled": true } },
-      "yAxis": [
-        { "type": "linear" },
-        { "type": "linear", "opposite": true }
-      ],
+      "yAxis": [{ "type": "linear" }, { "type": "linear", "opposite": true }],
       "series": { "stacking": null, "error_y": { "type": "data", "visible": true } }
     },
-    "series": [
-      { "name": "a" }
-    ]
+    "series": [{ "name": "a" }]
   },
   "output": {
     "layout": {
@@ -21,6 +16,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": false,
+      "legend": {
+        "traceorder": "normal"
+      },
       "xaxis": {
         "automargin": true,
         "showticklabels": true,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
@@ -2,13 +2,12 @@
   "input": {
     "options": {
       "globalSeriesType": "pie",
-      "textFormat": ""
+      "textFormat": "",
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" },
-      { "name": "b" },
-      { "name": "c" }
-    ]
+    "series": [{ "name": "a" }, { "name": "b" }, { "name": "c" }]
   },
   "output": {
     "layout": {
@@ -17,6 +16,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "annotations": [
         {
           "x": 0.24,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
@@ -2,11 +2,12 @@
   "input": {
     "options": {
       "globalSeriesType": "pie",
-      "textFormat": "{{ @@name }}"
+      "textFormat": "{{ @@name }}",
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" }
-    ]
+    "series": [{ "name": "a" }]
   },
   "output": {
     "layout": {
@@ -15,6 +16,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "annotations": []
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
@@ -2,11 +2,12 @@
   "input": {
     "options": {
       "globalSeriesType": "pie",
-      "textFormat": ""
+      "textFormat": "",
+      "legend": {
+        "traceorder": "normal"
+      }
     },
-    "series": [
-      { "name": "a" }
-    ]
+    "series": [{ "name": "a" }]
   },
   "output": {
     "layout": {
@@ -15,6 +16,9 @@
       "height": 300,
       "autosize": false,
       "showlegend": true,
+      "legend": {
+        "traceorder": "normal"
+      },
       "annotations": [
         {
           "x": 0.49,

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.js
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.js
@@ -124,6 +124,9 @@ export default function prepareLayout(element, options, data) {
     height: Math.max(5, Math.floor(element.offsetHeight)),
     autosize: false,
     showlegend: has(options, "legend") ? options.legend.enabled : true,
+    legend: {
+      traceorder: has(options, "legend") ? options.legend.traceorder : "normal",
+    },
   };
 
   switch (options.globalSeriesType) {

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.js
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.js
@@ -1,4 +1,4 @@
-import { filter, has, isNumber, isObject, isUndefined, map, max, min } from "lodash";
+import { filter, isNumber, isObject, isUndefined, map, max, min } from "lodash";
 import { getPieDimensions } from "./preparePieData";
 
 function getAxisTitle(axis) {
@@ -123,9 +123,9 @@ export default function prepareLayout(element, options, data) {
     width: Math.max(5, Math.floor(element.offsetWidth)),
     height: Math.max(5, Math.floor(element.offsetHeight)),
     autosize: false,
-    showlegend: has(options, "legend") ? options.legend.enabled : true,
+    showlegend: options.legend.enabled,
     legend: {
-      traceorder: has(options, "legend") ? options.legend.traceorder : "normal",
+      traceorder: options.legend.traceorder,
     },
   };
 

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.test.js
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable global-require, import/no-unresolved */
+import getOptions from "../getOptions";
 import prepareLayout from "./prepareLayout";
 
 const fakeElement = { offsetWidth: 400, offsetHeight: 300 };
@@ -8,55 +9,55 @@ describe("Visualizations", () => {
     describe("prepareLayout", () => {
       test("Pie", () => {
         const { input, output } = require("./fixtures/prepareLayout/pie");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Pie without annotations", () => {
         const { input, output } = require("./fixtures/prepareLayout/pie-without-annotations");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Pie with multiple series", () => {
         const { input, output } = require("./fixtures/prepareLayout/pie-multiple-series");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Box with single Y axis", () => {
         const { input, output } = require("./fixtures/prepareLayout/box-single-axis");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Box with second Y axis", () => {
         const { input, output } = require("./fixtures/prepareLayout/box-with-second-axis");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Default with single Y axis", () => {
         const { input, output } = require("./fixtures/prepareLayout/default-single-axis");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Default with second Y axis", () => {
         const { input, output } = require("./fixtures/prepareLayout/default-with-second-axis");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Default without legend", () => {
         const { input, output } = require("./fixtures/prepareLayout/default-without-legend");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
 
       test("Default with stacking", () => {
         const { input, output } = require("./fixtures/prepareLayout/default-with-stacking");
-        const layout = prepareLayout(fakeElement, input.options, input.series);
+        const layout = prepareLayout(fakeElement, getOptions(input.options), input.series);
         expect(layout).toEqual(output.layout);
       });
     });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Reported by user: order of legend items is reversed to order in which series appear on stacked bar chart.

Added two options: "Normal" (items are shown as defined in options) - the default value for backward compatibility, and "Reversed".

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/12139186/86349533-f36fcd80-bc69-11ea-8164-43d15b929f01.png)
![image](https://user-images.githubusercontent.com/12139186/86349557-fff42600-bc69-11ea-81ea-da4145090264.png)
