### PR TITLE
Add Event class-based Serializer to serializers and events handler

### DIFF
--- a/redash/handlers/events.py
+++ b/redash/handlers/events.py
@@ -1,61 +1,8 @@
 from flask import request
-import geolite2
-import maxminddb
-from user_agents import parse as parse_ua
 
 from redash.handlers.base import BaseResource, paginate
 from redash.permissions import require_admin
-
-
-def get_location(ip):
-    if ip is None:
-        return "Unknown"
-
-    with maxminddb.open_database(geolite2.geolite2_database()) as reader:
-        try:
-            match = reader.get(ip)
-            return match["country"]["names"]["en"]
-        except Exception:
-            return "Unknown"
-
-
-def event_details(event):
-    details = {}
-    if event.object_type == "data_source" and event.action == "execute_query":
-        details["query"] = event.additional_properties["query"]
-        details["data_source"] = event.object_id
-    elif event.object_type == "page" and event.action == "view":
-        details["page"] = event.object_id
-    else:
-        details["object_id"] = event.object_id
-        details["object_type"] = event.object_type
-
-    return details
-
-
-def serialize_event(event):
-    d = {
-        "org_id": event.org_id,
-        "user_id": event.user_id,
-        "action": event.action,
-        "object_type": event.object_type,
-        "object_id": event.object_id,
-        "created_at": event.created_at,
-    }
-
-    if event.user_id:
-        d["user_name"] = event.additional_properties.get(
-            "user_name", "User {}".format(event.user_id)
-        )
-
-    if not event.user_id:
-        d["user_name"] = event.additional_properties.get("api_key", "Unknown")
-
-    d["browser"] = str(parse_ua(event.additional_properties.get("user_agent", "")))
-    d["location"] = get_location(event.additional_properties.get("ip"))
-    d["details"] = event_details(event)
-
-    return d
+from redash.serializers import EventSerializer
 
 
 class EventsResource(BaseResource):
@@ -68,4 +15,4 @@ class EventsResource(BaseResource):
     def get(self):
         page = request.args.get("page", 1, type=int)
         page_size = request.args.get("page_size", 25, type=int)
-        return paginate(self.current_org.events, page, page_size, serialize_event)
+        return paginate(self.current_org.events, page, page_size, EventSerializer)

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -8,6 +8,9 @@ from funcy import project
 from flask_login import current_user
 from rq.job import JobStatus
 from rq.timeouts import JobTimeoutException
+import geolite2
+import maxminddb
+from user_agents import parse as parse_ua
 
 from redash import models
 from redash.permissions import has_access, view_only
@@ -338,3 +341,68 @@ def serialize_job(job):
             "query_result_id": query_result_id,
         }
     }
+
+
+def get_location(ip):
+    if ip is None:
+        return "Unknown"
+
+    with maxminddb.open_database(geolite2.geolite2_database()) as reader:
+        try:
+            match = reader.get(ip)
+            return match["country"]["names"]["en"]
+        except Exception:
+            return "Unknown"
+
+
+def event_details(event):
+    details = {}
+    if event.object_type == "data_source" and event.action == "execute_query":
+        details["query"] = event.additional_properties["query"]
+        details["data_source"] = event.object_id
+    elif event.object_type == "page" and event.action == "view":
+        details["page"] = event.object_id
+    else:
+        details["object_id"] = event.object_id
+        details["object_type"] = event.object_type
+
+    return details
+
+
+def serialize_event(event):
+    d = {
+        "org_id": event.org_id,
+        "user_id": event.user_id,
+        "action": event.action,
+        "object_type": event.object_type,
+        "object_id": event.object_id,
+        "created_at": event.created_at,
+    }
+
+    if event.user_id:
+        d["user_name"] = event.additional_properties.get(
+            "user_name", "User {}".format(event.user_id)
+        )
+
+    if not event.user_id:
+        d["user_name"] = event.additional_properties.get("api_key", "Unknown")
+
+    d["browser"] = str(parse_ua(event.additional_properties.get("user_agent", "")))
+    d["location"] = get_location(event.additional_properties.get("ip"))
+    d["details"] = event_details(event)
+
+    return d
+
+
+class EventSerializer(Serializer):
+    def __init__(self, object_or_list):
+        self.object_or_list = object_or_list
+
+    def serialize(self):
+        if isinstance(self.object_or_list, models.Event):
+            result = serialize_event(self.object_or_list)
+        else:
+            result = [
+                serialize_event(obj) for obj in self.object_or_list
+            ]
+        return result


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description
Hey! I want to contribute by refactoring of old function-based serializers to delete it from paginate.
```python
def paginate(query_set, page, page_size, serializer, **kwargs):
    count = query_set.count()

    if page < 1:
        abort(400, message="Page must be positive integer.")

    if (page - 1) * page_size + 1 > count > 0:
        abort(400, message="Page is out of range.")

    if page_size > 250 or page_size < 1:
        abort(400, message="Page size is out of range (1-250).")

    results = query_set.paginate(page, page_size)

    # support for old function based serializers
    if isclass(serializer):
        items = serializer(results.items, **kwargs).serialize()
    else:
        items = [serializer(result) for result in results.items]

    return {"count": count, "page": page, "page_size": page_size, "results": items}
```
I think I also need to move serialize_user() and I guess we could save only the first class-based type (in the other PR)
Later we can add abstraction and take out common methods for all children of Serializer.
What do you think? 

## Related Tickets & Documents
I know that dashboards were moved with the same way

## Mobile & Desktop Screenshots/Recordings (if there are UI changes) 