### PR TITLE
Add My Dashboards filter option to the Dashboards list

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -33,7 +33,13 @@ function useNavbarActiveState() {
   return useMemo(
     () => ({
       dashboards: includes(
-        ["Dashboards.List", "Dashboards.Favorites", "Dashboards.ViewOrEdit", "Dashboards.LegacyViewOrEdit"],
+        [
+          "Dashboards.List",
+          "Dashboards.Favorites",
+          "Dashboards.My",
+          "Dashboards.ViewOrEdit",
+          "Dashboards.LegacyViewOrEdit",
+        ],
         currentRoute.id
       ),
       queries: includes(

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -45,7 +45,7 @@ export const TYPES = mapValues(
     NUMBER_FORMAT_SPECS: ["/user-guide/visualizations/formatting-numbers", "Formatting Numbers"],
     GETTING_STARTED: ["/user-guide/getting-started", "Guide: Getting Started"],
     DASHBOARDS: ["/user-guide/dashboards", "Guide: Dashboards"],
-    QUERIES: ["/help/user-guide/querying", "Guide: Queries"],
+    QUERIES: ["/user-guide/querying", "Guide: Queries"],
     ALERTS: ["/user-guide/alerts", "Guide: Alerts"],
   },
   ([url, title]) => [DOMAIN + HELP_PATH + url, title]

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -37,6 +37,13 @@ const sidebarMenu = [
     title: "Favorites",
     icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
   },
+  {
+    key: "my",
+    href: "dashboards/my",
+    title: "My Dashboards",
+    icon: () => <Sidebar.ProfileImage user={currentUser} />,
+    isAvailable: () => currentUser.hasPermission("create_dashboard"),
+  },
 ];
 
 const listColumns = [
@@ -157,6 +164,7 @@ const DashboardListPage = itemsList(
       getResource({ params: { currentPage } }) {
         return {
           all: Dashboard.query.bind(Dashboard),
+          my: Dashboard.myDashboards.bind(Dashboard),
           favorites: Dashboard.favorites.bind(Dashboard),
         }[currentPage];
       },
@@ -181,5 +189,13 @@ routes.register(
     path: "/dashboards/favorites",
     title: "Favorite Dashboards",
     render: pageProps => <DashboardListPage {...pageProps} currentPage="favorites" />,
+  })
+);
+routes.register(
+  "Dashboards.My",
+  routeWithUserSession({
+    path: "/dashboards/my",
+    title: "My Dashboards",
+    render: pageProps => <DashboardListPage {...pageProps} currentPage="my" />,
   })
 );

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -30,19 +30,19 @@ const sidebarMenu = [
     key: "all",
     href: "dashboards",
     title: "All Dashboards",
-  },
-  {
-    key: "favorites",
-    href: "dashboards/favorites",
-    title: "Favorites",
-    icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
+    icon: () => <Sidebar.MenuIcon icon="zmdi zmdi-view-quilt" />,
   },
   {
     key: "my",
     href: "dashboards/my",
     title: "My Dashboards",
     icon: () => <Sidebar.ProfileImage user={currentUser} />,
-    isAvailable: () => currentUser.hasPermission("create_dashboard"),
+  },
+  {
+    key: "favorites",
+    href: "dashboards/favorites",
+    title: "Favorites",
+    icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
   },
 ];
 

--- a/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
+++ b/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
@@ -38,7 +38,7 @@ export default function DashboardListEmptyState({ page, searchTerm, selectedTags
       ) : (
         <span>Sorry, we couldn't find anything.</span>
       );
-      return <BigMessage children={my_msg} icon="fa-search" />;
+      return <BigMessage icon="fa-search">{my_msg}</BigMessage>;
     default:
       return (
         <DynamicComponent name="DashboardList.EmptyState">

--- a/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
+++ b/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
@@ -6,6 +6,8 @@ import EmptyState, { EmptyStateHelpMessage } from "@/components/empty-state/Empt
 import DynamicComponent from "@/components/DynamicComponent";
 import Link from "@/components/Link";
 import CreateDashboardDialog from "@/components/dashboards/CreateDashboardDialog";
+import { currentUser } from "@/services/auth";
+import HelpTrigger from "@/components/HelpTrigger";
 
 export interface DashboardListEmptyStateProps {
   page: string;
@@ -24,15 +26,19 @@ export default function DashboardListEmptyState({ page, searchTerm, selectedTags
     case "favorites":
       return <BigMessage message="Mark dashboards as Favorite to list them here." icon="fa-star" />;
     case "my":
-      return (
-        <div className="tiled bg-white p-15">
+      const my_msg = currentUser.hasPermission("create_dashboard") ? (
+        <span>
           <Link.Button type="primary" size="small" onClick={() => CreateDashboardDialog.showModal()}>
-            Create your first dashboard
+            Create your first dashboard!
           </Link.Button>{" "}
-          to populate My Dashboards list. Need help? Check out our{" "}
-          <Link href="https://redash.io/help/user-guide/dashboards/dashboard-editing">dashboard editing documentation</Link>.
-        </div>
+          <HelpTrigger className="f-14" type="DASHBOARDS" showTooltip={false}>
+            Need help?
+          </HelpTrigger>
+        </span>
+      ) : (
+        <span>Sorry, we couldn't find anything.</span>
       );
+      return <BigMessage children={my_msg} icon="fa-search" />;
     default:
       return (
         <DynamicComponent name="DashboardList.EmptyState">

--- a/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
+++ b/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
@@ -4,6 +4,8 @@ import BigMessage from "@/components/BigMessage";
 import NoTaggedObjectsFound from "@/components/NoTaggedObjectsFound";
 import EmptyState, { EmptyStateHelpMessage } from "@/components/empty-state/EmptyState";
 import DynamicComponent from "@/components/DynamicComponent";
+import Link from "@/components/Link";
+import CreateDashboardDialog from "@/components/dashboards/CreateDashboardDialog";
 
 export interface DashboardListEmptyStateProps {
   page: string;
@@ -22,7 +24,15 @@ export default function DashboardListEmptyState({ page, searchTerm, selectedTags
     case "favorites":
       return <BigMessage message="Mark dashboards as Favorite to list them here." icon="fa-star" />;
     case "my":
-      return <BigMessage message="Create your own dashboards to list them here." icon="fa-line-chart" />;
+      return (
+        <div className="tiled bg-white p-15">
+          <Link.Button type="primary" size="small" onClick={() => CreateDashboardDialog.showModal()}>
+            Create your first dashboard
+          </Link.Button>{" "}
+          to populate My Dashboards list. Need help? Check out our{" "}
+          <Link href="https://redash.io/help/user-guide/dashboards/dashboard-editing">dashboard editing documentation</Link>.
+        </div>
+      );
     default:
       return (
         <DynamicComponent name="DashboardList.EmptyState">

--- a/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
+++ b/client/app/pages/dashboards/components/DashboardListEmptyState.tsx
@@ -21,6 +21,8 @@ export default function DashboardListEmptyState({ page, searchTerm, selectedTags
   switch (page) {
     case "favorites":
       return <BigMessage message="Mark dashboards as Favorite to list them here." icon="fa-star" />;
+    case "my":
+      return <BigMessage message="Create your own dashboards to list them here." icon="fa-line-chart" />;
     default:
       return (
         <DynamicComponent name="DashboardList.EmptyState">

--- a/client/app/pages/queries-list/QueriesList.jsx
+++ b/client/app/pages/queries-list/QueriesList.jsx
@@ -33,19 +33,19 @@ const sidebarMenu = [
     key: "all",
     href: "queries",
     title: "All Queries",
-  },
-  {
-    key: "favorites",
-    href: "queries/favorites",
-    title: "Favorites",
-    icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
+    icon: () => <Sidebar.MenuIcon icon="fa fa-code" />,
   },
   {
     key: "my",
     href: "queries/my",
     title: "My Queries",
     icon: () => <Sidebar.ProfileImage user={currentUser} />,
-    isAvailable: () => currentUser.hasPermission("create_query"),
+  },
+  {
+    key: "favorites",
+    href: "queries/favorites",
+    title: "Favorites",
+    icon: () => <Sidebar.MenuIcon icon="fa fa-star" />,
   },
   {
     key: "archive",

--- a/client/app/pages/queries-list/QueriesListEmptyState.jsx
+++ b/client/app/pages/queries-list/QueriesListEmptyState.jsx
@@ -33,7 +33,7 @@ export default function QueriesListEmptyState({ page, searchTerm, selectedTags }
       ) : (
         <span>Sorry, we couldn't find anything.</span>
       );
-      return <BigMessage children={my_msg} icon="fa-search" />;
+      return <BigMessage icon="fa-search">{my_msg}</BigMessage>;
     default:
       return (
         <DynamicComponent name="QueriesList.EmptyState">

--- a/client/app/pages/queries-list/QueriesListEmptyState.jsx
+++ b/client/app/pages/queries-list/QueriesListEmptyState.jsx
@@ -5,6 +5,8 @@ import BigMessage from "@/components/BigMessage";
 import NoTaggedObjectsFound from "@/components/NoTaggedObjectsFound";
 import EmptyState, { EmptyStateHelpMessage } from "@/components/empty-state/EmptyState";
 import DynamicComponent from "@/components/DynamicComponent";
+import { currentUser } from "@/services/auth";
+import HelpTrigger from "@/components/HelpTrigger";
 
 export default function QueriesListEmptyState({ page, searchTerm, selectedTags }) {
   if (searchTerm !== "") {
@@ -19,15 +21,19 @@ export default function QueriesListEmptyState({ page, searchTerm, selectedTags }
     case "archive":
       return <BigMessage message="Archived queries will be listed here." icon="fa-archive" />;
     case "my":
-      return (
-        <div className="tiled bg-white p-15">
+      const my_msg = currentUser.hasPermission("create_query") ? (
+        <span>
           <Link.Button href="queries/new" type="primary" size="small">
-            Create your first query
+            Create your first query!
           </Link.Button>{" "}
-          to populate My Queries list. Need help? Check out our{" "}
-          <Link href="https://redash.io/help/user-guide/querying/writing-queries">query writing documentation</Link>.
-        </div>
+          <HelpTrigger className="f-13" type="QUERIES" showTooltip={false}>
+            Need help?
+          </HelpTrigger>
+        </span>
+      ) : (
+        <span>Sorry, we couldn't find anything.</span>
       );
+      return <BigMessage children={my_msg} icon="fa-search" />;
     default:
       return (
         <DynamicComponent name="QueriesList.EmptyState">

--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -168,6 +168,7 @@ const DashboardService = {
   delete: ({ id }) => axios.delete(`api/dashboards/${id}`).then(transformResponse),
   query: params => axios.get("api/dashboards", { params }).then(transformResponse),
   recent: params => axios.get("api/dashboards/recent", { params }).then(transformResponse),
+  myDashboards: params => axios.get("api/dashboards/my", { params }).then(transformResponse),
   favorites: params => axios.get("api/dashboards/favorites", { params }).then(transformResponse),
   favorite: ({ id }) => axios.post(`api/dashboards/${id}/favorite`),
   unfavorite: ({ id }) => axios.delete(`api/dashboards/${id}/favorite`),

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -11,6 +11,7 @@ from redash.handlers.alerts import (
 )
 from redash.handlers.base import org_scoped_rule
 from redash.handlers.dashboards import (
+    MyDashboardsResource,
     DashboardFavoriteListResource,
     DashboardListResource,
     DashboardResource,
@@ -208,6 +209,8 @@ api.add_org_resource(
     "/api/dashboards/<object_id>/favorite",
     endpoint="dashboard_favorite",
 )
+
+api.add_org_resource(MyDashboardsResource, "/api/dashboards/my", endpoint="my_dashboards")
 
 api.add_org_resource(QueryTagsResource, "/api/queries/tags", endpoint="query_tags")
 api.add_org_resource(

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1151,6 +1151,10 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
         )
 
     @classmethod
+    def search_by_user(cls, term, user, limit=None):
+        return cls.by_user(user).filter(cls.name.ilike("%{}%".format(term))).limit(limit)
+
+    @classmethod
     def all_tags(cls, org, user):
         dashboards = cls.all(org, user.group_ids, user.id)
 
@@ -1178,6 +1182,10 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
                 ),
             )
         ).filter(Favorite.user_id == user.id)
+
+    @classmethod
+    def by_user(cls, user):
+        return cls.all(user.org, user.group_ids, user.id).filter(Dashboard.user == user)
 
     @classmethod
     def get_by_slug_and_org(cls, slug, org):

--- a/tests/models/test_dashboards.py
+++ b/tests/models/test_dashboards.py
@@ -28,3 +28,25 @@ class DashboardTest(BaseTestCase):
             list(Dashboard.all_tags(self.factory.org, self.factory.user)),
             [("tag1", 3), ("tag2", 2), ("tag3", 1)],
         )
+
+
+class TestDashboardsByUser(BaseTestCase):
+    def test_returns_only_users_dashboards(self):
+        d = self.factory.create_dashboard(user=self.factory.user)
+        d2 = self.factory.create_dashboard(user=self.factory.create_user())
+
+        dashboards = Dashboard.by_user(self.factory.user)
+
+        # not using self.assertIn/NotIn because otherwise this fails :O
+        self.assertTrue(d in list(dashboards))
+        self.assertFalse(d2 in list(dashboards))
+
+    def test_returns_drafts_by_the_user(self):
+        d = self.factory.create_dashboard(is_draft=True)
+        d2 = self.factory.create_dashboard(is_draft=True, user=self.factory.create_user())
+
+        dashboards = Dashboard.by_user(self.factory.user)
+
+        # not using self.assertIn/NotIn because otherwise this fails :O
+        self.assertTrue(d in dashboards)
+        self.assertFalse(d2 in dashboards)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
Feature

## Description
Adds a My Dashboards filter option to the Dashboards list similar to the My Queries option.

An open question I had is whether list_dashboards is the appropriate permissions for this operation. My Queries uses view_queries, but directly translating to view_dashboards didn't seem to work.

I added some python tests, but I'm not very familiar with our testing infrastructure yet. What other tests would make sense here?

## Related Tickets & Documents
REDASH-687

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/76974990/106393196-a5ab7700-63aa-11eb-9883-448bda573f2d.png)
![image](https://user-images.githubusercontent.com/76974990/106393204-ae03b200-63aa-11eb-8a24-63a55c62ff58.png)
