### PR TITLE
Fix JSON Serialization Error for Cassandra

### DIFF
--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -38,6 +38,7 @@ class CassandraJSONEncoder(JSONEncoder):
 
         self.mapping = {
             Date: self.cql_encode_date_ext,
+            Time: self.cql_encode_time,
             OrderedDict: self.cql_encode_map_collection,
             OrderedMap: self.cql_encode_map_collection,
             OrderedMapSerializedKey: self.cql_encode_map_collection,
@@ -50,7 +51,12 @@ class CassandraJSONEncoder(JSONEncoder):
         }
     
     def cql_encode_date_ext(self, val):
-        return val.date().isoformat()
+        built_in_date = val.date()
+        return super(CassandraJSONEncoder, self).default(built_in_date)
+
+    def cql_encode_time(self, val):
+        built_in_time = val.time()
+        return super(CassandraJSONEncoder, self).default(built_in_time)
 
     def cql_encode_map_collection(self, val):
         return {

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -51,10 +51,10 @@ class CassandraJSONEncoder(JSONEncoder):
         return val.date().isoformat()
 
     def cql_encode_map_collection(self, val):
-        return (
-            self.mapping.get(type(k), super(CassandraJSONEncoder, self).default)(k),
-            self.mapping.get(type(v), super(CassandraJSONEncoder, self).default)(v)
-        ) for k, v in val.items())
+        return {
+            self.mapping.get(type(k), super(CassandraJSONEncoder, self).default)(k):
+            self.mapping.get(type(v), super(CassandraJSONEncoder, self).default)(v) 
+            for k, v in val.items()}
 
     def cql_encode_list_collection(self, val):
         return [self.mapping.get(type(v), super(CassandraJSONEncoder, self).default)(v) for v in val]

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -13,6 +13,7 @@ try:
     from cassandra.cluster import Cluster
     from cassandra.auth import PlainTextAuthProvider
     from cassandra.util import sortedset
+    from cassandra.util import Date
 
     enabled = True
 except ImportError:
@@ -33,6 +34,8 @@ class CassandraJSONEncoder(JSONEncoder):
     def default(self, o):
         if isinstance(o, sortedset):
             return list(o)
+        elif isinstance(o, Date):
+            return o.date().isoformat()
         return super(CassandraJSONEncoder, self).default(o)
 
 

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -32,8 +32,10 @@ def generate_ssl_options_dict(protocol, cert_path=None):
 
 
 class CassandraJSONEncoder(JSONEncoder):
-    def __init__(self):
-        super(CassandraJSONEncoder, self).__init__()
+    def __init__(self, *args, **kwargs):
+
+        super(CassandraJSONEncoder, self).__init__(*args, **kwargs)
+
         self.mapping = {
             Date: self.cql_encode_date_ext,
             OrderedDict: self.cql_encode_map_collection,

--- a/redash/query_runner/cass.py
+++ b/redash/query_runner/cass.py
@@ -34,7 +34,7 @@ def generate_ssl_options_dict(protocol, cert_path=None):
 class CassandraJSONEncoder(JSONEncoder):
     def __init__(self):
         super(CassandraJSONEncoder, self).__init__()
-        self.mapping = [
+        self.mapping = {
             Date: self.cql_encode_date_ext,
             OrderedDict: self.cql_encode_map_collection,
             OrderedMap: self.cql_encode_map_collection,
@@ -45,7 +45,7 @@ class CassandraJSONEncoder(JSONEncoder):
             sortedset: self.cql_encode_set_collection,
             frozenset: self.cql_encode_set_collection,
             types.GeneratorType: self.cql_encode_list_collection,
-        ]
+        }
     
     def cql_encode_date_ext(self, val):
         return val.date().isoformat()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,4 @@ PyAthena>=1.5.0
 ptvsd==4.3.2
 freezegun==0.3.12
 watchdog==0.9.0
+cassandra-driver==3.21.0

--- a/tests/query_runner/test_cass.py
+++ b/tests/query_runner/test_cass.py
@@ -2,8 +2,11 @@ import shutil
 import ssl
 from unittest import TestCase
 
-from redash.query_runner.cass import generate_ssl_options_dict
+from cassandra.cqltypes import UTF8Type
+from cassandra.util import OrderedMapSerializedKey
 
+from redash.query_runner.cass import generate_ssl_options_dict, CassandraJSONEncoder
+from redash.utils import json_dumps
 
 class TestCassandra(TestCase):
 
@@ -20,3 +23,12 @@ class TestCassandra(TestCase):
         }
         actual = generate_ssl_options_dict("PROTOCOL_TLSv1_2", "some/path")
         self.assertDictEqual(expected, actual)
