### PR TITLE
Pin python3 image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.7-slim
+FROM python:3.7-slim-buster
 
 EXPOSE 5000
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description

Approx. a day ago all `python:3.7` images were updated, particularly `python:3.7-slim` switched from Debian `buster` (10) to `bullseye` (11). As a result, our docker images failed to build (`msodbcsql17` failed to install due to missing `multiarch-support` package in `bullseye`). Suggested solution: explicitly pin `python:3.7-slim` to use `buster`-based image.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
