### PR TITLE
Longer timeout for refresh_queries

### DIFF
--- a/redash/tasks/schedule.py
+++ b/redash/tasks/schedule.py
@@ -61,7 +61,7 @@ def schedule(kwargs):
 
 def periodic_job_definitions():
     jobs = [
-        {"func": refresh_queries, "interval": 30, "result_ttl": 600},
+        {"func": refresh_queries, "timeout": 600, "interval": 30, "result_ttl": 600},
         {
             "func": remove_ghost_locks,
             "interval": timedelta(minutes=1),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When `refresh_queries` needs to handle a lot of scheduled queries, it may run longer than 3 minutes and time out. This PR extends the timeout from the implicit default of 3 minutes to an explicit 10 minutes.