### PR TITLE
Reset failure counter on adhoc success

### DIFF
--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -210,7 +210,7 @@ class QueryExecutor(object):
                 track_failure(self.query_model, error)
             raise result
         else:
-            if self.scheduled and self.query_model.schedule_failures > 0:
+            if self.query_model and self.query_model.schedule_failures > 0:
                 self.query_model = models.db.session.merge(self.query_model, load=False)
                 self.query_model.schedule_failures = 0
                 self.query_model.skip_updated_at = True

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -153,7 +153,7 @@ class QueryExecutor(object):
         self.job = get_current_job()
         self.query = query
         self.query_id = metadata.get("query_id")
-        self.scheduled = metadata.get("scheduled")
+        self.scheduled = metadata.get("scheduled", False)
         self.data_source_id = data_source_id
         self.metadata = metadata
         self.data_source = self._load_data_source()

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -201,7 +201,7 @@ class QueryExecutorTests(BaseTestCase):
         with patch.object(PostgreSQL, "run_query") as qr:
             qr.return_value = ([1, 2], None)
             result_id = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {}, scheduled_query_id=q.id
+                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id":q.id}, scheduled_query_id=q.id
             )
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 0)
@@ -219,20 +219,20 @@ class QueryExecutorTests(BaseTestCase):
             qr.side_effect = ValueError("broken")
 
             result = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {}, scheduled_query_id=q.id
+                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id":q.id}
             )
             self.assertTrue(isinstance(result, QueryExecutionError))
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 1)
 
             result = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {}, scheduled_query_id=q.id
+                "SELECT 1, 2", self.factory.data_source.id,{"scheduled": True, "query_id":q.id}}
             )
             self.assertTrue(isinstance(result, QueryExecutionError))
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 2)
 
-    def test_success_after_failure(self, _):
+    def test_scheduled_success_after_scheduled_failure(self, _):
         """
         Query execution success resets the failure counter.
         """
@@ -242,7 +242,7 @@ class QueryExecutorTests(BaseTestCase):
         with patch.object(PostgreSQL, "run_query") as qr:
             qr.side_effect = ValueError("broken")
             result = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {}, scheduled_query_id=q.id
+                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id": q.id}
             )
             self.assertTrue(isinstance(result, QueryExecutionError))
             q = models.Query.get_by_id(q.id)
@@ -251,7 +251,7 @@ class QueryExecutorTests(BaseTestCase):
         with patch.object(PostgreSQL, "run_query") as qr:
             qr.return_value = ([1, 2], None)
             execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {}, scheduled_query_id=q.id
+                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id": q.id}
             )
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 0)

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -201,7 +201,10 @@ class QueryExecutorTests(BaseTestCase):
         with patch.object(PostgreSQL, "run_query") as qr:
             qr.return_value = ([1, 2], None)
             result_id = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id":q.id}, scheduled_query_id=q.id
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": True, "query_id": q.id},
+                scheduled_query_id=q.id,
             )
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 0)
@@ -219,14 +222,18 @@ class QueryExecutorTests(BaseTestCase):
             qr.side_effect = ValueError("broken")
 
             result = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id":q.id}
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": True, "query_id": q.id},
             )
             self.assertTrue(isinstance(result, QueryExecutionError))
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 1)
 
             result = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id,{"scheduled": True, "query_id":q.id}}
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": True, "query_id": q.id},
             )
             self.assertTrue(isinstance(result, QueryExecutionError))
             q = models.Query.get_by_id(q.id)
@@ -242,7 +249,9 @@ class QueryExecutorTests(BaseTestCase):
         with patch.object(PostgreSQL, "run_query") as qr:
             qr.side_effect = ValueError("broken")
             result = execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id": q.id}
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": True, "query_id": q.id},
             )
             self.assertTrue(isinstance(result, QueryExecutionError))
             q = models.Query.get_by_id(q.id)
@@ -251,7 +260,39 @@ class QueryExecutorTests(BaseTestCase):
         with patch.object(PostgreSQL, "run_query") as qr:
             qr.return_value = ([1, 2], None)
             execute_query(
-                "SELECT 1, 2", self.factory.data_source.id, {"scheduled": True, "query_id": q.id}
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": True, "query_id": q.id},
+            )
+            q = models.Query.get_by_id(q.id)
+            self.assertEqual(q.schedule_failures, 0)
+
+    def test_adhoc_success_after_scheduled_failure(self, _):
+        """
+        Query execution success resets the failure counter, even if it runs as an adhoc query.
+        """
+        q = self.factory.create_query(
+            query_text="SELECT 1, 2", schedule={"interval": 300}
+        )
+        with patch.object(PostgreSQL, "run_query") as qr:
+            qr.side_effect = ValueError("broken")
+            result = execute_query(
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": True, "query_id": q.id},
+                user_id=self.factory.user.id,
+            )
+            self.assertTrue(isinstance(result, QueryExecutionError))
+            q = models.Query.get_by_id(q.id)
+            self.assertEqual(q.schedule_failures, 1)
+
+        with patch.object(PostgreSQL, "run_query") as qr:
+            qr.return_value = ([1, 2], None)
+            execute_query(
+                "SELECT 1, 2",
+                self.factory.data_source.id,
+                {"scheduled": False, "query_id": q.id},
+                user_id=self.factory.user.id,
             )
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 0)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Disclaimer: I might be changing the desired behavior here, so feel free to reject this PR.

Seems like successful executions for scheduled queries reset the failure counters, while successful executions for manual runs of those queries do not reset the counter. This PR uses `metadata` to lookup the query (this is done to avoid breaking APIs, but in the future, we can simplify the signature for `execute_query`) and resets the `schedule_failure` counter for all types of executions (scheduled / unscheduled).