### PR TITLE
fix lock head failure

### DIFF
--- a/viz-lib/src/visualizations/table/renderer.less
+++ b/viz-lib/src/visualizations/table/renderer.less
@@ -88,6 +88,7 @@
 
         // optimize room for th content
         &.ant-table-column-has-actions.ant-table-column-has-sorters {
+          z-index: 1;
           padding-right: 3px;
         }
 


### PR DESCRIPTION
Fix the failure to lock the header when there is a search box

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
When there is a search box in the table, slide the table up, and the lock table header will be invalid.
![image](https://user-images.githubusercontent.com/46274612/94639605-267c3880-030f-11eb-9c15-923112a64b19.png)

