### PR TITLE
Fix: add a merge migration to solve multi head issue

### DIFF
--- a/migrations/versions/89bc7873a3e0_fix_multiple_heads.py
+++ b/migrations/versions/89bc7873a3e0_fix_multiple_heads.py
@@ -1,0 +1,24 @@
+"""fix_multiple_heads
+
+Revision ID: 89bc7873a3e0
+Revises: 0ec979123ba4, d7d747033183
+Create Date: 2021-01-21 18:11:04.312259
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '89bc7873a3e0'
+down_revision = ('0ec979123ba4', 'd7d747033183')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,20 @@
+import os
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def test_only_single_head_revision_in_migrations():
+    """
+    If multiple developers are working on migrations and one of them is merged before the 
+    other you might end up with multiple heads (multiple revisions with the same down_revision).
+
+    This makes sure that there is only a single head revision in the migrations directory.
+
+    Adopted from https://blog.jerrycodes.com/multiple-heads-in-alembic-migrations/.
+    """
+    config = Config(os.path.join("migrations", 'alembic.ini'))
+    config.set_main_option('script_location', "migrations")
+    script = ScriptDirectory.from_config(config)
+
+    # This will raise if there are multiple heads
+    script.get_current_head()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

We recently had two migrations merged into master that had the same upstream migration. This PR:

1. Adds a merge migration.
2. Adds a unit test to catch such cases in the future.

## Related Tickets & Documents

#5317, #5267