### PR TITLE
Secret handling for Yandex, TreasureData, & Postgres/CockroachDB SSL

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -169,7 +169,7 @@ class PostgreSQL(BaseSQLQueryRunner):
             },
             "order": ["host", "port", "user", "password"],
             "required": ["dbname"],
-            "secret": ["password"],
+            "secret": ["password", "sslrootcertFile", "sslcertFile", "sslkeyFile"],
             "extra_options": [
                 "sslmode",
                 "sslrootcertFile",

--- a/redash/query_runner/treasuredata.py
+++ b/redash/query_runner/treasuredata.py
@@ -53,6 +53,7 @@ class TreasureData(BaseQueryRunner):
                     "default": False,
                 },
             },
+            "secret": ["apikey"],
             "required": ["apikey", "db"],
         }
 

--- a/redash/query_runner/yandex_metrica.py
+++ b/redash/query_runner/yandex_metrica.py
@@ -89,6 +89,7 @@ class YandexMetrica(BaseSQLQueryRunner):
         return {
             "type": "object",
             "properties": {"token": {"type": "string", "title": "OAuth Token"}},
+            "secret": ["token"],
             "required": ["token"],
         }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

This PR sets the OAuth token field for Yandex Metrica/AppMetrica, API key field for TreasureData, and SSL certfile/keyfile fields for Postgres/CockroachDB to be handled as secrets. This is to ensure they are redacted on REST API GETs, as is done with passwords/credentials on other data source types.

## Before & After

Before:
* Yandex:
  ```
  ❯ curl localhost:5000/api/data_sources/1 -H "Authorization: Key REDACTED"
  {"id": 1, "name": "test", "type": "yandex_metrika", "syntax": "yaml", "paused": 0, "pause_reason": null, "supports_auto_limit": true, "options": {"token": "test"}, "queue_name": "queries", "scheduled_queue_name": "scheduled_queries", "groups": {"2": false}, "view_only": false}
  ```
* TreasureData:
  ```
  ❯ curl localhost:5000/api/data_sources/2 -H "Authorization: Key REDACTED"
  {"id": 2, "name": "test treasure", "type": "treasuredata", "syntax": "sql", "paused": 0, "pause_reason": null, "supports_auto_limit": false, "options": {"apikey": "test", "db": "fdsa", "get_schema": false}, "queue_name": "queries", "scheduled_queue_name": "scheduled_queries", "groups": {"2": false}, "view_only": false}
  ```
* Postgres/CockroachDB:
  ```
  ❯ curl localhost:5000/api/data_sources/4 -H "Authorization: Key REDACTED"
  {"id": 4, "name": "test pg", "type": "pg", "syntax": "sql", "paused": 0, "pause_reason": null, "supports_auto_limit": true, "options": {"dbname": "test", "password": "--------", "sslcertFile": "RkFLRQo=", "sslkeyFile": "RkFLRQo=", "sslmode": "verify-full", "sslrootcertFile": "RkFLRQo="}, "queue_name": "queries", "scheduled_queue_name": "scheduled_queries", "groups": {"2": false}, "view_only": false}
  ```

After:
* Yandex:
  ```
  ❯ curl localhost:5000/api/data_sources/1 -H "Authorization: Key REDACTED"
  {"id": 1, "name": "test", "type": "yandex_metrika", "syntax": "yaml", "paused": 0, "pause_reason": null, "supports_auto_limit": true, "options": {"token": "--------"}, "queue_name": "queries", "scheduled_queue_name": "scheduled_queries", "groups": {"2": false}, "view_only": false}
  ```
* TreasureData:
  ```
  ❯ curl localhost:5000/api/data_sources/2 -H "Authorization: Key REDACTED"
  {"id": 2, "name": "test treasure", "type": "treasuredata", "syntax": "sql", "paused": 0, "pause_reason": null, "supports_auto_limit": false, "options": {"apikey": "--------", "db": "fdsa", "get_schema": false}, "queue_name": "queries", "scheduled_queue_name": "scheduled_queries", "groups": {"2": false}, "view_only": false}
  ```
* Postgres/CockroachDB:
  ```
  ❯ curl localhost:5000/api/data_sources/4 -H "Authorization: Key REDACTED"
  {"id": 4, "name": "test pg", "type": "pg", "syntax": "sql", "paused": 0, "pause_reason": null, "supports_auto_limit": true, "options": {"dbname": "kekw", "password": "--------", "sslcertFile": "--------", "sslkeyFile": "--------", "sslmode": "verify-full", "sslrootcertFile": "--------"}, "queue_name": "queries", "scheduled_queue_name": "scheduled_queries", "groups": {"2": false}, "view_only": false}
  ```
## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
