### PR TITLE
Obfuscate non-email alert destinations

### DIFF
--- a/redash/destinations/chatwork.py
+++ b/redash/destinations/chatwork.py
@@ -22,6 +22,7 @@ class ChatWork(BaseDestination):
                     "title": "Message Template",
                 },
             },
+            "secret": ["api_token"],
             "required": ["message_template", "api_token", "room_id"],
         }
 

--- a/redash/destinations/hangoutschat.py
+++ b/redash/destinations/hangoutschat.py
@@ -28,6 +28,7 @@ class HangoutsChat(BaseDestination):
                     "title": "Icon URL (32x32 or multiple, png format)",
                 },
             },
+            "secret": ["url"],
             "required": ["url"],
         }
 

--- a/redash/destinations/hipchat.py
+++ b/redash/destinations/hipchat.py
@@ -25,6 +25,7 @@ class HipChat(BaseDestination):
                     "title": "HipChat Notification URL (get it from the Integrations page)",
                 }
             },
+            "secret": ["url"],
             "required": ["url"],
         }
 

--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -16,6 +16,7 @@ class Mattermost(BaseDestination):
                 "icon_url": {"type": "string", "title": "Icon (URL)"},
                 "channel": {"type": "string", "title": "Channel"},
             },
+            "secret": "url"
         }
 
     @classmethod

--- a/redash/destinations/pagerduty.py
+++ b/redash/destinations/pagerduty.py
@@ -32,6 +32,7 @@ class PagerDuty(BaseDestination):
                     "title": "Description for the event, defaults to alert name",
                 },
             },
+            "secret": ["integration_key"],
             "required": ["integration_key"],
         }
 

--- a/redash/destinations/slack.py
+++ b/redash/destinations/slack.py
@@ -17,6 +17,7 @@ class Slack(BaseDestination):
                 "icon_url": {"type": "string", "title": "Icon (URL)"},
                 "channel": {"type": "string", "title": "Channel"},
             },
+            "secret": ["url"]
         }
 
     @classmethod

--- a/redash/destinations/webhook.py
+++ b/redash/destinations/webhook.py
@@ -18,7 +18,7 @@ class Webhook(BaseDestination):
                 "password": {"type": "string"},
             },
             "required": ["url"],
-            "secret": ["password"],
+            "secret": ["password", "url"],
         }
 
     @classmethod


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

This PR obfuscates alert destination option fields which may carry credentials intended to be kept secret (Webhook URLs, API Tokens, etc.) by designating such fields as `secret`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
