### PR TITLE
Guard against empty totalProcessedBytes in BigQuery responses

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -83,6 +83,13 @@ def _get_query_results(jobs, project_id, location, job_id, start_index):
     return query_reply
 
 
+def _get_total_bytes_processed_for_resp(bq_response):
+    # BigQuery hides the total bytes processed for queries
+    # to talbes with row-level access controls. Because of this
+    # the "totalBytesProcessed" field may or may not be defined on the response.
+    return int(bq_response.get("totalBytesProcessed", "0"))
+
+
 class BigQuery(BaseQueryRunner):
     should_annotate_query = False
     noop_query = "SELECT 1"
@@ -132,6 +139,7 @@ class BigQuery(BaseQueryRunner):
             "secret": ["jsonKeyFile"],
         }
 
+
     def _get_bigquery_service(self):
         scope = [
             "https://www.googleapis.com/auth/bigquery",
@@ -162,7 +170,7 @@ class BigQuery(BaseQueryRunner):
             job_data["useLegacySql"] = False
 
         response = jobs.query(projectId=self._get_project_id(), body=job_data).execute()
-        return int(response["totalBytesProcessed"])
+        return _get_total_bytes_processed_for_resp(response)
 
     def _get_job_data(self, query):
         job_data = {"configuration": {"query": {"query": query}}}
@@ -237,7 +245,7 @@ class BigQuery(BaseQueryRunner):
         data = {
             "columns": columns,
             "rows": rows,
-            "metadata": {"data_scanned": int(query_reply["totalBytesProcessed"])},
+            "metadata": {"data_scanned":  _get_total_bytes_processed_for_resp(query_reply)},
         }
 
         return data

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -84,9 +84,8 @@ def _get_query_results(jobs, project_id, location, job_id, start_index):
 
 
 def _get_total_bytes_processed_for_resp(bq_response):
-    # BigQuery hides the total bytes processed for queries
-    # to talbes with row-level access controls. Because of this
-    # the "totalBytesProcessed" field may or may not be defined on the response.
+    # BigQuery hides the total bytes processed for queries to tables with row-level access controls.
+    # For these queries the "totalBytesProcessed" field may not be defined in the response.
     return int(bq_response.get("totalBytesProcessed", "0"))
 
 

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -139,7 +139,6 @@ class BigQuery(BaseQueryRunner):
             "secret": ["jsonKeyFile"],
         }
 
-
     def _get_bigquery_service(self):
         scope = [
             "https://www.googleapis.com/auth/bigquery",
@@ -245,7 +244,7 @@ class BigQuery(BaseQueryRunner):
         data = {
             "columns": columns,
             "rows": rows,
-            "metadata": {"data_scanned":  _get_total_bytes_processed_for_resp(query_reply)},
+            "metadata": {"data_scanned": _get_total_bytes_processed_for_resp(query_reply)},
         }
 
         return data


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description
BigQuery recently added row-level access controls on tables: https://cloud.google.com/bigquery/docs/row-level-security-intro

When querying a BQ table with row-level ACLs in Redash, the redash query fails. This happens because BigQuery [hides the number of bytes processed](https://cloud.google.com/bigquery/docs/best-practices-row-level-security) on queries to tables with row-level ACLs, and redash [expects](https://github.com/getredash/redash/blob/5085495dd4564058b35e2a424dc62dd9dabe02d6/redash/query_runner/big_query.py#L240) the totalBytesProcessed field to be set on the BQ query response.

This change resolves the issue by creating a getter with a default for the "totalBytesProcessed" field on BigQuery responses that returns 0 when the field is absent.

## Related Tickets & Documents
Resolves https://github.com/getredash/redash/issues/5590

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
