### PR TITLE
Refresh CSRF tokens

### DIFF
--- a/client/app/services/axios.js
+++ b/client/app/services/axios.js
@@ -13,7 +13,7 @@ const getData = ({ data }) => data;
 
 axios.interceptors.response.use(getData);
 
-createAuthRefreshInterceptor(
+export const authRefreshInterceptor = createAuthRefreshInterceptor(
   axios,
   failedRequest => {
     const message = failedRequest.response.data.message || "";

--- a/client/app/services/axios.js
+++ b/client/app/services/axios.js
@@ -1,10 +1,11 @@
 import axiosLib from "axios";
 import { Auth } from "@/services/auth";
 import qs from "query-string";
-import Cookies from "js-cookie";
 
 export const axios = axiosLib.create({
   paramsSerializer: params => qs.stringify(params),
+  xsrfCookieName: "csrf_token",
+  xsrfHeaderName: "X-CSRF-TOKEN",
 });
 
 const getData = ({ data }) => data;
@@ -15,11 +16,6 @@ axios.interceptors.request.use(config => {
   const apiKey = Auth.getApiKey();
   if (apiKey) {
     config.headers.Authorization = `Key ${apiKey}`;
-  }
-
-  const csrfToken = Cookies.get("csrf_token");
-  if (csrfToken) {
-    config.headers.common["X-CSRF-TOKEN"] = csrfToken;
   }
 
   return config;

--- a/client/app/services/axios.js
+++ b/client/app/services/axios.js
@@ -20,7 +20,7 @@ export const authRefreshInterceptor = createAuthRefreshInterceptor(
     if (message.includes("CSRF")) {
       return axios.get("/ping");
     } else {
-      return Promise.reject();
+      return Promise.reject(failedRequest);
     }
   },
   { statusCodes: [400] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     "@ant-design/colors": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
-      "integrity": "sha1-WtQ9YZ6RHzSI66wwPWBuZqhCOQM=",
+      "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
       "requires": {
         "tinycolor2": "^1.4.1"
       }
@@ -4153,7 +4153,7 @@
     "array-tree-filter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha1-hzrAD+yDdJ8lWsjdCDgUtPYykZA="
+      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
     },
     "array-union": {
       "version": "1.0.2",
@@ -4393,6 +4393,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "axios-auth-refresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/axios-auth-refresh/-/axios-auth-refresh-3.0.0.tgz",
+      "integrity": "sha512-0XJnJY711f7opdT+b/au/xw1g4MYrjntXB8Oy5l48plbzOWLjUtJ+m8CtiNLgN3MAvGFJ/Q1NtQ7WKf2euKu6g=="
     },
     "axobject-query": {
       "version": "2.1.1",
@@ -6018,12 +6023,6 @@
         "monotone-convex-hull-2d": "^1.0.1"
       }
     },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
-    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -6053,7 +6052,7 @@
     "copy-to-clipboard": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha1-EVqhqZmP+rYZb5MHatbaO5E2Yq4=",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -6927,7 +6926,7 @@
     "dom-align": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.0.tgz",
-      "integrity": "sha1-VvtxVt8LkQmYMDZNLUj4iWP1opw="
+      "integrity": "sha512-YkoezQuhp3SLFGdOlr5xkqZ640iXrnHAwVYcDg8ZKRUtO7mSzSC2BA5V0VuyAwPSJA4CLIc6EDDJh4bEsD2+zA=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -8434,6 +8433,12 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -12141,11 +12146,6 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
       "dev": true
-    },
-    "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -16839,7 +16839,7 @@
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha1-DpAg3T0hAkRY1OvSfiPkAmmBBGQ="
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.10.0",
@@ -17327,7 +17327,7 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha1-GI1SHelbkIdAT9TctosT3wrk5/g="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "sharkdown": {
       "version": "0.1.1",
@@ -19946,7 +19946,7 @@
     "warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha1-Fungd+uKhtavfWSqHgX9hbRnjKM=",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "font-awesome": "^4.7.0",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.0",
-    "js-cookie": "^2.2.1",
     "lodash": "^4.17.10",
     "markdown": "0.5.0",
     "material-design-iconic-font": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ace-builds": "^1.4.12",
     "antd": "^4.4.3",
     "axios": "^0.19.0",
+    "axios-auth-refresh": "^3.0.0",
     "bootstrap": "^3.3.7",
     "classnames": "^2.2.6",
     "d3": "^3.5.17",

--- a/redash/security.py
+++ b/redash/security.py
@@ -27,6 +27,7 @@ def init_app(app):
     csrf.init_app(app)
     app.config["WTF_CSRF_CHECK_DEFAULT"] = False
     app.config["WTF_CSRF_SSL_STRICT"] = False
+    app.config["WTF_CSRF_TIME_LIMIT"] = settings.CSRF_TIME_LIMIT
 
     @app.after_request
     def inject_csrf_token(response):

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -506,3 +506,5 @@ REQUESTS_ALLOW_REDIRECTS = parse_boolean(
 ENFORCE_CSRF = parse_boolean(
     os.environ.get("REDASH_ENFORCE_CSRF", "false")
 )
+
+CSRF_TIME_LIMIT = int(os.environ.get("REDASH_CSRF_TIME_LIMIT", 3600 * 6))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
CSRF tokens should expire and reset every once in awhile. This PR expires them every 6 hours.
To prevent a scenario where users keep their Redash tab open for over 6 hours and then can't use the app since they have a stale CSRF token, I've added a retry mechanism in Axios.

* Also turns out Axios does CSRF cookie to header on it's own, so ca3e44a simplifies our code a bit and removes a dependency.

## Related Tickets & Documents
#5055 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/289488/93333100-7ea13e00-f82b-11ea-8b8d-491a1c67a875.png)