### PR TITLE
Adds query_text to the job serializer

### DIFF
--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -314,6 +314,7 @@ def serialize_job(job):
 
     status = STATUSES[job_status]
     result = query_result_id = None
+    query_text = job.args[0]
 
     if job.is_cancelled:
         error = "Query cancelled by user."
@@ -336,5 +337,6 @@ def serialize_job(job):
             "error": error,
             "result": result,
             "query_result_id": query_result_id,
+            "query_text": query_text,
         }
     }


### PR DESCRIPTION
## What type of PR is this?

- [x] Other

## Description

This PR adds `query_text` to the `job` serializer. Useful to be able to retrieve the query which is running (with parameters) when job are queued or started (Currently, the query text is only returned in the `query_result` object when the job is finished)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
