### PR TITLE
Adds configuration for `<Tooltip>` trigger on focus

### DIFF
--- a/client/app/components/CodeBlock.jsx
+++ b/client/app/components/CodeBlock.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Button from "antd/lib/button";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import CopyOutlinedIcon from "@ant-design/icons/CopyOutlined";
 import "./CodeBlock.less";
 

--- a/client/app/components/EmailSettingsWarning.jsx
+++ b/client/app/components/EmailSettingsWarning.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { clientConfig, currentUser } from "@/services/auth";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Alert from "antd/lib/alert";
 import HelpTrigger from "@/components/HelpTrigger";
 import { useUniqueId } from "@/lib/hooks/useUniqueId";

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -2,7 +2,7 @@ import { startsWith, get, some, mapValues } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Drawer from "antd/lib/drawer";
 import Link from "@/components/Link";
 import CloseOutlinedIcon from "@ant-design/icons/CloseOutlined";

--- a/client/app/components/InputWithCopy.jsx
+++ b/client/app/components/InputWithCopy.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Input from "antd/lib/input";
 import CopyOutlinedIcon from "@ant-design/icons/CopyOutlined";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 
 export default class InputWithCopy extends React.Component {
   constructor(props) {

--- a/client/app/components/ParameterApplyButton.jsx
+++ b/client/app/components/ParameterApplyButton.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "antd/lib/button";
 import Badge from "antd/lib/badge";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import KeyboardShortcuts from "@/services/KeyboardShortcuts";
 
 function ParameterApplyButton({ paramCount, onClick }) {

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -12,7 +12,7 @@ import Tag from "antd/lib/tag";
 import Input from "antd/lib/input";
 import Radio from "antd/lib/radio";
 import Form from "antd/lib/form";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import ParameterValueInput from "@/components/ParameterValueInput";
 import { ParameterMappingType } from "@/services/widget";
 import { Parameter, cloneParameter } from "@/services/parameters";

--- a/client/app/components/PermissionsEditorDialog/index.jsx
+++ b/client/app/components/PermissionsEditorDialog/index.jsx
@@ -7,7 +7,7 @@ import List from "antd/lib/list";
 import Modal from "antd/lib/modal";
 import Select from "antd/lib/select";
 import Tag from "antd/lib/tag";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 import { toHuman } from "@/lib/utils";
 import HelpTrigger from "@/components/HelpTrigger";

--- a/client/app/components/TimeAgo.jsx
+++ b/client/app/components/TimeAgo.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { Moment } from "@/components/proptypes";
 import { clientConfig } from "@/services/auth";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 
 function toMoment(value) {
   value = !isNil(value) ? moment(value) : null;

--- a/client/app/components/Tooltip.tsx
+++ b/client/app/components/Tooltip.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import AntTooltip, { TooltipProps } from "antd/lib/tooltip";
+
+export default function Tooltip(props: TooltipProps) {
+  return <AntTooltip {...props} />;
+}

--- a/client/app/components/Tooltip.tsx
+++ b/client/app/components/Tooltip.tsx
@@ -2,5 +2,5 @@ import React from "react";
 import AntTooltip, { TooltipProps } from "antd/lib/tooltip";
 
 export default function Tooltip(props: TooltipProps) {
-  return <AntTooltip {...props} />;
+  return <AntTooltip trigger={["hover", "focus"]} {...props} />;
 }

--- a/client/app/components/dashboards/TextboxDialog.jsx
+++ b/client/app/components/dashboards/TextboxDialog.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { useDebouncedCallback } from "use-debounce";
 import Modal from "antd/lib/modal";
 import Input from "antd/lib/input";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Divider from "antd/lib/divider";
 import Link from "@/components/Link";
 import HtmlContent from "@redash/viz/lib/components/HtmlContent";

--- a/client/app/components/groups/DeleteGroupButton.jsx
+++ b/client/app/components/groups/DeleteGroupButton.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "antd/lib/button";
 import Modal from "antd/lib/modal";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import notification from "@/services/notification";
 import Group from "@/services/group";
 

--- a/client/app/components/groups/ListItemAddon.jsx
+++ b/client/app/components/groups/ListItemAddon.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 
 export default function ListItemAddon({ isSelected, isStaged, alreadyInGroup, deselectedIcon }) {
   if (isStaged) {

--- a/client/app/components/queries/QueryEditor/AutoLimitCheckbox.jsx
+++ b/client/app/components/queries/QueryEditor/AutoLimitCheckbox.jsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import recordEvent from "@/services/recordEvent";
 import Checkbox from "antd/lib/checkbox";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 
 export default function AutoLimitCheckbox({ available, checked, onChange }) {
   const handleClick = useCallback(() => {

--- a/client/app/components/queries/QueryEditor/AutocompleteToggle.jsx
+++ b/client/app/components/queries/QueryEditor/AutocompleteToggle.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Button from "antd/lib/button";
 import PropTypes from "prop-types";
 import "@/redash-font/style.less";

--- a/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
+++ b/client/app/components/queries/QueryEditor/QueryEditorControls.jsx
@@ -1,7 +1,7 @@
 import { isFunction, map, filter, fromPairs, noop } from "lodash";
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Button from "antd/lib/button";
 import Select from "antd/lib/select";
 import KeyboardShortcuts, { humanReadableShortcut } from "@/services/KeyboardShortcuts";

--- a/client/app/components/queries/SchedulePhrase.jsx
+++ b/client/app/components/queries/SchedulePhrase.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import { localizeTime, durationHumanize } from "@/lib/utils";
 import { RefreshScheduleType, RefreshScheduleDefault } from "../proptypes";
 

--- a/client/app/components/queries/SchemaBrowser.jsx
+++ b/client/app/components/queries/SchemaBrowser.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { useDebouncedCallback } from "use-debounce";
 import Input from "antd/lib/input";
 import Button from "antd/lib/button";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import AutoSizer from "react-virtualized/dist/commonjs/AutoSizer";
 import List from "react-virtualized/dist/commonjs/List";
 import useDataSourceSchema from "@/pages/queries/hooks/useDataSourceSchema";

--- a/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.jsx
+++ b/client/app/components/queries/editor-components/databricks/DatabricksSchemaBrowser.jsx
@@ -6,7 +6,7 @@ import Button from "antd/lib/button";
 import SyncOutlinedIcon from "@ant-design/icons/SyncOutlined";
 import Input from "antd/lib/input";
 import Select from "antd/lib/select";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import { SchemaList, applyFilterOnSchema } from "@/components/queries/SchemaBrowser";
 import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
 import useDatabricksSchema from "./useDatabricksSchema";

--- a/client/app/components/tags-control/TagsControl.jsx
+++ b/client/app/components/tags-control/TagsControl.jsx
@@ -1,7 +1,7 @@
 import { map, trim } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import EditTagsDialog from "./EditTagsDialog";
 
 export class TagsControl extends React.Component {

--- a/client/app/config/antd-tooltip.jsx
+++ b/client/app/config/antd-tooltip.jsx
@@ -1,0 +1,3 @@
+import Tooltip from "antd/lib/tooltip";
+
+Tooltip.defaultProps = { ...Tooltip.defaultProps, trigger: ["hover", "focus"] };

--- a/client/app/config/antd-tooltip.jsx
+++ b/client/app/config/antd-tooltip.jsx
@@ -1,3 +1,0 @@
-import Tooltip from "antd/lib/tooltip";
-
-Tooltip.defaultProps = { ...Tooltip.defaultProps, trigger: ["hover", "focus"] };

--- a/client/app/config/index.js
+++ b/client/app/config/index.js
@@ -11,6 +11,7 @@ import "@redash/viz/lib";
 import "@/pages";
 
 import "./antd-spinner";
+import "./antd-tooltip";
 
 moment.updateLocale("en", {
   relativeTime: {

--- a/client/app/config/index.js
+++ b/client/app/config/index.js
@@ -11,7 +11,6 @@ import "@redash/viz/lib";
 import "@/pages";
 
 import "./antd-spinner";
-import "./antd-tooltip";
 
 moment.updateLocale("en", {
   relativeTime: {

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -8,7 +8,7 @@ import { Alert as AlertType } from "@/components/proptypes";
 
 import Form from "antd/lib/form";
 import Button from "antd/lib/button";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import AntAlert from "antd/lib/alert";
 import * as Grid from "antd/lib/grid";
 

--- a/client/app/pages/alert/components/AlertDestinations.jsx
+++ b/client/app/pages/alert/components/AlertDestinations.jsx
@@ -14,7 +14,7 @@ import ListItemAddon from "@/components/groups/ListItemAddon";
 import EmailSettingsWarning from "@/components/EmailSettingsWarning";
 
 import CloseOutlinedIcon from "@ant-design/icons/CloseOutlined";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Switch from "antd/lib/switch";
 import Button from "antd/lib/button";
 

--- a/client/app/pages/alert/components/Query.jsx
+++ b/client/app/pages/alert/components/Query.jsx
@@ -6,7 +6,7 @@ import QuerySelector from "@/components/QuerySelector";
 import SchedulePhrase from "@/components/queries/SchedulePhrase";
 import { Query as QueryType } from "@/components/proptypes";
 
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 
 import WarningFilledIcon from "@ant-design/icons/WarningFilled";
 import QuestionCircleTwoToneIcon from "@ant-design/icons/QuestionCircleTwoTone";

--- a/client/app/pages/dashboards/components/DashboardHeader.jsx
+++ b/client/app/pages/dashboards/components/DashboardHeader.jsx
@@ -7,7 +7,7 @@ import Dropdown from "antd/lib/dropdown";
 import Menu from "antd/lib/menu";
 import EllipsisOutlinedIcon from "@ant-design/icons/EllipsisOutlined";
 import Modal from "antd/lib/modal";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import FavoritesControl from "@/components/FavoritesControl";
 import EditInPlace from "@/components/EditInPlace";
 import { DashboardTagsControl } from "@/components/tags-control/TagsControl";

--- a/client/app/pages/queries/VisualizationEmbed.jsx
+++ b/client/app/pages/queries/VisualizationEmbed.jsx
@@ -7,7 +7,7 @@ import { markdown } from "markdown";
 import Button from "antd/lib/button";
 import Dropdown from "antd/lib/dropdown";
 import Menu from "antd/lib/menu";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Link from "@/components/Link";
 import routeWithApiKeySession from "@/components/ApplicationArea/routeWithApiKeySession";
 import Parameters from "@/components/Parameters";

--- a/client/app/pages/queries/components/QueryExecutionMetadata.jsx
+++ b/client/app/pages/queries/components/QueryExecutionMetadata.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import WarningTwoTone from "@ant-design/icons/WarningTwoTone";
 import TimeAgo from "@/components/TimeAgo";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import useAddToDashboardDialog from "../hooks/useAddToDashboardDialog";
 import useEmbedDialog from "../hooks/useEmbedDialog";
 import QueryControlDropdown from "@/components/EditVisualizationButton/QueryControlDropdown";

--- a/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
+++ b/client/app/pages/settings/components/AuthSettings/PasswordLoginSettings.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Alert from "antd/lib/alert";
 import Form from "antd/lib/form";
 import Checkbox from "antd/lib/checkbox";
-import Tooltip from "antd/lib/tooltip";
+import Tooltip from "@/components/Tooltip";
 import Skeleton from "antd/lib/skeleton";
 import DynamicComponent from "@/components/DynamicComponent";
 import { clientConfig } from "@/services/auth";


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Feature

## Description
Ant `<Tooltip>` API has a `trigger` prop that by default only receives `"hover"`. This PR changes the default to `"hover"` and `"focus"`, in order to make it accessible.

## Related Tickets & Documents
See a11y epic.
