### PR TITLE
Fixed failed query report returning blank email

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -211,7 +211,7 @@ def render_template(path, context):
     Using Flask's `render_template` function requires the entire app context to load, which in turn triggers any
     function decorated with the `context_processor` decorator, which is not explicitly required for rendering purposes.
     """
-    current_app.jinja_env.get_template(path).render(**context)
+    return current_app.jinja_env.get_template(path).render(**context)
 
 
 def query_is_select_no_limit(query):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Missing return statement to actually bring the rendered HTML back to `send_failure_report`. This was fine basically everywhere else since it used Flask's version of render_template, but for this more custom case, the string needs to be returned back to be inside the email.

## Related Tickets & Documents
https://github.com/getredash/redash/issues/5093

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
