### PR TITLE
Fix"Unable to locate package msodbcsql17"on M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.7-slim-buster
+FROM --platform=linux/amd64 python:3.7-slim-buster
 
 EXPOSE 5000
 


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

If you run the docker-compose on a Mac with the new M1 chip, you will get the "Unable to locate package msodbcsql17" error. Because there are currently no msodbcsql17 packages for arm64 architecture. The solution was to change the base image in the Dockerfile to change the installation to the older AMD architecture. 

FROM --platform=linux/amd64 python:3.7-slim-buster

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
