### PR TITLE
Eager load outdated queries

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -632,7 +632,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def outdated_queries(cls):
-        queries = (
+        queries = list(
             Query.query.options(
                 joinedload(Query.latest_query_data).load_only("retrieved_at")
             )

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -632,12 +632,13 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
 
     @classmethod
     def outdated_queries(cls):
-        queries = list(
+        queries = (
             Query.query.options(
                 joinedload(Query.latest_query_data).load_only("retrieved_at")
             )
             .filter(Query.schedule.isnot(None))
             .order_by(Query.id)
+            .all()
         )
 
         now = utils.utcnow()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When there is a large amount of outdated queries, some short-running queries can execute more than once per interval. It appears that it is caused by a race condition in which the `outdated_queries` query takes several seconds to complete, during that time some jobs start executing and the local copy of `scheduled_query_executions` becomes stale.

This PR eager-loads the outdated queries before getting fresh values into `scheduled_query_executions`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
