### PR TITLE
Correct get_schema parameter

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -195,7 +195,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
         if out_schema is None:
             query_runner = self.query_runner
-            schema = query_runner.get_schema(get_stats=refresh)
+            schema = query_runner.get_schema()
 
             try:
                 out_schema = self._sort_schema(schema)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

We pass value of `refresh` to parameter `get_stats` in function `query_runner.get_schema` which is wrong, and we should correct it by pass empty parameter

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
