### PR TITLE
Suggest Parameter Input and Parameter Label in one line

### DIFF
--- a/client/app/components/ParameterValueInput.less
+++ b/client/app/components/ParameterValueInput.less
@@ -5,7 +5,7 @@
 .parameter-input {
   display: inline-block;
   position: relative;
-  width: 100%;
+  width: auto;
 
   .@{ant-prefix}-input,
   .@{ant-prefix}-input-number {

--- a/client/app/components/Parameters.less
+++ b/client/app/components/Parameters.less
@@ -26,9 +26,9 @@
 }
 
 .parameter-heading {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  padding-bottom: 4px;
+  padding-right: 4px;
 
   label {
     margin-bottom: 1px;


### PR DESCRIPTION
I suggest **Parameter Input and Parameter Label** can place in one line, so the chart zone can save the place in query & dashboard.

I add a redash discuss: https://discuss.redash.io/t/parameter-input-and-parameter-label-is-in-one-line/6948

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

modify two parameter less files to support Parameter Input and Parameter label is in one line, so it can save one line to belong to chart/table zone.

[Parameter Input and Parameter label is in one line](https://discuss.redash.io/t/parameter-input-and-parameter-label-is-in-one-line/6948)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
