### PR TITLE
Add Column Type to Databricks schema browser

### DIFF
--- a/client/app/assets/less/inc/schema-browser.less
+++ b/client/app/assets/less/inc/schema-browser.less
@@ -66,6 +66,13 @@ div.table-name {
     position: relative;
     height: 18px;
 
+    .column-type {
+      color: fade(@text-color, 80%);
+      font-size: 10px;
+      margin-left: 2px;
+      text-transform: uppercase;
+    }
+
     .copy-to-editor {
       display: none;
     }

--- a/client/app/components/queries/QueryEditor/ace.js
+++ b/client/app/components/queries/QueryEditor/ace.js
@@ -1,4 +1,4 @@
-import { isNil, map } from "lodash";
+import { isNil, map, get } from "lodash";
 import AceEditor from "react-ace";
 import ace from "ace-builds";
 
@@ -30,11 +30,12 @@ defineDummySnippets("yaml");
 function buildTableColumnKeywords(table) {
   const keywords = [];
   table.columns.forEach(column => {
+    const columnName = get(column, "name", column);
     keywords.push({
-      name: `${table.name}.${column}`,
-      value: `${table.name}.${column}`,
+      name: `${table.name}.${columnName}`,
+      value: `${table.name}.${columnName}`,
       score: 100,
-      meta: "Column",
+      meta: get(column, "type", "Column"),
     });
   });
   return keywords;
@@ -54,7 +55,8 @@ function buildKeywordsFromSchema(schema) {
     });
     tableColumnKeywords[table.name] = buildTableColumnKeywords(table);
     table.columns.forEach(c => {
-      columnKeywords[c] = "Column";
+      const columnName = get(c, "name", c);
+      columnKeywords[columnName] = get(c, "type", "Column");
     });
   });
 

--- a/client/app/components/queries/QueryEditor/ace.js
+++ b/client/app/components/queries/QueryEditor/ace.js
@@ -1,4 +1,4 @@
-import { isNil, map, get } from "lodash";
+import { capitalize, isNil, map, get } from "lodash";
 import AceEditor from "react-ace";
 import ace from "ace-builds";
 
@@ -35,7 +35,7 @@ function buildTableColumnKeywords(table) {
       name: `${table.name}.${columnName}`,
       value: `${table.name}.${columnName}`,
       score: 100,
-      meta: get(column, "type", "Column"),
+      meta: capitalize(get(column, "type", "Column")),
     });
   });
   return keywords;
@@ -56,7 +56,7 @@ function buildKeywordsFromSchema(schema) {
     tableColumnKeywords[table.name] = buildTableColumnKeywords(table);
     table.columns.forEach(c => {
       const columnName = get(c, "name", c);
-      columnKeywords[columnName] = get(c, "type", "Column");
+      columnKeywords[columnName] = capitalize(get(c, "type", "Column"));
     });
   });
 

