### PR TITLE
Encrypt alert notification destinations

### DIFF
--- a/migrations/versions/d7d747033183_encrypt_alert_destinations.py
+++ b/migrations/versions/d7d747033183_encrypt_alert_destinations.py
@@ -1,0 +1,64 @@
+"""encrypt alert destinations
+
+Revision ID: d7d747033183
+Revises: e5c7a4e2df4d
+Create Date: 2020-12-14 21:42:48.661684
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table
+from sqlalchemy_utils.types.encrypted.encrypted_type import FernetEngine
+
+from redash import settings
+from redash.utils.configuration import ConfigurationContainer
+from redash.models.base import key_type
+from redash.models.types import (
+    EncryptedConfiguration,
+    Configuration,
+)
+
+
+# revision identifiers, used by Alembic.
+revision = 'd7d747033183'
+down_revision = 'e5c7a4e2df4d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "notification_destinations",
+        sa.Column("encrypted_options", postgresql.BYTEA(), nullable=True)
+    )
+
+    # copy values
+    notification_destinations = table(
+        "notification_destinations",
+        sa.Column("id", key_type("NotificationDestination"), primary_key=True),
+        sa.Column(
+            "encrypted_options",
+            ConfigurationContainer.as_mutable(
+                EncryptedConfiguration(
+                    sa.Text, settings.DATASOURCE_SECRET_KEY, FernetEngine
+                )
+            ),
+        ),
+        sa.Column("options", ConfigurationContainer.as_mutable(Configuration)),
+    )
+
+    conn = op.get_bind()
+    for dest in conn.execute(notification_destinations.select()):
+        conn.execute(
+            notification_destinations.update()
+                .where(notification_destinations.c.id == dest.id)
+                .values(encrypted_options=dest.options)
+        )
+
+    op.drop_column("notification_destinations", "options")
+    op.alter_column("notification_destinations", "encrypted_options", nullable=False)
+
+
+def downgrade():
+    pass

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1351,7 +1351,14 @@ class NotificationDestination(BelongsToOrgMixin, db.Model):
     user = db.relationship(User, backref="notification_destinations")
     name = Column(db.String(255))
     type = Column(db.String(255))
-    options = Column(ConfigurationContainer.as_mutable(Configuration))
+    options = Column(
+        "encrypted_options",
+        ConfigurationContainer.as_mutable(
+            EncryptedConfiguration(
+                db.Text, settings.DATASOURCE_SECRET_KEY, FernetEngine
+            )
+        ),
+    )
     created_at = Column(db.DateTime(True), default=db.func.now())
 
     __tablename__ = "notification_destinations"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Other

## Description

This PR makes Redash automatically encrypt details for alert destination options, with the same secret key used to encrypt data source options. It also adds a migration to encrypt existing alert destinations with the current secret key, and modifies the `reencrypt` command to consider alert destinations as well.

The migration was largely based off of the migration for encrypting data source options, #2970

## Testing

Tested manually by:
* Creating alert destinations pre-migration
* Executing migration, observing that the database now only contains encrypted options, and also observing that the alert destination pages still work
* Running `reencrypt` with a new key (without restarting server with new key), observing that both the data source and alert destination pages were now broken
* Restarting server with new key, observing that both the data source and alert destination pages now work again

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
