### PR TITLE
Add ambiguous link

### DIFF
--- a/client/app/components/Link.tsx
+++ b/client/app/components/Link.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Button, { ButtonProps as AntdButtonProps } from "antd/lib/button";
+import PlainButton, { PlainButtonProps } from "@/components/PlainButton";
 
 function DefaultLinkComponent({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   return <a {...props}>{children}</a>;
@@ -13,6 +14,18 @@ interface LinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 
 function Link({ children, ...props }: LinkProps) {
   return <Link.Component {...props}>{children}</Link.Component>;
 }
+
+type LinkButtonProps = PlainButtonProps | LinkProps;
+
+function LinkOrButton(props: LinkButtonProps) {
+  if ("href" in props) {
+    return <Link {...props} />;
+  }
+
+  return <PlainButton type="link" {...props} />;
+}
+
+Link.OrButton = LinkOrButton;
 
 interface LinkWithIconProps extends LinkProps {
   children: string;

--- a/client/app/components/PlainButton.tsx
+++ b/client/app/components/PlainButton.tsx
@@ -3,11 +3,11 @@ import React from "react";
 
 import "./PlainButton.less";
 
-interface PlainButtonType extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+export interface PlainButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
   type?: "link" | "button";
 }
 
-function PlainButton({ className, type, ...rest }: PlainButtonType) {
+function PlainButton({ className, type, ...rest }: PlainButtonProps) {
   return (
     <button
       className={classNames("plain-button", "clickable", { "plain-button-link": type === "link" }, className)}

--- a/client/app/components/cards-list/CardsList.tsx
+++ b/client/app/components/cards-list/CardsList.tsx
@@ -10,8 +10,8 @@ import "./CardsList.less";
 export interface CardsListItem {
   title: string;
   imgSrc: string;
-  onClick?: () => void;
   href?: string;
+  onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 export interface CardsListProps {
@@ -26,11 +26,10 @@ interface ListItemProps {
 
 function ListItem({ item, keySuffix }: ListItemProps) {
   return (
-    // @ts-expect-error TODO: refactor component
-    <Link key={`card${keySuffix}`} className="visual-card" onClick={item.onClick} href={item.href}>
+    <Link.OrButton key={`card${keySuffix}`} className="visual-card" onClick={item.onClick} href={item.href}>
       <img alt={item.title} src={item.imgSrc} />
       <h3>{item.title}</h3>
-    </Link>
+    </Link.OrButton>
   );
 }
 

--- a/client/app/components/empty-state/EmptyState.jsx
+++ b/client/app/components/empty-state/EmptyState.jsx
@@ -17,9 +17,9 @@ export function Step({ show, completed, text, url, urlTarget, urlText, onClick }
 
   return (
     <li className={classNames({ done: completed })}>
-      <Link href={url} onClick={onClick} target={urlTarget}>
+      <Link.OrButton href={url} onClick={onClick} target={urlTarget}>
         {urlText}
-      </Link>{" "}
+      </Link.OrButton>{" "}
       {text}
     </li>
   );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Refactor

## Description
Adds a new component that will conditionally render a `<Link>` or `<Button>` according to the presence of an `href` in order to treat components that can receive both and should look alike regardless.

There are some remaining components keeping both, but they represent a genuine use of it.