### PR TITLE
Fix viz-lib failing with npm version 7

### DIFF
--- a/viz-lib/package.json
+++ b/viz-lib/package.json
@@ -20,6 +20,10 @@
     "type": "git",
     "url": "git+https://github.com/getredash/redash.git"
   },
+  "engines": {
+    "node": "^12.0.0",
+    "npm": "^6.0.0"
+  },
   "author": "Redash",
   "license": "BSD-2-Clause",
   "peerDependencies": {

--- a/viz-lib/package.json
+++ b/viz-lib/package.json
@@ -23,10 +23,10 @@
   "author": "Redash",
   "license": "BSD-2-Clause",
   "peerDependencies": {
-    "antd": ">=4.0.0",
-    "@ant-design/icons": ">=4.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "antd": "^4.4.3",
+    "@ant-design/icons": "^4.2.1",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description

After npm 7 the peerDependencies are actually installed, so this was creating a conflict. I've changed the way they are declared and also took the opportunity to add `engines` to the file.

Fixes #5235

## Related Tickets & Documents
--

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
--