### PR TITLE
Fix: pagination is broken on the dashboard list page

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1120,7 +1120,7 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
                 joinedload(Dashboard.user).load_only(
                     "id", "name", "_profile_image_url", "email"
                 )
-            )
+            ).distinct(Dashboard.created_at, Dashboard.slug)
             .outerjoin(Widget)
             .outerjoin(Visualization)
             .outerjoin(Query)

--- a/tests/models/test_dashboards.py
+++ b/tests/models/test_dashboards.py
@@ -50,3 +50,32 @@ class TestDashboardsByUser(BaseTestCase):
         # not using self.assertIn/NotIn because otherwise this fails :O
         self.assertTrue(d in dashboards)
         self.assertFalse(d2 in dashboards)
+
+
+    def test_returns_correct_number_of_dashboards(self):
+        # Solving https://github.com/getredash/redash/issues/5466
+        
+        usr = self.factory.create_user()
+
+        ds1 = self.factory.create_data_source()
+        ds2 = self.factory.create_data_source()
+
+        qry1 = self.factory.create_query(data_source=ds1, user=usr)
+        qry2 = self.factory.create_query(data_source=ds2, user=usr)
+
+        viz1 = self.factory.create_visualization(query_rel=qry1, )
+        viz2 = self.factory.create_visualization(query_rel=qry2, )
+
+        def create_dashboard():
+            dash = self.factory.create_dashboard(name="boy howdy", user=usr)
+            self.factory.create_widget(dashboard=dash, visualization=viz1)
+            self.factory.create_widget(dashboard=dash, visualization=viz2)
+
+            return dash
+
+        d1 = create_dashboard()
+        d2 = create_dashboard()
+        
+        results = Dashboard.all(self.factory.org, usr.group_ids, usr.id)
+
+        self.assertEqual(2, results.count(), "The incorrect number of dashboards were returned")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

The `Dashboard.all()` query fetches duplicate rows because of its outer join conditions. This PR adds back a `.distinct()` construct de-duplicates the resullt set. DISTINCT is called on `created_at` and `slug` because a generic `distinct()` fails when comparing the JSON fields.

## Related Tickets & Documents

Closes #5466 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before

![CleanShot 2021-06-15 at 14 50 10](https://user-images.githubusercontent.com/17067911/122115078-a688f680-cde9-11eb-81fd-359173a4bd6f.png)


### After

![CleanShot 2021-06-15 at 14 51 14](https://user-images.githubusercontent.com/17067911/122115093-aab51400-cde9-11eb-96fa-08c4a4bf5766.png)

