### PR TITLE
Update Slack Alert Destination Configuration Wizard

### DIFF
--- a/redash/destinations/slack.py
+++ b/redash/destinations/slack.py
@@ -12,12 +12,8 @@ class Slack(BaseDestination):
             "type": "object",
             "properties": {
                 "url": {"type": "string", "title": "Slack Webhook URL"},
-                "username": {"type": "string", "title": "Username"},
-                "icon_emoji": {"type": "string", "title": "Icon (Emoji)"},
-                "icon_url": {"type": "string", "title": "Icon (URL)"},
-                "channel": {"type": "string", "title": "Channel"},
             },
-            "secret": ["url"]
+            "secret": ["url"],
         }
 
     @classmethod
@@ -55,15 +51,6 @@ class Slack(BaseDestination):
             color = "#27ae60"
 
         payload = {"attachments": [{"text": text, "color": color, "fields": fields}]}
-
-        if options.get("username"):
-            payload["username"] = options.get("username")
-        if options.get("icon_emoji"):
-            payload["icon_emoji"] = options.get("icon_emoji")
-        if options.get("icon_url"):
-            payload["icon_url"] = options.get("icon_url")
-        if options.get("channel"):
-            payload["channel"] = options.get("channel")
 
         try:
             resp = requests.post(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

Slack has updated its means of accepting Webhooks. You now create an app, allow for incoming webhooks, then create a url per channel.

Our alert configuration, allows / encourages users to designate a channel there, but that is fully ignored by Slack so we should remove it (ie if I create a URL for #channel2, even if i enter #channel2 in the alert destination configuration wizard, messages will still go to #channel1).

Bot icon, name etc are also now controlled on the Slack side through app settings so we should cut those fields from our config UI.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/289488/121801930-8834c680-cc42-11eb-996c-1a1dedcb107a.png)