--- a/client/app/components/queries/QueryEditor/ace.js
+++ b/client/app/components/queries/QueryEditor/ace.js
@@ -30,7 +30,7 @@ defineDummySnippets("yaml");
 function buildTableColumnKeywords(table) {
   const keywords = [];
   table.columns.forEach(column => {
-    const columnName = get(column, "name", column);
+    const columnName = get(column, "name");
     keywords.push({
       name: `${table.name}.${columnName}`,
       value: `${table.name}.${columnName}`,

--- a/client/app/components/queries/QueryEditor/index.jsx
+++ b/client/app/components/queries/QueryEditor/index.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState, useCallback, useImperativeHandle }
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { AceEditor, snippetsModule, updateSchemaCompleter } from "./ace";
+import { SchemaItemType } from "@/components/queries/SchemaBrowser";
 import resizeObserver from "@/services/resizeObserver";
 import QuerySnippet from "@/services/query-snippet";
 
@@ -157,13 +158,7 @@ QueryEditor.propTypes = {
   syntax: PropTypes.string,
   value: PropTypes.string,
   autocompleteEnabled: PropTypes.bool,
-  schema: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      size: PropTypes.number,
-      columns: PropTypes.arrayOf(PropTypes.string).isRequired,
-    })
-  ),
+  schema: PropTypes.arrayOf(SchemaItemType),
   onChange: PropTypes.func,
   onSelectionChange: PropTypes.func,
 };

--- a/client/app/components/queries/SchemaBrowser.jsx
+++ b/client/app/components/queries/SchemaBrowser.jsx
@@ -12,13 +12,10 @@ import useDataSourceSchema from "@/pages/queries/hooks/useDataSourceSchema";
 import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
 import LoadingState from "../items-list/components/LoadingState";
 
-const SchemaItemColumnType = PropTypes.oneOfType([
-  PropTypes.string,
-  PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    type: PropTypes.string,
-  }),
-]);
+const SchemaItemColumnType = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string,
+});
 
 export const SchemaItemType = PropTypes.shape({
   name: PropTypes.string.isRequired,
@@ -60,7 +57,7 @@ function SchemaItem({ item, expanded, onToggle, onSelect, ...props }) {
       {expanded && (
         <div>
           {map(item.columns, column => {
-            const columnName = get(column, "name", column);
+            const columnName = get(column, "name");
             const columnType = get(column, "type");
             return (
               <div key={columnName} className="table-open">
@@ -163,7 +160,7 @@ export function applyFilterOnSchema(schema, filterString) {
       schema,
       item =>
         includes(item.name.toLowerCase(), nameFilter) ||
-        some(item.columns, column => includes(get(column, "name", column).toLowerCase(), columnFilter))
+        some(item.columns, column => includes(get(column, "name").toLowerCase(), columnFilter))
     );
   }
 
@@ -175,7 +172,7 @@ export function applyFilterOnSchema(schema, filterString) {
       if (includes(item.name.toLowerCase(), nameFilter)) {
         item = {
           ...item,
-          columns: filter(item.columns, column => includes(get(column, "name", column).toLowerCase(), columnFilter)),
+          columns: filter(item.columns, column => includes(get(column, "name").toLowerCase(), columnFilter)),
         };
         return item.columns.length > 0 ? item : null;
       }

--- a/client/app/components/queries/SchemaBrowser.jsx
+++ b/client/app/components/queries/SchemaBrowser.jsx
@@ -1,4 +1,4 @@
-import { isNil, map, filter, some, includes } from "lodash";
+import { isNil, map, filter, some, includes, get } from "lodash";
 import cx from "classnames";
 import React, { useState, useCallback, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
@@ -12,10 +12,18 @@ import useDataSourceSchema from "@/pages/queries/hooks/useDataSourceSchema";
 import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
 import LoadingState from "../items-list/components/LoadingState";
 
-const SchemaItemType = PropTypes.shape({
+const SchemaItemColumnType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string,
+  }),
+]);
+
+export const SchemaItemType = PropTypes.shape({
   name: PropTypes.string.isRequired,
   size: PropTypes.number,
-  columns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  columns: PropTypes.arrayOf(SchemaItemColumnType).isRequired,
 });
 
 const schemaTableHeight = 22;
@@ -51,16 +59,20 @@ function SchemaItem({ item, expanded, onToggle, onSelect, ...props }) {
       </div>
       {expanded && (
         <div>
-          {map(item.columns, column => (
-            <div key={column} className="table-open">
-              {column}
-              <i
-                className="fa fa-angle-double-right copy-to-editor"
-                aria-hidden="true"
-                onClick={e => handleSelect(e, column)}
-              />
-            </div>
-          ))}
+          {map(item.columns, column => {
+            const columnName = get(column, "name", column);
+            const columnType = get(column, "type");
+            return (
+              <div key={columnName} className="table-open">
+                {columnName} {columnType && <span className="column-type">{columnType}</span>}
+                <i
+                  className="fa fa-angle-double-right copy-to-editor"
+                  aria-hidden="true"
+                  onClick={e => handleSelect(e, columnName)}
+                />
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
@@ -151,7 +163,7 @@ export function applyFilterOnSchema(schema, filterString) {
       schema,
       item =>
         includes(item.name.toLowerCase(), nameFilter) ||
-        some(item.columns, column => includes(column.toLowerCase(), columnFilter))
+        some(item.columns, column => includes(get(column, "name", column).toLowerCase(), columnFilter))
     );
   }
 
@@ -161,7 +173,10 @@ export function applyFilterOnSchema(schema, filterString) {
   return filter(
     map(schema, item => {
       if (includes(item.name.toLowerCase(), nameFilter)) {
-        item = { ...item, columns: filter(item.columns, column => includes(column.toLowerCase(), columnFilter)) };
+        item = {
+          ...item,
+          columns: filter(item.columns, column => includes(get(column, "name", column).toLowerCase(), columnFilter)),
+        };
         return item.columns.length > 0 ? item : null;
       }
     })

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -1,10 +1,14 @@
-import { has } from "lodash";
+import { has, map, isObject } from "lodash";
 import { axios } from "@/services/axios";
 import { fetchDataFromJob } from "@/services/query-result";
 
 export const SCHEMA_NOT_SUPPORTED = 1;
 export const SCHEMA_LOAD_ERROR = 2;
 export const IMG_ROOT = "/static/images/db-logos";
+
+function mapSchemaColumnsToObject(columns) {
+  return map(columns, column => (isObject(column) ? column : { name: column }));
+}
 
 const DataSource = {
   query: () => axios.get("api/data_sources"),
@@ -21,14 +25,17 @@ const DataSource = {
       params.refresh = true;
     }
 
-    return axios.get(`api/data_sources/${data.id}/schema`, { params }).then(data => {
-      if (has(data, "job")) {
-        return fetchDataFromJob(data.job.id).catch(error =>
-          error.code === SCHEMA_NOT_SUPPORTED ? [] : Promise.reject(new Error(data.job.error))
-        );
-      }
-      return has(data, "schema") ? data.schema : Promise.reject();
-    });
+    return axios
+      .get(`api/data_sources/${data.id}/schema`, { params })
+      .then(data => {
+        if (has(data, "job")) {
+          return fetchDataFromJob(data.job.id).catch(error =>
+            error.code === SCHEMA_NOT_SUPPORTED ? [] : Promise.reject(new Error(data.job.error))
+          );
+        }
+        return has(data, "schema") ? data.schema : Promise.reject();
+      })
+      .then(tables => map(tables, table => ({ ...table, columns: mapSchemaColumnsToObject(table.columns) })));
   },
 };
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -210,7 +210,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
     def _sort_schema(self, schema):
         return [
-            {"name": i["name"], "columns": sorted(i["columns"])}
+            {"name": i["name"], "columns": sorted(i["columns"], key=lambda x: x["name"] if isinstance(x, dict) else x)}
             for i in sorted(schema, key=lambda x: x["name"])
         ]
 

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -156,7 +156,7 @@ class Databricks(BaseSQLQueryRunner):
             if table_name not in schema:
                 schema[table_name] = {"name": table_name, "columns": []}
 
-            schema[table_name]["columns"].append(column[3])
+            schema[table_name]["columns"].append({"name": column[3], "type": column[5]})
 
         return list(schema.values())
 

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -72,9 +72,9 @@ def _wait(conn, timeout=None):
 
 def full_table_name(schema, name):
     if "." in name:
-        name = u'"{}"'.format(name)
+        name = '"{}"'.format(name)
 
-    return u"{}.{}".format(schema, name)
+    return "{}.{}".format(schema, name)
 
 
 def build_schema(query_result, schema):
@@ -108,9 +108,9 @@ def build_schema(query_result, schema):
 
 
 def _create_cert_file(configuration, key, ssl_config):
-    file_key = key + 'File'
+    file_key = key + "File"
     if file_key in configuration:
-        with NamedTemporaryFile(mode='w', delete=False) as cert_file:
+        with NamedTemporaryFile(mode="w", delete=False) as cert_file:
             cert_bytes = b64decode(configuration[file_key])
             cert_file.write(cert_bytes.decode("utf-8"))
 
@@ -119,16 +119,16 @@ def _create_cert_file(configuration, key, ssl_config):
 
 def _cleanup_ssl_certs(ssl_config):
     for k, v in ssl_config.items():
-        if k != 'sslmode':
+        if k != "sslmode":
             os.remove(v)
 
 
 def _get_ssl_config(configuration):
-    ssl_config = {'sslmode': configuration.get('sslmode', 'prefer')}
+    ssl_config = {"sslmode": configuration.get("sslmode", "prefer")}
 
-    _create_cert_file(configuration, 'sslrootcert', ssl_config)
-    _create_cert_file(configuration, 'sslcert', ssl_config)
-    _create_cert_file(configuration, 'sslkey', ssl_config)
+    _create_cert_file(configuration, "sslrootcert", ssl_config)
+    _create_cert_file(configuration, "sslcert", ssl_config)
+    _create_cert_file(configuration, "sslkey", ssl_config)
 
     return ssl_config
 
@@ -159,23 +159,19 @@ class PostgreSQL(BaseSQLQueryRunner):
                         {"value": "verify-full", "name": "Verify Full"},
                     ],
                 },
-                "sslrootcertFile": {
-                    "type": "string",
-                    "title": "SSL Root Certificate"
-                },
-                "sslcertFile": {
-                    "type": "string",
-                    "title": "SSL Client Certificate"
-                },
-                "sslkeyFile": {
-                    "type": "string",
-                    "title": "SSL Client Key"
-                },
+                "sslrootcertFile": {"type": "string", "title": "SSL Root Certificate"},
+                "sslcertFile": {"type": "string", "title": "SSL Client Certificate"},
+                "sslkeyFile": {"type": "string", "title": "SSL Client Key"},
             },
             "order": ["host", "port", "user", "password"],
             "required": ["dbname"],
             "secret": ["password"],
-            "extra_options": ["sslmode", "sslrootcertFile", "sslcertFile", "sslkeyFile"],
+            "extra_options": [
+                "sslmode",
+                "sslrootcertFile",
+                "sslcertFile",
+                "sslkeyFile",
+            ],
         }
 
     @classmethod
@@ -243,7 +239,7 @@ class PostgreSQL(BaseSQLQueryRunner):
             port=self.configuration.get("port"),
             dbname=self.configuration.get("dbname"),
             async_=True,
-            **self.ssl_config
+            **self.ssl_config,
         )
 
         return connection
@@ -290,7 +286,6 @@ class PostgreSQL(BaseSQLQueryRunner):
 
 
 class Redshift(PostgreSQL):
-
     @classmethod
     def type(cls):
         return "redshift"
@@ -402,8 +397,8 @@ class Redshift(PostgreSQL):
 
         return list(schema.values())
 
-class RedshiftIAM(Redshift):
 
+class RedshiftIAM(Redshift):
     @classmethod
     def type(cls):
         return "redshift_iam"
@@ -418,11 +413,15 @@ class RedshiftIAM(Redshift):
 
     def _login_method_selection(self):
         if self.configuration.get("rolename"):
-            if not self.configuration.get("aws_access_key_id") or not self.configuration.get("aws_secret_access_key"):
+            if not self.configuration.get(
+                "aws_access_key_id"
+            ) or not self.configuration.get("aws_secret_access_key"):
                 return "ASSUME_ROLE_NO_KEYS"
             else:
                 return "ASSUME_ROLE_KEYS"
-        elif self.configuration.get("aws_access_key_id") and self.configuration.get("aws_secret_access_key"):
+        elif self.configuration.get("aws_access_key_id") and self.configuration.get(
+            "aws_secret_access_key"
+        ):
             return "KEYS"
         elif not self.configuration.get("password"):
             return "ROLE"
@@ -435,7 +434,10 @@ class RedshiftIAM(Redshift):
                 "rolename": {"type": "string", "title": "IAM Role Name"},
                 "aws_region": {"type": "string", "title": "AWS Region"},
                 "aws_access_key_id": {"type": "string", "title": "AWS Access Key ID"},
-                "aws_secret_access_key": {"type": "string", "title": "AWS Secret Access Key"},
+                "aws_secret_access_key": {
+                    "type": "string",
+                    "title": "AWS Secret Access Key",
+                },
                 "clusterid": {"type": "string", "title": "Redshift Cluster ID"},
                 "user": {"type": "string"},
                 "host": {"type": "string"},
@@ -479,39 +481,47 @@ class RedshiftIAM(Redshift):
 
         login_method = self._login_method_selection()
 
-
         if login_method == "KEYS":
-            client = boto3.client("redshift",
-                                  region_name=self.configuration.get("aws_region"),
-                                  aws_access_key_id=self.configuration.get("aws_access_key_id"),
-                                  aws_secret_access_key=self.configuration.get("aws_secret_access_key"))
+            client = boto3.client(
+                "redshift",
+                region_name=self.configuration.get("aws_region"),
+                aws_access_key_id=self.configuration.get("aws_access_key_id"),
+                aws_secret_access_key=self.configuration.get("aws_secret_access_key"),
+            )
         elif login_method == "ROLE":
-            client = boto3.client("redshift",
-                                  region_name=self.configuration.get("aws_region"))
+            client = boto3.client(
+                "redshift", region_name=self.configuration.get("aws_region")
+            )
         else:
             if login_method == "ASSUME_ROLE_KEYS":
-                assume_client = client = boto3.client('sts',
-                                                      region_name=self.configuration.get("aws_region"),
-                                                      aws_access_key_id=self.configuration.get("aws_access_key_id"),
-                                                      aws_secret_access_key=self.configuration.get(
-                                                          "aws_secret_access_key"))
+                assume_client = client = boto3.client(
+                    "sts",
+                    region_name=self.configuration.get("aws_region"),
+                    aws_access_key_id=self.configuration.get("aws_access_key_id"),
+                    aws_secret_access_key=self.configuration.get(
+                        "aws_secret_access_key"
+                    ),
+                )
             else:
-                assume_client = client = boto3.client('sts',
-                                                      region_name=self.configuration.get("aws_region"))
+                assume_client = client = boto3.client(
+                    "sts", region_name=self.configuration.get("aws_region")
+                )
             role_session = f"redash_{uuid4().hex}"
             session_keys = assume_client.assume_role(
-                RoleArn=self.configuration.get("rolename"),
-                RoleSessionName=role_session)["Credentials"]
-            client = boto3.client("redshift",
-                                  region_name=self.configuration.get("aws_region"),
-                                  aws_access_key_id=session_keys["AccessKeyId"],
-                                  aws_secret_access_key=session_keys["SecretAccessKey"],
-                                  aws_session_token=session_keys["SessionToken"]
-                                  )
+                RoleArn=self.configuration.get("rolename"), RoleSessionName=role_session
+            )["Credentials"]
+            client = boto3.client(
+                "redshift",
+                region_name=self.configuration.get("aws_region"),
+                aws_access_key_id=session_keys["AccessKeyId"],
+                aws_secret_access_key=session_keys["SecretAccessKey"],
+                aws_session_token=session_keys["SessionToken"],
+            )
         credentials = client.get_cluster_credentials(
             DbUser=self.configuration.get("user"),
             DbName=self.configuration.get("dbname"),
-            ClusterIdentifier=self.configuration.get("clusterid"))
+            ClusterIdentifier=self.configuration.get("clusterid"),
+        )
         db_user = credentials["DbUser"]
         db_password = credentials["DbPassword"]
         connection = psycopg2.connect(

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -104,7 +104,11 @@ def build_schema(query_result, schema):
         if table_name not in schema:
             schema[table_name] = {"name": table_name, "columns": []}
 
-        schema[table_name]["columns"].append(row["column_name"])
+        column = row["column_name"]
+        if row.get("data_type") is not None:
+            column = {"name": row["column_name"], "type": row["data_type"]}
+
+        schema[table_name]["columns"].append(column)
 
 
 def _create_cert_file(configuration, key, ssl_config):
@@ -206,7 +210,8 @@ class PostgreSQL(BaseSQLQueryRunner):
         query = """
         SELECT s.nspname as table_schema,
                c.relname as table_name,
-               a.attname as column_name
+               a.attname as column_name,
+               null as data_type
         FROM pg_class c
         JOIN pg_namespace s
         ON c.relnamespace = s.oid
@@ -221,7 +226,8 @@ class PostgreSQL(BaseSQLQueryRunner):
 
         SELECT table_schema,
                table_name,
-               column_name
+               column_name,
+               data_type
         FROM information_schema.columns
         WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
         """


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description
This PR adds a "Column Type" for both Databricks and Postgres query runner.

**Caveats**
- Column types are not unified in between different query runners, e.g.: Postgres uses "Integer" and Databricks shows as "Int". I'm not sure there's a "pretty" way of fixing this though. I tried to make sure it is Upper case in the schema browser and Capitalized for the Autocomplete.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1792" alt="Screen Shot 2020-07-21 at 22 22 15" src="https://user-images.githubusercontent.com/3356951/88123157-ac0d9a80-cba0-11ea-8de4-1b531373c8f8.png">
