### PR TITLE
test: Fix Exception: Can't query private addresses.

### DIFF
--- a/tests/query_runner/test_http.py
+++ b/tests/query_runner/test_http.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from redash.utils.requests_session import requests, ConfiguredSession
 from redash.query_runner import BaseHTTPQueryRunner
+from redash import settings
 
 
 class RequiresAuthQueryRunner(BaseHTTPQueryRunner):
@@ -10,6 +11,13 @@ class RequiresAuthQueryRunner(BaseHTTPQueryRunner):
 
 
 class TestBaseHTTPQueryRunner(TestCase):
+    def setUp(self):
+        super(TestBaseHTTPQueryRunner, self).setUp()
+        settings.ENFORCE_PRIVATE_ADDRESS_BLOCK = False
+
+    def tearDown(self):
+        settings.ENFORCE_PRIVATE_ADDRESS_BLOCK = True
+
     def test_requires_authentication_default(self):
         self.assertFalse(BaseHTTPQueryRunner.requires_authentication)
         schema = BaseHTTPQueryRunner.configuration_schema()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [x] Other

## Description
Hi there,
test_http.py failed on my env. That's  because `socket.gethostbyname('example.com')` returns 127.0.0.1.

```
...
self = <redash.query_runner.BaseHTTPQueryRunner object at 0x7f2e47896410>
url = 'https://example.com/', auth = ('username', 'password'), http_method = 'get'
kwargs = {}

    def get_response(self, url, auth=None, http_method="get", **kwargs):
        if is_private_address(url) and settings.ENFORCE_PRIVATE_ADDRESS_BLOCK:
>           raise Exception("Can't query private addresses.")
E           Exception: Can't query private addresses.

redash/query_runner/__init__.py:289: Exception
...
```

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
