### PR TITLE
Add Username and Password fields to MongoDB config

### DIFF
--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -133,6 +133,8 @@ class MongoDB(BaseQueryRunner):
             "type": "object",
             "properties": {
                 "connectionString": {"type": "string", "title": "Connection String"},
+                "username": {"type": "string"},
+                "password": {"type": "string"},
                 "dbName": {"type": "string", "title": "Database Name"},
                 "replicaSetName": {"type": "string", "title": "Replica Set Name"},
                 "readPreference": {
@@ -147,6 +149,7 @@ class MongoDB(BaseQueryRunner):
                     "title": "Replica Set Read Preference",
                 },
             },
+            "secret": ["password"],
             "required": ["connectionString", "dbName"],
         }
 
@@ -175,6 +178,12 @@ class MongoDB(BaseQueryRunner):
             readPreference = self.configuration.get("readPreference")
             if readPreference:
                 kwargs["readPreference"] = readPreference
+
+        if "username" in self.configuration:
+            kwargs["username"] = self.configuration["username"]
+
+        if "password" in self.configuration:
+            kwargs["password"] = self.configuration["password"]
 
         db_connection = pymongo.MongoClient(
             self.configuration["connectionString"], **kwargs


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

This PR adds `Username` and `Password` fields to the MongoDB data source configuration, where the `Password` field is set to secret. The intention is to allow users to keep MongoDB passwords secret in the data source configuration. Previously this was not possible as the password would have to be embedded into the connection string, which was available in plaintext in the UI and REST API.

If a user supplies the `Username` and/or `Password` config field(s), Redash will use them to override whatever is set in the connection string when creating the PyMongo client. This allows for existing, pre-patch MongoDB sources to still function, while allowing new/modified MongoDB sources to have secret credentials

## Testing

Added a small unit test to verify that params are passed correctly to PyMongo, and manually tested by putting incorrect credentials in the connection string, and correct user/pass in config fields, and verifying that the mongodb datasource still worked.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/1356899/101962547-507c9180-3bc1-11eb-93cd-c3d8f0d397d6.png)
