### PR TITLE
Cypress: Fix flaky share embed spec

### DIFF
--- a/client/cypress/integration/embed/share_embed_spec.js
+++ b/client/cypress/integration/embed/share_embed_spec.js
@@ -21,6 +21,8 @@ describe("Embedded Queries", () => {
 
           // check the feature is disabled
           cy.visit(`/queries/${query.id}/source`);
+          cy.getByTestId("ExecuteButton").click();
+          cy.getByTestId("QueryPageVisualizationTabs", { timeout: 10000 }).should("exist");
           cy.getByTestId("QueryPageHeaderMoreButton").click();
           cy.get(".ant-dropdown-menu-item")
             .should("exist")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description
I noticed there is a new flaky test in share embed spec. It looks like results are not being saved to the query after the first execution. I debugged a little bit and I think this may be related to #5088 differences of Query not having the `apply_auto_limit` and we sending the requests with a `true` value. Needs some more investigation though.

This PR should fix the flaky test for now.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--