### PR TITLE
CSRF Exempts

### DIFF
--- a/client/app/services/axios.js
+++ b/client/app/services/axios.js
@@ -15,11 +15,11 @@ axios.interceptors.request.use(config => {
   const apiKey = Auth.getApiKey();
   if (apiKey) {
     config.headers.Authorization = `Key ${apiKey}`;
-  } else {
-    const csrfToken = Cookies.get("csrf_token");
-    if (csrfToken) {
-      config.headers.common["X-CSRF-TOKEN"] = csrfToken;
-    }
+  }
+
+  const csrfToken = Cookies.get("csrf_token");
+  if (csrfToken) {
+    config.headers.common["X-CSRF-TOKEN"] = csrfToken;
   }
 
   return config;

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -251,10 +251,11 @@ def init_app(app):
     login_manager.init_app(app)
     login_manager.anonymous_user = models.AnonymousUser
 
-    app.register_blueprint(google_oauth.blueprint)
-    app.register_blueprint(saml_auth.blueprint)
-    app.register_blueprint(remote_user_auth.blueprint)
-    app.register_blueprint(ldap_auth.blueprint)
+    from redash.security import csrf
+    for auth in [google_oauth, saml_auth, remote_user_auth, ldap_auth]:
+        blueprint = auth.blueprint
+        csrf.exempt(blueprint)
+        app.register_blueprint(blueprint)
 
     user_logged_in.connect(log_user_logged_in)
     login_manager.request_loader(request_loader)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
oauth endpoints should be exempt from CSRF checks. Since we use a custom call to `CSRFProtect.protect()`, I've added a workaround until this gets merged to flask-wtf.

## Related Tickets & Documents
#5055 