### PR TITLE
Add default limit (1000) to SQL queries

### DIFF
--- a/client/app/components/queries/QueryEditor/AutoLimitCheckbox.jsx
+++ b/client/app/components/queries/QueryEditor/AutoLimitCheckbox.jsx
@@ -1,0 +1,37 @@
+import React, { useCallback } from "react";
+import PropTypes from "prop-types";
+import recordEvent from "@/services/recordEvent";
+import Checkbox from "antd/lib/checkbox";
+import Tooltip from "antd/lib/tooltip";
+
+export default function AutoLimitCheckbox({ available, checked, onChange }) {
+  const handleClick = useCallback(() => {
+    recordEvent("checkbox_auto_limit", "screen", "query_editor", { state: !checked });
+    onChange(!checked);
+  }, [checked, onChange]);
+
+  let tooltipMessage = null;
+  if (!available) {
+    tooltipMessage = "Auto limiting is not available for this Data Source type.";
+  } else {
+    tooltipMessage = "Auto limit results to first 1000 rows.";
+  }
+
+  return (
+    <Tooltip placement="top" title={tooltipMessage}>
+      <Checkbox
+        className="query-editor-controls-checkbox"
+        disabled={!available}
+        onClick={handleClick}
+        checked={available && checked}>
+        LIMIT 1000
+      </Checkbox>
+    </Tooltip>
+  );
+}
+
+AutoLimitCheckbox.propTypes = {
+  available: PropTypes.bool,
+  checked: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+};

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -8,6 +8,7 @@ import KeyboardShortcuts, { humanReadableShortcut } from "@/services/KeyboardSho
 
 import AutocompleteToggle from "./AutocompleteToggle";
 import "./QueryEditorControls.less";
