### PR TITLE
Add override mechanism to customize default Webpack config

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,44 @@
+You can use this folder to add scripts and configurations to customize Redash build and development loop.
+
+## How to customize Webpack
+
+### Configurable parameters
+
+You can override the values of configurable parameters by exporting a `CONFIG` object from the module located at `scripts/config`.
+
+Currently the following parameters are supported:
+
+- **staticPath**: Override the location of Redash static files (default = `/static/`).
+
+#### Example Configuration (`scripts/config.js`):
+
+```javascript
+module.exports = {
+  staticPath: "my/redash/static/path"
+};
+```
+
+### Programmatically
+
+For advanced customization, you can provide a script to apply any kind of overrides to the default config as provided by `webpack.config.js`.
+
+The override module must be located under `scripts/webpack/overrides`. It should export a `function` that receives the Webpack configuration object and returns the overridden version.
+
+#### Example Override Script (`scripts/webpack/overrides.js`):
+
+This is an example of an override that enables Webpack stats.
+
+```javascript
+function applyOverrides(webpackConfig) {
+  return {
+    ...webpackConfig,
+    stats: {
+      children: true,
+      modules: true,
+      chunkModules: true
+    }
+  };
+}
+
+module.exports = applyOverrides;
+```

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,9 +13,26 @@ const fs = require("fs");
 
 const path = require("path");
 
+function optionalRequire(module, defaultReturn = undefined) {
+  try {
+    require.resolve(module);
+  } catch (e) {
+    if (e && e.code === "MODULE_NOT_FOUND") {
+      // Module was not found, return default value if any
+      return defaultReturn;
+    }
+    throw e;
+  }
+  return require(module);
+}
+
+// Load optionally configuration object (see scripts/README)
+const CONFIG = optionalRequire("./scripts/config", {});
+
 const isProduction = process.env.NODE_ENV === "production";
 
 const redashBackend = process.env.REDASH_BACKEND || "http://localhost:5000";
+const staticPath = CONFIG.staticPath || "/static/";
 
 const basePath = path.join(__dirname, "client");
 const appPath = path.join(__dirname, "client", "app");
@@ -23,6 +40,19 @@ const appPath = path.join(__dirname, "client", "app");
 const extensionsRelativePath =
   process.env.EXTENSIONS_DIRECTORY || path.join("client", "app", "extensions");
 const extensionPath = path.join(__dirname, extensionsRelativePath);
+
+// Function to apply configuration overrides (see scripts/README)
+function maybeApplyOverrides(config) {
+  const overridesLocation = process.env.REDASH_WEBPACK_OVERRIDES || "./scripts/webpack/overrides";
+  const applyOverrides = optionalRequire(overridesLocation);
+  if (!applyOverrides) {
+    return config;
+  }
+  console.info("Custom overrides found. Applying them...");
+  const newConfig = applyOverrides(config);
+  console.info("Custom overrides applied successfully.");
+  return newConfig;
+}
 
 const config = {
   mode: isProduction ? "production" : "development",
@@ -37,7 +67,7 @@ const config = {
   output: {
     path: path.join(basePath, "./dist"),
     filename: isProduction ? "[name].[chunkhash].js" : "[name].js",
-    publicPath: "/static/"
+    publicPath: staticPath
   },
   resolve: {
     symlinks: false,
@@ -55,7 +85,8 @@ const config = {
       template: "./client/app/index.html",
       filename: "index.html",
       excludeChunks: ["server"],
-      release: process.env.BUILD_VERSION || "dev"
+      release: process.env.BUILD_VERSION || "dev",
+      staticPath
     }),
     new HtmlWebpackPlugin({
       template: "./client/app/multi_org.html",
@@ -194,7 +225,7 @@ const config = {
       rewrites: [{ from: /./, to: "/static/index.html" }]
     },
     contentBase: false,
-    publicPath: "/static/",
+    publicPath: staticPath,
     proxy: [
       {
         context: [
@@ -238,4 +269,4 @@ if (process.env.BUNDLE_ANALYZER) {
   config.plugins.push(new BundleAnalyzerPlugin());
 }
 
-module.exports = config;
+module.exports = maybeApplyOverrides(config);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [x] Other

## Description
This PR adds the possibility to customize Redash build and development loop by applying custom configuration and/or overrides to Webpack.

## How to customize Webpack

### Configurable parameters

You can override the values of configurable parameters by exporting a `CONFIG` object from the module located at `scripts/config`.

Currently the following parameters are supported:

- **staticPath**: Override the location of Redash static files (default = `/static/`).

#### Example Configuration (`scripts/config.js`):

```javascript
module.exports = {
  staticPath: "my/redash/static/path"
};
```

### Programmatically

For advanced customization, you can provide a script to apply any kind of overrides to the default config as provided by `webpack.config.js`.

The override module must be located under `scripts/webpack/overrides`. It should export a `function` that receives the Webpack configuration object and returns the overridden version.

#### Example Override Script (`scripts/webpack/overrides.js`):

This is an example of an override that enables Webpack stats.

```javascript
function applyOverrides(webpackConfig) {
  return {
    ...webpackConfig,
    stats: {
      children: true,
      modules: true,
      chunkModules: true
    }
  };
}

module.exports = applyOverrides;
```


## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
