### PR TITLE
Unused qr should respect env setting

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -20,7 +20,9 @@ def get_object_counts():
     status["queries_count"] = Query.query.count()
     if settings.FEATURE_SHOW_QUERY_RESULTS_COUNT:
         status["query_results_count"] = QueryResult.query.count()
-        status["unused_query_results_count"] = QueryResult.unused().count()
+        status["unused_query_results_count"] = QueryResult.unused(
+            settings.QUERY_RESULTS_CLEANUP_MAX_AGE
+        ).count()
     status["dashboards_count"] = Dashboard.query.count()
     status["widgets_count"] = Widget.query.count()
     return status

--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -20,9 +20,7 @@ def get_object_counts():
     status["queries_count"] = Query.query.count()
     if settings.FEATURE_SHOW_QUERY_RESULTS_COUNT:
         status["query_results_count"] = QueryResult.query.count()
-        status["unused_query_results_count"] = QueryResult.unused(
-            settings.QUERY_RESULTS_CLEANUP_MAX_AGE
-        ).count()
+        status["unused_query_results_count"] = QueryResult.unused(settings.QUERY_RESULTS_CLEANUP_MAX_AGE).count()
     status["dashboards_count"] = Dashboard.query.count()
     status["widgets_count"] = Widget.query.count()
     return status


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

`Monitor` get `unused_query_results_count` value should respect environment settting `settings.QUERY_RESULTS_CLEANUP_MAX_AGE`

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
