### PR TITLE
StorageDescriptorの無いテーブルで止まらないようにした

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -179,6 +179,8 @@ class Athena(BaseQueryRunner):
             for database in databases["DatabaseList"]:
                 iterator = table_paginator.paginate(DatabaseName=database["Name"])
                 for table in iterator.search("TableList[]"):
+                    if 'StorageDescriptor' not in table:
+                        continue
                     table_name = "%s.%s" % (database["Name"], table["Name"])
                     if table_name not in schema:
                         column = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
AWS Glue has a key called StorageDescriptor. This key is nullable on AWS, but not on redash. Therefore, if a table without StorageDescriptor exists in Glue, it will fail to retrieve the schema.

## Related Tickets & Documents
https://docs.aws.amazon.com/glue/latest/webapi/API_PartitionInput.html#Glue-Type-PartitionInput-StorageDescriptor

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
