### PR TITLE
Add support for more JWT algorithms

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -66,7 +66,7 @@ def request_loader(request):
         user = hmac_load_user_from_request(request)
     elif settings.AUTH_TYPE == "api_key":
         user = api_key_load_user_from_request(request)
-    else:
+    elif settings.AUTH_TYPE != "jwt":
         logger.warning(
             "Unknown authentication type ({}). Using default (HMAC).".format(
                 settings.AUTH_TYPE

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,8 @@ semver==2.8.1
 xlsxwriter==1.2.2
 pystache==0.5.4
 parsedatetime==2.4
-PyJWT==1.7.1
-cryptography==2.8
+PyJWT==2.0.0
+cryptography==3.3.1
 simplejson==3.16.0
 ua-parser==0.8.0
 user-agents==2.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description
This adds support for JWTs signed using HMAC and EC keys by upgrading to the latest PyJWT version. The JWKS of our IDP includes EC keys - others might as well.
Changes:

- Bumps PyJWT to 2.0.0 to include ECAlgorithm and HMACAlgorithm
- Pick proper algorithm based on the JWT `kty` key
- Adds `AUTH_TYPE="jwt"`: Not too sure about the intended logic in `request_loader`. It would also work by only using `auth_jwt_login_enabled`, but producing a warning on each request seems weird in case of a JWT-only setup?

Manually tested `get_public_keys` on a few JWKS urls.