### PR TITLE
Add root to all static asset paths that mis it

### DIFF
--- a/client/app/components/PreviewCard.jsx
+++ b/client/app/components/PreviewCard.jsx
@@ -69,7 +69,7 @@ UserPreviewCard.defaultProps = {
 // DataSourcePreviewCard
 
 export function DataSourcePreviewCard({ dataSource, withLink, children, ...props }) {
-  const imageUrl = `static/images/db-logos/${dataSource.type}.png`;
+  const imageUrl = `/static/images/db-logos/${dataSource.type}.png`;
   const title = withLink ? <Link href={"data_sources/" + dataSource.id}>{dataSource.name}</Link> : dataSource.name;
   return (
     <PreviewCard {...props} imageUrl={imageUrl} title={title}>

--- a/client/app/components/empty-state/EmptyState.jsx
+++ b/client/app/components/empty-state/EmptyState.jsx
@@ -179,7 +179,7 @@ function EmptyState({
   ];
 
   const stepsItems = getStepsItems ? getStepsItems(defaultStepsItems) : defaultStepsItems;
-  const imageSource = illustrationPath ? illustrationPath : "static/images/illustrations/" + illustration + ".svg";
+  const imageSource = illustrationPath ? illustrationPath : "/static/images/illustrations/" + illustration + ".svg";
 
   return (
     <div className="empty-state bg-white tiled">

--- a/client/app/pages/queries/components/QuerySourceTypeIcon.jsx
+++ b/client/app/pages/queries/components/QuerySourceTypeIcon.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 export function QuerySourceTypeIcon(props) {
-  return <img src={`static/images/db-logos/${props.type}.png`} width="20" alt={props.alt} />;
+  return <img src={`/static/images/db-logos/${props.type}.png`} width="20" alt={props.alt} />;
 }
 
 QuerySourceTypeIcon.propTypes = {

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -17,7 +17,7 @@ function EmptyState({ title, message, refreshButton }) {
     <div className="query-results-empty-state">
       <div className="empty-state-content">
         <div>
-          <img src="static/images/illustrations/no-query-results.svg" alt="No Query Results Illustration" />
+          <img src="/static/images/illustrations/no-query-results.svg" alt="No Query Results Illustration" />
         </div>
         <h3>{title}</h3>
         <div className="m-b-20">{message}</div>

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -4,7 +4,7 @@ import { fetchDataFromJob } from "@/services/query-result";
 
 export const SCHEMA_NOT_SUPPORTED = 1;
 export const SCHEMA_LOAD_ERROR = 2;
-export const IMG_ROOT = "static/images/db-logos";
+export const IMG_ROOT = "/static/images/db-logos";
 
 function mapSchemaColumnsToObject(columns) {
   return map(columns, column => (isObject(column) ? column : { name: column }));

--- a/client/app/services/destination.js
+++ b/client/app/services/destination.js
@@ -1,6 +1,6 @@
 import { axios } from "@/services/axios";
 
-export const IMG_ROOT = "static/images/destinations";
+export const IMG_ROOT = "/static/images/destinations";
 
 const Destination = {
   query: () => axios.get("api/destinations"),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix


## Description

Static assets are already prefixed with the root denomination in most of
Redash. There are just a few places where these paths are missing.
Normally this doesn't really matter if Redash is used like most people
do with the Open Source edition.

We however had to toggle the organizations feature on (using REDASH_MULTI_ORG),
at which point a prefixed organisation "name-slug" is added before all
page paths (http://localhost:5000/org_a/).

Now the static assets without root path were suddenly expected to be in
our organizations respective slug-namespace.
(http://localhost:5000/org_a/static/images/db-logos/postgres.png for
example).

This pull update 6 cases of "wrongly routed"
asset paths to be in line with a  "/" like the already existing cases listed below:

- https://github.com/getredash/redash/blob/a682265e1396cf46b7baf8cc593239b6129c5662/redash/templates/layouts/signed_out.html#L10-L12
- https://github.com/getredash/redash/blob/9097feb100b10e022df16e3c7dc3f490754a2f95/client/app/multi_org.html#L10-L12
- https://github.com/getredash/redash/blob/5afd0554d0b27b35177a21b2c1a6174e44d315fc/redash/templates/invite.html#L26
- https://github.com/getredash/redash/blob/5afd0554d0b27b35177a21b2c1a6174e44d315fc/redash/templates/login.html#L18
- https://github.com/getredash/redash/blob/de052ff02be9ff8d4187d273364c78ca22d65eb0/client/cypress/integration/visualizations/map_spec.js#L21

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before the fix:
![Screenshot 2020-10-23 at 09 50 27](https://user-images.githubusercontent.com/3583395/96973370-16273a00-1518-11eb-8f9c-d03cae23b31f.png)
![Screenshot 2020-10-23 at 09 50 44](https://user-images.githubusercontent.com/3583395/96973374-18899400-1518-11eb-9fe8-eec4afec59db.png)
![Screenshot 2020-10-23 at 09 51 06](https://user-images.githubusercontent.com/3583395/96973388-1b848480-1518-11eb-9668-72532b2ac9af.png)

After the fix:
![Screenshot 2020-10-23 at 10 02 54](https://user-images.githubusercontent.com/3583395/96973397-20e1cf00-1518-11eb-9dc6-bc30f7d22dab.png)
![Screenshot 2020-10-23 at 10 03 03](https://user-images.githubusercontent.com/3583395/96973401-2212fc00-1518-11eb-932d-64d31941be73.png)
![Screenshot 2020-10-23 at 10 03 32](https://user-images.githubusercontent.com/3583395/96973406-23442900-1518-11eb-8601-adacff367356.png)
