### PR TITLE
Add live regions to tooltip

### DIFF
--- a/client/app/components/Tooltip.tsx
+++ b/client/app/components/Tooltip.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import AntTooltip, { TooltipProps } from "antd/lib/tooltip";
+import { isNil } from "lodash";
 
 export default function Tooltip({ title, ...restProps }: TooltipProps) {
-  const liveTitle = (
+  const liveTitle = isNil(title) ? (
     <span role="status" aria-live="assertive" aria-relevant="additions">
       {title}
     </span>
-  );
+  ) : null;
 
   return <AntTooltip trigger={["hover", "focus"]} title={liveTitle} {...restProps} />;
 }

--- a/client/app/components/Tooltip.tsx
+++ b/client/app/components/Tooltip.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import AntTooltip, { TooltipProps } from "antd/lib/tooltip";
 
-export default function Tooltip(props: TooltipProps) {
-  return <AntTooltip trigger={["hover", "focus"]} {...props} />;
+export default function Tooltip({ title, ...restProps }: TooltipProps) {
+  const liveTitle = (
+    <span role="status" aria-live="assertive" aria-relevant="additions">
+      {title}
+    </span>
+  );
+
+  return <AntTooltip trigger={["hover", "focus"]} title={liveTitle} {...restProps} />;
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Feature

## Description
This makes the tooltip accessible, as it makes it's content notifiable to screen readers, which otherwise would not occur (tooltips are appended to the body).

## Related Tickets & Documents
See a11y epic.