### PR TITLE
Speed up BigQuery get schema operation in massively tables environment

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -274,41 +274,30 @@ class BigQuery(BaseQueryRunner):
         service = self._get_bigquery_service()
         project_id = self._get_project_id()
         datasets = service.datasets().list(projectId=project_id).execute()
-        schema = []
+
+        query_base = """
+        SELECT table_schema, table_name, column_name
+        FROM `{dataset_id}`.INFORMATION_SCHEMA.COLUMNS
+        WHERE table_schema NOT IN ('information_schema')
+        """
+
+        schema = {}
         for dataset in datasets.get("datasets", []):
             dataset_id = dataset["datasetReference"]["datasetId"]
-            tables = (
-                service.tables()
-                .list(projectId=project_id, datasetId=dataset_id)
-                .execute()
-            )
-            while True:
-                for table in tables.get("tables", []):
-                    table_data = (
-                        service.tables()
-                        .get(
-                            projectId=project_id,
-                            datasetId=dataset_id,
-                            tableId=table["tableReference"]["tableId"],
-                        )
-                        .execute()
-                    )
-                    table_schema = self._get_columns_schema(table_data)
-                    schema.append(table_schema)
+            query = query_base.format(dataset_id=dataset_id)
 
-                next_token = tables.get("nextPageToken", None)
-                if next_token is None:
-                    break
+            results, error = self.run_query(query, None)
+            if error is not None:
+                raise Exception("Failed getting schema.")
 
-                tables = (
-                    service.tables()
-                    .list(
-                        projectId=project_id, datasetId=dataset_id, pageToken=next_token
-                    )
-                    .execute()
-                )
+            results = json_loads(results)
+            for row in results["rows"]:
+                table_name = "{0}.{1}".format(row["table_schema"], row["table_name"])
+                if table_name not in schema:
+                    schema[table_name] = {"name": table_name, "columns": []}
+                schema[table_name]["columns"].append(row["column_name"])
 
-        return schema
+        return list(schema.values())
 
     def run_query(self, query, user):
         logger.debug("BigQuery got query: %s", query)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Refactor
- [x] Feature

## Description

This implementation enable to speed up get_schema operation in BigQuery environments which have massively tables (about over 1k tables).

In the environment which has about 1k tables , it takes about **10 minutes** by current implementation. Very slow operation caused the operation timeout at default timeout settings. 

The cause of the slow operation is calling get table's column list api per table in current implementation. 
New implementation improve operation time to **10 seconds** in same environment by improving to call one api to get all table's column list.

## Related Tickets & Documents
- [BigQuery  Information Schema Reference](https://cloud.google.com/bigquery/docs/information-schema-tables)

New implementation uses every dataset's INFORMATION_SCHEMA. COLUMNS view to get table's column list in dataset.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
