### PR TITLE
Fixing failure report rendering

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -211,7 +211,7 @@ def render_template(path, context):
     Using Flask's `render_template` function requires the entire app context to load, which in turn triggers any
     function decorated with the `context_processor` decorator, which is not explicitly required for rendering purposes.
     """
-    current_app.jinja_env.get_template(path).render(**context)
+    return current_app.jinja_env.get_template(path).render(**context)
 
 
 def query_is_select_no_limit(query):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,14 @@
 from collections import namedtuple
 from unittest import TestCase
 
+from redash import create_app
 from redash.utils import (
     build_url,
     collect_parameters_from_request,
     filter_none,
     json_dumps,
     generate_token,
+    reder_template,
 )
 
 
@@ -78,3 +80,15 @@ class TestGenerateToken(TestCase):
     def test_format(self):
         token = generate_token(40)
         self.assertRegex(token, r"[a-zA-Z0-9]{40}")
+        
+class TestRenderTemplate(TestCase):
+    def test_render(self):
+        app = create_app()
+        with app.app_context():
+            d = {"failures": [{"id": 1, "name": "Failure Unit Test", "failed_at": "May 04, 2021 02:07PM UTC", "failure_reason": "", "failure_count": 1, "comment": None}]}
+            html, text = [
+                render_template("emails/failures.{}".format(f), d)
+                for f in ["html", "txt"]
+            ]
+            self.assertIn('Failure Unit Test',html)
+            self.assertIn('Failure Unit Test',text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from redash.utils import (
     filter_none,
     json_dumps,
     generate_token,
-    reder_template,
+    render_template,
 )
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Missing return statement to actually bring the rendered HTML back to send_failure_report. This was fine basically everywhere else since it used Flask's version of render_template, but for this more custom case, the string needs to be returned back to be inside the email.

## Related Tickets & Documents
#5093

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