+
+    def test_cass_json_encoder_1(self):
+        om = OrderedMapSerializedKey(UTF8Type, 2)
+
+        try:
+            json_data = json_dumps(om, cls=CassandraJSONEncoder)
+            self.assertEqual(json_data, {})
+        except Exception as e:
+            self.fail(repr(e))

--- a/tests/query_runner/test_cass.py
+++ b/tests/query_runner/test_cass.py
@@ -55,4 +55,13 @@ class TestCassandra(TestCase):
             self.assertEqual(json_obj, "00:00:00")
         except Exception as e:
             self.fail(repr(e))
-    
+
+    def test_cass_json_encoder_4(self):
+        built_in_float = 7.0
+
+        try:
+            json_data = json_dumps(built_in_float, cls=CassandraJSONEncoder)
+            json_obj = json_loads(json_data)
+            self.assertEqual(json_obj, built_in_float)
+        except Exception as e:
+            self.fail(repr(e))    

--- a/tests/query_runner/test_cass.py
+++ b/tests/query_runner/test_cass.py
@@ -1,12 +1,13 @@
+import datetime
 import shutil
 import ssl
 from unittest import TestCase
 
 from cassandra.cqltypes import UTF8Type
-from cassandra.util import OrderedMapSerializedKey
+from cassandra.util import OrderedMapSerializedKey, Date
 
 from redash.query_runner.cass import generate_ssl_options_dict, CassandraJSONEncoder
-from redash.utils import json_dumps
+from redash.utils import json_dumps, json_loads
 
 class TestCassandra(TestCase):
 
@@ -29,6 +30,18 @@ class TestCassandra(TestCase):
 
         try:
             json_data = json_dumps(om, cls=CassandraJSONEncoder)
-            self.assertEqual(json_data, {})
+            json_obj = json_loads(json_data)
+            self.assertEqual(json_obj, {})
+        except Exception as e:
+            self.fail(repr(e))
+
+    def test_cass_json_encoder_2(self):
+        expected_date = datetime.date(2020, 9, 22)
+        cass_date = Date(expected_date)
+
+        try:
+            json_data = json_dumps(cass_date, cls=CassandraJSONEncoder)
+            json_obj = json_loads(json_data)
+            self.assertEqual(json_obj, expected_date.isoformat())
         except Exception as e:
             self.fail(repr(e))

--- a/tests/query_runner/test_cass.py
+++ b/tests/query_runner/test_cass.py
@@ -4,7 +4,7 @@ import ssl
 from unittest import TestCase
 
 from cassandra.cqltypes import UTF8Type
-from cassandra.util import OrderedMapSerializedKey, Date
+from cassandra.util import OrderedMapSerializedKey, Date, Time
 
 from redash.query_runner.cass import generate_ssl_options_dict, CassandraJSONEncoder
 from redash.utils import json_dumps, json_loads
@@ -45,3 +45,14 @@ class TestCassandra(TestCase):
             self.assertEqual(json_obj, expected_date.isoformat())
         except Exception as e:
             self.fail(repr(e))
+
+    def test_cass_json_encoder_3(self):
+        cass_time = Time("00:00:00.000000001")
+
+        try:
+            json_data = json_dumps(cass_time, cls=CassandraJSONEncoder)
+            json_obj = json_loads(json_data)
+            self.assertEqual(json_obj, "00:00:00")
+        except Exception as e:
+            self.fail(repr(e))
+    


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
From issues #4970 and #4931, we know that the current  `CassandraJSONEncoder` has the limitation to encode custom datatype in Cassandra (e.g. `cassandra.util.Date` and `OrderedMapSerializedKey`). This PR is to handle these problems.

## Related Tickets & Documents

Close #4970, Close #4931.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
