### PR TITLE
SFS-001: Adding support for the optional host connection property

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -1,6 +1,5 @@
 try:
     import snowflake.connector
-
     enabled = True
 except ImportError:
     enabled = False
@@ -45,8 +44,9 @@ class Snowflake(BaseQueryRunner):
                 "warehouse": {"type": "string"},
                 "database": {"type": "string"},
                 "region": {"type": "string", "default": "us-west"},
+                "host": {"type": "string"},
             },
-            "order": ["account", "user", "password", "warehouse", "database", "region"],
+            "order": ["account", "user", "password", "warehouse", "database", "region", "host"],
             "required": ["user", "password", "account", "database", "warehouse"],
             "secret": ["password"],
         }
@@ -64,16 +64,23 @@ class Snowflake(BaseQueryRunner):
 
     def _get_connection(self):
         region = self.configuration.get("region")
+        account = self.configuration["account"]
 
         # for us-west we don't need to pass a region (and if we do, it fails to connect)
         if region == "us-west":
             region = None
 
+        if self.configuration.__contains__("host"):
+            host = self.configuration.get("host")
+        else:
+            host = "{}.{}.snowflakecomputing.com".format(account, region)
+
         connection = snowflake.connector.connect(
-            user=self.configuration["user"],
-            password=self.configuration["password"],
-            account=self.configuration["account"],
-            region=region,
+            user = self.configuration["user"],
+            password = self.configuration["password"],
+            account = account,
+            region = region,
+            host = host
         )
 
         return connection

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -39,16 +39,19 @@ class Snowflake(BaseQueryRunner):
             "type": "object",
             "properties": {
                 "account": {"type": "string"},
+                "region": {"type": "string", "default": "us-west"},
                 "user": {"type": "string"},
                 "password": {"type": "string"},
                 "warehouse": {"type": "string"},
                 "database": {"type": "string"},
-                "region": {"type": "string", "default": "us-west"},
                 "host": {"type": "string"},
             },
-            "order": ["account", "user", "password", "warehouse", "database", "region", "host"],
+            "order": ["account", "region", "user", "password", "warehouse", "database", "host"],
             "required": ["user", "password", "account", "database", "warehouse"],
             "secret": ["password"],
+            "extra_options": [
+                "host",
+            ],
         }
 
     @classmethod
@@ -76,7 +79,7 @@ class Snowflake(BaseQueryRunner):
             if region:
                 host = "{}.{}.snowflakecomputing.com".format(account, region)
             else:
-                host = "{}.snowflakecomputing.com".format(account, region)
+                host = "{}.snowflakecomputing.com".format(account)
 
 
         connection = snowflake.connector.connect(

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -73,7 +73,11 @@ class Snowflake(BaseQueryRunner):
         if self.configuration.__contains__("host"):
             host = self.configuration.get("host")
         else:
-            host = "{}.{}.snowflakecomputing.com".format(account, region)
+            if region:
+                host = "{}.{}.snowflakecomputing.com".format(account, region)
+            else:
+                host = "{}.snowflakecomputing.com".format(account, region)
+
 
         connection = snowflake.connector.connect(
             user = self.configuration["user"],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description
Adding support for the optional "host" property for a Snowflake connection. This is used when there is a custom hostname, as per the Snowflake Python connector documentation.

## Related Tickets & Documents
As per my conversation with Jesse :)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/69909379/117113848-ba295200-ad93-11eb-818f-8bf08e295adb.png)
