### PR TITLE
Extend sync_user_details expiry

### DIFF
--- a/redash/tasks/schedule.py
+++ b/redash/tasks/schedule.py
@@ -72,7 +72,12 @@ def periodic_job_definitions():
             "func": refresh_schemas,
             "interval": timedelta(minutes=settings.SCHEMAS_REFRESH_SCHEDULE),
         },
-        {"func": sync_user_details, "timeout": 60, "interval": timedelta(minutes=1),},
+        {
+            "func": sync_user_details,
+            "timeout": 60,
+            "interval": timedelta(minutes=1),
+            "result_ttl": 600,
+        },
         {"func": purge_failed_jobs, "timeout": 3600, "interval": timedelta(days=1)},
         {
             "func": send_aggregated_errors,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
`sync_user_details` can occasionally get removed from the schedule because it has a short `interval` (60 seconds) resulting in a short `result_ttl` (120 seconds). If during these 120 seconds, for whatever reason the scheduler is unable to re-run the task, it expires and gets off the schedule.

This PR extends the grace period to re-run the sync job to 10 minutes.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
