### PR TITLE
Fix disabled hot reload flow

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,8 @@ const CONFIG = optionalRequire("./scripts/config", {});
 
 const isProduction = process.env.NODE_ENV === "production";
 const isDevelopment = !isProduction;
-const isHotReloadingEnabled = isDevelopment && process.env.HOT_RELOAD === "true";
+const isHotReloadingEnabled =
+  isDevelopment && process.env.HOT_RELOAD === "true";
 
 const redashBackend = process.env.REDASH_BACKEND || "http://localhost:5000";
 const baseHref = CONFIG.baseHref || "/";
@@ -154,7 +155,7 @@ const config = {
         test: /\.css$/,
         use: [
           {
-            loader: isDevelopment ? "style-loader" : MiniCssExtractPlugin.loader
+            loader: isProduction ? MiniCssExtractPlugin.loader : "style-loader"
           },
           {
             loader: "css-loader",
@@ -168,7 +169,7 @@ const config = {
         test: /\.less$/,
         use: [
           {
-            loader: isDevelopment ? "style-loader" : MiniCssExtractPlugin.loader
+            loader: isProduction ? MiniCssExtractPlugin.loader : "style-loader"
           },
           {
             loader: "css-loader",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,7 +154,7 @@ const config = {
         test: /\.css$/,
         use: [
           {
-            loader: isHotReloadingEnabled ? "style-loader" : MiniCssExtractPlugin.loader
+            loader: isDevelopment ? "style-loader" : MiniCssExtractPlugin.loader
           },
           {
             loader: "css-loader",
@@ -168,7 +168,7 @@ const config = {
         test: /\.less$/,
         use: [
           {
-            loader: isHotReloadingEnabled ? "style-loader" : MiniCssExtractPlugin.loader
+            loader: isDevelopment ? "style-loader" : MiniCssExtractPlugin.loader
           },
           {
             loader: "css-loader",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

#5291 introduced HMR support, but broke the flow where HOT_RELOAD isn't enabled.
This PR fixes it.

The original PR kept the `MiniCssExtractPlugin` in prod, but `MiniCssExtractPlugin.loader` only when HMR isn't enabled. Now the conditions are in sync.
