### PR TITLE
Fix annotation bug causing Oracle queries not to run - ORA-00933

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class Oracle(BaseSQLQueryRunner):
+    should_annotate_query = False
     noop_query = "SELECT 1 FROM dual"
 
     @classmethod


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Oracle does not like comments `/* such as this */` at the beginning or end of queries. Thus, annotating the query needs to be turned off.

## Screenshot of error

When the query is annotated, this error occurs: `Error running query: Query failed. ORA-00933: SQL command not properly ended.`.

![image](https://user-images.githubusercontent.com/9849069/93403096-90e3a200-f854-11ea-8666-d8c188a5417f.png)

