### PR TITLE
Expire sessions after 6 hours of inactivity

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -2,9 +2,10 @@ import hashlib
 import hmac
 import logging
 import time
+from datetime import timedelta
 from urllib.parse import urlsplit, urlunsplit
 
-from flask import jsonify, redirect, request, url_for
+from flask import jsonify, redirect, request, url_for, session
 from flask_login import LoginManager, login_user, logout_user, user_logged_in
 from redash import models, settings
 from redash.authentication import jwt_auth
@@ -250,6 +251,12 @@ def init_app(app):
 
     login_manager.init_app(app)
     login_manager.anonymous_user = models.AnonymousUser
+    login_manager.REMEMBER_COOKIE_DURATION = settings.REMEMBER_COOKIE_DURATION
+
+    @app.before_request
+    def extend_session():
+        session.permanent = True
+        app.permanent_session_lifetime = timedelta(seconds=settings.SESSION_EXPIRY_TIME)
 
     from redash.security import csrf
     for auth in [google_oauth, saml_auth, remote_user_auth, ldap_auth]:

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -92,6 +92,8 @@ SESSION_COOKIE_SECURE = parse_boolean(
 SESSION_COOKIE_HTTPONLY = parse_boolean(
     os.environ.get("REDASH_SESSION_COOKIE_HTTPONLY", "true")
 )
+SESSION_EXPIRY_TIME = int(os.environ.get("REDASH_SESSION_EXPIRY_TIME", 60 * 60 * 6))
+
 # Whether the session cookie is set to secure.
 REMEMBER_COOKIE_SECURE = parse_boolean(
     os.environ.get("REDASH_REMEMBER_COOKIE_SECURE") or str(COOKIES_SECURE)
@@ -99,6 +101,10 @@ REMEMBER_COOKIE_SECURE = parse_boolean(
 # Whether the remember cookie is set HttpOnly.
 REMEMBER_COOKIE_HTTPONLY = parse_boolean(
     os.environ.get("REDASH_REMEMBER_COOKIE_HTTPONLY", "true")
+)
+# The amount of time before the remember cookie expires.
+REMEMBER_COOKIE_DURATION = int(
+    os.environ.get("REDASH_REMEMBER_COOKIE_DURATION", 60 * 60 * 24 * 31)
 )
 
 # Doesn't set X-Frame-Options by default since it's highly dependent

--- a/redash/templates/login.html
+++ b/redash/templates/login.html
@@ -39,7 +39,6 @@
 
     <form role="form" method="post" name="login">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-      <input type="hidden" name="remember" value="on">
       <div class="form-group">
         <label for="inputEmail">{{ username_prompt or 'Email' }}</label>
         <input type="text" class="form-control" id="inputEmail" name="email" value="{{email}}" data-test="Email">
@@ -47,6 +46,10 @@
       <div class="form-group">
         <label for="inputPassword">Password</label>
         <input type="password" class="form-control" id="inputPassword" name="password" data-test="Password">
+      </div>
+      <div class="form-group">
+        <input type="checkbox" id="inputRemember" name="remember" checked>
+        <label for="inputRemember">Remember me</label>
       </div>
 
       <button type="submit" class="btn btn-primary btn-block m-t-25">Log In</button>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Redash sessions don't expire and when they do expire - they refresh automatically because there's no way for users to opt out of "remember me" when they login.

This PR lets users opt out of "remember me" when they log in, effectively forcing their session to end (and not refresh) after 6 hours of inactivity. Every request extends the session by another 6 hours.

If users pick "Remember me", sessions would still expire, but get refreshed for up to 31 days, then they would have to log in again.
If they uncheck "Remember me", sessions would expire after 6 hours and would require a login.