### PR TITLE
Add support for Iframebox in dashboard to include third party visualizations

### DIFF
--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { chain, cloneDeep, find } from "lodash";
 import cx from "classnames";
 import { Responsive, WidthProvider } from "react-grid-layout";
-import { VisualizationWidget, TextboxWidget, RestrictedWidget } from "@/components/dashboards/dashboard-widget";
+import { VisualizationWidget, TextboxWidget, IframeboxWidget, RestrictedWidget } from "@/components/dashboards/dashboard-widget";
 import { FiltersType } from "@/components/Filters";
 import cfg from "@/config/dashboard-grid-options";
 import AutoHeightController from "./AutoHeightController";
@@ -69,6 +69,9 @@ const DashboardWidget = React.memo(
     }
     if (type === WidgetTypeEnum.TEXTBOX) {
       return <TextboxWidget widget={widget} canEdit={canEdit} isPublic={isPublic} onDelete={onDelete} />;
+    }
+    if (type === WidgetTypeEnum.IFRAMEBOX) {
+      return <IframeboxWidget widget={widget} canEdit={canEdit} isPublic={isPublic} onDelete={onDelete} />;
     }
     return <RestrictedWidget widget={widget} />;
   },

--- a/client/app/components/dashboards/IframeboxDialog.jsx
+++ b/client/app/components/dashboards/IframeboxDialog.jsx
@@ -37,7 +37,7 @@ function IframeboxDialog({ dialog, isNew, ...props }) {
   );
 
   const saveWidget = useCallback(() => {
-    dialog.close(text, title).catch(() => {
+    dialog.close({ text, title }).catch(() => {
       notification.error(isNew ? "Widget could not be added" : "Widget could not be saved");
     });
   }, [dialog, isNew, text, title]);
@@ -53,7 +53,7 @@ function IframeboxDialog({ dialog, isNew, ...props }) {
       <div className="iframebox-dialog">
         <Input
           value={title}
-          onChange={setTitle}
+          onChange={event => setTitle(event.target.value)}
           placeholder="Title..."
         />
         <Divider dashed />

--- a/client/app/components/dashboards/IframeboxDialog.jsx
+++ b/client/app/components/dashboards/IframeboxDialog.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import { useDebouncedCallback } from "use-debounce";
 import Modal from "antd/lib/modal";
 import Input from "antd/lib/input";
-import Tooltip from "antd/lib/tooltip";
 import Divider from "antd/lib/divider";
 import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 import notification from "@/services/notification";
@@ -17,6 +16,7 @@ export function toIframe(text) {
 
 function IframeboxDialog({ dialog, isNew, ...props }) {
   const [text, setText] = useState(toString(props.text));
+  const [title, setTitle] = useState(toString(props.title));
   const [preview, setPreview] = useState(null);
 
   useEffect(() => {
@@ -37,10 +37,10 @@ function IframeboxDialog({ dialog, isNew, ...props }) {
   );
 
   const saveWidget = useCallback(() => {
-    dialog.close(text).catch(() => {
+    dialog.close(text, title).catch(() => {
       notification.error(isNew ? "Widget could not be added" : "Widget could not be saved");
     });
-  }, [dialog, isNew, text]);
+  }, [dialog, isNew, text, title]);
 
   return (
     <Modal
@@ -50,7 +50,13 @@ function IframeboxDialog({ dialog, isNew, ...props }) {
       okText={isNew ? "Add to Dashboard" : "Save"}
       width={500}
       wrapProps={{ "data-test": "IframeboxDialog" }}>
-      <div className="textbox-dialog">
+      <div className="iframebox-dialog">
+        <Input
+          value={title}
+          onChange={setTitle}
+          placeholder="Title..."
+        />
+        <Divider dashed />
         <Input.TextArea
           className="resize-vertical"
           rows="5"
@@ -78,11 +84,13 @@ IframeboxDialog.propTypes = {
   dialog: DialogPropType.isRequired,
   isNew: PropTypes.bool,
   text: PropTypes.string,
+  title: PropTypes.string,
 };
 
 IframeboxDialog.defaultProps = {
   isNew: false,
   text: "",
+  title: "",
 };
 
 export default wrapDialog(IframeboxDialog);

--- a/client/app/components/dashboards/IframeboxDialog.jsx
+++ b/client/app/components/dashboards/IframeboxDialog.jsx
@@ -37,7 +37,7 @@ function IframeboxDialog({ dialog, isNew, ...props }) {
   );
 
   const saveWidget = useCallback(() => {
-    dialog.close({ text, title }).catch(() => {
+    dialog.close(text, title).catch(() => {
       notification.error(isNew ? "Widget could not be added" : "Widget could not be saved");
     });
   }, [dialog, isNew, text, title]);

--- a/client/app/components/dashboards/IframeboxDialog.jsx
+++ b/client/app/components/dashboards/IframeboxDialog.jsx
@@ -1,0 +1,88 @@
+import { toString } from "lodash";
+import React, { useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import { useDebouncedCallback } from "use-debounce";
+import Modal from "antd/lib/modal";
+import Input from "antd/lib/input";
+import Tooltip from "antd/lib/tooltip";
+import Divider from "antd/lib/divider";
+import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
+import notification from "@/services/notification";
+
+import "./IframeboxDialog.less";
+
+export function toIframe(text) {
+  return `<iframe style='height:100%;width:100%;' src=${text}></iframe>`
+}
+
+function IframeboxDialog({ dialog, isNew, ...props }) {
+  const [text, setText] = useState(toString(props.text));
+  const [preview, setPreview] = useState(null);
+
+  useEffect(() => {
+    setText(props.text);
+    setPreview(toIframe(props.text));
+  }, [props.text]);
+
+  const [updatePreview] = useDebouncedCallback(() => {
+    setPreview(toIframe(text));
+  }, 200);
+
+  const handleInputChange = useCallback(
+    event => {
+      setText(event.target.value);
+      updatePreview();
+    },
+    [updatePreview]
+  );
+
+  const saveWidget = useCallback(() => {
+    dialog.close(text).catch(() => {
+      notification.error(isNew ? "Widget could not be added" : "Widget could not be saved");
+    });
+  }, [dialog, isNew, text]);
+
+  return (
+    <Modal
+      {...dialog.props}
+      title={isNew ? "Add Iframebox" : "Edit Iframebox"}
+      onOk={saveWidget}
+      okText={isNew ? "Add to Dashboard" : "Save"}
+      width={500}
+      wrapProps={{ "data-test": "IframeboxDialog" }}>
+      <div className="textbox-dialog">
+        <Input.TextArea
+          className="resize-vertical"
+          rows="5"
+          value={text}
+          onChange={handleInputChange}
+          autoFocus
+          placeholder="Site to be linked..."
+        />
+        {text && (
+          <React.Fragment>
+            <Divider dashed />
+            <strong className="preview-title">Preview:</strong>
+            <div
+              className="preview"
+              dangerouslySetInnerHTML={{ __html: preview }} // eslint-disable-line react/no-danger
+            />
+          </React.Fragment>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+IframeboxDialog.propTypes = {
+  dialog: DialogPropType.isRequired,
+  isNew: PropTypes.bool,
+  text: PropTypes.string,
+};
+
+IframeboxDialog.defaultProps = {
+  isNew: false,
+  text: "",
+};
+
+export default wrapDialog(IframeboxDialog);

--- a/client/app/components/dashboards/IframeboxDialog.less
+++ b/client/app/components/dashboards/IframeboxDialog.less
@@ -1,0 +1,18 @@
+.iframebox-dialog {
+  small {
+    display: block;
+    margin-top: 4px;
+  }
+
+  .preview {
+    padding: 9px 9px 1px;
+    background-color: #f7f7f7;
+    margin-top: 8px;
+    word-wrap: break-word
+  }
+
+  .preview-title {
+    display: block;
+    margin-top: -5px;
+  }
+}

--- a/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
@@ -7,17 +7,21 @@ import Widget from "./Widget";
 function IframeboxWidget(props) {
   const { widget, canEdit } = props;
   const [text, setText] = useState(widget.text);
+  const [title, setTitle] = useState(widget.options.title);
 
   const editIframeBox = () => {
     IframeboxDialog.showModal({
       text: widget.text,
-    }).onClose(newText => {
+      title: widget.options.title,
+    }).onClose((newText, newTitle) => {
       widget.text = newText;
       widget.options = {
         ...widget.options,
+        title: newTitle,
         isIframe: true,
       };
       setText(newText);
+      setTitle(newTitle);
       return widget.save();
     });
   };
@@ -33,9 +37,20 @@ function IframeboxWidget(props) {
   }
 
   return (
-    <Widget {...props} menuOptions={canEdit ? IframeboxMenuOptions : null} className="widget-text">
+    <Widget
+      {...props}
+      menuOptions={canEdit ? IframeboxMenuOptions : null}
+      className="widget-text"
+      header={
+        <div className="t-header widget clearfix">
+          <div className="th-title">
+            {title}
+          </div>
+        </div>
+      }
+    >
       <div
-        className="body-row-auto scrollbox t-body p-15 markdown"
+        className="body-row-auto t-body p-15"
         dangerouslySetInnerHTML={{ __html: toIframe(text || "") }} // eslint-disable-line react/no-danger
       />
     </Widget>

--- a/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import Menu from "antd/lib/menu";
+import IframeboxDialog, { toIframe } from '@/components/dashboards/IframeboxDialog';
+import Widget from "./Widget";
+
+function IframeboxWidget(props) {
+  const { widget, canEdit } = props;
+  const [text, setText] = useState(widget.text);
+
+  const editIframeBox = () => {
+    IframeboxDialog.showModal({
+      text: widget.text,
+    }).onClose(newText => {
+      widget.text = newText;
+      widget.options = {
+        ...widget.options,
+        isIframe: true,
+      };
+      setText(newText);
+      return widget.save();
+    });
+  };
+
+  const IframeboxMenuOptions = [
+    <Menu.Item key="edit" onClick={editIframeBox}>
+      Edit
+    </Menu.Item>,
+  ];
+
+  if (!widget.width) {
+    return null;
+  }
+
+  return (
+    <Widget {...props} menuOptions={canEdit ? IframeboxMenuOptions : null} className="widget-text">
+      <div
+        className="body-row-auto scrollbox t-body p-15 markdown"
+        dangerouslySetInnerHTML={{ __html: toIframe(text || "") }} // eslint-disable-line react/no-danger
+      />
+    </Widget>
+  );
+}
+
+IframeboxWidget.propTypes = {
+  widget: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  canEdit: PropTypes.bool,
+};
+
+IframeboxWidget.defaultProps = {
+  canEdit: false,
+};
+
+export default IframeboxWidget;

--- a/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
@@ -13,15 +13,15 @@ function IframeboxWidget(props) {
     IframeboxDialog.showModal({
       text: widget.text,
       title: widget.options.title,
-    }).onClose((newText, newTitle) => {
-      widget.text = newText;
+    }).onClose((o) => {
+      widget.text = o.text;
       widget.options = {
         ...widget.options,
-        title: newTitle,
+        title: o.title,
         isIframe: true,
       };
-      setText(newText);
-      setTitle(newTitle);
+      setText(o.text);
+      setTitle(o.title);
       return widget.save();
     });
   };

--- a/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/IframeboxWidget.jsx
@@ -13,15 +13,15 @@ function IframeboxWidget(props) {
     IframeboxDialog.showModal({
       text: widget.text,
       title: widget.options.title,
-    }).onClose((o) => {
-      widget.text = o.text;
+    }).onClose((newText, newTitle) => {
+      widget.text = newText;
       widget.options = {
         ...widget.options,
-        title: o.title,
+        title: newTitle,
         isIframe: true,
       };
-      setText(o.text);
-      setTitle(o.title);
+      setText(newText);
+      setTitle(newTitle);
       return widget.save();
     });
   };

--- a/client/app/components/dashboards/dashboard-widget/index.js
+++ b/client/app/components/dashboards/dashboard-widget/index.js
@@ -1,3 +1,4 @@
 export { default as VisualizationWidget } from "./VisualizationWidget";
 export { default as TextboxWidget } from "./TextboxWidget";
+export { default as IframeboxWidget } from "./IframeboxWidget";
 export { default as RestrictedWidget } from "./RestrictedWidget";

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -39,7 +39,7 @@ DashboardSettings.propTypes = {
 };
 
 function AddWidgetContainer({ dashboardOptions, className, ...props }) {
-  const { showAddTextboxDialog, showAddWidgetDialog } = dashboardOptions;
+  const { showAddTextboxDialog, showAddWidgetDialog, showAddIframeboxDialog } = dashboardOptions;
   return (
     <div className={cx("add-widget-container", className)} {...props}>
       <h2>
@@ -52,6 +52,9 @@ function AddWidgetContainer({ dashboardOptions, className, ...props }) {
       <div>
         <Button className="m-r-15" onClick={showAddTextboxDialog} data-test="AddTextboxButton">
           Add Textbox
+        </Button>
+        <Button className="m-r-15" onClick={showAddIframeboxDialog} data-test="AddIframeboxButton">
+          Add Iframe
         </Button>
         <Button type="primary" onClick={showAddWidgetDialog} data-test="AddWidgetButton">
           Add Widget

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -177,10 +177,11 @@ function useDashboard(dashboardData) {
   const showAddIframeboxDialog = useCallback(() => {
     IframeboxDialog.showModal({
       isNew: true,
-    }).onClose(text =>
+    }).onClose((text, title) =>
       dashboard
         .addWidget(text, {
-          isIframe: true
+          title,
+          isIframe: true,
         })
         .then(() => setDashboard(currentDashboard => extend({}, currentDashboard)))
     );

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -177,7 +177,7 @@ function useDashboard(dashboardData) {
   const showAddIframeboxDialog = useCallback(() => {
     IframeboxDialog.showModal({
       isNew: true,
-    }).onClose(({ text, title }) =>
+    }).onClose((text, title) =>
       dashboard
         .addWidget(text, {
           title,

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -177,7 +177,7 @@ function useDashboard(dashboardData) {
   const showAddIframeboxDialog = useCallback(() => {
     IframeboxDialog.showModal({
       isNew: true,
-    }).onClose((text, title) =>
+    }).onClose(({ text, title }) =>
       dashboard
         .addWidget(text, {
           title,

--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -8,6 +8,7 @@ import recordEvent from "@/services/recordEvent";
 import { QueryResultError } from "@/services/query";
 import AddWidgetDialog from "@/components/dashboards/AddWidgetDialog";
 import TextboxDialog from "@/components/dashboards/TextboxDialog";
+import IframeboxDialog from '@/components/dashboards/IframeboxDialog';
 import PermissionsEditorDialog from "@/components/PermissionsEditorDialog";
 import { editableMappingsToParameterMappings, synchronizeWidgetTitles } from "@/components/ParameterMappingInput";
 import ShareDashboardDialog from "../components/ShareDashboardDialog";
@@ -173,6 +174,18 @@ function useDashboard(dashboardData) {
     );
   }, [dashboard]);
 
+  const showAddIframeboxDialog = useCallback(() => {
+    IframeboxDialog.showModal({
+      isNew: true,
+    }).onClose(text =>
+      dashboard
+        .addWidget(text, {
+          isIframe: true
+        })
+        .then(() => setDashboard(currentDashboard => extend({}, currentDashboard)))
+    );
+  }, [dashboard]);
+
   const showAddWidgetDialog = useCallback(() => {
     AddWidgetDialog.showModal({
       dashboard,
@@ -237,6 +250,7 @@ function useDashboard(dashboardData) {
     toggleFullscreen,
     showShareDashboardDialog,
     showAddTextboxDialog,
+    showAddIframeboxDialog,
     showAddWidgetDialog,
     managePermissions,
   };

--- a/client/app/services/widget.js
+++ b/client/app/services/widget.js
@@ -9,6 +9,7 @@ import { Query } from "./query";
 
 export const WidgetTypeEnum = {
   TEXTBOX: "textbox",
+  IFRAMEBOX: "iframebox",
   VISUALIZATION: "visualization",
   RESTRICTED: "restricted",
 };
@@ -103,6 +104,8 @@ class Widget {
       return WidgetTypeEnum.VISUALIZATION;
     } else if (this.restricted) {
       return WidgetTypeEnum.RESTRICTED;
+    } else if (this.options.isIframe) {
+      return WidgetTypeEnum.IFRAMEBOX;
     }
     return WidgetTypeEnum.TEXTBOX;
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Adds an Iframe box (like text box) in Dashboard. It supports unsafe HTML as well.
This helps in adding third party visualizations to the dashboard. REDASH_CONTENT_SECURITY_POLICY will need to be modified according to the url you want to import.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screenshot from 2020-06-10 18-38-04](https://user-images.githubusercontent.com/32140134/92802047-cb23ee00-f3d3-11ea-8808-c3026f3b7ed3.png)
![Screenshot from 2020-06-10 18-38-15](https://user-images.githubusercontent.com/32140134/92802054-cc551b00-f3d3-11ea-8571-8fc3c33bfd11.png)
![Screenshot from 2020-06-10 18-49-03](https://user-images.githubusercontent.com/32140134/92802058-ccedb180-f3d3-11ea-9cc0-1f078a1d0156.png)
![Screenshot from 2020-06-10 19-20-26](https://user-images.githubusercontent.com/32140134/92802061-cd864800-f3d3-11ea-8bb0-4d9693f6f0f6.png)
