### PR TITLE
Load extensions on db init

### DIFF
--- a/redash/settings/dynamic_settings.py
+++ b/redash/settings/dynamic_settings.py
@@ -57,3 +57,7 @@ def database_key_definitions(default):
     )
 
     return definitions
+
+# Since you can define custom primary key types using `database_key_definitions`, you may want to load certain extensions when creating the database. 
+# To do so, simply add the name of the extension you'd like to load to this list.
+database_extensions = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Following #5008, it might be best to allow any custom database extensions to load before creating the database. This PR allows specifying these extensions using the dynamic settings module.

Also, it will only try to create tables and stamp the DB if the tables exist already.

## Related Tickets & Documents
#5008 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
