### PR TITLE
Updated Cypress to v5.3 and fixed e2e tests

### DIFF
--- a/.circleci/Dockerfile.cypress
+++ b/.circleci/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM cypress/browsers:chrome67
+FROM cypress/browsers:node14.0.0-chrome84
 
 ENV APP /usr/src/app
 WORKDIR $APP

--- a/client/cypress/integration/dashboard/dashboard_spec.js
+++ b/client/cypress/integration/dashboard/dashboard_spec.js
@@ -87,6 +87,7 @@ describe("Dashboard", () => {
     });
 
     beforeEach(function() {
+      cy.login();
       cy.visit(this.dashboardUrl);
       cy.viewport(800 + menuWidth, 800);
     });

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -501,11 +501,11 @@ describe("Parameter", () => {
         .as("Param")
         .type("Redash");
 
-      cy.getByTestId("ParameterApplyButton").should("be", "visible");
+      cy.getByTestId("ParameterApplyButton").should("be.visible");
 
       cy.get("@Param").clear();
 
-      cy.getByTestId("ParameterApplyButton").should("not.be", "visible");
+      cy.getByTestId("ParameterApplyButton").should("not.be.visible");
     });
 
     it("updates dirty counter", () => {

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -505,7 +505,7 @@ describe("Parameter", () => {
 
       cy.get("@Param").clear();
 
-      cy.getByTestId("ParameterApplyButton").should("not.be.visible");
+      cy.getByTestId("ParameterApplyButton").should("not.be", "visible");
     });
 
     it("updates dirty counter", () => {

--- a/client/cypress/integration/visualizations/choropleth_spec.js
+++ b/client/cypress/integration/visualizations/choropleth_spec.js
@@ -36,15 +36,11 @@ describe("Choropleth", () => {
       cy.visit(`queries/${id}/source`);
       cy.getByTestId("ExecuteButton").click();
     });
+    cy.getByTestId("NewVisualization").click();
+    cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.CHOROPLETH");
   });
 
   it("creates visualization", () => {
-    cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.CHOROPLETH
-    `);
-
     cy.clickThrough(`
       VisualizationEditor.Tabs.General
       Choropleth.Editor.MapType

--- a/client/cypress/integration/visualizations/choropleth_spec.js
+++ b/client/cypress/integration/visualizations/choropleth_spec.js
@@ -44,7 +44,7 @@ describe("Choropleth", () => {
     cy.clickThrough(`
       VisualizationEditor.Tabs.General
       Choropleth.Editor.MapType
-      Choropleth.Editor.MapType.Countries
+      Choropleth.Editor.MapType.countries
       Choropleth.Editor.KeyColumn
       Choropleth.Editor.KeyColumn.name
       Choropleth.Editor.KeyType

--- a/client/cypress/integration/visualizations/choropleth_spec.js
+++ b/client/cypress/integration/visualizations/choropleth_spec.js
@@ -47,8 +47,8 @@ describe("Choropleth", () => {
       Choropleth.Editor.MapType.countries
       Choropleth.Editor.KeyColumn
       Choropleth.Editor.KeyColumn.name
-      Choropleth.Editor.KeyType
-      Choropleth.Editor.KeyType.name
+      Choropleth.Editor.TargetField
+      Choropleth.Editor.TargetField.name
       Choropleth.Editor.ValueColumn
       Choropleth.Editor.ValueColumn.value
     `);

--- a/client/cypress/integration/visualizations/choropleth_spec.js
+++ b/client/cypress/integration/visualizations/choropleth_spec.js
@@ -48,11 +48,11 @@ describe("Choropleth", () => {
     cy.clickThrough(`
       VisualizationEditor.Tabs.General
       Choropleth.Editor.MapType
-      Choropleth.Editor.MapType.countries
+      Choropleth.Editor.MapType.Countries
       Choropleth.Editor.KeyColumn
       Choropleth.Editor.KeyColumn.name
-      Choropleth.Editor.TargetField
-      Choropleth.Editor.TargetField.name
+      Choropleth.Editor.KeyType
+      Choropleth.Editor.KeyType.name
       Choropleth.Editor.ValueColumn
       Choropleth.Editor.ValueColumn.value
     `);

--- a/client/cypress/integration/visualizations/cohort_spec.js
+++ b/client/cypress/integration/visualizations/cohort_spec.js
@@ -26,15 +26,11 @@ describe("Cohort", () => {
       cy.visit(`queries/${id}/source`);
       cy.getByTestId("ExecuteButton").click();
     });
+    cy.getByTestId("NewVisualization").click();
+    cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.COHORT");
   });
 
   it("creates visualization", () => {
-    cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COHORT
-    `);
-
     cy.clickThrough(`
       VisualizationEditor.Tabs.Options
       Cohort.TimeInterval

--- a/client/cypress/integration/visualizations/counter_spec.js
+++ b/client/cypress/integration/visualizations/counter_spec.js
@@ -14,14 +14,12 @@ describe("Counter", () => {
       cy.visit(`queries/${id}/source`);
       cy.getByTestId("ExecuteButton").click();
     });
+    cy.getByTestId("NewVisualization").click();
+    cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.COUNTER");
   });
 
   it("creates simple Counter", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
     `);
@@ -37,10 +35,6 @@ describe("Counter", () => {
 
   it("creates Counter with custom label", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
     `);
@@ -60,10 +54,6 @@ describe("Counter", () => {
 
   it("creates Counter with non-numeric value", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.c
 
@@ -86,10 +76,6 @@ describe("Counter", () => {
 
   it("creates Counter with target value (trend positive)", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
 
@@ -108,10 +94,6 @@ describe("Counter", () => {
 
   it("creates Counter with custom row number (trend negative)", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
 
@@ -135,10 +117,6 @@ describe("Counter", () => {
 
   it("creates Counter with count rows", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
 
@@ -156,10 +134,6 @@ describe("Counter", () => {
 
   it("creates Counter with formatting", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
 
@@ -188,10 +162,6 @@ describe("Counter", () => {
 
   it("creates Counter with target value formatting", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.COUNTER
-
       Counter.General.ValueColumn
       Counter.General.ValueColumn.a
 

--- a/client/cypress/integration/visualizations/funnel_spec.js
+++ b/client/cypress/integration/visualizations/funnel_spec.js
@@ -32,10 +32,8 @@ describe("Funnel", () => {
   it("creates visualization", () => {
     cy.clickThrough(`
       NewVisualization
-      VisualizationType
-      VisualizationType.FUNNEL
     `);
-
+    cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.FUNNEL");
     cy.clickThrough(`
       VisualizationEditor.Tabs.General
 

--- a/client/cypress/integration/visualizations/pivot_spec.js
+++ b/client/cypress/integration/visualizations/pivot_spec.js
@@ -18,8 +18,7 @@ const SQL = `
 
 function createPivotThroughUI(visualizationName, options = {}) {
   cy.getByTestId("NewVisualization").click();
-  cy.getByTestId("VisualizationType").click();
-  cy.getByTestId("VisualizationType.PIVOT").click();
+  cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.PIVOT");
   cy.getByTestId("VisualizationName")
     .clear()
     .type(visualizationName);

--- a/client/cypress/integration/visualizations/sankey_sunburst_spec.js
+++ b/client/cypress/integration/visualizations/sankey_sunburst_spec.js
@@ -26,15 +26,14 @@ describe("Sankey and Sunburst", () => {
       cy.createQuery({ query: SQL }).then(({ id }) => {
         cy.visit(`queries/${id}/source`);
         cy.getByTestId("ExecuteButton").click();
+        cy.getByTestId("NewVisualization").click();
+        cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.SUNBURST_SEQUENCE");
       });
     });
 
     it("creates Sunburst", () => {
       const visualizationName = "Sunburst";
 
-      cy.getByTestId("NewVisualization").click();
-      cy.getByTestId("VisualizationType").click();
-      cy.getByTestId("VisualizationType.SUNBURST_SEQUENCE").click();
       cy.getByTestId("VisualizationName")
         .clear()
         .type(visualizationName);
@@ -53,9 +52,6 @@ describe("Sankey and Sunburst", () => {
     it("creates Sankey", () => {
       const visualizationName = "Sankey";
 
-      cy.getByTestId("NewVisualization").click();
-      cy.getByTestId("VisualizationType").click();
-      cy.getByTestId("VisualizationType.SANKEY").click();
       cy.getByTestId("VisualizationName")
         .clear()
         .type(visualizationName);

--- a/client/cypress/integration/visualizations/word_cloud_spec.js
+++ b/client/cypress/integration/visualizations/word_cloud_spec.js
@@ -67,14 +67,12 @@ describe("Word Cloud", () => {
       cy.getByTestId("ExecuteButton").click();
     });
     cy.document().then(injectFont);
+    cy.getByTestId("NewVisualization").click();
+    cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.WORD_CLOUD");
   });
 
   it("creates visualization with automatic word frequencies", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.WORD_CLOUD
-
       WordCloud.WordsColumn
       WordCloud.WordsColumn.a
     `);
@@ -91,10 +89,6 @@ describe("Word Cloud", () => {
 
   it("creates visualization with word frequencies from another column", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.WORD_CLOUD
-
       WordCloud.WordsColumn
       WordCloud.WordsColumn.b
 
@@ -114,10 +108,6 @@ describe("Word Cloud", () => {
 
   it("creates visualization with word length and frequencies limits", () => {
     cy.clickThrough(`
-      NewVisualization
-      VisualizationType
-      VisualizationType.WORD_CLOUD
-
       WordCloud.WordsColumn
       WordCloud.WordsColumn.b
 

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -69,6 +69,14 @@ Cypress.Commands.add("clickThrough", (...args) => {
   return undefined;
 });
 
+/**
+ * Selects ANTD selector option
+ */
+Cypress.Commands.add("selectAntdOption", { prevSubject: "element" }, (subject, testId) => {
+  cy.wrap(subject).click();
+  return cy.getByTestId(testId).click({ force: true });
+});
+
 Cypress.Commands.add("fillInputs", (elements, { wait = 0 } = {}) => {
   each(elements, (value, testId) => {
     cy.getByTestId(testId)

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
   command = "npm ci && npm run build"
 
 [build.environment]
+  NODE_VERSION = "12.18.4"
   CYPRESS_INSTALL_BINARY = "0"
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = "1"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6736,6 +6736,12 @@
         }
       }
     },
+    "blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -7827,14 +7833,48 @@
       }
     },
     "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "requires": {
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "cli-truncate": {
@@ -9053,9 +9093,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.12.1.tgz",
-      "integrity": "sha512-9SGIPEmqU8vuRA6xst2CMTYd9sCFCxKSzrHt0wr+w2iAQMCIIsXsQ5Gplns1sT6LDbZcmLv6uehabAOl3fhc9Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.3.0.tgz",
+      "integrity": "sha512-XgebyqL7Th6/8YenE1ddb7+d4EiCG2Jvg/5c8+HPfFFY/gXnOVhoCVUU3KW8qg3JL7g0B+iJbHd5hxuCqbd1RQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -9064,26 +9104,27 @@
         "@types/sinonjs__fake-timers": "^6.0.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.1.2",
+        "blob-util": "2.0.2",
         "bluebird": "^3.7.2",
         "cachedir": "^2.3.0",
-        "chalk": "^2.4.2",
+        "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
-        "cli-table3": "~0.5.1",
+        "cli-table3": "~0.6.0",
         "commander": "^4.1.1",
         "common-tags": "^1.8.0",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
-        "execa": "^1.0.0",
+        "execa": "^4.0.2",
         "executable": "^4.1.1",
         "extract-zip": "^1.7.0",
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.1",
         "getos": "^3.2.1",
         "is-ci": "^2.0.0",
         "is-installed-globally": "^0.3.2",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
         "lodash": "^4.17.19",
-        "log-symbols": "^3.0.0",
+        "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
         "ospath": "^1.2.2",
@@ -9091,23 +9132,62 @@
         "ramda": "~0.26.1",
         "request-progress": "^3.0.0",
         "supports-color": "^7.1.0",
-        "tmp": "~0.1.0",
+        "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "bluebird": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
           "dev": true
         },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
         "commander": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
         },
         "debug": {
           "version": "4.2.0",
@@ -9118,15 +9198,42 @@
             "ms": "2.1.2"
           }
         },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+        "execa": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
           }
         },
         "graceful-fs": {
@@ -9139,6 +9246,28 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
           "dev": true
         },
         "minimist": {
@@ -9159,6 +9288,55 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9169,12 +9347,27 @@
           }
         },
         "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
           "dev": true,
           "requires": {
-            "rimraf": "^2.6.3"
+            "rimraf": "^3.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -16443,12 +16636,57 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "log-update": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "copy-webpack-plugin": "^4.5.3",
     "css-loader": "^0.28.7",
-    "cypress": "^4.12.1",
+    "cypress": "^5.3.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
     "enzyme-to-json": "^3.3.5",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Updated Cypress to v5 and fixed some e2e tests.
Most of the test on v5 were failing because of some subtle differences in animation detection,
v5 was clicking wrong element in all antd selects (while it was playing open animation).

I've added specific helper method for antd select and updated tests where possible.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
