### PR TITLE
Fix problem with ElasticSearch

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -122,6 +122,8 @@ class BaseElasticSearch(BaseQueryRunner):
         for index_name in mappings_data:
             index_mappings = mappings_data[index_name]
             for m in index_mappings.get("mappings", {}):
+                if not hasattr(index_mappings["mappings"][m], "__getitem__"):
+                    continue
                 if "properties" not in index_mappings["mappings"][m]:
                     continue
                 for property_name in index_mappings["mappings"][m]["properties"]:
@@ -147,7 +149,12 @@ class BaseElasticSearch(BaseQueryRunner):
             """
             path = path or []
             result = []
-            for field, description in doc["properties"].items():
+            properties = []
+            try:
+                properties = doc["properties"].items()
+            except (TypeError, KeyError):
+                pass
+            for field, description in properties:
                 if "properties" in description:
                     result.extend(parse_doc(description, path + [field]))
                 else:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

When I connected the ElasticSearch with latest Redash, I got this error.

```
Error running query: argument of type 'bool' is not iterable
```

Also, the list of Data Source tables was not loaded and popup with error was shown.

In the service calling get_schema() i found this exception:

```
Error retrieving schema: Traceback (most recent call last):
File "/app/redash/tasks/general.py", line 83, in get_schema
    return data_source.get_schema(refresh)
File "/app/redash/models/__init__.py", line 198, in get_schema
    schema = query_runner.get_schema(get_stats=refresh)
File "/app/redash/query_runner/elasticsearch.py", line 176, in get_schema
    columns.extend(parse_doc(items))
File "/app/redash/query_runner/elasticsearch.py", line 150, in parse_doc
    for field, description in doc["properties"].items():
KeyError: 'properties'
```

Next, I found this PR https://github.com/getredash/redash/pull/3692 and had improved it.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
