### PR TITLE
Use legacy resolver in pip to fix broken build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,9 @@ WORKDIR /app
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PIP_NO_CACHE_DIR=1
 
+# Use legacy resolver to work around broken build due to resolver changes in pip
+ENV PIP_USE_DEPRECATED=legacy-resolver
+
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.
 COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

There have been upstream (`python:3.7-slim` image) changes that
bring in `pip` version 20.3.1, which makes new `2020-resolver`
the default.  Due to that, un-resolvable dependency conflicts
in  `requirements_all_ds.txt` now cause the build to fail.

This is a workaround until the package versions can be updated
to work with the new pip resolver.

## Related Tickets & Documents

Fixes #5300 and fixes #5307 
