### PR TITLE
Fix: Edit Source button disappeared for users without CanEdit perms

### DIFF
--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -179,7 +179,7 @@ export default function QueryPageHeader({
 
         {!queryFlags.isNew && queryFlags.canViewSource && (
           <span>
-            {!sourceMode && queryFlags.canEdit && (
+            {!sourceMode && (
               <Link.Button className="m-r-5" href={query.getUrl(true, selectedVisualization)}>
                 <i className="fa fa-pencil-square-o" aria-hidden="true" />
                 <span className="m-l-5">Edit Source</span>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This fixes a regression in the V10 beta where the `Edit Source` button on the query screen would not appear for users without `canEdit` permission on the query. These users should only need `canViewSource` permission.

## Related Tickets & Documents

Closes #5560

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)


### Before
![CleanShot 2021-08-17 at 14 21 33](https://user-images.githubusercontent.com/17067911/129787821-8e83a5e6-eddc-4d56-aeeb-c997c91d5ede.png)


### After

![CleanShot 2021-08-17 at 14 21 39](https://user-images.githubusercontent.com/17067911/129787889-89c84c8b-bdf0-4655-adc1-1490d8b8131a.png)