### PR TITLE
Replace redundant external links

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/VersionInfo.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/VersionInfo.jsx
@@ -13,10 +13,9 @@ export default function VersionInfo() {
       {clientConfig.newVersionAvailable && currentUser.hasPermission("super_admin") && (
         <div className="m-t-10">
           {/* eslint-disable react/jsx-no-target-blank */}
-          <Link href="https://version.redash.io/" className="update-available" target="_blank" rel="noopener">
-            Update Available <i className="fa fa-external-link m-l-5" aria-hidden="true" />
-            <span className="sr-only">(opens in a new tab)</span>
-          </Link>
+          <Link.External href="https://version.redash.io/" className="update-available">
+            Update Available
+          </Link.External>
         </div>
       )}
     </React.Fragment>

--- a/client/app/components/HelpTrigger.jsx
+++ b/client/app/components/HelpTrigger.jsx
@@ -9,6 +9,7 @@ import PlainButton from "@/components/PlainButton";
 import CloseOutlinedIcon from "@ant-design/icons/CloseOutlined";
 import BigMessage from "@/components/BigMessage";
 import DynamicComponent, { registerComponent } from "@/components/DynamicComponent";
+import { WithIcon } from "@/components/WithIcon";
 
 import "./HelpTrigger.less";
 
@@ -171,13 +172,7 @@ export function helpTriggerWithTypes(types, allowedDomains = [], drawerClassName
               this.props.showTooltip ? (
                 <>
                   {tooltip}
-                  {shouldRenderAsLink && (
-                    <>
-                      {" "}
-                      <i className="fa fa-external-link" style={{ marginLeft: 5 }} aria-hidden="true" />
-                      <span className="sr-only">(opens in a new tab)</span>
-                    </>
-                  )}
+                  {shouldRenderAsLink && <WithIcon style={{ marginLeft: 5 }} />}
                 </>
               ) : null
             }>
@@ -202,11 +197,7 @@ export function helpTriggerWithTypes(types, allowedDomains = [], drawerClassName
               <div className="drawer-menu">
                 {url && (
                   <Tooltip title="Open page in a new window" placement="left">
-                    {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                    <Link href={url} target="_blank">
-                      <i className="fa fa-external-link" aria-hidden="true" />
-                      <span className="sr-only">(opens in a new tab)</span>
-                    </Link>
+                    <Link.External href={url} />
                   </Tooltip>
                 )}
                 <Tooltip title="Close" placement="bottom">

--- a/client/app/components/Link.tsx
+++ b/client/app/components/Link.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Button, { ButtonProps as AntdButtonProps } from "antd/lib/button";
+import { withIcon, WithIconProps } from "./WithIcon";
 
 function DefaultLinkComponent({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   return <a {...props}>{children}</a>;
@@ -7,35 +8,21 @@ function DefaultLinkComponent({ children, ...props }: React.AnchorHTMLAttributes
 
 Link.Component = DefaultLinkComponent;
 
-interface LinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "role" | "type" | "target"> {
+interface LinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "role" | "type"> {
   href: string;
+  target?: never; // use external link
 }
 function Link({ children, ...props }: LinkProps) {
   return <Link.Component {...props}>{children}</Link.Component>;
 }
 
-interface LinkWithIconProps extends LinkProps {
-  children: string;
-  icon: JSX.Element;
-  alt: string;
-  target?: "_self" | "_blank" | "_parent" | "_top";
-}
-
-function LinkWithIcon({ icon, alt, children, ...props }: LinkWithIconProps) {
-  return (
-    <Link.Component {...props}>
-      {children} {icon} <span className="sr-only">{alt}</span>
-    </Link.Component>
-  );
-}
-
-Link.WithIcon = LinkWithIcon;
+Link.WithIcon = withIcon(Link.Component);
 
 function ExternalLink({
   icon = <i className="fa fa-external-link" aria-hidden="true" />,
   alt = "(opens in a new tab)",
   ...props
-}: Omit<LinkWithIconProps, "target">) {
+}: LinkProps & Partial<WithIconProps>) {
   return <Link.WithIcon target="_blank" rel="noopener noreferrer" icon={icon} alt={alt} {...props} />;
 }
 

--- a/client/app/components/WithIcon.tsx
+++ b/client/app/components/WithIcon.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+export interface WithIconProps {
+  children?: string;
+  icon: JSX.Element;
+  alt: string;
+}
+
+export function withIcon<ComponentProps extends object>(Component: React.ComponentType<ComponentProps>) {
+  return class WithIcon extends React.Component<ComponentProps & WithIconProps> {
+    render() {
+      const { children, icon, alt, ...props } = this.props;
+      return (
+        <Component {...(props as ComponentProps)}>
+          {children}
+          {children && " "}
+          {icon} <span className="sr-only">{alt}</span>
+        </Component>
+      );
+    }
+  };
+}
+
+/**
+ * Accessible wrapper for adding icons to a component.
+ * Defaults to the external icon.
+ */
+export function WithIcon({
+  icon = <i className="fa fa-external-link" aria-hidden="true" />,
+  alt = "(opens in a new tab)",
+  children,
+  ...props
+}: Partial<WithIconProps> & React.ComponentProps<"span">) {
+  return (
+    <span {...props}>
+      {children}
+      {children && " "}
+      {icon} <span className="sr-only">{alt}</span>
+    </span>
+  );
+}

--- a/client/app/components/dashboards/TextboxDialog.jsx
+++ b/client/app/components/dashboards/TextboxDialog.jsx
@@ -80,12 +80,9 @@ function TextboxDialog({ dialog, isNew, ...props }) {
         />
         <small>
           Supports basic{" "}
-          <Link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://www.markdownguide.org/cheat-sheet/#basic-syntax">
-            <Tooltip title="Markdown guide opens in new window">Markdown</Tooltip>
-          </Link>
+          <Link.External href="https://www.markdownguide.org/cheat-sheet/#basic-syntax">
+            <Tooltip title="Markdown guide">Markdown</Tooltip>
+          </Link.External>
           .
         </small>
         {text && (

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -139,10 +139,7 @@ export default class AlertView extends React.Component {
               <h4>
                 Destinations{" "}
                 <Tooltip title="Open Alert Destinations page in a new tab.">
-                  <Link href="destinations" target="_blank">
-                    <i className="fa fa-external-link f-13" aria-hidden="true" />
-                    <span className="sr-only">(opens in a new tab)</span>
-                  </Link>
+                  <Link.External href="destinations" className="f-13" />
                 </Tooltip>
               </h4>
               <AlertDestinations alertId={alert.id} />

--- a/client/app/pages/alert/components/Query.jsx
+++ b/client/app/pages/alert/components/Query.jsx
@@ -40,10 +40,9 @@ export default function QueryFormItem({ query, queryResult, onChange, editMode }
         <QuerySelector onChange={onChange} selectedQuery={query} className="alert-query-selector" type="select" />
       ) : (
         <Tooltip title="Open query in a new tab.">
-          <Link href={`queries/${query.id}`} target="_blank" rel="noopener noreferrer" className="alert-query-link">
-            {query.name} <i className="fa fa-external-link" aria-hidden="true" />
-            <span className="sr-only">(opens in a new tab)</span>
-          </Link>
+          <Link.External href={`queries/${query.id}`} className="alert-query-link">
+            {query.name}
+          </Link.External>
         </Tooltip>
       )}
       <div className="ant-form-item-explain">{query && queryHint}</div>

--- a/client/app/pages/queries/VisualizationEmbed.jsx
+++ b/client/app/pages/queries/VisualizationEmbed.jsx
@@ -17,6 +17,7 @@ import Timer from "@/components/Timer";
 import QueryResultsLink from "@/components/EditVisualizationButton/QueryResultsLink";
 import VisualizationName from "@/components/visualizations/VisualizationName";
 import VisualizationRenderer from "@/components/visualizations/VisualizationRenderer";
+import { WithIcon } from "@/components/WithIcon";
 
 import FileOutlinedIcon from "@ant-design/icons/FileOutlined";
 import FileExcelOutlinedIcon from "@ant-design/icons/FileExcelOutlined";
@@ -120,8 +121,7 @@ function VisualizationEmbedFooter({
         <span className="hidden-print">
           <Tooltip title="Open in Redash">
             <Link.Button className="icon-button" href={queryUrl} target="_blank">
-              <i className="fa fa-external-link" aria-hidden="true" />
-              <span className="sr-only">Open in Redash</span>
+              <WithIcon alt="Open in Redash" />
             </Link.Button>
           </Tooltip>
           {!query.hasParameters() && (

--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -10,6 +10,7 @@ import Link from "@/components/Link";
 import EditInPlace from "@/components/EditInPlace";
 import FavoritesControl from "@/components/FavoritesControl";
 import { QueryTagsControl } from "@/components/tags-control/TagsControl";
+import { WithIcon } from "@/components/WithIcon";
 import getTags from "@/services/getTags";
 import { clientConfig } from "@/services/auth";
 import useQueryFlags from "../hooks/useQueryFlags";
@@ -88,12 +89,7 @@ export default function QueryPageHeader({
         {
           fork: {
             isEnabled: !queryFlags.isNew && queryFlags.canFork && !isDuplicating,
-            title: (
-              <React.Fragment>
-                Fork <i className="fa fa-external-link m-l-5" aria-hidden="true" />
-                <span className="sr-only">(opens in a new tab)</span>
-              </React.Fragment>
-            ),
+            title: <WithIcon>Fork</WithIcon>,
             onClick: duplicateQuery,
           },
         },

--- a/client/app/services/restoreSession.jsx
+++ b/client/app/services/restoreSession.jsx
@@ -1,6 +1,7 @@
 import { map } from "lodash";
 import React from "react";
 import Modal from "antd/lib/modal";
+import { WithIcon } from "@/components/WithIcon";
 import { Auth } from "@/services/auth";
 
 const SESSION_RESTORED_MESSAGE = "redash_session_restored";
@@ -30,12 +31,7 @@ function showRestoreSessionPrompt(loginUrl, onSuccess) {
 
   Modal.warning({
     content: "Your session has expired. Please login to continue.",
-    okText: (
-      <React.Fragment>
-        Login <i className="fa fa-external-link m-r-5" aria-hidden="true" />
-        <span className="sr-only">(opens in a new tab)</span>
-      </React.Fragment>
-    ),
+    okText: <WithIcon alt="(go to page)">Login</WithIcon>,
     centered: true,
     mask: true,
     maskClosable: false,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Refactor

## Description
Moves the icon and a11y parts of `<Link>` into a separate file and add it as a wrapper as well.

## Related Tickets & Documents
#5418, See a11y epic.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
