### PR TITLE
Get the user's current groups from props instead of useEffect()

### DIFF
--- a/client/app/pages/users/components/UserInfoForm.jsx
+++ b/client/app/pages/users/components/UserInfoForm.jsx
@@ -61,7 +61,7 @@ export default function UserInfoForm(props) {
                 type: "select",
                 mode: "multiple",
                 options: map(allGroups, group => ({ name: group.name, value: group.id })),
-                initialValue: map(groups, group => group.id),
+                initialValue: user.groupIds,
                 loading: isLoadingGroups,
                 placeholder: isLoadingGroups ? "Loading..." : "",
               }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

`useEffect()` doesn't run until _after_ the component renders. Before the hook runs, the value of `groups` === []. And this is passed to `<DynamicForm>`'s `initialValue` prop. The `initialValue` is not re-evaluated after useEffect() completes. So the users groups are never updated. This change pulls the user's current groups from `user` prop on the page.


## Related Tickets & Documents

Closes #5449 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before

![CleanShot 2021-03-30 at 16 08 54](https://user-images.githubusercontent.com/17067911/113057126-4a132500-9172-11eb-933b-cd9fe3b4b8e0.png)

### After

![CleanShot 2021-03-30 at 16 08 42](https://user-images.githubusercontent.com/17067911/113057144-4e3f4280-9172-11eb-8372-ee8f5c54f276.png)


