### PR TITLE
Add more information to the query results object when no results are available 

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -121,7 +121,16 @@ def run_query(query, parameters, data_source, query_id, should_apply_auto_limit,
                 "Query ID": query_id,
             },
         )
-        return serialize_job(job)
+
+        response = {
+            "data_source_id": data_source.id,
+            "query_id": query_id,
+            "parameters": parameters,
+            "query": query_text 
+        }
+
+        response.update(serialize_job(job))
+        return response
 
 
 def get_download_filename(query_result, query, filetype):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Other

## Description

Currently, when calling `POST /api/queries/<id>/results`, if no query results are available, the API return only a job object. This PR adds `data_source_id`, `query_id`, `parameters` and `query` text to the API returned object.

## Related Tickets & Documents

See https://github.com/getredash/redash/pull/5224 for previous work/proposition

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
