### PR TITLE
Fix duplicate stylesheets

### DIFF
--- a/client/app/components/CodeBlock.less
+++ b/client/app/components/CodeBlock.less
@@ -1,4 +1,4 @@
-@import '~antd/lib/button/style/index';
+@import (reference, less) "~@/assets/less/ant";
 
 .code-block {
   background: rgba(0, 0, 0, 0.06);

--- a/client/app/components/HelpTrigger.less
+++ b/client/app/components/HelpTrigger.less
@@ -1,4 +1,4 @@
-@import  (reference, less) "~@/assets/less/ant";
+@import (reference, less) "~@/assets/less/ant";
 
 @help-doc-bg: #f7f7f7; // according to https://github.com/getredash/website/blob/13daff2d8b570956565f482236f6245042e8477f/src/scss/_components/_variables.scss#L15
 

--- a/client/app/components/HelpTrigger.less
+++ b/client/app/components/HelpTrigger.less
@@ -1,4 +1,4 @@
-@import "~antd/lib/drawer/style/drawer";
+@import  (reference, less) "~@/assets/less/ant";
 
 @help-doc-bg: #f7f7f7; // according to https://github.com/getredash/website/blob/13daff2d8b570956565f482236f6245042e8477f/src/scss/_components/_variables.scss#L15
 

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -1,4 +1,4 @@
-@import '~antd/lib/modal/style/index'; // for ant @vars
+@import (reference, less) "~@/assets/less/ant"; // for ant @vars
 
 .parameters-mapping-list {
   .keyword {

--- a/client/app/components/ParameterMappingInput.less
+++ b/client/app/components/ParameterMappingInput.less
@@ -63,7 +63,8 @@
     margin-right: 3px;
   }
 
-  &.disabled, .fa {
+  &.disabled,
+  .fa {
     color: #a4a4a4;
   }
 

--- a/client/app/components/ParameterValueInput.less
+++ b/client/app/components/ParameterValueInput.less
@@ -1,4 +1,4 @@
-@import "~antd/lib/input-number/style/index"; // for ant @vars
+@import (reference, less) "~@/assets/less/ant"; // for ant @vars
 
 @input-dirty: #fffce1;
 

--- a/client/app/components/Parameters.less
+++ b/client/app/components/Parameters.less
@@ -1,4 +1,4 @@
-@import "../assets/less/ant";
+@import (reference, less) "~@/assets/less/ant";
 
 .parameter-block {
   display: inline-block;

--- a/client/app/components/TagsList.less
+++ b/client/app/components/TagsList.less
@@ -1,4 +1,4 @@
-@import "~@/assets/less/ant";
+@import (reference, less) "~@/assets/less/ant";
 
 .tags-list {
   .tags-list-title {

--- a/client/app/components/cards-list/CardsList.less
+++ b/client/app/components/cards-list/CardsList.less
@@ -1,5 +1,4 @@
-
-@import (reference, less) '~@/assets/less/inc/variables';
+@import (reference, less) "~@/assets/less/inc/variables";
 
 .visual-card-list {
   width: 100%;
@@ -7,7 +6,7 @@
 }
 
 .visual-card {
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid fade(@redash-gray, 15%);
   border-radius: 3px;
   margin: 5px;

--- a/client/app/components/cards-list/CardsList.less
+++ b/client/app/components/cards-list/CardsList.less
@@ -1,5 +1,5 @@
 
-@import '../../assets/less/inc/variables';
+@import (reference, less) '~@/assets/less/inc/variables';
 
 .visual-card-list {
   width: 100%;

--- a/client/app/components/dashboards/dashboard-widget/Widget.less
+++ b/client/app/components/dashboards/dashboard-widget/Widget.less
@@ -1,4 +1,4 @@
-@import "../../../assets/less/inc/variables";
+@import (reference, less) "~@/assets/less/inc/variables";
 
 .tile .t-header .th-title a.query-link {
   color: rgba(0, 0, 0, 0.5);

--- a/client/app/components/dynamic-form/DynamicForm.less
+++ b/client/app/components/dynamic-form/DynamicForm.less
@@ -1,4 +1,4 @@
-@import "~@/assets/less/ant";
+@import (reference, less) "~@/assets/less/ant";
 
 @btn-extra-options-bg: fade(@redash-gray, 10%);
 @btn-extra-options-border: fade(@redash-gray, 15%);

--- a/client/app/components/dynamic-parameters/DynamicParameters.less
+++ b/client/app/components/dynamic-parameters/DynamicParameters.less
@@ -1,4 +1,4 @@
-@import "../../assets/less/inc/variables";
+@import (reference, less) "~@/assets/less/inc/variables";
 
 .date-range-parameter,
 .date-parameter {

--- a/client/app/components/empty-state/empty-state.less
+++ b/client/app/components/empty-state/empty-state.less
@@ -3,7 +3,7 @@
 // Empty states
 .empty-state {
   width: 100%;
-  margin: 0px auto 10px;
+  margin: 0 auto 10px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -18,7 +18,7 @@
   }
 
   .empty-state__steps {
-    padding-left: 0px;
+    padding-left: 0;
   }
 
   .empty-state__summary {

--- a/client/app/components/queries/EmbedQueryDialog.less
+++ b/client/app/components/queries/EmbedQueryDialog.less
@@ -1,4 +1,4 @@
-@import '~antd/lib/button/style/index';
+@import (reference, less) "~@/assets/less/ant";
 
 .embed-query-dialog {
   label {

--- a/client/app/components/queries/add-to-dashboard-dialog.less
+++ b/client/app/components/queries/add-to-dashboard-dialog.less
@@ -1,4 +1,4 @@
-@import (reference, less) '~@/assets/less/main.less';
+@import (reference, less) "~@/assets/less/main.less";
 
 .ant-list {
   &.add-to-dashboard-dialog-search-results {
@@ -13,7 +13,8 @@
       padding: 12px;
       cursor: pointer;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         @table-row-hover-bg: fade(@redash-gray, 5%);
         background-color: @table-row-hover-bg;
       }

--- a/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.less
+++ b/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.less
@@ -1,4 +1,4 @@
-@import "~@/assets/less/ant";
+@import (reference, less) "~@/assets/less/ant";
 
 .databricks-schema-browser {
   .schema-control {

--- a/client/app/pages/dashboards/DashboardPage.less
+++ b/client/app/pages/dashboards/DashboardPage.less
@@ -1,4 +1,4 @@
-@import "~@/assets/less/inc/variables";
+@import (reference, less) "~@/assets/less/inc/variables";
 
 /****
   grid bg - based on 6 cols, 35px rows and 15px spacing

--- a/client/app/pages/dashboards/components/DashboardHeader.less
+++ b/client/app/pages/dashboards/components/DashboardHeader.less
@@ -1,4 +1,4 @@
-@import "~@/components/ApplicationArea/ApplicationLayout/index.less";
+@import (reference, less) "~@/components/ApplicationArea/ApplicationLayout/index.less";
 
 .dashboard-header {
   display: flex;

--- a/client/app/redash-font/style.less
+++ b/client/app/redash-font/style.less
@@ -1,4 +1,4 @@
-@import "variables";
+@import "./variables";
 
 @font-face {
   font-family: '@{icomoon-font-family}';
@@ -28,12 +28,12 @@ i.icon {
 
 .icon-flash-off {
   &:before {
-    content: @icon-flash-off; 
+    content: @icon-flash-off;
   }
 }
 .icon-flash {
   &:before {
-    content: @icon-flash; 
+    content: @icon-flash;
   }
 }
 

--- a/client/app/redash-font/style.less
+++ b/client/app/redash-font/style.less
@@ -1,19 +1,19 @@
 @import "./variables";
 
 @font-face {
-  font-family: '@{icomoon-font-family}';
-  src:  url('@{icomoon-font-path}/@{icomoon-font-family}.eot?ehpufm');
-  src:  url('@{icomoon-font-path}/@{icomoon-font-family}.eot?ehpufm#iefix') format('embedded-opentype'),
-    url('@{icomoon-font-path}/@{icomoon-font-family}.ttf?ehpufm') format('truetype'),
-    url('@{icomoon-font-path}/@{icomoon-font-family}.woff?ehpufm') format('woff'),
-    url('@{icomoon-font-path}/@{icomoon-font-family}.svg?ehpufm#@{icomoon-font-family}') format('svg');
+  font-family: "@{icomoon-font-family}";
+  src: url("@{icomoon-font-path}/@{icomoon-font-family}.eot?ehpufm");
+  src: url("@{icomoon-font-path}/@{icomoon-font-family}.eot?ehpufm#iefix") format("embedded-opentype"),
+    url("@{icomoon-font-path}/@{icomoon-font-family}.ttf?ehpufm") format("truetype"),
+    url("@{icomoon-font-path}/@{icomoon-font-family}.woff?ehpufm") format("woff"),
+    url("@{icomoon-font-path}/@{icomoon-font-family}.svg?ehpufm#@{icomoon-font-family}") format("svg");
   font-weight: normal;
   font-style: normal;
 }
 
 i.icon {
   /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: '@{icomoon-font-family}' !important;
+  font-family: "@{icomoon-font-family}" !important;
   speak: none;
   font-style: normal;
   font-weight: normal;
@@ -36,4 +36,3 @@ i.icon {
     content: @icon-flash;
   }
 }
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

It's quite a common mistake: very often people forget/don't know that `@import` in less works differently from `import` in JS. By default imported Less files are injected in place of `@import` directive. For importing only a definitions from specific files, `(reference)` modifier should be used.

Also, another useful trick: Node modules resolution works in Less via `~` path prefix; Webpack aliases could be used similarly: `@import "~<alias>/..."`, e.g. `@import "~@databricks/..."`

https://github.com/getredash/redash/commit/6b8cd4f2f1eb6f5ee4772fdefcc94bce3dc1df46 is the actual fix, other commit is just a code style fix.
