### PR TITLE
Add plain button

### DIFF
--- a/client/app/components/PlainButton.less
+++ b/client/app/components/PlainButton.less
@@ -1,0 +1,22 @@
+@import (reference, less) "~@/assets/less/ant";
+
+.plain-button {
+  all: unset;
+  transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+
+  .@{dropdown-prefix-cls}-menu-item > & {
+    width: 100%;
+    margin: -5px -12px;
+    padding: 5px 12px;
+  }
+
+  .@{menu-prefix-cls}-item > & {
+    width: 100%;
+    margin: 0 -16px;
+    padding: 0 16px;
+  }
+}
+
+.plain-button-link {
+  .btn-link();
+}

--- a/client/app/components/PlainButton.tsx
+++ b/client/app/components/PlainButton.tsx
@@ -1,0 +1,20 @@
+import classNames from "classnames";
+import React from "react";
+
+import "./PlainButton.less";
+
+interface PlainButtonType extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+  type?: "link" | "button";
+}
+
+function PlainButton({ className, type, ...props }: PlainButtonType) {
+  return (
+    <button
+      className={classNames("plain-button", "clickable", type === "link" ? "plain-button-link" : "", className)}
+      type="button"
+      {...props}
+    />
+  );
+}
+
+export default PlainButton;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Feature

## Description
This PR is a split on #5409
It is the first step to fix issues on standardization, interactivity and improve keyboard accessibility.

All anchors `<a>` need to be replaced by proper semantic components other than those in `viz-lib`.

### The following behavior for links, buttons, link-like and button-like components is aimed:

- Links that look like links:  `<Link>` - Renders `<a>`
- Buttons that look like buttons: `<Button>` - Renders Antd `<Button>`
- Links that look like buttons:  `<Link.Button>` - Renders Antd `<Button>`, which is rendered as an `<a>`
- Text Buttons "buttons that look like links": `<PlainButton>` - Renders styleless `<button>`