### PR TITLE
Add auth_saml_sp_settings to allow configuring #1669

### DIFF
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -29,6 +29,7 @@ def get_saml_client(org):
     sso_url = org.get_setting("auth_saml_sso_url")
     x509_cert = org.get_setting("auth_saml_x509_cert")
     metadata_url = org.get_setting("auth_saml_metadata_url")
+    sp_settings = org.get_setting("auth_saml_sp_settings")
 
     if settings.SAML_SCHEME_OVERRIDE:
         acs_url = url_for(
@@ -87,6 +88,10 @@ def get_saml_client(org):
 
     if acs_url is not None and acs_url != "":
         saml_settings["entityid"] = acs_url
+
+    if sp_settings:
+        import json
+        saml_settings["service"]["sp"].update(json.loads(sp_settings))
 
     sp_config = Saml2Config()
     sp_config.load(saml_settings)

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -20,6 +20,7 @@ SAML_ENTITY_ID = os.environ.get("REDASH_SAML_ENTITY_ID", "")
 SAML_NAMEID_FORMAT = os.environ.get("REDASH_SAML_NAMEID_FORMAT", "")
 SAML_SSO_URL = os.environ.get("REDASH_SAML_SSO_URL", "")
 SAML_X509_CERT = os.environ.get("REDASH_SAML_X509_CERT", "")
+SAML_SP_SETTINGS = os.environ.get("REDASH_SAML_SP_SETTINGS", "")
 SAML_LOGIN_ENABLED = SAML_SSO_URL != "" and SAML_METADATA_URL != ""
 
 DATE_FORMAT = os.environ.get("REDASH_DATE_FORMAT", "DD/MM/YY")
@@ -61,6 +62,7 @@ settings = {
     "auth_saml_nameid_format": SAML_NAMEID_FORMAT,
     "auth_saml_sso_url": SAML_SSO_URL,
     "auth_saml_x509_cert": SAML_X509_CERT,
+    "auth_saml_sp_settings": SAML_SP_SETTINGS,
     "date_format": DATE_FORMAT,
     "time_format": TIME_FORMAT,
     "integer_format": INTEGER_FORMAT,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Adds a new configuration option, auth_saml_sp_settings, to allow arbitrarily configuring the Service Provider (SP) in pysaml2. 

Similar to the closed PR #2208 which allowed configuring SAML signature requirements, but this PR is more general in that the setting is a JSON string, allowing any SP setting to be set or overridden. Set through the environment variable `REDASH_SAML_SP_SETTINGS`, no UI.

For example, to implement #1669, to allow compatibility with many popular SAML IdP services, set to:

```json
{"want_assertions_signed": false, "want_response_signed": true}
```

## Related Tickets & Documents

#1669 (SAML: Don't require signed assertions)
#2208 (feat: make SAML signature requirements configurable)