### PR TITLE
Update cx_Oracle to 8.1.0

### DIFF
--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -1,4 +1,4 @@
 # Requires installation of, or similar versions of:
-#    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
-#    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm
-cx_Oracle==5.3
+#    oracle-instantclient19.10-basic-19.10.0.0.0-1.x86_64.rpm
+#    oracle-instantclient19.10-devel-19.10.0.0.0-1.x86_64.rpm
+cx_Oracle==8.1.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ x ] Other

## Description
Update [cx_Oracle to 8.1.0](https://pypi.org/project/cx-Oracle/8.1)

> cx_Oracle 8 has been tested with Python versions 3.6 through 3.9. You can use cx_Oracle with Oracle 11.2, 12c, 18c, 19c and 21c client libraries. Oracle's standard client-server version interoperability allows connection to both older and newer databases. For example Oracle 19c client libraries can connect to Oracle Database 11.2. Older versions of cx_Oracle may work with older versions of Python.
