### PR TITLE
Don't disable the test connection button.

### DIFF
--- a/client/app/pages/data-sources/EditDataSource.jsx
+++ b/client/app/pages/data-sources/EditDataSource.jsx
@@ -108,7 +108,7 @@ class EditDataSource extends React.Component {
       type,
       actions: [
         { name: "Delete", type: "danger", callback: this.deleteDataSource },
-        { name: "Test Connection", pullRight: true, callback: this.testConnection, disableWhenDirty: true },
+        { name: "Test Connection", pullRight: true, callback: this.testConnection, disableWhenDirty: false },
       ],
       onSubmit: this.saveDataSource,
       feedbackIcons: true,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->


- [x] Bug Fix

## Description

This fixes the issue where the Test button is disabled after a user saves changes. As discussed in #5455 I don't think it makes sense to disable the test connection button.

## Related Tickets & Documents

Closes #5455 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A
