### PR TITLE
Extra actions on Queries and Dashboards pages

### DIFF
--- a/client/app/components/items-list/hooks/useItemsListExtraActions.js
+++ b/client/app/components/items-list/hooks/useItemsListExtraActions.js
@@ -14,6 +14,9 @@ export default function useItemsListExtraActions(controller, listColumns, ExtraA
 
   const areAllItemsSelected = useMemo(() => {
     const allItems = controller.pageItems;
+    if (allItems.length === 0 || selectedItems.length === 0) {
+      return false;
+    }
     return intersection(selectedItems, allItems).length === allItems.length;
   }, [selectedItems, controller.pageItems]);
 

--- a/client/app/components/items-list/hooks/useItemsListExtraActions.js
+++ b/client/app/components/items-list/hooks/useItemsListExtraActions.js
@@ -39,16 +39,18 @@ export default function useItemsListExtraActions(controller, listColumns, ExtraA
     [selectedItems]
   );
 
-  const checkboxColumn = useMemo(() => {
-    return Columns.custom(
-      (text, item) => <Checkbox checked={includes(selectedItems, item)} onChange={() => toggleItem(item)} />,
-      {
-        title: () => <Checkbox checked={areAllItemsSelected} onChange={toggleAllItems} />,
-        field: "id",
-        width: "1%",
-      }
-    );
-  }, [selectedItems, areAllItemsSelected, toggleAllItems, toggleItem]);
+  const checkboxColumn = useMemo(
+    () =>
+      Columns.custom(
+        (text, item) => <Checkbox checked={includes(selectedItems, item)} onChange={() => toggleItem(item)} />,
+        {
+          title: () => <Checkbox checked={areAllItemsSelected} onChange={toggleAllItems} />,
+          field: "id",
+          width: "1%",
+        }
+      ),
+    [selectedItems, areAllItemsSelected, toggleAllItems, toggleItem]
+  );
 
   const Component = useCallback(
     function ItemsListExtraActionsComponentWrapper(props) {
@@ -62,13 +64,14 @@ export default function useItemsListExtraActions(controller, listColumns, ExtraA
     [ExtraActionsComponent]
   );
 
-  return useMemo(() => {
-    return {
+  return useMemo(
+    () => ({
       areExtraActionsAvailable: actionsState.isAvailable,
       listColumns: actionsState.isAvailable ? [checkboxColumn, ...listColumns] : listColumns,
       Component,
       selectedItems,
       setSelectedItems,
-    };
-  }, [actionsState, listColumns, checkboxColumn, selectedItems, Component]);
+    }),
+    [actionsState, listColumns, checkboxColumn, selectedItems, Component]
+  );
 }

--- a/client/app/components/items-list/hooks/useItemsListExtraActions.js
+++ b/client/app/components/items-list/hooks/useItemsListExtraActions.js
@@ -1,0 +1,71 @@
+import { filter, includes, intersection } from "lodash";
+import React, { useState, useMemo, useEffect, useCallback } from "react";
+import Checkbox from "antd/lib/checkbox";
+import { Columns } from "../components/ItemsTable";
+
+export default function useItemsListExtraActions(controller, listColumns, ExtraActionsComponent) {
+  const [actionsState, setActionsState] = useState({ isAvailable: false });
+  const [selectedItems, setSelectedItems] = useState([]);
+
+  // clear selection when page changes
+  useEffect(() => {
+    setSelectedItems([]);
+  }, [controller.pageItems, actionsState.isAvailable]);
+
+  const areAllItemsSelected = useMemo(() => {
+    const allItems = controller.pageItems;
+    return intersection(selectedItems, allItems).length === allItems.length;
+  }, [selectedItems, controller.pageItems]);
+
+  const toggleAllItems = useCallback(() => {
+    if (areAllItemsSelected) {
+      setSelectedItems([]);
+    } else {
+      setSelectedItems(controller.pageItems);
+    }
+  }, [areAllItemsSelected, controller.pageItems]);
+
+  const toggleItem = useCallback(
+    item => {
+      if (includes(selectedItems, item)) {
+        setSelectedItems(filter(selectedItems, s => s !== item));
+      } else {
+        setSelectedItems([...selectedItems, item]);
+      }
+    },
+    [selectedItems]
+  );
+
+  const checkboxColumn = useMemo(() => {
+    return Columns.custom(
+      (text, item) => <Checkbox checked={includes(selectedItems, item)} onChange={() => toggleItem(item)} />,
+      {
+        title: () => <Checkbox checked={areAllItemsSelected} onChange={toggleAllItems} />,
+        field: "id",
+        width: "1%",
+      }
+    );
+  }, [selectedItems, areAllItemsSelected, toggleAllItems, toggleItem]);
+
+  const Component = useCallback(
+    function ItemsListExtraActionsComponentWrapper(props) {
+      // this check mostly needed to avoid eslint exhaustive deps warning
+      if (!ExtraActionsComponent) {
+        return null;
+      }
+
+      return <ExtraActionsComponent onStateChange={setActionsState} {...props} />;
+    },
+    [ExtraActionsComponent]
+  );
+
+  return useMemo(() => {
+    return {
+      areExtraActionsAvailable: actionsState.isAvailable,
+      listColumns: actionsState.isAvailable ? [checkboxColumn, ...listColumns] : listColumns,
+      Component,
+      selectedItems,
+      setSelectedItems,
+    };
+  }, [actionsState, listColumns, checkboxColumn, selectedItems, Component]);
+}

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -22,117 +22,114 @@ import DashboardListEmptyState from "./components/DashboardListEmptyState";
 
 import "./dashboard-list.css";
 
-class DashboardList extends React.Component {
-  static propTypes = {
-    controller: ControllerType.isRequired,
-  };
+const sidebarMenu = [
+  {
+    key: "all",
+    href: "dashboards",
+    title: "All Dashboards",
+  },
+  {
+    key: "favorites",
+    href: "dashboards/favorites",
+    title: "Favorites",
+    icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
+  },
+];
 
-  sidebarMenu = [
-    {
-      key: "all",
-      href: "dashboards",
-      title: "All Dashboards",
-    },
-    {
-      key: "favorites",
-      href: "dashboards/favorites",
-      title: "Favorites",
-      icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
-    },
-  ];
-
-  listColumns = [
-    Columns.favorites({ className: "p-r-0" }),
-    Columns.custom.sortable(
-      (text, item) => (
-        <React.Fragment>
-          <Link className="table-main-title" href={item.url} data-test={`DashboardId${item.id}`}>
-            {item.name}
-          </Link>
-          <DashboardTagsControl
-            className="d-block"
-            tags={item.tags}
-            isDraft={item.is_draft}
-            isArchived={item.is_archived}
-          />
-        </React.Fragment>
-      ),
-      {
-        title: "Name",
-        field: "name",
-        width: null,
-      }
+const listColumns = [
+  Columns.favorites({ className: "p-r-0" }),
+  Columns.custom.sortable(
+    (text, item) => (
+      <React.Fragment>
+        <Link className="table-main-title" href={item.url} data-test={`DashboardId${item.id}`}>
+          {item.name}
+        </Link>
+        <DashboardTagsControl
+          className="d-block"
+          tags={item.tags}
+          isDraft={item.is_draft}
+          isArchived={item.is_archived}
+        />
+      </React.Fragment>
     ),
-    Columns.custom((text, item) => item.user.name, { title: "Created By", width: "1%" }),
-    Columns.dateTime.sortable({
-      title: "Created At",
-      field: "created_at",
-      width: "1%",
-    }),
-  ];
+    {
+      title: "Name",
+      field: "name",
+      width: null,
+    }
+  ),
+  Columns.custom((text, item) => item.user.name, { title: "Created By", width: "1%" }),
+  Columns.dateTime.sortable({
+    title: "Created At",
+    field: "created_at",
+    width: "1%",
+  }),
+];
 
-  render() {
-    const { controller } = this.props;
-    return (
-      <div className="page-dashboard-list">
-        <div className="container">
-          <PageHeader
-            title={controller.params.pageTitle}
-            actions={
-              currentUser.hasPermission("create_dashboard") ? (
-                <Button block type="primary" onClick={() => CreateDashboardDialog.showModal()}>
-                  <i className="fa fa-plus m-r-5" />
-                  New Dashboard
-                </Button>
-              ) : null
-            }
-          />
-          <Layout>
-            <Layout.Sidebar className="m-b-0">
-              <Sidebar.SearchInput
-                placeholder="Search Dashboards..."
-                value={controller.searchTerm}
-                onChange={controller.updateSearch}
-              />
-              <Sidebar.Menu items={this.sidebarMenu} selected={controller.params.currentPage} />
-              <Sidebar.Tags url="api/dashboards/tags" onChange={controller.updateSelectedTags} showUnselectAll />
-            </Layout.Sidebar>
-            <Layout.Content>
-              <div data-test="DashboardLayoutContent">
-                {controller.isLoaded && controller.isEmpty ? (
-                  <DashboardListEmptyState
-                    page={controller.params.currentPage}
-                    searchTerm={controller.searchTerm}
-                    selectedTags={controller.selectedTags}
+function DashboardList({ controller }) {
+  return (
+    <div className="page-dashboard-list">
+      <div className="container">
+        <PageHeader
+          title={controller.params.pageTitle}
+          actions={
+            currentUser.hasPermission("create_dashboard") ? (
+              <Button block type="primary" onClick={() => CreateDashboardDialog.showModal()}>
+                <i className="fa fa-plus m-r-5" />
+                New Dashboard
+              </Button>
+            ) : null
+          }
+        />
+        <Layout>
+          <Layout.Sidebar className="m-b-0">
+            <Sidebar.SearchInput
+              placeholder="Search Dashboards..."
+              value={controller.searchTerm}
+              onChange={controller.updateSearch}
+            />
+            <Sidebar.Menu items={sidebarMenu} selected={controller.params.currentPage} />
+            <Sidebar.Tags url="api/dashboards/tags" onChange={controller.updateSelectedTags} showUnselectAll />
+          </Layout.Sidebar>
+          <Layout.Content>
+            <div data-test="DashboardLayoutContent">
+              {controller.isLoaded && controller.isEmpty ? (
+                <DashboardListEmptyState
+                  page={controller.params.currentPage}
+                  searchTerm={controller.searchTerm}
+                  selectedTags={controller.selectedTags}
+                />
+              ) : (
+                <div className="bg-white tiled table-responsive">
+                  <ItemsTable
+                    items={controller.pageItems}
+                    loading={!controller.isLoaded}
+                    columns={listColumns}
+                    orderByField={controller.orderByField}
+                    orderByReverse={controller.orderByReverse}
+                    toggleSorting={controller.toggleSorting}
                   />
-                ) : (
-                  <div className="bg-white tiled table-responsive">
-                    <ItemsTable
-                      items={controller.pageItems}
-                      loading={!controller.isLoaded}
-                      columns={this.listColumns}
-                      orderByField={controller.orderByField}
-                      orderByReverse={controller.orderByReverse}
-                      toggleSorting={controller.toggleSorting}
-                    />
-                    <Paginator
-                      showPageSizeSelect
-                      totalCount={controller.totalItemsCount}
-                      pageSize={controller.itemsPerPage}
-                      onPageSizeChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
-                      page={controller.page}
-                      onChange={page => controller.updatePagination({ page })}
-                    />
-                  </div>
-                )}
-              </div>
-            </Layout.Content>
-          </Layout>
-        </div>
+                  <Paginator
+                    showPageSizeSelect
+                    totalCount={controller.totalItemsCount}
+                    pageSize={controller.itemsPerPage}
+                    onPageSizeChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
+                    page={controller.page}
+                    onChange={page => controller.updatePagination({ page })}
+                  />
+                </div>
+              )}
+            </div>
+          </Layout.Content>
+        </Layout>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+DashboardList.propTypes = {
+  controller: ControllerType.isRequired,
+};
 
 const DashboardListPage = itemsList(
   DashboardList,

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -1,16 +1,19 @@
 import React from "react";
+import cx from "classnames";
 
 import Button from "antd/lib/button";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
 import Link from "@/components/Link";
 import PageHeader from "@/components/PageHeader";
 import Paginator from "@/components/Paginator";
+import DynamicComponent from "@/components/DynamicComponent";
 import { DashboardTagsControl } from "@/components/tags-control/TagsControl";
 import { wrap as itemsList, ControllerType } from "@/components/items-list/ItemsList";
 import { ResourceItemsSource } from "@/components/items-list/classes/ItemsSource";
 import { UrlStateStorage } from "@/components/items-list/classes/StateStorage";
 import * as Sidebar from "@/components/items-list/components/Sidebar";
 import ItemsTable, { Columns } from "@/components/items-list/components/ItemsTable";
+import useItemsListExtraActions from "@/components/items-list/hooks/useItemsListExtraActions";
 import CreateDashboardDialog from "@/components/dashboards/CreateDashboardDialog";
 import Layout from "@/components/layouts/ContentWithSidebar";
 
@@ -66,7 +69,18 @@ const listColumns = [
   }),
 ];
 
+function DashboardListExtraActions(props) {
+  return <DynamicComponent name="DashboardList.Actions" {...props} />;
+}
+
 function DashboardList({ controller }) {
+  const {
+    areExtraActionsAvailable,
+    listColumns: tableColumns,
+    Component: ExtraActionsComponent,
+    selectedItems,
+  } = useItemsListExtraActions(controller, listColumns, DashboardListExtraActions);
+
   return (
     <div className="page-dashboard-list">
       <div className="container">
@@ -100,24 +114,29 @@ function DashboardList({ controller }) {
                   selectedTags={controller.selectedTags}
                 />
               ) : (
-                <div className="bg-white tiled table-responsive">
-                  <ItemsTable
-                    items={controller.pageItems}
-                    loading={!controller.isLoaded}
-                    columns={listColumns}
-                    orderByField={controller.orderByField}
-                    orderByReverse={controller.orderByReverse}
-                    toggleSorting={controller.toggleSorting}
-                  />
-                  <Paginator
-                    showPageSizeSelect
-                    totalCount={controller.totalItemsCount}
-                    pageSize={controller.itemsPerPage}
-                    onPageSizeChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
-                    page={controller.page}
-                    onChange={page => controller.updatePagination({ page })}
-                  />
-                </div>
+                <React.Fragment>
+                  <div className={cx({ "m-b-10": areExtraActionsAvailable })}>
+                    <ExtraActionsComponent selectedItems={selectedItems} />
+                  </div>
+                  <div className="bg-white tiled table-responsive">
+                    <ItemsTable
+                      items={controller.pageItems}
+                      loading={!controller.isLoaded}
+                      columns={tableColumns}
+                      orderByField={controller.orderByField}
+                      orderByReverse={controller.orderByReverse}
+                      toggleSorting={controller.toggleSorting}
+                    />
+                    <Paginator
+                      showPageSizeSelect
+                      totalCount={controller.totalItemsCount}
+                      pageSize={controller.itemsPerPage}
+                      onPageSizeChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
+                      page={controller.page}
+                      onChange={page => controller.updatePagination({ page })}
+                    />
+                  </div>
+                </React.Fragment>
               )}
             </div>
           </Layout.Content>

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -6,6 +6,7 @@ import cx from "classnames";
 import Button from "antd/lib/button";
 import Checkbox from "antd/lib/checkbox";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
+import DynamicComponent from "@/components/DynamicComponent";
 import DashboardGrid from "@/components/dashboards/DashboardGrid";
 import Parameters from "@/components/Parameters";
 import Filters from "@/components/Filters";
@@ -112,7 +113,10 @@ function DashboardComponent(props) {
 
   return (
     <div className="container" ref={setPageContainer} data-test={`DashboardId${dashboard.id}Container`}>
-      <DashboardHeader dashboardOptions={dashboardOptions} />
+      <DashboardHeader
+        dashboardOptions={dashboardOptions}
+        headerExtra={<DynamicComponent name="Dashboard.HeaderExtra" dashboard={dashboard} />}
+      />
       {!isEmpty(globalParameters) && (
         <div className="dashboard-parameters m-b-10 p-15 bg-white tiled" data-test="DashboardParameters">
           <Parameters parameters={globalParameters} onValuesChange={refreshDashboard} />

--- a/client/app/pages/dashboards/DashboardPage.jsx
+++ b/client/app/pages/dashboards/DashboardPage.jsx
@@ -115,7 +115,9 @@ function DashboardComponent(props) {
     <div className="container" ref={setPageContainer} data-test={`DashboardId${dashboard.id}Container`}>
       <DashboardHeader
         dashboardOptions={dashboardOptions}
-        headerExtra={<DynamicComponent name="Dashboard.HeaderExtra" dashboard={dashboard} />}
+        headerExtra={
+          <DynamicComponent name="Dashboard.HeaderExtra" dashboard={dashboard} dashboardOptions={dashboardOptions} />
+        }
       />
       {!isEmpty(globalParameters) && (
         <div className="dashboard-parameters m-b-10 p-15 bg-white tiled" data-test="DashboardParameters">

--- a/client/app/pages/dashboards/components/DashboardHeader.jsx
+++ b/client/app/pages/dashboards/components/DashboardHeader.jsx
@@ -166,7 +166,7 @@ DashboardMoreOptionsButton.propTypes = {
   dashboardOptions: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-function DashboardControl({ dashboardOptions }) {
+function DashboardControl({ dashboardOptions, headerExtra }) {
   const {
     dashboard,
     togglePublished,
@@ -198,6 +198,7 @@ function DashboardControl({ dashboardOptions }) {
               </Button>
             </Tooltip>
           )}
+          {headerExtra}
           {showShareButton && (
             <Tooltip title="Dashboard Sharing Options">
               <Button
@@ -218,9 +219,10 @@ function DashboardControl({ dashboardOptions }) {
 
 DashboardControl.propTypes = {
   dashboardOptions: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  headerExtra: PropTypes.node,
 };
 
-function DashboardEditControl({ dashboardOptions }) {
+function DashboardEditControl({ dashboardOptions, headerExtra }) {
   const { setEditingLayout, doneBtnClickedWhileSaving, dashboardStatus, retrySaveDashboardLayout } = dashboardOptions;
   let status;
   if (dashboardStatus === DashboardStatusEnum.SAVED) {
@@ -250,26 +252,29 @@ function DashboardEditControl({ dashboardOptions }) {
           {!doneBtnClickedWhileSaving && <i className="fa fa-check m-r-5" />} Done Editing
         </Button>
       )}
+      {headerExtra}
     </div>
   );
 }
 
 DashboardEditControl.propTypes = {
   dashboardOptions: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  headerExtra: PropTypes.node,
 };
 
-export default function DashboardHeader({ dashboardOptions }) {
+export default function DashboardHeader({ dashboardOptions, headerExtra }) {
   const { editingLayout } = dashboardOptions;
   const DashboardControlComponent = editingLayout ? DashboardEditControl : DashboardControl;
 
   return (
     <div className="dashboard-header">
       <DashboardPageTitle dashboardOptions={dashboardOptions} />
-      <DashboardControlComponent dashboardOptions={dashboardOptions} />
+      <DashboardControlComponent dashboardOptions={dashboardOptions} headerExtra={headerExtra} />
     </div>
   );
 }
 
 DashboardHeader.propTypes = {
   dashboardOptions: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  headerExtra: PropTypes.node,
 };

--- a/client/app/pages/queries-list/QueriesList.jsx
+++ b/client/app/pages/queries-list/QueriesList.jsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useRef } from "react";
+import cx from "classnames";
 
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
 import Link from "@/components/Link";
 import PageHeader from "@/components/PageHeader";
 import Paginator from "@/components/Paginator";
+import DynamicComponent from "@/components/DynamicComponent";
 import { QueryTagsControl } from "@/components/tags-control/TagsControl";
 import SchedulePhrase from "@/components/queries/SchedulePhrase";
 
 import { wrap as itemsList, ControllerType } from "@/components/items-list/ItemsList";
+import useItemsListExtraActions from "@/components/items-list/hooks/useItemsListExtraActions";
 import { ResourceItemsSource } from "@/components/items-list/classes/ItemsSource";
 import { UrlStateStorage } from "@/components/items-list/classes/StateStorage";
 
@@ -84,6 +87,10 @@ const listColumns = [
   }),
 ];
 
+function QueriesListExtraActions(props) {
+  return <DynamicComponent name="QueriesList.Actions" {...props} />;
+}
+
 function QueriesList({ controller }) {
   const controllerRef = useRef();
   controllerRef.current = controller;
@@ -100,6 +107,13 @@ function QueriesList({ controller }) {
       unlistenLocationChanges();
     };
   }, []);
+
+  const {
+    areExtraActionsAvailable,
+    listColumns: tableColumns,
+    Component: ExtraActionsComponent,
+    selectedItems,
+  } = useItemsListExtraActions(controller, listColumns, QueriesListExtraActions);
 
   return (
     <div className="page-queries-list">
@@ -133,24 +147,29 @@ function QueriesList({ controller }) {
                 selectedTags={controller.selectedTags}
               />
             ) : (
-              <div className="bg-white tiled table-responsive">
-                <ItemsTable
-                  items={controller.pageItems}
-                  loading={!controller.isLoaded}
-                  columns={listColumns}
-                  orderByField={controller.orderByField}
-                  orderByReverse={controller.orderByReverse}
-                  toggleSorting={controller.toggleSorting}
-                />
-                <Paginator
-                  showPageSizeSelect
-                  totalCount={controller.totalItemsCount}
-                  pageSize={controller.itemsPerPage}
-                  onPageSizeChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
-                  page={controller.page}
-                  onChange={page => controller.updatePagination({ page })}
-                />
-              </div>
+              <React.Fragment>
+                <div className={cx({ "m-b-10": areExtraActionsAvailable })}>
+                  <ExtraActionsComponent selectedItems={selectedItems} />
+                </div>
+                <div className="bg-white tiled table-responsive">
+                  <ItemsTable
+                    items={controller.pageItems}
+                    loading={!controller.isLoaded}
+                    columns={tableColumns}
+                    orderByField={controller.orderByField}
+                    orderByReverse={controller.orderByReverse}
+                    toggleSorting={controller.toggleSorting}
+                  />
+                  <Paginator
+                    showPageSizeSelect
+                    totalCount={controller.totalItemsCount}
+                    pageSize={controller.itemsPerPage}
+                    onPageSizeChange={itemsPerPage => controller.updatePagination({ itemsPerPage })}
+                    page={controller.page}
+                    onChange={page => controller.updatePagination({ page })}
+                  />
+                </div>
+              </React.Fragment>
             )}
           </Layout.Content>
         </Layout>

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -7,6 +7,7 @@ import useMedia from "use-media";
 import Button from "antd/lib/button";
 import Select from "antd/lib/select";
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
+import DynamicComponent from "@/components/DynamicComponent";
 import Resizable from "@/components/Resizable";
 import Parameters from "@/components/Parameters";
 import EditInPlace from "@/components/EditInPlace";
@@ -190,6 +191,7 @@ function QuerySource(props) {
           dataSource={dataSource}
           sourceMode
           selectedVisualization={selectedVisualization}
+          headerExtra={<DynamicComponent name="QuerySource.HeaderExtra" query={query} />}
           onChange={setQuery}
         />
       </div>

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -8,6 +8,7 @@ import FullscreenOutlinedIcon from "@ant-design/icons/FullscreenOutlined";
 import FullscreenExitOutlinedIcon from "@ant-design/icons/FullscreenExitOutlined";
 
 import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
+import DynamicComponent from "@/components/DynamicComponent";
 import EditInPlace from "@/components/EditInPlace";
 import Parameters from "@/components/Parameters";
 
@@ -102,14 +103,16 @@ function QueryView(props) {
           onChange={setQuery}
           selectedVisualization={selectedVisualization}
           headerExtra={
-            <QueryViewButton
-              className="m-r-5"
-              type="primary"
-              shortcut="mod+enter, alt+enter, ctrl+enter"
-              disabled={!queryFlags.canExecute || isExecuting || areParametersDirty}
-              onClick={doExecuteQuery}>
-              Refresh
-            </QueryViewButton>
+            <DynamicComponent name="QueryView.HeaderExtra" query={query}>
+              <QueryViewButton
+                className="m-r-5"
+                type="primary"
+                shortcut="mod+enter, alt+enter, ctrl+enter"
+                disabled={!queryFlags.canExecute || isExecuting || areParametersDirty}
+                onClick={doExecuteQuery}>
+                Refresh
+              </QueryViewButton>
+            </DynamicComponent>
           }
           tagsExtra={
             !query.description &&


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description

Added some new extension points (also see screenshots):

- Query View and Source pages: ability to add extra actions in page header
- Dashboard page: ability to add extra actions in page header
- Query and Dashboard List pages: ability to add a toolbar with actions that will be rendered above the table. Toolbar component should call `onStateChange` to notify parent that it's available, in that case page will allow to select items in the table and pass selection to the toolbar component.

Example of the toolbar component:

```jsx
function ExtraActionsComponent({ selectedItems, onStateChange }) {
  useEffect(() => {
    onStateChange({ isAvailable: true });
  }, [onStateChange]);

  return <Button disabled={selectedItems.length === 0}>Very useful button</Button>;
}
```

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/12139186/95287607-f84aab80-086e-11eb-90bd-418c281afd56.png)
![image](https://user-images.githubusercontent.com/12139186/95288388-d3573800-0870-11eb-8258-b88e94c6c69b.png)
![image](https://user-images.githubusercontent.com/12139186/95287772-7c9d2e80-086f-11eb-9d29-a5da10222b14.png)
![image](https://user-images.githubusercontent.com/12139186/95287787-858e0000-086f-11eb-9d9f-5c00323b3110.png)
