### PR TITLE
Fix 500 error of GET /api/users

### DIFF
--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -1,5 +1,3 @@
-import re
-import time
 from flask import request
 from flask_restful import abort
 from flask_login import current_user, login_user
@@ -123,14 +121,14 @@ class UserListResource(BaseResource):
         disabled = request.args.get("disabled", "false")  # get enabled users by default
         try:
             disabled = parse_boolean(disabled)
-        except ValueError as e:
+        except ValueError:
             abort(400, message="disabled must be boolean.")
 
         pending = request.args.get("pending", None)  # get both active and pending by default
         if pending is not None:
             try:
                 pending = parse_boolean(pending)
-            except ValueError as e:
+            except ValueError:
                 abort(400, message="pending must be boolean.")
 
         users = self.get_users(disabled, pending, search_term)

--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -121,13 +121,17 @@ class UserListResource(BaseResource):
         search_term = request.args.get("q", "")
 
         disabled = request.args.get("disabled", "false")  # get enabled users by default
-        disabled = parse_boolean(disabled)
+        try:
+            disabled = parse_boolean(disabled)
+        except ValueError as e:
+            abort(400, message="disabled must be boolean.")
 
-        pending = request.args.get(
-            "pending", None
-        )  # get both active and pending by default
+        pending = request.args.get("pending", None)  # get both active and pending by default
         if pending is not None:
-            pending = parse_boolean(pending)
+            try:
+                pending = parse_boolean(pending)
+            except ValueError as e:
+                abort(400, message="pending must be boolean.")
 
         users = self.get_users(disabled, pending, search_term)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ max-line-length = 120
 
 [flake8]
 ignore = E501
-exclude = .git
+exclude = .git,.venv,node_modules
 max-complexity = 10

--- a/tests/handlers/test_users.py
+++ b/tests/handlers/test_users.py
@@ -1,4 +1,4 @@
-from redash import models, settings
+from redash import models
 from tests import BaseTestCase
 from mock import patch
 
@@ -236,6 +236,7 @@ class TestUserListGet(BaseTestCase):
         rv = self.make_request("get", "/api/users?pending=something")
         self.assertEqual(rv.status_code, 400)
 
+
 class TestUserResourceGet(BaseTestCase):
     def test_returns_api_key_for_your_own_user(self):
         rv = self.make_request("get", "/api/users/{}".format(self.factory.user.id))
@@ -283,9 +284,7 @@ class TestUserResourcePost(BaseTestCase):
     def test_marks_email_as_not_verified_when_changed(self, _):
         user = self.factory.user
         user.is_email_verified = True
-        rv = self.make_request(
-            "post", "/api/users/{}".format(user.id), data={"email": "donald@trump.biz"}
-        )
+        self.make_request("post", "/api/users/{}".format(user.id), data={"email": "donald@trump.biz"})
         self.assertFalse(user.is_email_verified)
 
     @patch("redash.settings.email_server_is_configured", return_value=False)
@@ -294,9 +293,7 @@ class TestUserResourcePost(BaseTestCase):
     ):
         user = self.factory.user
         user.is_email_verified = True
-        rv = self.make_request(
-            "post", "/api/users/{}".format(user.id), data={"email": "donald@trump.biz"}
-        )
+        self.make_request("post", "/api/users/{}".format(user.id), data={"email": "donald@trump.biz"})
         self.assertTrue(user.is_email_verified)
 
     def test_returns_200_for_admin_changing_other_user(self):

--- a/tests/handlers/test_users.py
+++ b/tests/handlers/test_users.py
@@ -228,6 +228,13 @@ class TestUserListGet(BaseTestCase):
             ],
         )
 
+    def test_returns_400_with_invalid_disabled(self):
+        rv = self.make_request("get", "/api/users?disabled=something")
+        self.assertEqual(rv.status_code, 400)
+
+    def test_returns_400_with_invalid_pending(self):
+        rv = self.make_request("get", "/api/users?pending=something")
+        self.assertEqual(rv.status_code, 400)
 
 class TestUserResourceGet(BaseTestCase):
     def test_returns_api_key_for_your_own_user(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Hi there,
Fixed API GET /api/users with the unexpected boolean format. 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
