### PR TITLE
snowflake: add option to lowercase column names

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -52,7 +52,15 @@ class Snowflake(BaseQueryRunner):
                 },
                 "host": {"type": "string"},
             },
-            "order": ["account", "user", "password", "warehouse", "database", "region", "host"],
+            "order": [
+                "account",
+                "user",
+                "password",
+                "warehouse",
+                "database",
+                "region",
+                "host",
+            ],
             "required": ["user", "password", "account", "database", "warehouse"],
             "secret": ["password"],
             "extra_options": [
@@ -87,14 +95,12 @@ class Snowflake(BaseQueryRunner):
             else:
                 host = "{}.snowflakecomputing.com".format(account)
 
-
-
         connection = snowflake.connector.connect(
             user=self.configuration["user"],
             password=self.configuration["password"],
             account=account,
             region=region,
-            host = host,
+            host=host,
         )
 
         return connection

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -1,5 +1,6 @@
 try:
     import snowflake.connector
+
     enabled = True
 except ImportError:
     enabled = False
@@ -39,14 +40,19 @@ class Snowflake(BaseQueryRunner):
             "type": "object",
             "properties": {
                 "account": {"type": "string"},
-                "region": {"type": "string", "default": "us-west"},
                 "user": {"type": "string"},
                 "password": {"type": "string"},
                 "warehouse": {"type": "string"},
                 "database": {"type": "string"},
+                "region": {"type": "string", "default": "us-west"},
+                "lower_case_columns": {
+                    "type": "boolean",
+                    "title": "Lower Case Column Names in Results",
+                    "default": False,
+                },
                 "host": {"type": "string"},
             },
-            "order": ["account", "region", "user", "password", "warehouse", "database", "host"],
+            "order": ["account", "user", "password", "warehouse", "database", "region", "host"],
             "required": ["user", "password", "account", "database", "warehouse"],
             "secret": ["password"],
             "extra_options": [
@@ -82,19 +88,29 @@ class Snowflake(BaseQueryRunner):
                 host = "{}.snowflakecomputing.com".format(account)
 
 
+
         connection = snowflake.connector.connect(
-            user = self.configuration["user"],
-            password = self.configuration["password"],
-            account = account,
-            region = region,
-            host = host
+            user=self.configuration["user"],
+            password=self.configuration["password"],
+            account=account,
+            region=region,
+            host = host,
         )
 
         return connection
 
+    def _column_name(self, column_name):
+        if self.configuration.get("lower_case_columns", False):
+            return column_name.lower()
+
+        return column_name
+
     def _parse_results(self, cursor):
         columns = self.fetch_columns(
-            [(i[0], self.determine_type(i[1], i[5])) for i in cursor.description]
+            [
+                (self._column_name(i[0]), self.determine_type(i[1], i[5]))
+                for i in cursor.description
+            ]
         )
         rows = [
             dict(zip((column["name"] for column in columns), row)) for row in cursor
@@ -137,10 +153,10 @@ class Snowflake(BaseQueryRunner):
             cursor.close()
             connection.close()
 
-        return data, error    
-    
+        return data, error
+
     def _database_name_includes_schema(self):
-        return '.' in self.configuration.get('database')
+        return "." in self.configuration.get("database")
 
     def get_schema(self, get_stats=False):
         if self._database_name_includes_schema():


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->


- [x] Feature

## Description

This PR ports a feature from the app.redash.io snowflake query runner: an option to automatically lowercase column names returned by snowflake. This is important for users migrating from app.redash.io to OSS with `redash-migrate` because otherwise their visualisations won't work.

## Related Tickets & Documents

https://discuss.redash.io/t/sso-version-does-not-include-lower-case-column-names-in-results-when-connecting-with-snowflake/9470

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![CleanShot 2021-11-25 at 22 13 58@2x](https://user-images.githubusercontent.com/17067911/143526120-d200ce5d-e929-4532-816c-f5572ff19724.png)

![CleanShot 2021-11-25 at 22 15 15@2x](https://user-images.githubusercontent.com/17067911/143526164-4deb9da4-d052-411b-9f19-08c82c783f6f.png)

