### PR TITLE
Use the correct rq connection in `get_queues_status`

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -30,7 +30,7 @@ def get_object_counts():
 
 
 def get_queues_status():
-    return {queue.name: {"size": len(queue)} for queue in Queue.all()}
+    return {queue.name: {"size": len(queue)} for queue in Queue.all(connection=rq_redis_connection)}
 
 
 def get_db_sizes():


### PR DESCRIPTION
This fixes rq throwing a `NoRedisConnectionException` exception when configured with a non-local redis instance.

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

If you have an external redis instance configured then the status CLI will spit out a trace that looks something like this:
```
$ /app/manage.py status
Traceback (most recent call last):
  File "/app/manage.py", line 9, in <module>
    manager()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 586, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 426, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/app/redash/cli/__init__.py", line 47, in status
    print(simplejson.dumps(get_status(), indent=2))
  File "/app/redash/monitor.py", line 57, in get_status
    status["manager"]["queues"] = get_queues_status()
  File "/app/redash/monitor.py", line 33, in get_queues_status
    return {queue.name: {"size": len(queue)} for queue in Queue.all()}
  File "/usr/local/lib/python3.7/site-packages/rq/queue.py", line 34, in all
    connection = resolve_connection(connection)
  File "/usr/local/lib/python3.7/site-packages/rq/connections.py", line 69, in resolve_connection
    raise NoRedisConnectionException('Could not resolve a Redis connection')
rq.connections.NoRedisConnectionException: Could not resolve a Redis connection
```



## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
