### PR TITLE
Fix circleci builds

### DIFF
--- a/.circleci/docker-compose.circle.yml
+++ b/.circleci/docker-compose.circle.yml
@@ -13,6 +13,7 @@ services:
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
+      REDASH_COOKIE_SECRET: "2H9gNG9obnAQ9qnR9BDTQUph6CbXKCzF"
   redis:
     image: redis:3.0-alpine
     restart: unless-stopped

--- a/.circleci/docker-compose.cypress.yml
+++ b/.circleci/docker-compose.cypress.yml
@@ -12,6 +12,7 @@ x-redash-environment: &redash-environment
   REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
   REDASH_RATELIMIT_ENABLED: "false"
   REDASH_ENFORCE_CSRF: "true"
+  REDASH_COOKIE_SECRET: "2H9gNG9obnAQ9qnR9BDTQUph6CbXKCzF"
 services:
   server:
     <<: *redash-service

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,3 +66,4 @@ werkzeug==0.16.1
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
 Authlib==0.15.5
+advocate==1.0.0

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -41,4 +41,3 @@ cmem-cmempy==21.2.3
 xlrd==2.0.1
 openpyxl==3.0.7
 firebolt-sqlalchemy
-advocate==1.0.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

This PR ports two changes from the `10.0.x` branch that were necessary to make circleci builds work to release V10.1

1. Because of c616c84d5701f1741839b1da7651500d7c534292, circleci needs to declare a cookie secret.
2. After becc70f14335bf96f39ff9e9250a4a451759b9ff, circleci builds failed whenever `requirements_all_ds.txt` was not installed. This PR moves advocate into the main `requirements.txt` where it belongs.

## Related Tickets & Documents

These exact changes were part of https://github.com/getredash/redash/pull/5655

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes.
