### PR TITLE
install older pip to avoid dependency conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,9 @@ ENV PIP_NO_CACHE_DIR=1
 # We first copy only the requirements file, to avoid rebuilding on every file
 # change.
 COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./
+
+# use a sane version of pip until things go back to normal (mid 2021 perhaps)
+RUN pip install pip==20.2.4;
 RUN if [ "x$skip_dev_deps" = "x" ] ; then pip install -r requirements.txt -r requirements_dev.txt; else pip install -r requirements.txt; fi
 RUN if [ "x$skip_ds_deps" = "x" ] ; then pip install -r requirements_all_ds.txt ; else echo "Skipping pip install -r requirements_all_ds.txt" ; fi
 


### PR DESCRIPTION
PIP recently introduce strict dependency checks, while this is a good thing it basically breaks a large amount of libs in ways that are not trivial to fix (ie. dependency of a dependency).

Using an older version of PIP is the wise thing to do until the ecosystem gets around this change of pinning dependencies.

```
The conflict is caused by:
    atsd-client 3.0.5 depends on python-dateutil
    azure-kusto-data 0.0.35 depends on python-dateutil>=2.8.0
    dql 0.5.26 depends on python-dateutil<2.7.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
