### PR TITLE
Prevent assigning view only data sources to queries

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -366,6 +366,12 @@ class QueryResource(BaseResource):
         if "tags" in query_def:
             query_def["tags"] = [tag for tag in query_def["tags"] if tag]
 
+        if "data_source_id" in query_def:
+            data_source = models.DataSource.get_by_id_and_org(
+                query_def["data_source_id"], self.current_org
+            )
+            require_access(data_source, self.current_user, not_view_only)
+
         query_def["last_modified_by"] = self.current_user
         query_def["changed_by"] = self.current_user
         # SQLAlchemy handles the case where a concurrent transaction beats us

--- a/tests/handlers/test_queries.py
+++ b/tests/handlers/test_queries.py
@@ -121,6 +121,22 @@ class TestQueryResourcePost(BaseTestCase):
         )
         self.assertEqual(rv.status_code, 409)
 
+    def test_prevents_association_with_view_only_data_sources(self):
+        view_only_data_source = self.factory.create_data_source(view_only=True)
+        my_data_source = self.factory.create_data_source()
+
+        my_query = self.factory.create_query(data_source=my_data_source)
+        db.session.add(my_query)
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{0}".format(my_query.id),
+            data={"data_source_id": view_only_data_source.id},
+            user=self.factory.user,
+        )
+
+        self.assertEqual(rv.status_code, 403)
+
     def test_allows_association_with_authorized_dropdown_queries(self):
         data_source = self.factory.create_data_source(group=self.factory.default_group)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Creating a new query (`POST /queries`) checks that the current user has execution privileges on the provided data source. However, modifying an existing query (`POST /queries/<query_id>`) does not perform that check. This allows changing the data source to one that you may view but not execute queries on.