### PR TITLE
Refine Dockerfile caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,9 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 ARG databricks_odbc_driver_url=https://databricks.com/wp-content/uploads/2.6.10.1010-2/SimbaSparkODBC-2.6.10.1010-2-Debian-64bit.zip
-ADD $databricks_odbc_driver_url /tmp/simba_odbc.zip
-RUN unzip /tmp/simba_odbc.zip -d /tmp/ \
+RUN wget --quiet $databricks_odbc_driver_url -O /tmp/simba_odbc.zip \
+  && chmod 600 /tmp/simba_odbc.zip \
+  && unzip /tmp/simba_odbc.zip -d /tmp/ \
   && dpkg -i /tmp/SimbaSparkODBC-*/*.deb \
   && echo "[Simba]\nDriver = /opt/simba/spark/lib/64/libsparkodbc_sb64.so" >> /etc/odbcinst.ini \
   && rm /tmp/simba_odbc.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,11 +82,15 @@ ENV PIP_NO_CACHE_DIR=1
 # rollback pip version to avoid legacy resolver problem
 RUN pip install pip==20.2.4;
 
-# We first copy only the requirements file, to avoid rebuilding on every file
-# change.
-COPY requirements.txt requirements_bundles.txt requirements_dev.txt requirements_all_ds.txt ./
-RUN if [ "x$skip_dev_deps" = "x" ] ; then pip install -r requirements.txt -r requirements_dev.txt; else pip install -r requirements.txt; fi
+# We first copy only the requirements file, to avoid rebuilding on every file change.
+COPY requirements_all_ds.txt ./
 RUN if [ "x$skip_ds_deps" = "x" ] ; then pip install -r requirements_all_ds.txt ; else echo "Skipping pip install -r requirements_all_ds.txt" ; fi
+
+COPY requirements_bundles.txt requirements_dev.txt ./
+RUN if [ "x$skip_dev_deps" = "x" ] ; then pip install -r requirements_dev.txt ; fi
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
 
 COPY . /app
 COPY --from=frontend-builder /frontend/client/dist /app/client/dist


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Building the local Docker can sometime take a while. This mostly happens when PIP files change, but there are a couple of commands that always invalidate the cache and can be optimized:

* The ADD command will always invalidate the cache when getting the file from a URL, so instead I am running a wget inside the container. This will only get invalidated when the Databricks ODBC driver version changes.
* Once any PIP requirement file changes, the entire cache is invalidated. This doesn't matter if you skip all_ds, but I usually don't skip. Instead of having everything run at once, I split it to 3 statements and ordered them by the frequency of their change (I tend to believe requirements.txt is the one that changes most, so I put it last).
For me this changed the time to run docker-compose build from 15 minutes (in some scenarios) to 20 seconds (given no requirement changes, but even so - this will still improve significantly)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
