### PR TITLE
use `--no-install-recommends` in `apt-get` in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN useradd --create-home redash
 
 # Ubuntu packages
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get --no-install-recommends install -y \
     curl \
     gnupg \
     build-essential \
@@ -58,7 +58,7 @@ RUN apt-get update && \
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
   curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
   apt-get update && \
-  ACCEPT_EULA=Y apt-get install -y msodbcsql17 && \
+  ACCEPT_EULA=Y apt-get --no-install-recommends install -y msodbcsql17 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [*] Refactor

## Description

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>
