### PR TITLE
Query Source: Add Shift+Enter shortcut for query execution

### DIFF
--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -1,4 +1,4 @@
-import { isFunction, map, filter, fromPairs } from "lodash";
+import { isFunction, map, filter, fromPairs, noop } from "lodash";
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import Tooltip from "antd/lib/tooltip";
@@ -43,10 +43,10 @@ export default function EditorControl({
   useEffect(() => {
     const buttons = filter(
       [addParameterButtonProps, formatButtonProps, saveButtonProps, executeButtonProps],
-      b => b.shortcut && !b.disabled && isFunction(b.onClick)
+      b => b.shortcut && isFunction(b.onClick)
     );
     if (buttons.length > 0) {
-      const shortcuts = fromPairs(map(buttons, b => [b.shortcut, b.onClick]));
+      const shortcuts = fromPairs(map(buttons, b => [b.shortcut, b.disabled ? noop : b.onClick]));
       KeyboardShortcuts.bind(shortcuts);
       return () => {
         KeyboardShortcuts.unbind(shortcuts);

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -1,4 +1,4 @@
-import { isFunction, map, filter, fromPairs } from "lodash";
+import { isFunction, map, filter, fromPairs, noop } from "lodash";
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import Tooltip from "antd/lib/tooltip";
@@ -43,10 +43,10 @@ export default function EditorControl({
   useEffect(() => {
     const buttons = filter(
       [addParameterButtonProps, formatButtonProps, saveButtonProps, executeButtonProps],
-      b => b.shortcut && !b.disabled && isFunction(b.onClick)
+      b => b.shortcut && (!b.disabled || b.keepShortcutKeysWhenDisabled) && isFunction(b.onClick)
     );
     if (buttons.length > 0) {
-      const shortcuts = fromPairs(map(buttons, b => [b.shortcut, b.onClick]));
+      const shortcuts = fromPairs(map(buttons, b => [b.shortcut, b.disabled ? noop : b.onClick]));
       KeyboardShortcuts.bind(shortcuts);
       return () => {
         KeyboardShortcuts.unbind(shortcuts);
@@ -137,6 +137,7 @@ const ButtonPropsPropType = PropTypes.oneOfType([
     onClick: PropTypes.func,
     text: PropTypes.node,
     shortcut: PropTypes.string,
+    keepShortcutKeysWhenDisabled: PropTypes.bool,
   }),
 ]);
 

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -1,4 +1,4 @@
-import { isFunction, map, filter, fromPairs, noop } from "lodash";
+import { isFunction, map, filter, fromPairs } from "lodash";
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import Tooltip from "antd/lib/tooltip";
@@ -43,10 +43,10 @@ export default function EditorControl({
   useEffect(() => {
     const buttons = filter(
       [addParameterButtonProps, formatButtonProps, saveButtonProps, executeButtonProps],
-      b => b.shortcut && (!b.disabled || b.keepShortcutKeysWhenDisabled) && isFunction(b.onClick)
+      b => b.shortcut && !b.disabled && isFunction(b.onClick)
     );
     if (buttons.length > 0) {
-      const shortcuts = fromPairs(map(buttons, b => [b.shortcut, b.disabled ? noop : b.onClick]));
+      const shortcuts = fromPairs(map(buttons, b => [b.shortcut, b.onClick]));
       KeyboardShortcuts.bind(shortcuts);
       return () => {
         KeyboardShortcuts.unbind(shortcuts);
@@ -137,7 +137,6 @@ const ButtonPropsPropType = PropTypes.oneOfType([
     onClick: PropTypes.func,
     text: PropTypes.node,
     shortcut: PropTypes.string,
-    keepShortcutKeysWhenDisabled: PropTypes.bool,
   }),
 ]);
 

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -295,7 +295,7 @@ function QuerySource(props) {
                       }
                       executeButtonProps={{
                         disabled: !queryFlags.canExecute || isQueryExecuting || areParametersDirty,
-                        shortcut: "mod+enter, alt+enter, ctrl+enter",
+                        shortcut: "mod+enter, alt+enter, ctrl+enter, shift+enter",
                         onClick: doExecuteQuery,
                         text: (
                           <span className="hidden-xs">{selectedText === null ? "Execute" : "Execute Selected"}</span>

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -296,7 +296,6 @@ function QuerySource(props) {
                       executeButtonProps={{
                         disabled: !queryFlags.canExecute || isQueryExecuting || areParametersDirty,
                         shortcut: "mod+enter, alt+enter, ctrl+enter, shift+enter",
-                        keepShortcutKeysWhenDisabled: true,
                         onClick: doExecuteQuery,
                         text: (
                           <span className="hidden-xs">{selectedText === null ? "Execute" : "Execute Selected"}</span>

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -296,6 +296,7 @@ function QuerySource(props) {
                       executeButtonProps={{
                         disabled: !queryFlags.canExecute || isQueryExecuting || areParametersDirty,
                         shortcut: "mod+enter, alt+enter, ctrl+enter, shift+enter",
+                        keepShortcutKeysWhenDisabled: true,
                         onClick: doExecuteQuery,
                         text: (
                           <span className="hidden-xs">{selectedText === null ? "Execute" : "Execute Selected"}</span>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Feature

## Description
This is the default set of keys used for Jupyter Notebooks, so it makes sense to support it too.

Note:
1. This is only applied to the Query Source Page
2. I tried to make 314eae5bb78328877b5829354ccae8c29a3bae52 from the QueryEditor component, without success. The main idea is not to have an annoying behavior of a new line added when you press Shift+Enter and the query cannot execute.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--