### PR TITLE
Fix for `<Link>` misuses

### DIFF
--- a/client/app/components/PlainButton.tsx
+++ b/client/app/components/PlainButton.tsx
@@ -3,11 +3,11 @@ import React from "react";
 
 import "./PlainButton.less";
 
-interface PlainButtonType extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+export interface PlainButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
   type?: "link" | "button";
 }
 
-function PlainButton({ className, type, ...rest }: PlainButtonType) {
+function PlainButton({ className, type, ...rest }: PlainButtonProps) {
   return (
     <button
       className={classNames("plain-button", "clickable", { "plain-button-link": type === "link" }, className)}

--- a/client/app/components/cards-list/CardsList.tsx
+++ b/client/app/components/cards-list/CardsList.tsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import Input from "antd/lib/input";
 import Link from "@/components/Link";
+import PlainButton from "@/components/PlainButton";
 import EmptyState from "@/components/items-list/components/EmptyState";
 
 import "./CardsList.less";
@@ -10,8 +11,8 @@ import "./CardsList.less";
 export interface CardsListItem {
   title: string;
   imgSrc: string;
-  onClick?: () => void;
   href?: string;
+  onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 export interface CardsListProps {
@@ -25,13 +26,19 @@ interface ListItemProps {
 }
 
 function ListItem({ item, keySuffix }: ListItemProps) {
-  return (
-    // @ts-expect-error TODO: refactor component
-    <Link key={`card${keySuffix}`} className="visual-card" onClick={item.onClick} href={item.href}>
-      <img alt={item.title} src={item.imgSrc} />
-      <h3>{item.title}</h3>
-    </Link>
-  );
+  const commonProps = {
+    key: `card${keySuffix}`,
+    className: "visual-card",
+    onClick: item.onClick,
+    children: (
+      <>
+        <img alt={item.title} src={item.imgSrc} />
+        <h3>{item.title}</h3>
+      </>
+    ),
+  };
+
+  return item.href ? <Link href={item.href} {...commonProps} /> : <PlainButton type="link" {...commonProps} />;
 }
 
 export default function CardsList({ items = [], showSearch = false }: CardsListProps) {

--- a/client/app/components/empty-state/EmptyState.jsx
+++ b/client/app/components/empty-state/EmptyState.jsx
@@ -4,23 +4,24 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import CloseOutlinedIcon from "@ant-design/icons/CloseOutlined";
 import Link from "@/components/Link";
+import PlainButton from "@/components/PlainButton";
 import CreateDashboardDialog from "@/components/dashboards/CreateDashboardDialog";
 import HelpTrigger from "@/components/HelpTrigger";
 import { currentUser } from "@/services/auth";
 import organizationStatus from "@/services/organizationStatus";
+
 import "./empty-state.less";
 
-export function Step({ show, completed, text, url, urlTarget, urlText, onClick }) {
+export function Step({ show, completed, text, url, urlText, onClick }) {
   if (!show) {
     return null;
   }
 
+  const commonProps = { children: urlText, onClick };
+
   return (
     <li className={classNames({ done: completed })}>
-      <Link href={url} onClick={onClick} target={urlTarget}>
-        {urlText}
-      </Link>{" "}
-      {text}
+      {url ? <Link href={url} {...commonProps} /> : <PlainButton type="link" {...commonProps} />} {text}
     </li>
   );
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Bug Fix

## Description
Add a conditional render for situations in which `<Link>` `href` could come empty from `props`. 

## Related Tickets & Documents
Follows #5435

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
