### PR TITLE
Fix QuerySourceDropdown value type

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -213,7 +213,7 @@ function QuerySource(props) {
                 <DynamicComponent
                   name={"QuerySourceDropdown"}
                   dataSources={dataSources}
-                  value={dataSource ? String(dataSource.id) : undefined}
+                  value={dataSource ? dataSource.id : undefined}
                   disabled={!queryFlags.canEdit || !dataSourcesLoaded || dataSources.length === 0}
                   loading={!dataSourcesLoaded}
                   onChange={handleDataSourceChange}

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -213,7 +213,7 @@ function QuerySource(props) {
                 <DynamicComponent
                   name={"QuerySourceDropdown"}
                   dataSources={dataSources}
-                  value={dataSource ? dataSource.id : undefined}
+                  value={dataSource ? String(dataSource.id) : undefined}
                   disabled={!queryFlags.canEdit || !dataSourcesLoaded || dataSources.length === 0}
                   loading={!dataSourcesLoaded}
                   onChange={handleDataSourceChange}

--- a/client/app/pages/queries/components/QuerySourceDropdown.jsx
+++ b/client/app/pages/queries/components/QuerySourceDropdown.jsx
@@ -29,7 +29,7 @@ export function QuerySourceDropdown(props) {
 
 QuerySourceDropdown.propTypes = {
   dataSources: PropTypes.any,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   onChange: PropTypes.func,

--- a/client/app/pages/queries/components/QuerySourceDropdownItem.jsx
+++ b/client/app/pages/queries/components/QuerySourceDropdownItem.jsx
@@ -15,7 +15,7 @@ export function QuerySourceDropdownItem({ dataSource, children }) {
 QuerySourceDropdownItem.propTypes = {
   dataSource: PropTypes.shape({
     name: PropTypes.string,
-    id: PropTypes.string,
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     type: PropTypes.string,
   }).isRequired,
   children: PropTypes.element,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Bug Fix

## Description
TLDR: added a type casting to get rid of an error from the console.

`dataSource.id` is a prop passed down via `value` to `QuerySourceDropdown`, which in turn not only has only string as an option on PropTypes, but also passes it down to AntD's `Select`, which also only accepts strings. I considered accepting string and number and casting them to string, but it added more complexity than simply casting in the mother component. Also keeping it clean can help spotting errors in the future.