### PR TITLE
Reset failure counter on adhoc success

### DIFF
--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -94,7 +94,7 @@ def enqueue_query(
                         "data_source_id": data_source.id,
                         "org_id": data_source.org_id,
                         "scheduled": scheduled_query_id is not None,
-                        "query_id": metadata.get("Query ID"),
+                        "query_id": metadata.get("query_id", metadata.get("Query ID")),
                         "user_id": user_id,
                     },
                 }

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -150,22 +150,28 @@ def _resolve_user(user_id, is_api_key, query_id):
 
 class QueryExecutor(object):
     def __init__(
-        self, query, data_source_id, user_id, is_api_key, metadata, scheduled_query
+        self, query, data_source_id, user_id, is_api_key, metadata, is_scheduled_query
     ):
         self.job = get_current_job()
         self.query = query
         self.data_source_id = data_source_id
         self.metadata = metadata
         self.data_source = self._load_data_source()
+        self.query_id = metadata.get("query_id")
         self.user = _resolve_user(user_id, is_api_key, metadata.get("Query ID"))
+        self.query_model = (
+            models.Query.query.get(self.query_id)
+            if self.query_id and self.query_id != "adhoc"
+            else None
+        )
 
         # Close DB connection to prevent holding a connection for a long time while the query is executing.
         models.db.session.close()
         self.query_hash = gen_query_hash(self.query)
-        self.scheduled_query = scheduled_query
-        # Load existing tracker or create a new one if the job was created before code update:
-        if scheduled_query:
-            models.scheduled_queries_executions.update(scheduled_query.id)
+        self.is_scheduled_query = is_scheduled_query
+        if self.is_scheduled_query:
+            # Load existing tracker or create a new one if the job was created before code update:
+            models.scheduled_queries_executions.update(self.query_model.id)
 
     def run(self):
         signal.signal(signal.SIGINT, signal_handler)
@@ -202,20 +208,16 @@ class QueryExecutor(object):
 
         if error is not None and data is None:
             result = QueryExecutionError(error)
-            if self.scheduled_query is not None:
-                self.scheduled_query = models.db.session.merge(
-                    self.scheduled_query, load=False
-                )
-                track_failure(self.scheduled_query, error)
+            if self.is_scheduled_query:
+                self.query_model = models.db.session.merge(self.query_model, load=False)
+                track_failure(self.query_model, error)
             raise result
         else:
-            if self.scheduled_query and self.scheduled_query.schedule_failures > 0:
-                self.scheduled_query = models.db.session.merge(
-                    self.scheduled_query, load=False
-                )
-                self.scheduled_query.schedule_failures = 0
-                self.scheduled_query.skip_updated_at = True
-                models.db.session.add(self.scheduled_query)
+            if self.query_model and self.query_model.schedule_failures > 0:
+                self.query_model = models.db.session.merge(self.query_model, load=False)
+                self.query_model.schedule_failures = 0
+                self.query_model.skip_updated_at = True
+                models.db.session.add(self.query_model)
 
             query_result = models.QueryResult.store_result(
                 self.data_source.org_id,
@@ -242,7 +244,7 @@ class QueryExecutor(object):
     def _annotate_query(self, query_runner):
         self.metadata["Job ID"] = self.job.id
         self.metadata["Query Hash"] = self.query_hash
-        self.metadata["Scheduled"] = self.scheduled_query is not None
+        self.metadata["Scheduled"] = self.is_scheduled_query
 
         return query_runner.annotate_query(self.query, self.metadata)
 
@@ -275,14 +277,14 @@ def execute_query(
     scheduled_query_id=None,
     is_api_key=False,
 ):
-    if scheduled_query_id is not None:
-        scheduled_query = models.Query.query.get(scheduled_query_id)
-    else:
-        scheduled_query = None
-
     try:
         return QueryExecutor(
-            query, data_source_id, user_id, is_api_key, metadata, scheduled_query
+            query,
+            data_source_id,
+            user_id,
+            is_api_key,
+            metadata,
+            scheduled_query_id is not None,
         ).run()
     except QueryExecutionError as e:
         models.db.session.rollback()

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -75,7 +75,7 @@ class HardLimitingWorker(HerokuWorker):
     """
 
     grace_period = 15
-    queue_class = CancellableQueue
+    queue_class = RedashQueue
     job_class = CancellableJob
 
     def stop_executing_job(self, job):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Scheduled queries that fail increment their `schedule_failures` counter, which affects the next time the query will be executed. Repeated failures can cause queries to effectively stop running.

`schedule_failures` is only reset back to 0 when a scheduled query finishes successfully. This PR enables it to reset when the same query is executed manually by a user.

Closes #4778.