### PR TITLE
Add `defaultDataset` option for BigQuery

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -168,10 +168,8 @@ class BigQuery(BaseQueryRunner):
 
     def _get_location(self):
         return self.configuration.get("location")
-    
     def _get_default_dataset(self):
         return self.configuration.get("defaultDataset")
-    
     def _get_total_bytes_processed(self, jobs, query):
         job_data = {"query": query, "dryRun": True}
 

--- a/redash/query_runner/big_query_gce.py
+++ b/redash/query_runner/big_query_gce.py
@@ -50,6 +50,10 @@ class BigQueryGCE(BigQuery):
                     "title": "Use Standard SQL",
                     "default": True,
                 },
+                "defaultDataset": {
+                    "type": "string",
+                    "title": "Default Dataset",
+                },
                 "location": {
                     "type": "string",
                     "title": "Processing Location",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This PR adds the ability to set `defaultDataset` option to the existing query runner for BigQuery.

- `Default Dataset` option is available in the data source setting.
- The updated query runner specify `query.defaultDataset.datasetId` option when requesting query result to BigQuery.

## Related Tickets & Documents

Not found in open PRs and the forum.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/16531769/111622712-d9444280-882c-11eb-8784-d6d0a9d0f45c.png)

