### PR TITLE
Keep widget loading when fetch request is replaced

### DIFF
--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -143,18 +143,24 @@ class Widget {
       if (maxAge === undefined || force) {
         maxAge = force ? 0 : undefined;
       }
-      this.queryResult = this.getQuery().getQueryResult(maxAge);
 
-      this.queryResult
+      const queryResult = this.getQuery().getQueryResult(maxAge);
+      this.queryResult = queryResult;
+
+      queryResult
         .toPromise()
         .then(result => {
-          this.loading = false;
-          this.data = result;
+          if (this.queryResult === queryResult) {
+            this.loading = false;
+            this.data = result;
+          }
           return result;
         })
         .catch(error => {
-          this.loading = false;
-          this.data = error;
+          if (this.queryResult === queryResult) {
+            this.loading = false;
+            this.data = error;
+          }
           return error;
         });
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description

**The bug (tested in [this dashboard](https://redash-preview.netlify.app/dashboards/111-test-param-update)):**
![dashboard-param-update](https://user-images.githubusercontent.com/3356951/90693479-4b2fbb80-e24d-11ea-929d-ff1df559a159.gif)

Basically, a parameter update when triggered again during an update wouldn't reflect on the widget state when the second refresh was finished.

**Explanation on the cause:**
This is caused by the Memoization introduced in #4734 😕. That takes the assumption that the widget updates can be based on Loading status updates, i.e.: a widget will only need to be re-rendered when its loading state updates. For this case, the loading state was set to `false` right after the first request was done, not triggering a second update on the later one. Considering it makes sense to keep the with the loading indication in that circumstance, that's what I did here.


## Related Tickets & Documents
#4734 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--