### PR TITLE
Cancel queued queries

### DIFF
--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -11,10 +11,8 @@ from rq.job import Job as BaseJob, JobStatus
 
 class CancellableJob(BaseJob):
     def cancel(self, pipeline=None):
-        # TODO - add tests that verify that queued jobs are removed from queue and running jobs are actively cancelled
-        if self.is_started:
-            self.meta["cancelled"] = True
-            self.save_meta()
+        self.meta["cancelled"] = True
+        self.save_meta()
 
         super().cancel(pipeline=pipeline)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Queries get cancelled by having a 'cancelled' meta directive added to the Job, but this only happens for actively running jobs. The job serializer uses that directive to let the UI know that the job has been cancelled. The result of this is that queued jobs appear like they aren't cancelled in the UI. This PR fixes it by appending the 'cancelled' directive to all cancelled jobs.