### PR TITLE
Fix for Cypress flakiness generated by param_spec

### DIFF
--- a/client/cypress/integration/dashboard/parameter_spec.js
+++ b/client/cypress/integration/dashboard/parameter_spec.js
@@ -1,4 +1,3 @@
-import { each } from "lodash";
 import { createQueryAndAddWidget, editDashboard } from "../../support/dashboard";
 import { dragParam, expectParamOrder } from "../../support/parameters";
 
@@ -44,24 +43,25 @@ describe("Dashboard Parameters", () => {
   const saveMappingOptions = (close = true) => {
     cy.getByTestId("EditParamMappingPopover")
       .filter(":visible")
+      .as("Popover")
       .within(() => {
         cy.contains("button", "OK").click();
       });
 
-    cy.getByTestId("EditParamMappingPopover").should("not.be.visible");
-
     if (close) {
       cy.contains("button", "OK").click();
     }
+
+    return cy.get("@Popover").should("not.be.visible");
   };
 
   const setWidgetParametersToDashboard = parameters => {
-    each(parameters, ({ name: paramName }, i) => {
+    cy.wrap(parameters).each(({ name: paramName }, i) => {
       cy.getByTestId(`EditParamMappingButton-${paramName}`).click();
       cy.getByTestId("NewDashboardParameterOption")
         .filter(":visible")
         .click();
-      saveMappingOptions(i === parameters.length - 1);
+      return saveMappingOptions(i === parameters.length - 1);
     });
   };
 

--- a/client/cypress/integration/dashboard/parameter_spec.js
+++ b/client/cypress/integration/dashboard/parameter_spec.js
@@ -40,7 +40,7 @@ describe("Dashboard Parameters", () => {
       .click();
   };
 
-  const saveMappingOptions = (closeMappingMenu = true) => {
+  const saveMappingOptions = (closeMappingMenu = false) => {
     return cy
       .getByTestId("EditParamMappingPopover")
       .filter(":visible")
@@ -48,18 +48,14 @@ describe("Dashboard Parameters", () => {
       .within(() => {
         // This is needed to grant the element will have finished loading
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(150);
-        cy.get(".ant-btn:enabled:not(.ant-btn-loading)")
-          .contains("OK")
-          .click();
+        cy.wait(200);
+        cy.contains("button", "OK").click();
       })
       .then(() => {
-        cy.get("@Popover").should("not.be.visible");
         if (closeMappingMenu) {
-          cy.get(".ant-btn:enabled:not(.ant-btn-loading)")
-            .contains("OK")
-            .click();
+          cy.contains("button", "OK").click();
         }
+        return cy.get("@Popover").should("not.be.visible");
       });
   };
 

--- a/client/cypress/integration/dashboard/parameter_spec.js
+++ b/client/cypress/integration/dashboard/parameter_spec.js
@@ -40,19 +40,27 @@ describe("Dashboard Parameters", () => {
       .click();
   };
 
-  const saveMappingOptions = (close = true) => {
-    cy.getByTestId("EditParamMappingPopover")
+  const saveMappingOptions = (closeMappingMenu = true) => {
+    return cy
+      .getByTestId("EditParamMappingPopover")
       .filter(":visible")
       .as("Popover")
       .within(() => {
-        cy.contains("button", "OK").click();
+        // This is needed to grant the element will have finished loading
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(150);
+        cy.get(".ant-btn:enabled:not(.ant-btn-loading)")
+          .contains("OK")
+          .click();
+      })
+      .then(() => {
+        cy.get("@Popover").should("not.be.visible");
+        if (closeMappingMenu) {
+          cy.get(".ant-btn:enabled:not(.ant-btn-loading)")
+            .contains("OK")
+            .click();
+        }
       });
-
-    if (close) {
-      cy.contains("button", "OK").click();
-    }
-
-    return cy.get("@Popover").should("not.be.visible");
   };
 
   const setWidgetParametersToDashboard = parameters => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Bug Fix

## Description
Caused by #5286
Due to how Cypress behaves within loops, sometimes the next iteration is reached before current specs are evaluated, raising an unexpected behavior. This attempts to fix it.