### PR TITLE
Improve QR serialized performance to xlsx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ sshtunnel==0.1.5
 supervisor==4.1.0
 supervisor_checks==0.8.1
 werkzeug==0.16.1
+pyexcelerate==0.10.0
 # Install the dependencies of the bin/bundle-extensions script here.
 # It has its own requirements file to simplify the frontend client build process
 -r requirements_bundles.txt


### PR DESCRIPTION
According to: https://gist.github.com/acdha/4976b9831224d2713997
we found out pyexcelerate xlsx writer pref better
than xlsxwriter and it have bulk load mode

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor

## Description

According to: https://gist.github.com/acdha/4976b9831224d2713997 and my test in our company env, we found out `pyexcelerate` xlsx writer pref better than `xlsxwriter` and it have bulk load mode, so I think we should use `pyexcelerate`

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