+import AutoLimitCheckbox from "@/components/queries/QueryEditor/AutoLimitCheckbox";
 
 export function ButtonTooltip({ title, shortcut, ...props }) {
   shortcut = humanReadableShortcut(shortcut, 1); // show only primary shortcut
@@ -38,6 +39,7 @@ export default function EditorControl({
   saveButtonProps,
   executeButtonProps,
   autocompleteToggleProps,
+  autoLimitCheckboxProps,
   dataSourceSelectorProps,
 }) {
   useEffect(() => {
@@ -84,6 +86,7 @@ export default function EditorControl({
           onToggle={autocompleteToggleProps.onToggle}
         />
       )}
+      {autoLimitCheckboxProps !== false && <AutoLimitCheckbox {...autoLimitCheckboxProps} />}
       {dataSourceSelectorProps === false && <span className="query-editor-controls-spacer" />}
       {dataSourceSelectorProps !== false && (
         <Select
@@ -153,6 +156,7 @@ EditorControl.propTypes = {
       onToggle: PropTypes.func,
     }),
   ]),
+  autoLimitCheckboxProps: PropTypes.oneOfType([PropTypes.shape(AutoLimitCheckbox.propTypes)]),
   dataSourceSelectorProps: PropTypes.oneOfType([
     PropTypes.bool, // `false` to hide
     PropTypes.shape({
@@ -175,5 +179,6 @@ EditorControl.defaultProps = {
   saveButtonProps: false,
   executeButtonProps: false,
   autocompleteToggleProps: false,
+  autoLimitCheckboxProps: false,
   dataSourceSelectorProps: false,
 };

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -156,7 +156,10 @@ EditorControl.propTypes = {
       onToggle: PropTypes.func,
     }),
   ]),
-  autoLimitCheckboxProps: PropTypes.oneOfType([PropTypes.shape(AutoLimitCheckbox.propTypes)]),
+  autoLimitCheckboxProps: PropTypes.oneOfType([
+    PropTypes.bool, // `false` to hide
+    PropTypes.shape(AutoLimitCheckbox.propTypes),
+  ]),
   dataSourceSelectorProps: PropTypes.oneOfType([
     PropTypes.bool, // `false` to hide
     PropTypes.shape({

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.less
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.less
@@ -21,6 +21,12 @@
     }
   }
 
+  .query-editor-controls-checkbox {
+    display: inline-block;
+    white-space: nowrap;
+    margin: auto 5px;
+  }
+
   .query-editor-controls-spacer {
     flex: 1 1 auto;
     height: 35px; // same as Antd <Select>

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -26,6 +26,7 @@ import { getEditorComponents } from "@/components/queries/editor-components";
 import useQuery from "./hooks/useQuery";
 import useVisualizationTabHandler from "./hooks/useVisualizationTabHandler";
 import useAutocompleteFlags from "./hooks/useAutocompleteFlags";
+import useAutoLimitFlags from "./hooks/useAutoLimitFlags";
 import useQueryExecute from "./hooks/useQueryExecute";
 import useQueryResultData from "@/lib/useQueryResultData";
 import useQueryDataSources from "./hooks/useQueryDataSources";
@@ -77,6 +78,7 @@ function QuerySource(props) {
 
   const editorRef = useRef(null);
   const [autocompleteAvailable, autocompleteEnabled, toggleAutocomplete] = useAutocompleteFlags(schema);
+  const [autoLimitAvailable, autoLimitChecked, setAutoLimit] = useAutoLimitFlags(dataSource, query, setQuery);
 
   const [handleQueryEditorChange] = useDebouncedCallback(queryText => {
     setQuery(extend(query.clone(), { query: queryText }));
@@ -305,6 +307,11 @@ function QuerySource(props) {
                         available: autocompleteAvailable,
                         enabled: autocompleteEnabled,
                         onToggle: toggleAutocomplete,
+                      }}
+                      autoLimitCheckboxProps={{
+                        available: autoLimitAvailable,
+                        checked: autoLimitChecked,
+                        onChange: setAutoLimit,
                       }}
                       dataSourceSelectorProps={
                         dataSource

--- a/client/app/pages/queries/hooks/useAutoLimitFlags.js
+++ b/client/app/pages/queries/hooks/useAutoLimitFlags.js
@@ -3,19 +3,19 @@ import localOptions from "@/lib/localOptions";
 import { get, extend } from "lodash";
 
 function isAutoLimitAvailable(dataSource) {
-  return get(dataSource, "apply_auto_limit", false);
+  return get(dataSource, "supports_auto_limit", false);
 }
 
 export default function useAutoLimitFlags(dataSource, query, setQuery) {
   const isAvailable = isAutoLimitAvailable(dataSource);
   const [isChecked, setIsChecked] = useState(localOptions.get("applyAutoLimit", true));
-  query.options.applyAutoLimit = isAvailable && isChecked;
+  query.options.apply_auto_limit = isAvailable && isChecked;
 
   const setAutoLimit = useCallback(
     state => {
       setIsChecked(state);
       localOptions.set("applyAutoLimit", state);
-      setQuery(extend(query.clone(), { options: { ...query.options, applyAutoLimit: isAvailable && state } }));
+      setQuery(extend(query.clone(), { options: { ...query.options, apply_auto_limit: isAvailable && state } }));
     },
     [query, setQuery, isAvailable]
   );

--- a/client/app/pages/queries/hooks/useAutoLimitFlags.js
+++ b/client/app/pages/queries/hooks/useAutoLimitFlags.js
@@ -1,0 +1,24 @@
+import { useCallback, useState } from "react";
+import localOptions from "@/lib/localOptions";
+import { get, extend } from "lodash";
+
+function isAutoLimitAvailable(dataSource) {
+  return get(dataSource, "apply_auto_limit", false);
+}
+
+export default function useAutoLimitFlags(dataSource, query, setQuery) {
+  const isAvailable = isAutoLimitAvailable(dataSource);
+  const [isChecked, setIsChecked] = useState(localOptions.get("applyAutoLimit", true));
+  query.options.applyAutoLimit = isAvailable && isChecked;
+
+  const setAutoLimit = useCallback(
+    state => {
+      setIsChecked(state);
+      localOptions.set("applyAutoLimit", state);
+      setQuery(extend(query.clone(), { options: { ...query.options, applyAutoLimit: isAvailable && state } }));
+    },
+    [query, setQuery, isAvailable]
+  );
+
+  return [isAvailable, isChecked, setAutoLimit];
+}

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -435,11 +435,11 @@ class QueryResult {
     return `${queryName.replace(/ /g, "_") + moment(this.getUpdatedAt()).format("_YYYY_MM_DD")}.${fileType}`;
   }
 
-  static getByQueryId(id, parameters, maxAge) {
+  static getByQueryId(id, parameters, applyAutoLimit, maxAge) {
     const queryResult = new QueryResult();
 
     axios
-      .post(`api/queries/${id}/results`, { id, parameters, max_age: maxAge })
+      .post(`api/queries/${id}/results`, { id, parameters, apply_auto_limit: applyAutoLimit, max_age: maxAge })
       .then(response => {
         queryResult.update(response);
 
@@ -454,13 +454,14 @@ class QueryResult {
     return queryResult;
   }
 
-  static get(dataSourceId, query, parameters, maxAge, queryId) {
+  static get(dataSourceId, query, parameters, applyAutoLimit, maxAge, queryId) {
     const queryResult = new QueryResult();
 
     const params = {
       data_source_id: dataSourceId,
       parameters,
       query,
+      apply_auto_limit: applyAutoLimit,
       max_age: maxAge,
     };
 

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -187,7 +187,7 @@ export class Query {
   }
 
   getAutoLimit() {
-    return this.options.applyAutoLimit;
+    return this.options.apply_auto_limit;
   }
 
   getParametersDefs(update = true) {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -130,7 +130,8 @@ export class Query {
   }
 
   getQueryResult(maxAge) {
-    const execute = () => QueryResult.getByQueryId(this.id, this.getParameters().getExecutionValues(), maxAge);
+    const execute = () =>
+      QueryResult.getByQueryId(this.id, this.getParameters().getExecutionValues(), this.getAutoLimit(), maxAge);
     return this.prepareQueryResultExecution(execute, maxAge);
   }
 
@@ -141,7 +142,8 @@ export class Query {
     }
 
     const parameters = this.getParameters().getExecutionValues({ joinListValues: true });
-    const execute = () => QueryResult.get(this.data_source_id, queryText, parameters, maxAge, this.id);
+    const execute = () =>
+      QueryResult.get(this.data_source_id, queryText, parameters, this.getAutoLimit(), maxAge, this.id);
     return this.prepareQueryResultExecution(execute, maxAge);
   }
 
@@ -182,6 +184,10 @@ export class Query {
     }
 
     return this.$parameters;
+  }
+
+  getAutoLimit() {
+    return this.options.applyAutoLimit;
   }
 
   getParametersDefs(update = true) {

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -488,9 +488,9 @@ class QueryRefreshResource(BaseResource):
 
         parameter_values = collect_parameters_from_request(request.args)
         parameterized_query = ParameterizedQuery(query.query_text, org=self.current_org)
-
+        apply_auto_limit = query.options.get("apply_auto_limit", False)
         return run_query(
-            parameterized_query, parameter_values, query.data_source, query.id
+            parameterized_query, parameter_values, query.data_source, query.id, apply_auto_limit
         )
 
 

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -488,9 +488,9 @@ class QueryRefreshResource(BaseResource):
 
         parameter_values = collect_parameters_from_request(request.args)
         parameterized_query = ParameterizedQuery(query.query_text, org=self.current_org)
-        apply_auto_limit = query.options.get("apply_auto_limit", False)
+        should_apply_auto_limit = query.options.get("apply_auto_limit", False)
         return run_query(
-            parameterized_query, parameter_values, query.data_source, query.id, apply_auto_limit
+            parameterized_query, parameter_values, query.data_source, query.id, should_apply_auto_limit
         )
 
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -20,7 +20,6 @@ from redash.tasks import Job
 from redash.tasks.queries import enqueue_query
 from redash.utils import (
     collect_parameters_from_request,
-    gen_query_hash,
     json_dumps,
     utcnow,
     to_filename,
@@ -77,7 +76,7 @@ def run_query(query, parameters, data_source, query_id, apply_auto_limit, max_ag
     except (InvalidParameterError, QueryDetachedFromDataSourceError) as e:
         abort(400, message=str(e))
 
-    query_text = data_source.query_runner.apply_auto_limit(query.text, apply_auto_limit)
+    query_text = _apply_auto_limit(data_source, query, apply_auto_limit)
 
     if query.missing_params:
         return error_response(
@@ -123,6 +122,10 @@ def run_query(query, parameters, data_source, query_id, apply_auto_limit, max_ag
             },
         )
         return serialize_job(job)
+
+
+def _apply_auto_limit(data_source, query, apply_auto_limit):
+    return data_source.query_runner.apply_auto_limit(query.text, apply_auto_limit)
 
 
 def get_download_filename(query_result, query, filetype):

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -30,7 +30,7 @@ from redash.query_runner import (
     TYPE_BOOLEAN,
     TYPE_DATE,
     TYPE_DATETIME,
-)
+    BaseQueryRunner)
 from redash.utils import (
     generate_token,
     json_dumps,
@@ -38,7 +38,7 @@ from redash.utils import (
     mustache_render,
     base_url,
     sentry,
-)
+    gen_query_hash)
 from redash.utils.configuration import ConfigurationContainer
 from redash.models.parameterized_query import ParameterizedQuery
 
@@ -122,7 +122,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
             "syntax": self.query_runner.syntax,
             "paused": self.paused,
             "pause_reason": self.pause_reason,
-            "apply_auto_limit": self.query_runner.supports_auto_limit
+            "supports_auto_limit": self.query_runner.supports_auto_limit
         }
 
         if all:
@@ -359,7 +359,7 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
 
     @classmethod
     def get_latest(cls, data_source, query, max_age=0):
-        query_hash = utils.gen_query_hash(query)
+        query_hash = gen_query_hash(query)
 
         if max_age == -1:
             query = cls.query.filter(
@@ -865,11 +865,21 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         api_keys = db.session.execute(query, {"id": self.id}).fetchall()
         return [api_key[0] for api_key in api_keys]
 
+    def update_query_hash(self):
+        apply_auto_limit = False
+        if self.options is not None:
+            apply_auto_limit = self.options.get("apply_auto_limit", False)
+        if self.data_source is not None:
+            query_runner = self.data_source.query_runner
+        else:
+            query_runner = BaseQueryRunner({})
+        self.query_hash = query_runner.gen_query_hash(self.query_text, apply_auto_limit)
 
-@listens_for(Query.query_text, "set")
-def gen_query_hash(target, val, oldval, initiator):
-    target.query_hash = utils.gen_query_hash(val)
-    target.schedule_failures = 0
+
+@listens_for(Query, "before_insert")
+@listens_for(Query, "before_update")
+def receive_before_insert_update(mapper, connection, target):
+    target.update_query_hash()
 
 
 @listens_for(Query.user_id, "set")

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -122,6 +122,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
             "syntax": self.query_runner.syntax,
             "paused": self.paused,
             "pause_reason": self.pause_reason,
+            "apply_auto_limit": self.query_runner.supports_auto_limit
         }
 
         if all:

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -866,14 +866,9 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         return [api_key[0] for api_key in api_keys]
 
     def update_query_hash(self):
-        apply_auto_limit = False
-        if self.options is not None:
-            apply_auto_limit = self.options.get("apply_auto_limit", False)
-        if self.data_source is not None:
-            query_runner = self.data_source.query_runner
-        else:
-            query_runner = BaseQueryRunner({})
-        self.query_hash = query_runner.gen_query_hash(self.query_text, apply_auto_limit)
+        should_apply_auto_limit = self.options.get("apply_auto_limit", False) if self.options else False
+        query_runner = self.data_source.query_runner if self.data_source else BaseQueryRunner({})
+        self.query_hash = query_runner.gen_query_hash(self.query_text, should_apply_auto_limit)
 
 
 @listens_for(Query, "before_insert")

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from six import text_type
 from sshtunnel import open_tunnel
-from redash import settings
+from redash import settings, utils
 from redash.utils import json_loads, query_is_select_no_limit, add_limit_to_query
 from rq.timeouts import JobTimeoutException
 
@@ -196,6 +196,10 @@ class BaseQueryRunner(object):
 
     def apply_auto_limit(self, query_text, set_auto_limit):
         return query_text
+
+    def gen_query_hash(self, query_text, set_auto_limit=False):
+        query_text = self.apply_auto_limit(query_text, set_auto_limit)
+        return utils.gen_query_hash(query_text)
 
 
 class BaseSQLQueryRunner(BaseQueryRunner):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -1,8 +1,6 @@
 import logging
 
 from contextlib import ExitStack
-
-import sqlparse
 from dateutil import parser
 from functools import wraps
 import socket

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -1,6 +1,8 @@
 import logging
 
 from contextlib import ExitStack
+
+import sqlparse
 from dateutil import parser
 from functools import wraps
 import socket
@@ -10,7 +12,7 @@ from urllib.parse import urlparse
 from six import text_type
 from sshtunnel import open_tunnel
 from redash import settings
-from redash.utils import json_loads
+from redash.utils import json_loads, query_is_select_no_limit, add_limit_to_query
 from rq.timeouts import JobTimeoutException
 
 from redash.utils.requests_session import requests, requests_session
@@ -83,7 +85,7 @@ class BaseQueryRunner(object):
         """Returns this query runner's configured host.
         This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
 
-        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port`
         configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
         """
         if "host" in self.configuration:
@@ -96,7 +98,7 @@ class BaseQueryRunner(object):
         """Sets this query runner's configured host.
         This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
 
-        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port`
         configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
         """
         if "host" in self.configuration:
@@ -109,7 +111,7 @@ class BaseQueryRunner(object):
         """Returns this query runner's configured port.
         This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
 
-        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port`
         configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
         """
         if "port" in self.configuration:
@@ -122,7 +124,7 @@ class BaseQueryRunner(object):
         """Sets this query runner's configured port.
         This is used primarily for temporarily swapping endpoints when using SSH tunnels to connect to a data source.
 
-        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port` 
+        `BaseQueryRunner`'s naïve implementation supports query runner implementations that store endpoints using `host` and `port`
         configuration values. If your query runner uses a different schema (e.g. a web address), you should override this function.
         """
         if "port" in self.configuration:
@@ -190,6 +192,13 @@ class BaseQueryRunner(object):
             **({"deprecated": True} if cls.deprecated else {}),
         }
 
+    @property
+    def supports_auto_limit(self):
+        return False
+
+    def apply_auto_limit(self, query_text, set_auto_limit):
+        return query_text
+
 
 class BaseSQLQueryRunner(BaseQueryRunner):
     def get_schema(self, get_stats=False):
@@ -207,6 +216,22 @@ class BaseSQLQueryRunner(BaseQueryRunner):
             if type(tables_dict[t]) == dict:
                 res = self._run_query_internal("select count(*) as cnt from %s" % t)
                 tables_dict[t]["size"] = res[0]["cnt"]
+
+    @property
+    def supports_auto_limit(self):
+        return True
+
+    def apply_auto_limit(self, query_text, set_auto_limit):
+        if set_auto_limit:
+            from redash.query_runner.databricks import split_sql_statements
+            query_list = split_sql_statements(query_text)
+            # we only check for last one in the list because it is the one that we show result
+            last_query = query_list[-1]
+            if query_is_select_no_limit(last_query):
+                query_list[-1] = add_limit_to_query(last_query)
+            return ";\n".join(query_list)
+        else:
+            return query_text
 
 
 def is_private_address(url):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -194,7 +194,7 @@ class BaseQueryRunner(object):
     def supports_auto_limit(self):
         return False
 
-    def apply_auto_limit(self, query_text, set_auto_limit):
+    def apply_auto_limit(self, query_text, should_apply_auto_limit):
         return query_text
 
     def gen_query_hash(self, query_text, set_auto_limit=False):
@@ -223,15 +223,15 @@ class BaseSQLQueryRunner(BaseQueryRunner):
     def supports_auto_limit(self):
         return True
 
-    def apply_auto_limit(self, query_text, set_auto_limit):
-        if set_auto_limit:
-            from redash.query_runner.databricks import split_sql_statements
-            query_list = split_sql_statements(query_text)
+    def apply_auto_limit(self, query_text, should_apply_auto_limit):
+        if should_apply_auto_limit:
+            from redash.query_runner.databricks import split_sql_statements, combine_sql_statements
+            queries = split_sql_statements(query_text)
             # we only check for last one in the list because it is the one that we show result
-            last_query = query_list[-1]
+            last_query = queries[-1]
             if query_is_select_no_limit(last_query):
-                query_list[-1] = add_limit_to_query(last_query)
-            return ";\n".join(query_list)
+                queries[-1] = add_limit_to_query(last_query)
+            return combine_sql_statements(queries)
         else:
             return query_text
 

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     enabled = False
 
-
 TYPES_MAP = {
     str: TYPE_STRING,
     bool: TYPE_BOOLEAN,
@@ -81,6 +80,10 @@ def split_sql_statements(query):
         return result
 
     return [""]  # if all statements were empty - return a single empty statement
+
+
+def combine_sql_statements(queries):
+    return ";\n".join(queries)
 
 
 class Databricks(BaseSQLQueryRunner):

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -77,7 +77,7 @@ class RefreshQueriesError(Exception):
 
 
 def _apply_auto_limit(query_text, query):
-    set_auto_limit = True
+    set_auto_limit = query.options.get("apply_auto_limit", False)
     return query.data_source.query_runner.apply_auto_limit(query_text, set_auto_limit)
 
 

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -76,6 +76,11 @@ class RefreshQueriesError(Exception):
     pass
 
 
+def _apply_auto_limit(query_text, query):
+    set_auto_limit = True
+    return query.data_source.query_runner.apply_auto_limit(query_text, set_auto_limit)
+
+
 def refresh_queries():
     logger.info("Refreshing queries...")
     enqueued = []
@@ -84,8 +89,10 @@ def refresh_queries():
             continue
 
         try:
+            query_text = _apply_default_parameters(query)
+            query_text = _apply_auto_limit(query_text, query)
             enqueue_query(
-                _apply_default_parameters(query),
+                query_text,
                 query.data_source,
                 query.user_id,
                 scheduled_query=query,

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -77,8 +77,8 @@ class RefreshQueriesError(Exception):
 
 
 def _apply_auto_limit(query_text, query):
-    set_auto_limit = query.options.get("apply_auto_limit", False)
-    return query.data_source.query_runner.apply_auto_limit(query_text, set_auto_limit)
+    should_apply_auto_limit = query.options.get("apply_auto_limit", False)
+    return query.data_source.query_runner.apply_auto_limit(query_text, should_apply_auto_limit)
 
 
 def refresh_queries():

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -13,6 +13,7 @@ import binascii
 import pystache
 import pytz
 import simplejson
+import sqlparse
 from flask import current_app
 from funcy import select_values
 from redash import settings
@@ -70,8 +71,8 @@ def generate_token(length):
 
 class JSONEncoder(simplejson.JSONEncoder):
     """Adapter for `simplejson.dumps`."""
-    
-    
+
+
     def default(self, o):
         # Some SQLAlchemy collections are lazy.
         if isinstance(o, Query):
@@ -213,3 +214,32 @@ def render_template(path, context):
     function decorated with the `context_processor` decorator, which is not explicitly required for rendering purposes.
     """
     current_app.jinja_env.get_template(path).render(**context)
+
+def query_is_select_no_limit(query):
+    parsed_query = sqlparse.parse(query)[0]
+    last_keyword_idx = find_last_keyword_idx(parsed_query)
+    # Either invalid query or query that is not select
+    if last_keyword_idx == -1 or parsed_query.tokens[0].value.upper() != "SELECT":
+        return False
+
+    no_limit = parsed_query.tokens[last_keyword_idx].value.upper() != "LIMIT" \
+               and parsed_query.tokens[last_keyword_idx].value.upper() != "OFFSET"
+    return no_limit
+
+def find_last_keyword_idx(parsed_query):
+    for i in reversed(range(len(parsed_query.tokens))):
+        if parsed_query.tokens[i].ttype in sqlparse.tokens.Keyword:
+            return i
+    return -1
+
+def add_limit_to_query(query):
+    # this function will only be called if query_is_select_no_limit returns True
+    parsed_query = sqlparse.parse(query)[0]
+    limit_tokens = sqlparse.parse(" LIMIT 1000")[0].tokens
+    length = len(parsed_query.tokens)
+    if parsed_query.tokens[length - 1].ttype == sqlparse.tokens.Punctuation:
+        parsed_query.tokens[length - 1:length - 1] = limit_tokens
+    else:
+        parsed_query.tokens += limit_tokens
+    return str(parsed_query)
+

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -21,7 +21,6 @@ from sqlalchemy.orm.query import Query
 
 from .human_time import parse_human_time
 
-
 COMMENTS_REGEX = re.compile("/\*.*?\*/")
 WRITER_ENCODING = os.environ.get("REDASH_CSV_WRITER_ENCODING", "utf-8")
 WRITER_ERRORS = os.environ.get("REDASH_CSV_WRITER_ERRORS", "strict")
@@ -71,7 +70,6 @@ def generate_token(length):
 
 class JSONEncoder(simplejson.JSONEncoder):
     """Adapter for `simplejson.dumps`."""
-
 
     def default(self, o):
         # Some SQLAlchemy collections are lazy.
@@ -215,6 +213,7 @@ def render_template(path, context):
     """
     current_app.jinja_env.get_template(path).render(**context)
 
+
 def query_is_select_no_limit(query):
     parsed_query = sqlparse.parse(query)[0]
     last_keyword_idx = find_last_keyword_idx(parsed_query)
@@ -226,11 +225,13 @@ def query_is_select_no_limit(query):
                and parsed_query.tokens[last_keyword_idx].value.upper() != "OFFSET"
     return no_limit
 
+
 def find_last_keyword_idx(parsed_query):
     for i in reversed(range(len(parsed_query.tokens))):
         if parsed_query.tokens[i].ttype in sqlparse.tokens.Keyword:
             return i
     return -1
+
 
 def add_limit_to_query(query):
     # this function will only be called if query_is_select_no_limit returns True
@@ -242,4 +243,3 @@ def add_limit_to_query(query):
     else:
         parsed_query.tokens += limit_tokens
     return str(parsed_query)
-

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -234,7 +234,6 @@ def find_last_keyword_idx(parsed_query):
 
 
 def add_limit_to_query(query):
-    # this function will only be called if query_is_select_no_limit returns True
     parsed_query = sqlparse.parse(query)[0]
     limit_tokens = sqlparse.parse(" LIMIT 1000")[0].tokens
     length = len(parsed_query.tokens)

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -45,17 +45,14 @@ class TestQueryResultsContentDispositionHeaders(BaseTestCase):
 
 class TestQueryResultListAPI(BaseTestCase):
     def test_get_existing_result(self):
-        ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="phoenix"
-        )
-        query_result = self.factory.create_query_result(data_source=ds)
-        query = self.factory.create_query(data_source=ds)
+        query_result = self.factory.create_query_result()
+        query = self.factory.create_query()
 
         rv = self.make_request(
             "post",
             "/api/query_results",
             data={
-                "data_source_id": ds.id,
+                "data_source_id": self.factory.data_source.id,
                 "query": query.query_text,
             },
         )
@@ -93,6 +90,7 @@ class TestQueryResultListAPI(BaseTestCase):
             data={
                 "data_source_id": ds.id,
                 "query": query.query_text,
+                "apply_auto_limit": True
             },
         )
 
@@ -113,6 +111,7 @@ class TestQueryResultListAPI(BaseTestCase):
             data={
                 "data_source_id": ds.id,
                 "query": query.query_text,
+                "apply_auto_limit": True
             },
         )
 

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -1,3 +1,4 @@
+from redash.query_runner import BaseSQLQueryRunner, BaseQueryRunner
 from tests import BaseTestCase
 
 from redash.models import db
@@ -39,19 +40,22 @@ class TestQueryResultsContentDispositionHeaders(BaseTestCase):
         try:
             rv.headers['Content-Disposition'].encode('ascii')
         except Exception as e:
-            self.fail(repr(e))            
+            self.fail(repr(e))
 
 
 class TestQueryResultListAPI(BaseTestCase):
     def test_get_existing_result(self):
-        query_result = self.factory.create_query_result()
-        query = self.factory.create_query()
+        ds = self.factory.create_data_source(
+            group=self.factory.org.default_group, type="phoenix"
+        )
+        query_result = self.factory.create_query_result(data_source=ds)
+        query = self.factory.create_query(data_source=ds)
 
         rv = self.make_request(
             "post",
             "/api/query_results",
             data={
-                "data_source_id": self.factory.data_source.id,
+                "data_source_id": ds.id,
                 "query": query.query_text,
             },
         )
@@ -75,6 +79,45 @@ class TestQueryResultListAPI(BaseTestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertNotIn("query_result", rv.json)
         self.assertIn("job", rv.json)
+
+    def test_add_limit_change_query_sql(self):
+        ds = self.factory.create_data_source(
+            group=self.factory.org.default_group, type="databricks"
+        )
+        query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
+        query_result = self.factory.create_query_result(data_source=ds, query_hash=query.query_hash)
+
+        rv = self.make_request(
+            "post",
+            "/api/query_results",
+            data={
+                "data_source_id": ds.id,
+                "query": query.query_text,
+            },
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertNotIn("query_result", rv.json)
+        self.assertIn("job", rv.json)
+
+    def test_add_limit_no_change_for_nonsql(self):
+        ds = self.factory.create_data_source(
+            group=self.factory.org.default_group, type="druid"
+        )
+        query = self.factory.create_query(query_text="SELECT 5", data_source=ds)
+        query_result = self.factory.create_query_result(data_source=ds, query_hash=query.query_hash)
+
+        rv = self.make_request(
+            "post",
+            "/api/query_results",
+            data={
+                "data_source_id": ds.id,
+                "query": query.query_text,
+            },
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(query_result.id, rv.json["query_result"]["id"])
 
     def test_execute_query_without_access(self):
         group = self.factory.create_group()

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -79,7 +79,7 @@ class TestQueryResultListAPI(BaseTestCase):
 
     def test_add_limit_change_query_sql(self):
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="databricks"
+            group=self.factory.org.default_group, type="pg"
         )
         query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
         query_result = self.factory.create_query_result(data_source=ds, query_hash=query.query_hash)
@@ -100,7 +100,7 @@ class TestQueryResultListAPI(BaseTestCase):
 
     def test_add_limit_no_change_for_nonsql(self):
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="druid"
+            group=self.factory.org.default_group, type="prometheus"
         )
         query = self.factory.create_query(query_text="SELECT 5", data_source=ds)
         query_result = self.factory.create_query_result(data_source=ds, query_hash=query.query_hash)

--- a/tests/query_runner/test_basesql_queryrunner.py
+++ b/tests/query_runner/test_basesql_queryrunner.py
@@ -1,6 +1,7 @@
 import unittest
 
 from redash.query_runner import BaseSQLQueryRunner, BaseQueryRunner
+from redash.utils import gen_query_hash
 
 
 class TestBaseSQLQueryRunner(unittest.TestCase):
@@ -82,6 +83,19 @@ class TestBaseSQLQueryRunner(unittest.TestCase):
         origin_query_text = "select * from raw_events -- comment"
         query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
         self.assertEqual("select * from raw_events LIMIT 1000", query_text)
+
+    def test_gen_query_hash_baseSQL(self):
+        origin_query_text = "select *"
+        expected_query_text = "select * LIMIT 1000"
+        base_runner = BaseQueryRunner({})
+        self.assertEqual(base_runner.gen_query_hash(expected_query_text),
+                         self.query_runner.gen_query_hash(origin_query_text, True))
+
+    def test_gen_query_hash_NoneSQL(self):
+        origin_query_text = "select *"
+        base_runner = BaseQueryRunner({})
+        self.assertEqual(gen_query_hash(origin_query_text),
+                         base_runner.gen_query_hash(origin_query_text, True))
 
 
 if __name__ == '__main__':

--- a/tests/query_runner/test_basesql_queryrunner.py
+++ b/tests/query_runner/test_basesql_queryrunner.py
@@ -1,0 +1,89 @@
+import unittest
+
+from redash.query_runner import BaseSQLQueryRunner, BaseQueryRunner
+
+
+class TestBaseSQLQueryRunner(unittest.TestCase):
+
+    def setUp(self):
+        self.query_runner = BaseSQLQueryRunner({})
+
+    def test_apply_auto_limit_origin_no_limit_1(self):
+        origin_query_text = "SELECT 2"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual("SELECT 2 LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_origin_have_limit_1(self):
+        origin_query_text = "SELECT 2 LIMIT 100"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text, query_text)
+
+    def test_apply_auto_limit_origin_have_limit_2(self):
+        origin_query_text = "SELECT * FROM fake WHERE id IN (SELECT id FROM fake_2 LIMIT 200) LIMIT 200"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text, query_text)
+
+    def test_apply_auto_limit_origin_no_limit_2(self):
+        origin_query_text = "SELECT * FROM fake WHERE id IN (SELECT id FROM fake_2 LIMIT 200)"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text + " LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_non_select_query(self):
+        origin_query_text = "create table execution_times as " \
+                            "(select id, retrieved_at, data_source_id, query, runtime, query_hash " \
+                            "from query_results order by 1 desc)"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text, query_text)
+
+    def test_apply_auto_limit_error_query(self):
+        origin_query_text = "dklsk jdhsajhdiwc kkdsakjdwi mdklsjal"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text, query_text)
+
+    def test_apply_auto_limit_multi_query_add_limit_1(self):
+        origin_query_text = "insert into execution_times (id, retrieved_at, data_source_id, query, runtime, query_hash) " \
+                            "select id, retrieved_at, data_source_id, query, runtime, query_hash from query_results " \
+                            "where id > (select max(id) from execution_times);\n" \
+                            "select max(id), 'execution_times' as table_name from execution_times " \
+                            "union all " \
+                            "select max(id), 'query_results' as table_name from query_results"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text + " LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_multi_query_add_limit_2(self):
+        origin_query_text = "use database demo;\n" \
+                            "select * from data"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text + " LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_multi_query_end_with_punc(self):
+        origin_query_text = "select * from table1;\n" \
+                            "select * from table2"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual("select * from table1;\n" \
+                         "select * from table2 LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_multi_query_last_not_select(self):
+        origin_query_text = "select * from table1;\n" \
+                            "CREATE TABLE Persons (PersonID int)"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual(origin_query_text, query_text)
+
+    def test_apply_auto_limit_last_command_comment(self):
+        origin_query_text = "select * from raw_events; # comment"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual("select * from raw_events LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_last_command_comment_2(self):
+        origin_query_text = "select * from raw_events; -- comment"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual("select * from raw_events LIMIT 1000", query_text)
+
+    def test_apply_auto_limit_inline_comment(self):
+        origin_query_text = "select * from raw_events -- comment"
+        query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
+        self.assertEqual("select * from raw_events LIMIT 1000", query_text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/query_runner/test_basesql_queryrunner.py
+++ b/tests/query_runner/test_basesql_queryrunner.py
@@ -29,9 +29,9 @@ class TestBaseSQLQueryRunner(unittest.TestCase):
         self.assertEqual(origin_query_text + " LIMIT 1000", query_text)
 
     def test_apply_auto_limit_non_select_query(self):
-        origin_query_text = "create table execution_times as " \
-                            "(select id, retrieved_at, data_source_id, query, runtime, query_hash " \
-                            "from query_results order by 1 desc)"
+        origin_query_text = ("create table execution_times as "
+                             "(select id, retrieved_at, data_source_id, query, runtime, query_hash "
+                             "from query_results order by 1 desc)")
         query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
         self.assertEqual(origin_query_text, query_text)
 
@@ -41,12 +41,12 @@ class TestBaseSQLQueryRunner(unittest.TestCase):
         self.assertEqual(origin_query_text, query_text)
 
     def test_apply_auto_limit_multi_query_add_limit_1(self):
-        origin_query_text = "insert into execution_times (id, retrieved_at, data_source_id, query, runtime, query_hash) " \
-                            "select id, retrieved_at, data_source_id, query, runtime, query_hash from query_results " \
-                            "where id > (select max(id) from execution_times);\n" \
-                            "select max(id), 'execution_times' as table_name from execution_times " \
-                            "union all " \
-                            "select max(id), 'query_results' as table_name from query_results"
+        origin_query_text = ("insert into execution_times (id, retrieved_at, data_source_id, query, runtime, query_hash) "
+                            "select id, retrieved_at, data_source_id, query, runtime, query_hash from query_results "
+                            "where id > (select max(id) from execution_times);\n"
+                            "select max(id), 'execution_times' as table_name from execution_times "
+                            "union all "
+                            "select max(id), 'query_results' as table_name from query_results")
         query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
         self.assertEqual(origin_query_text + " LIMIT 1000", query_text)
 
@@ -57,15 +57,14 @@ class TestBaseSQLQueryRunner(unittest.TestCase):
         self.assertEqual(origin_query_text + " LIMIT 1000", query_text)
 
     def test_apply_auto_limit_multi_query_end_with_punc(self):
-        origin_query_text = "select * from table1;\n" \
-                            "select * from table2"
+        origin_query_text = ("select * from table1;\n"
+                             "select * from table2")
         query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
-        self.assertEqual("select * from table1;\n" \
-                         "select * from table2 LIMIT 1000", query_text)
+        self.assertEqual("select * from table1;\nselect * from table2 LIMIT 1000", query_text)
 
     def test_apply_auto_limit_multi_query_last_not_select(self):
-        origin_query_text = "select * from table1;\n" \
-                            "CREATE TABLE Persons (PersonID int)"
+        origin_query_text = ("select * from table1;\n"
+                             "CREATE TABLE Persons (PersonID int)")
         query_text = self.query_runner.apply_auto_limit(origin_query_text, True)
         self.assertEqual(origin_query_text, query_text)
 

--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -12,9 +12,10 @@ class TestRefreshQuery(BaseTestCase):
         refresh_queries() launches an execution task for each query returned
         from Query.outdated_queries().
         """
-        query1 = self.factory.create_query()
+        query1 = self.factory.create_query(options={"apply_auto_limit": True})
         query2 = self.factory.create_query(
-            query_text="select 42;", data_source=self.factory.create_data_source()
+            query_text="select 42;", data_source=self.factory.create_data_source(),
+            options={"apply_auto_limit": True}
         )
         oq = staticmethod(lambda: [query1, query2])
         with patch(ENQUEUE_QUERY) as add_job_mock, patch.object(
@@ -32,7 +33,7 @@ class TestRefreshQuery(BaseTestCase):
                         metadata=ANY,
                     ),
                     call(
-                        "select 42 LIMIT 1000;",
+                        "select 42 LIMIT 1000",
                         query2.data_source,
                         query2.user_id,
                         scheduled_query=query2,
@@ -50,9 +51,9 @@ class TestRefreshQuery(BaseTestCase):
         ds = self.factory.create_data_source(
             group=self.factory.org.default_group, type="phoenix"
         )
-        query1 = self.factory.create_query(data_source=ds)
+        query1 = self.factory.create_query(data_source=ds, options={"apply_auto_limit": True})
         query2 = self.factory.create_query(
-            query_text="select 42;", data_source=ds
+            query_text="select 42;", data_source=ds, options={"apply_auto_limit": True}
         )
         oq = staticmethod(lambda: [query1, query2])
         with patch(ENQUEUE_QUERY) as add_job_mock, patch.object(
@@ -85,7 +86,7 @@ class TestRefreshQuery(BaseTestCase):
         refresh_queries() does not launch execution tasks for queries whose
         data source is paused.
         """
-        query = self.factory.create_query()
+        query = self.factory.create_query(options={"apply_auto_limit": True})
         oq = staticmethod(lambda: [query])
         query.data_source.pause()
         with patch.object(Query, "outdated_queries", oq):
@@ -113,7 +114,7 @@ class TestRefreshQuery(BaseTestCase):
         ds = self.factory.create_data_source(
             group=self.factory.org.default_group, type="phoenix"
         )
-        query = self.factory.create_query(data_source=ds)
+        query = self.factory.create_query(data_source=ds, options={"apply_auto_limit": True})
         oq = staticmethod(lambda: [query])
         query.data_source.pause()
         with patch.object(Query, "outdated_queries", oq):
@@ -148,7 +149,8 @@ class TestRefreshQuery(BaseTestCase):
                         "value": "42",
                         "title": "n",
                     }
-                ]
+                ],
+                "apply_auto_limit": True
             },
         )
         oq = staticmethod(lambda: [query])
@@ -182,7 +184,9 @@ class TestRefreshQuery(BaseTestCase):
                         "value": "42",
                         "title": "n",
                     }
-                ]
+                ],
+                "apply_auto_limit": True
+
             },
             data_source=ds,
         )
@@ -214,7 +218,8 @@ class TestRefreshQuery(BaseTestCase):
                         "value": 42,  # <-- should be text!
                         "title": "n",
                     }
-                ]
+                ],
+                "apply_auto_limit": True
             },
         )
         oq = staticmethod(lambda: [query])
@@ -241,7 +246,8 @@ class TestRefreshQuery(BaseTestCase):
                         "queryId": 100,
                         "title": "n",
                     }
