### PR TITLE
adding inital query to mysql datasource

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -67,7 +67,7 @@ class Mysql(BaseSQLQueryRunner):
                 "db": {"type": "string", "title": "Database name"},
                 "port": {"type": "number", "default": 3306},
                 "initial_query": {
-                    "type": "string",
+                    "type": "textarea",
                     "title": "Initial sql query"
                 }
             },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
added optional initial query to be executed on every connection established. This is useful to modify any session variables like the transaction isolation level.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screenshot 2021-05-01 at 20 34 22](https://user-images.githubusercontent.com/1055937/116791734-a6909980-aabc-11eb-8820-660b4d7128ae.png)

