### PR TITLE
fix: Compose version due to --build-arg

### DIFF
--- a/.circleci/docker-compose.circle.yml
+++ b/.circleci/docker-compose.circle.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.2'
 services:
   redash:
     build: ../

--- a/.circleci/docker-compose.cypress.yml
+++ b/.circleci/docker-compose.cypress.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.2'
 services:
   server:
     build: ../

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # This configuration file is for the **development** setup.
 # For a production example please refer to getredash/setup repository on GitHub.
-version: "2"
+version: "2.2"
 x-redash-service: &redash-service
   build:
     context: .


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
Hi there,
`docker-compose --build-arg` requires compose file version 2.2.

## Related Tickets & Documents
a part of #4888

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
