### PR TITLE
Changed 'Delete Alert' into 'Delete' for consistency

### DIFF
--- a/client/app/pages/alert/components/MenuButton.jsx
+++ b/client/app/pages/alert/components/MenuButton.jsx
@@ -52,7 +52,7 @@ export default function MenuButton({ doDelete, canEdit, mute, unmute, muted }) {
             )}
           </Menu.Item>
           <Menu.Item>
-            <a onClick={confirmDelete}>Delete Alert</a>
+            <a onClick={confirmDelete}>Delete</a>
           </Menu.Item>
         </Menu>
       }>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Other

## Description
_Delete_ action had inconsistent labels between Alerts and endpoints. This changes alert one to "delete".

## Related Tickets & Documents
[REDASH-432](https://databricks.atlassian.net/browse/REDASH-432)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Kapture 2020-11-24 at 15 10 52](https://user-images.githubusercontent.com/44540213/100134737-6c650100-2e67-11eb-86f2-a82487aabafb.gif)
