### PR TITLE
Fix Schema Browser items height for Firefox

### DIFF
--- a/client/app/assets/less/inc/schema-browser.less
+++ b/client/app/assets/less/inc/schema-browser.less
@@ -6,6 +6,7 @@ div.table-name {
   padding: 2px 22px 2px 10px;
   border-radius: @redash-radius;
   position: relative;
+  height: 22px;
 
   .copy-to-editor {
     display: none;
@@ -64,6 +65,7 @@ div.table-name {
     text-overflow: ellipsis;
     white-space: nowrap;
     position: relative;
+    height: 18px;
 
     .copy-to-editor {
       display: none;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
The SchemaBrowser virtualization relies on the Table name having 22px and column 18px of height.

For Chrome the items were taking the 18px height by default, but for FF they weren't (not 100% sure about why).

@kravets-levko lmk if you got any other ideas. 

(See images below for a visible explanation)

## Related Tickets & Documents
Fixes #4987 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
| Before | After |
| ------ | ----- |
| <img width="300" src="https://user-images.githubusercontent.com/3356951/86404053-41de9580-bc85-11ea-9754-a64c457144e1.gif" /> | <img width="300" src="https://user-images.githubusercontent.com/3356951/86404074-4dca5780-bc85-11ea-8895-58162839590f.gif" /> |

