### PR TITLE
bugfix: fail to parse elasticsearch mappings

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -122,6 +122,8 @@ class BaseElasticSearch(BaseQueryRunner):
         for index_name in mappings_data:
             index_mappings = mappings_data[index_name]
             for m in index_mappings.get("mappings", {}):
+                if not isinstance(index_mappings["mappings"][m], dict):
+                    continue
                 if "properties" not in index_mappings["mappings"][m]:
                     continue
                 for property_name in index_mappings["mappings"][m]["properties"]:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Elasticsearch query_runner may raise TypeError when `dynamic` setting presents.

e.g. for the following mapping:
```
{
  "some_datasource": {
    "mappings": {
      "_meta": {...},
      "date_detection":true,
      "_source":Object{...},
      "numeric_detection":false,
      "dynamic_date_formats":[...],
      "dynamic":"true",
      "dynamic_templates":[...],
      "properties":{...}
    }
  },
  .....
}
```
`date_detection` and `numeric_detection` have bool values. `BaseElasticSearch._get_query_mappings` will raise "TypeError: argument of type 'bool' is not iterable" and fails to return any results for queries.


Check [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-field-mapping.html) for more details.

This PR add an additional condition check to ignore such fields.