-                ]
+                ],
+                "apply_auto_limit": True
             },
         )
 

--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -49,7 +49,7 @@ class TestRefreshQuery(BaseTestCase):
         from Query.outdated_queries().
         """
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="phoenix"
+            group=self.factory.org.default_group, type="prometheus"
         )
         query1 = self.factory.create_query(data_source=ds, options={"apply_auto_limit": True})
         query2 = self.factory.create_query(
@@ -112,7 +112,7 @@ class TestRefreshQuery(BaseTestCase):
         data source is paused.
         """
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="phoenix"
+            group=self.factory.org.default_group, type="prometheus"
         )
         query = self.factory.create_query(data_source=ds, options={"apply_auto_limit": True})
         oq = staticmethod(lambda: [query])
@@ -171,7 +171,7 @@ class TestRefreshQuery(BaseTestCase):
         Scheduled queries with parameters use saved values.
         """
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="phoenix"
+            group=self.factory.org.default_group, type="prometheus"
         )
         query = self.factory.create_query(
             query_text="select {{n}}",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 import pytz
 from dateutil.parser import parse as date_parse
+
 from tests import BaseTestCase
 
 from redash import models, redis_connection
@@ -470,6 +471,37 @@ class TestQueryAll(BaseTestCase):
         self.assertEqual(["alice", "bob"], [q.user.name for q in qs1])
         qs2 = base.order_by(models.User.name.desc())
         self.assertEqual(["bob", "alice"], [q.user.name for q in qs2])
+
+    def test_update_query_hash_basesql_with_options(self):
+        ds = self.factory.create_data_source(
+            group=self.factory.org.default_group, type="databricks"
+        )
+        query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
+        query.options = {"apply_auto_limit": True}
+        origin_hash = query.query_hash
+        query.update_query_hash()
+        self.assertNotEqual(origin_hash, query.query_hash)
+
+    def test_update_query_hash_basesql_no_options(self):
+        ds = self.factory.create_data_source(
+            group=self.factory.org.default_group, type="databricks"
+        )
+        query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
+        query.options = {}
+        origin_hash = query.query_hash
+        query.update_query_hash()
+        self.assertEqual(origin_hash, query.query_hash)
+
+    def test_update_query_hash_non_basesql(self):
+        ds = self.factory.create_data_source(
+            group=self.factory.org.default_group, type="druid"
+        )
+        query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
+        query.options = {"apply_auto_limit": True}
+        origin_hash = query.query_hash
+        query.update_query_hash()
+        self.assertEqual(origin_hash, query.query_hash)
+
 
 
 class TestGroup(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -474,7 +474,7 @@ class TestQueryAll(BaseTestCase):
 
     def test_update_query_hash_basesql_with_options(self):
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="databricks"
+            group=self.factory.org.default_group, type="pg"
         )
         query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
         query.options = {"apply_auto_limit": True}
@@ -484,7 +484,7 @@ class TestQueryAll(BaseTestCase):
 
     def test_update_query_hash_basesql_no_options(self):
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="databricks"
+            group=self.factory.org.default_group, type="pg"
         )
         query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
         query.options = {}
@@ -494,7 +494,7 @@ class TestQueryAll(BaseTestCase):
 
     def test_update_query_hash_non_basesql(self):
         ds = self.factory.create_data_source(
-            group=self.factory.org.default_group, type="druid"
+            group=self.factory.org.default_group, type="prometheus"
         )
         query = self.factory.create_query(query_text="SELECT 2", data_source=ds)
         query.options = {"apply_auto_limit": True}

--- a/tests/utils/test_query_limit.py
+++ b/tests/utils/test_query_limit.py
@@ -1,0 +1,41 @@
+import unittest
+
+from redash.utils import query_is_select_no_limit, add_limit_to_query
+
+
+class TestQueryLimit(unittest.TestCase):
+    def test_check_query_limit_no_limit(self):
+        query = "SELECT *"
+        self.assertEqual(True, query_is_select_no_limit(query))
+
+    def test_check_query_limit_non_select(self):
+        query = "Create Table (PersonID INT)"
+        self.assertEqual(False, query_is_select_no_limit(query))
+
+    def test_check_query_limit_invalid_1(self):
+        query = "OFFSET 5"
+        self.assertEqual(False, query_is_select_no_limit(query))
+
+    def test_check_query_limit_invalid_2(self):
+        query = "TABLE A FROM TABLE B"
+        self.assertEqual(False, query_is_select_no_limit(query))
+
+    def test_check_query_with_limit(self):
+        query = "SELECT * LIMIT 5"
+        self.assertEqual(False, query_is_select_no_limit(query))
+
+    def test_check_query_with_offset(self):
+        query = "SELECT * LIMIT 5 OFFSET 3"
+        self.assertEqual(False, query_is_select_no_limit(query))
+
+    def test_add_limit_query_no_limit(self):
+        query = "SELECT *"
+        self.assertEqual("SELECT * LIMIT 1000", add_limit_to_query(query))
+
+    def test_add_limit_query_with_punc(self):
+        query = "SELECT *;"
+        self.assertEqual("SELECT * LIMIT 1000;", add_limit_to_query(query))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Add a default limit 1000 for query execution, now it contains both the frontend changes(add a checkbox) and backend changes.
## Related Tickets & Documents

REDASH-112, Closes #976.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
This is for data source that currently support auto limit
<img width="861" alt="Screen Shot 2020-08-27 at 10 12 49 AM" src="https://user-images.githubusercontent.com/25569264/91473627-03f98a00-e84e-11ea-8838-244ccd9f3369.png">


This is for data source that currently not support auto limit
<img width="858" alt="Screen Shot 2020-08-27 at 10 13 05 AM" src="https://user-images.githubusercontent.com/25569264/91473638-078d1100-e84e-11ea-8a36-c121fd2f4126.png">


