### PR TITLE
Handle outdated page error while scheduler not running

### DIFF
--- a/client/app/pages/admin/OutdatedQueries.jsx
+++ b/client/app/pages/admin/OutdatedQueries.jsx
@@ -103,11 +103,10 @@ class OutdatedQueries extends React.Component {
               onChange={autoUpdate => this.setState({ autoUpdate })}
             />
           </div>
-          {controller.params.lastUpdatedAt && (
-            <div className="m-t-5">
-              Last updated: <TimeAgo date={controller.params.lastUpdatedAt * 1000} />
-            </div>
-          )}
+          <div className="m-t-5">
+            Last updated: {controller.params.lastUpdatedAt ?
+            <TimeAgo date={controller.params.lastUpdatedAt * 1000} /> : "Seem rq scheduler no running"}
+          </div>
         </div>
         {!controller.isLoaded && <LoadingState />}
         {controller.isLoaded && controller.isEmpty && (

--- a/redash/handlers/admin.py
+++ b/redash/handlers/admin.py
@@ -36,7 +36,7 @@ def outdated_queries():
         "queries": QuerySerializer(
             outdated_queries, with_stats=True, with_last_modified_by=False
         ).serialize(),
-        "updated_at": manager_status["last_refresh_at"],
+        "updated_at": manager_status.get("last_refresh_at", None),
     }
     return json_response(response)
 


### PR DESCRIPTION
While rq scheduler not running, webserver will raise
error due to redis key 'redash:status' not exists.
This patch fix the bug and give user hint that rq
scheduler not running

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

While rq scheduler not running, webserver will raise
error due to redis key 'redash:status' not exists.
This patch fix the bug and give user hint that rq
scheduler not running

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="1674" alt="Screen Shot 2021-01-09 at 11 17 14" src="https://user-images.githubusercontent.com/15820530/104081828-47d4b500-526c-11eb-9a59-249f1b2e6622.png">

