### PR TITLE
Backport SQLALCHEMY_ENABLE_POOL_PRE_PING to 8.x release branch

### DIFF
--- a/redash/models/base.py
+++ b/redash/models/base.py
@@ -12,10 +12,14 @@ from redash.utils import json_dumps
 class RedashSQLAlchemy(SQLAlchemy):
     def apply_driver_hacks(self, app, info, options):
         options.update(json_serializer=json_dumps)
+        if settings.SQLALCHEMY_ENABLE_POOL_PRE_PING:
+            options.update(pool_pre_ping=True)
         super(RedashSQLAlchemy, self).apply_driver_hacks(app, info, options)
 
     def apply_pool_defaults(self, app, options):
         super(RedashSQLAlchemy, self).apply_pool_defaults(app, options)
+        if settings.SQLALCHEMY_ENABLE_POOL_PRE_PING:
+            options["pool_pre_ping"] = True
         if settings.SQLALCHEMY_DISABLE_POOL:
             options['poolclass'] = NullPool
             # Remove options NullPool does not support:

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -20,6 +20,7 @@ SQLALCHEMY_DATABASE_URI = os.environ.get("REDASH_DATABASE_URL", os.environ.get('
 SQLALCHEMY_MAX_OVERFLOW = int_or_none(os.environ.get("SQLALCHEMY_MAX_OVERFLOW"))
 SQLALCHEMY_POOL_SIZE = int_or_none(os.environ.get("SQLALCHEMY_POOL_SIZE"))
 SQLALCHEMY_DISABLE_POOL = parse_boolean(os.environ.get("SQLALCHEMY_DISABLE_POOL", "false"))
+SQLALCHEMY_ENABLE_POOL_PRE_PING = parse_boolean(os.environ.get("SQLALCHEMY_ENABLE_POOL_PRE_PING", "false"))
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
 


### PR DESCRIPTION
Fixes #5035.

Add db thread pool option to keep idle connections alive (#4741)
* Add SQLALCHEMY_ENABLE_POOL_PRE_PING setting
* Change SQLALCHEMY_ENABLE_POOL_PRE_PING default value to false.

Co-authored-by: Arik Fraimovich <arik@arikfr.com>