### PR TITLE
add auth related options to Hive data source

### DIFF
--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -50,8 +50,29 @@ class Hive(BaseSQLQueryRunner):
                 "port": {"type": "number"},
                 "database": {"type": "string"},
                 "username": {"type": "string"},
+                "auth": {
+                    "type": "string",
+                    "extendedEnum": [{"value": value, "name": value} for value in ("NONE", "NOSASL", "CUSTOM", "LDAP", "KERBEROS")],
+                },
+                "password": {
+                    "type": "string",
+                    "title": "Password (LDAP or CUSTOM mode)"
+                },
+                "kerberos_service_name": {
+                    "type": "string",
+                    "title": "Kerberos Service Name (KERBEROS mode)",
+                },
             },
-            "order": ["host", "port", "database", "username"],
+            "order": [
+                "host",
+                "port",
+                "database",
+                "username",
+                "auth",
+                "password",
+                "kerberos_service_name",
+            ],
+            "secret": ["password"],
             "required": ["host"],
         }
 
@@ -110,6 +131,9 @@ class Hive(BaseSQLQueryRunner):
             port=self.configuration.get("port", None),
             database=self.configuration.get("database", "default"),
             username=self.configuration.get("username", None),
+            auth=self.configuration.get("auth", None),
+            kerberos_service_name=self.configuration.get("kerberos_service_name", None),
+            password=self.configuration.get("password", None),
         )
 
         return connection


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

Add auth related option to connect to hive. (In our use case, NOSASL mode).

ref: https://github.com/dropbox/PyHive/blob/master/pyhive/hive.py#L100

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
