### PR TITLE
Remove unnecessary space in rq log

### DIFF
--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -248,7 +248,7 @@ class QueryExecutor(object):
 
     def _log_progress(self, state):
         logger.info(
-            "job=execute_query state=%s query_hash=%s type=%s ds_id=%d  "
+            "job=execute_query state=%s query_hash=%s type=%s ds_id=%d "
             "job_id=%s queue=%s query_id=%s username=%s",
             state,
             self.query_hash,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

I found out we have a unnecessary space in rq log and I think we should remove it. The example of the log like

```log
-- between "ds_id=1" and "job_id"
query_hash=53d2d2df553b8410dcc797bbbd79aa69 type=pg ds_id=1  job_id=d0061efc-cfad-4ccd-bd2b-24f2e2463dc1
```

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
