### PR TITLE
Truncate large Databricks ODBC result sizes

### DIFF
--- a/client/app/lib/useQueryResultData.js
+++ b/client/app/lib/useQueryResultData.js
@@ -9,6 +9,7 @@ function getQueryResultData(queryResult, queryResultStatus = null) {
     filters: invoke(queryResult, "getFilters") || [],
     updatedAt: invoke(queryResult, "getUpdatedAt") || null,
     retrievedAt: get(queryResult, "query_result.retrieved_at", null),
+    truncated: invoke(queryResult, "getTruncated") || null,
     log: invoke(queryResult, "getLog") || [],
     error: invoke(queryResult, "getError") || null,
     runtime: invoke(queryResult, "getRuntime") || null,

--- a/client/app/pages/queries/components/QueryExecutionMetadata.jsx
+++ b/client/app/pages/queries/components/QueryExecutionMetadata.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+import WarningTwoTone from "@ant-design/icons/WarningTwoTone";
 import TimeAgo from "@/components/TimeAgo";
+import Tooltip from "antd/lib/tooltip";
 import useAddToDashboardDialog from "../hooks/useAddToDashboardDialog";
 import useEmbedDialog from "../hooks/useEmbedDialog";
 import QueryControlDropdown from "@/components/EditVisualizationButton/QueryControlDropdown";
@@ -42,6 +44,18 @@ export default function QueryExecutionMetadata({
       )}
       <span className="m-l-5 m-r-10">
         <span>
+          {queryResultData.truncated === true && (
+            <span className="m-r-5">
+              <Tooltip
+                title={
+                  "Result truncated to " +
+                  queryResultData.rows.length +
+                  " rows. Databricks may truncate query results that are unstably large."
+                }>
+                <WarningTwoTone twoToneColor="#FF9800" />
+              </Tooltip>
+            </span>
+          )}
           <strong>{queryResultData.rows.length}</strong> {pluralize("row", queryResultData.rows.length)}
         </span>
         <span className="m-l-5">

--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -271,6 +271,10 @@ class QueryResult {
     return this.getColumnNames().map(col => getColumnFriendlyName(col));
   }
 
+  getTruncated() {
+    return this.query_result.data ? this.query_result.data.truncated : null;
+  }
+
   getFilters() {
     if (!this.getColumns()) {
       return [];

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -180,7 +180,7 @@ class Databricks(BaseSQLQueryRunner):
                 data = {"columns": columns, "rows": rows}
 
                 if (
-                    len(result_set) >= settings.DATABRICKS_ROW_LIMIT
+                    len(result_set) >= ROW_LIMIT
                     and cursor.fetchone() is not None
                 ):
                     logger.warning("Truncated result set.")

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import sqlparse
 from redash.query_runner import (
     NotSupported,

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -12,6 +12,7 @@ from redash.query_runner import (
     TYPE_INTEGER,
     TYPE_FLOAT,
 )
+from redash.settings import cast_int_or_default
 from redash.utils import json_dumps, json_loads
 from redash import __version__, settings, statsd_client
 
@@ -31,8 +32,9 @@ TYPES_MAP = {
     float: TYPE_FLOAT,
 }
 
-logger = logging.getLogger(__name__)
+ROW_LIMIT = cast_int_or_default(os.environ.get("DATABRICKS_ROW_LIMIT"), 20000)
 
+logger = logging.getLogger(__name__)
 
 def _build_odbc_connection_string(**kwargs):
     return ";".join([f"{k}={v}" for k, v in kwargs.items()])
@@ -161,7 +163,7 @@ class Databricks(BaseSQLQueryRunner):
                 cursor.execute(stmt)
 
             if cursor.description is not None:
-                result_set = cursor.fetchmany(settings.DATABRICKS_ROW_LIMIT)
+                result_set = cursor.fetchmany(ROW_LIMIT)
                 columns = self.fetch_columns(
                     [
                         (i[0], TYPES_MAP.get(i[1], TYPE_STRING))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -513,6 +513,5 @@ ENFORCE_CSRF = parse_boolean(
 )
 
 # Databricks
-DATABRICKS_ROW_LIMIT = int(os.environ.get("REDASH_DATABRICKS_ROW_LIMIT", 20000))
 
 CSRF_TIME_LIMIT = int(os.environ.get("REDASH_CSRF_TIME_LIMIT", 3600 * 6))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -511,4 +511,7 @@ ENFORCE_CSRF = parse_boolean(
     os.environ.get("REDASH_ENFORCE_CSRF", "false")
 )
 
+# Databricks
+DATABRICKS_ROW_LIMIT = int(os.environ.get("REDASH_DATABRICKS_ROW_LIMIT", 20000))
+
 CSRF_TIME_LIMIT = int(os.environ.get("REDASH_CSRF_TIME_LIMIT", 3600 * 6))

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -11,6 +11,7 @@ from .helpers import (
     int_or_none,
     set_from_string,
     add_decode_responses_to_redis_url,
+    cast_int_or_default
 )
 from .organization import DATE_FORMAT, TIME_FORMAT  # noqa
 

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -29,6 +29,11 @@ def parse_boolean(s):
     else:
         raise ValueError("Invalid boolean value %r" % s)
 
+def cast_int_or_default(val, default=None):
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
 
 def int_or_none(value):
     if value is None:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature


## Description

This PR adds a row limiter to the Databricks query runner to limit exposure to platform instability caused by users attempting to load huge result sets, resulting in Redash Web worker crashes. The PR adds an additional parameter to the query result data which can be used by the front end to signal any warnings in the UI associated with this query result.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
