### PR TITLE
Correct cleanup_query_results comment

### DIFF
--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -118,7 +118,7 @@ def refresh_queries():
 def cleanup_query_results():
     """
     Job to cleanup unused query results -- such that no query links to them anymore, and older than
-    settings.QUERY_RESULTS_MAX_AGE (a week by default, so it's less likely to be open in someone's browser and be used).
+    settings.QUERY_RESULTS_CLEANUP_MAX_AGE (a week by default, so it's less likely to be open in someone's browser and be used).
 
     Each time the job deletes only settings.QUERY_RESULTS_CLEANUP_COUNT (100 by default) query results so it won't choke
     the database in case of many such results.


### PR DESCRIPTION
Correct comment from QUERY_RESULTS_MAX_AGE
to QUERY_RESULTS_CLEANUP_MAX_AGE

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

Just correct function cleanup_query_results comment from QUERY_RESULTS_MAX_AGE to QUERY_RESULTS_CLEANUP_MAX_AGE

## Related Tickets & Documents

None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

None
