### PR TITLE
Fix: Specify the protobuf version

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -1,4 +1,5 @@
 google-api-python-client==1.7.11
+protobuf==3.17.3
 gspread==3.1.0
 impyla==0.16.0
 influxdb==5.2.3


### PR DESCRIPTION

- [x] Bug Fix

protobuf package with a dependency of google-api-python-client released a new version (3.18.0) on September 16, 2021. Since then, the Docker build is failing, and it is presumed that there is a conflict with other DataSource packages that use protobuf. (phoenixdb, pydgraph)

`redash_server_1 exited with code 139`


To solve the problem, I specify the version of protobuf as 3.17.3.


`protobuf==3.17.3`

#5593
