### PR TITLE
Loosen some type restrictions

### DIFF
--- a/client/app/components/proptypes.js
+++ b/client/app/components/proptypes.js
@@ -95,10 +95,10 @@ export const Destination = PropTypes.shape({
 });
 
 export const Query = PropTypes.shape({
-  id: PropTypes.number.isRequired,
+  id: PropTypes.any.isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string,
-  data_source_id: PropTypes.number.isRequired,
+  data_source_id: PropTypes.any.isRequired,
   created_at: PropTypes.string.isRequired,
   updated_at: PropTypes.string,
   user: UserProfile,
@@ -119,7 +119,7 @@ export const AlertOptions = PropTypes.shape({
 });
 
 export const Alert = PropTypes.shape({
-  id: PropTypes.number,
+  id: PropTypes.any,
   name: PropTypes.string,
   created_at: PropTypes.string,
   last_triggered_at: PropTypes.string,

--- a/client/app/pages/alert/components/AlertDestinations.jsx
+++ b/client/app/pages/alert/components/AlertDestinations.jsx
@@ -60,7 +60,7 @@ ListItem.propTypes = {
 
 export default class AlertDestinations extends React.Component {
   static propTypes = {
-    alertId: PropTypes.number.isRequired,
+    alertId: PropTypes.any.isRequired,
   };
 
   state = {

--- a/client/app/pages/queries/hooks/useQueryDataSources.js
+++ b/client/app/pages/queries/hooks/useQueryDataSources.js
@@ -1,4 +1,4 @@
-import { filter, find } from "lodash";
+import { filter, find, toString } from "lodash";
 import { useState, useMemo, useEffect } from "react";
 import DataSource from "@/services/data-source";
 
@@ -9,10 +9,10 @@ export default function useQueryDataSources(query) {
     allDataSources,
     query.data_source_id,
   ]);
-  const dataSource = useMemo(() => find(dataSources, { id: query.data_source_id }) || null, [
-    query.data_source_id,
-    dataSources,
-  ]);
+  const dataSource = useMemo(
+    () => find(dataSources, ds => toString(ds.id) === toString(query.data_source_id)) || null,
+    [query.data_source_id, dataSources]
+  );
 
   useEffect(() => {
     let cancelDataSourceLoading = false;

--- a/redash/handlers/alerts.py
+++ b/redash/handlers/alerts.py
@@ -146,7 +146,6 @@ class AlertSubscriptionListResource(BaseResource):
         return d
 
     def get(self, alert_id):
-        alert_id = int(alert_id)
         alert = models.Alert.get_by_id_and_org(alert_id, self.current_org)
         require_access(alert, self.current_user, view_only)
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1308,6 +1308,7 @@ class ApiKey(TimestampMixin, GFKBase, db.Model):
     api_key = Column(db.String(255), index=True, default=lambda: generate_token(40))
     active = Column(db.Boolean, default=True)
     # 'object' provided by GFKBase
+    object_id = Column(key_type("ApiKey"))
     created_by_id = Column(key_type("User"), db.ForeignKey("users.id"), nullable=True)
     created_by = db.relationship(User)
 

--- a/redash/models/base.py
+++ b/redash/models/base.py
@@ -4,6 +4,7 @@ from flask_sqlalchemy import BaseQuery, SQLAlchemy
 from sqlalchemy.orm import object_session
 from sqlalchemy.pool import NullPool
 from sqlalchemy_searchable import make_searchable, vectorizer, SearchQueryMixin
+from sqlalchemy.dialects import postgresql
 
 from redash import settings
 from redash.utils import json_dumps
@@ -45,6 +46,11 @@ class SearchBaseQuery(BaseQuery, SearchQueryMixin):
 
 @vectorizer(db.Integer)
 def integer_vectorizer(column):
+    return db.func.cast(column, db.Text)
+
+
+@vectorizer(postgresql.UUID)
+def uuid_vectorizer(column):
     return db.func.cast(column, db.Text)
 
 

--- a/redash/models/changes.py
+++ b/redash/models/changes.py
@@ -9,6 +9,7 @@ from .types import PseudoJSON
 class Change(GFKBase, db.Model):
     id = primary_key("Change")
     # 'object' defined in GFKBase
+    object_id = Column(key_type("Change"))
     object_version = Column(db.Integer, default=0)
     user_id = Column(key_type("User"), db.ForeignKey("users.id"))
     user = db.relationship("User", backref="changes")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Following #5008, some frontend proptypes and backend castings were still too strict to allow different types for primary key columns. This is unnoticeable if you keep using integers, but if you use a different type, some frontend features stop working. This PR loosens these restrictions on the frontend and backend.

## Related Tickets & Documents
#5008