### PR TITLE
Adds a rate limit for requests to /forgot.

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -148,6 +148,7 @@ def verify(token, org_slug=None):
 
 
 @routes.route(org_scoped_rule("/forgot"), methods=["GET", "POST"])
+@limiter.limit(settings.THROTTLE_PASS_RESET_PATTERN)
 def forgot_password(org_slug=None):
     if not current_org.get_setting("auth_password_login_enabled"):
         abort(404)

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -304,6 +304,7 @@ ALERTS_DEFAULT_MAIL_SUBJECT_TEMPLATE = os.environ.get(
 RATELIMIT_ENABLED = parse_boolean(os.environ.get("REDASH_RATELIMIT_ENABLED", "true"))
 THROTTLE_LOGIN_PATTERN = os.environ.get("REDASH_THROTTLE_LOGIN_PATTERN", "50/hour")
 LIMITER_STORAGE = os.environ.get("REDASH_LIMITER_STORAGE", REDIS_URL)
+THROTTLE_PASS_RESET_PATTERN = os.environ.get("REDASH_THROTTLE_PASS_RESET_PATTERN", "10/hour")
 
 # CORS settings for the Query Result API (and possibly future external APIs).
 # In most cases all you need to do is set REDASH_CORS_ACCESS_CONTROL_ALLOW_ORIGIN

--- a/tests/handlers/test_authentication.py
+++ b/tests/handlers/test_authentication.py
@@ -120,6 +120,16 @@ class TestLogin(BaseTestCase):
         response = self.get_request("/login", org=self.factory.org)
         self.assertEqual(response.status_code, 429)
 
+    def test_throttle_password_reset(self):
+        limiter.enabled = True
+        # Extract the limit from settings (ex: '10/hour')
+        limit = settings.THROTTLE_PASS_RESET_PATTERN.split("/")[0]
+        for _ in range(0, int(limit)):
+            self.get_request("/forgot", org=self.factory.org)
+
+        response = self.get_request("/forgot", org=self.factory.org)
+        self.assertEqual(response.status_code, 429)
+
 
 class TestSession(BaseTestCase):
     # really simple test just to trigger this route


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

This PR adds a setting to rate limit network requests to the `/forgot` endpoint. Otherwise, visitors can trigger an unlimited number of password reset emails.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A
