### PR TITLE
Update Slack Alert Destination Configuration Wizard: Support legacy webhooks

### DIFF
--- a/redash/destinations/slack.py
+++ b/redash/destinations/slack.py
@@ -49,6 +49,15 @@ class Slack(BaseDestination):
 
         payload = {"attachments": [{"text": text, "color": color, "fields": fields}]}
 
+        if options.get("username"):
+            payload["username"] = options.get("username")
+        if options.get("icon_emoji"):
+            payload["icon_emoji"] = options.get("icon_emoji")
+        if options.get("icon_url"):
+            payload["icon_url"] = options.get("icon_url")
+        if options.get("channel"):
+            payload["channel"] = options.get("channel")
+
         try:
             resp = requests.post(options.get("url"), data=json_dumps(payload), timeout=5.0)
             logging.warning(resp.text)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Following up on #5514, this PR will keep the webhook call the same in case it was created with a legacy webhook.

## Related Tickets & Documents
#5514 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
