### PR TITLE
Bump token threshold for enabling autocomplete

### DIFF
--- a/client/app/pages/queries/hooks/useAutocompleteFlags.js
+++ b/client/app/pages/queries/hooks/useAutocompleteFlags.js
@@ -7,7 +7,7 @@ function calculateTokensCount(schema) {
 }
 
 export default function useAutocompleteFlags(schema) {
-  const isAvailable = useMemo(() => calculateTokensCount(schema) <= 5000, [schema]);
+  const isAvailable = useMemo(() => calculateTokensCount(schema) <= 15000, [schema]);
   const [isEnabled, setIsEnabled] = useState(localOptions.get("liveAutocomplete", true));
 
   const toggleAutocomplete = useCallback(state => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [x] Other

## Description

Could we possibly bump the tokens threshold for enabling autocomplete? At my company, we've been circumventing the 5000 tokens limit through a patch since Redash 7 or 8. Below is a screencap of typing on a data source with ~13k tokens - you can see that the performance is just fine.

I'm also happy to take a stab at configuring this through an environment variable, if that sounds like a better option. Thanks!
 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/16146623/89373815-48f72a00-d6af-11ea-8c95-cb2c7e899898.png)