### PR TITLE
Skip tables with no storage descriptor

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -179,6 +179,8 @@ class Athena(BaseQueryRunner):
             for database in databases["DatabaseList"]:
                 iterator = table_paginator.paginate(DatabaseName=database["Name"])
                 for table in iterator.search("TableList[]"):
+                    if 'StorageDescriptor' not in table:
+                        continue
                     table_name = "%s.%s" % (database["Name"], table["Name"])
                     if table_name not in schema:
                         column = [

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -181,7 +181,7 @@ class Athena(BaseQueryRunner):
                 for table in iterator.search("TableList[]"):
                     table_name = "%s.%s" % (database["Name"], table["Name"])
                     if 'StorageDescriptor' not in table:
-                        logger.warning("Glue table dosen't have StorageDescriptor: %s", table_name)
+                        logger.warning("Glue table doesn't have StorageDescriptor: %s", table_name)
                         continue
                     if table_name not in schema:
                         column = [

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -179,9 +179,10 @@ class Athena(BaseQueryRunner):
             for database in databases["DatabaseList"]:
                 iterator = table_paginator.paginate(DatabaseName=database["Name"])
                 for table in iterator.search("TableList[]"):
-                    if 'StorageDescriptor' not in table:
-                        continue
                     table_name = "%s.%s" % (database["Name"], table["Name"])
+                    if 'StorageDescriptor' not in table:
+                        logger.warning("Glue table dosen't have StorageDescriptor: %s", table_name)
+                        continue
                     if table_name not in schema:
                         column = [
                             columns["Name"]

--- a/tests/query_runner/test_athena.py
+++ b/tests/query_runner/test_athena.py
@@ -213,3 +213,29 @@ class TestGlueSchema(TestCase):
             assert query_runner.get_schema() == [
                 {"columns": ["region"], "name": "test1.csv"}
             ]
+
+    def test_no_storage_descriptor_table(self):
+        """
+        For some reason, not all Glue tables contain a "StorageDescriptor" entry.
+        """
+        query_runner = Athena({'glue': True, 'region': 'mars-east-1'})
+
+        self.stubber.add_response('get_databases', {'DatabaseList': [{'Name': 'test1'}]}, {})
+        self.stubber.add_response(
+            'get_tables',
+            {
+                'TableList': [
+                    {
+                        'Name': 'no_storage_descriptor_table',
+                        'PartitionKeys': [],
+                        'TableType': 'EXTERNAL_TABLE',
+                        'Parameters': {
+                            'EXTERNAL': 'TRUE'
+                        },
+                    }
+                ]
+            },
+            {'DatabaseName': 'test1'},
+        )
+        with self.stubber:
+            assert query_runner.get_schema() == []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
AWS Glue table has a key called StorageDescriptor. This key is nullable on AWS, but not on redash. Therefore, if tables without StorageDescriptor exist in Glue, some schema refreshes will fail.
As a solution, skip retrying tables with no StorageDescriptor.

![image](https://user-images.githubusercontent.com/19870416/112291541-8c041d00-8cd3-11eb-948a-d61db2742405.png)

## Related Tickets & Documents
https://docs.aws.amazon.com/glue/latest/webapi/API_PartitionInput.html#Glue-Type-PartitionInput-StorageDescriptor