### PR TITLE
Fix Databricks Schema Browser scrollbar

### DIFF
--- a/client/app/assets/less/inc/schema-browser.less
+++ b/client/app/assets/less/inc/schema-browser.less
@@ -27,8 +27,7 @@ div.table-name {
 }
 
 .schema-browser {
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   border: none;
   padding-top: 10px;
   position: relative;

--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -137,10 +137,6 @@ a.label-tag {
   }
 }
 
-.schema-browser {
-  overflow-y: auto;
-}
-
 .query-page-wrapper {
   display: flex;
   flex-direction: column;

--- a/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.jsx
+++ b/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.jsx
@@ -119,13 +119,15 @@ export default function DatabricksSchemaBrowser({
           }
         />
       </div>
-      <SchemaList
-        loading={loadingDatabases || loadingSchema}
-        schema={filteredSchema}
-        expandedFlags={expandedFlags}
-        onTableExpand={toggleTable}
-        onItemSelect={onItemSelect}
-      />
+      <div className="schema-list-wrapper">
+        <SchemaList
+          loading={loadingDatabases || loadingSchema}
+          schema={filteredSchema}
+          expandedFlags={expandedFlags}
+          onTableExpand={toggleTable}
+          onItemSelect={onItemSelect}
+        />
+      </div>
     </div>
   );
 }

--- a/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.less
+++ b/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.less
@@ -31,7 +31,8 @@
     }
   }
 
-  .schema-browser {
+  .schema-list-wrapper {
+    height: 100%;
     border: 1px solid #eaeaea;
     border-top: 0;
     border-radius: 0 0 4px 4px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Issue: Double scrollbox on SchemaBrowser (the `.schema-browser` had an extra scrollbar)

This PR fixes the DB SchemaBrowser scrollbar by moving the border definition to an external wrapper as it seems the `AutoSizer` doesn't work that well when the parent has a border and creates an overflow.

I also took the opportunity and removed the scrollbar from the `.schema-browser` since after we update that component, it is the AutoSizer the one that contains the scroll.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**
<img width="602" alt="Screen Shot 2020-07-02 at 15 58 34" src="https://user-images.githubusercontent.com/3356951/86399033-f3c59400-bc7c-11ea-94a7-76570ae035df.png">
2 scroll areas were created

**After**
<img width="612" alt="Screen Shot 2020-07-02 at 15 57 02" src="https://user-images.githubusercontent.com/3356951/86399025-ef997680-bc7c-11ea-8b0c-247edb52e9c8.png">
Only one scroll area remaining -> the one from AutoSizer