### PR TITLE
Remove build args from Cypress start script

### DIFF
--- a/client/cypress/cypress.js
+++ b/client/cypress/cypress.js
@@ -44,9 +44,7 @@ function seedDatabase(seedValues) {
 
 function buildServer() {
   console.log("Building the server...");
-  execSync("docker-compose -p cypress build --build-arg skip_dev_deps=true --build-arg skip_ds_deps=true", {
-    stdio: "inherit",
-  });
+  execSync("docker-compose -p cypress build", { stdio: "inherit" });
 }
 
 function startServer() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

This fixes Cypress `npm run cypress start` as on local development it uses the `dev_worker` that was failing as we were skipping dev deps. For CI it still has that set from `docker-compose.cypress.yml`.

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--