### PR TITLE
Fix: make plotly charts have unbounded hoverlabel name length

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
@@ -35,6 +35,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },    
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
@@ -47,6 +47,9 @@
         "range": null,
         "overlaying": "y",
         "side": "right"
+      },    
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
@@ -33,6 +33,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },    
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
@@ -45,6 +45,9 @@
         "range": null,
         "overlaying": "y",
         "side": "right"
+      },    
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
@@ -32,6 +32,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },    
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
@@ -31,6 +31,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },    
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
@@ -19,6 +19,9 @@
       "legend": {
         "traceorder": "normal"
       },
+      "hoverlabel": {
+        "namelength": -1
+      },
       "annotations": [
         {
           "x": 0.24,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
@@ -19,6 +19,9 @@
       "legend": {
         "traceorder": "normal"
       },
+      "hoverlabel": {
+        "namelength": -1
+      },
       "annotations": []
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
@@ -19,6 +19,9 @@
       "legend": {
         "traceorder": "normal"
       },
+      "hoverlabel": {
+        "namelength": -1
+      },
       "annotations": [
         {
           "x": 0.49,

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -117,6 +117,9 @@ export default function prepareLayout(element: any, options: any, data: any) {
     legend: {
       traceorder: options.legend.traceorder,
     },
+    hoverlabel: {
+      namelength: -1,
+    },
   };
 
   switch (options.globalSeriesType) {


### PR DESCRIPTION
## Summary
Make all plotly charts have uncapped [hover label name length](https://plotly.com/python/reference/layout/#layout-hoverlabel-namelength).

The default value for this is 15, which is not very convenient for most charting use cases.

i found that a similar line of code used to exist in this repo, but removed (possibly unintentionally): https://github.com/getredash/redash/commit/50f817e26547a1d20263e52f5bd74a158ad666fb

Related issue:
https://github.com/plotly/plotly.js/issues/460

## Testing
- updated frontend unit test fixtures
- testing via netlify previews

[This PR's preview](https://deploy-preview-5661--redash-preview.netlify.app/queries/486/source#862)
![image](https://user-images.githubusercontent.com/1988030/143989159-e5d85996-5cdd-4c50-bd23-c052450560b8.png)

[Some other preview](https://deploy-preview-5660--redash-preview.netlify.app/queries/486/source#862)
![image](https://user-images.githubusercontent.com/1988030/143989222-a01f4204-8624-4a3c-a9a3-93b170c78796.png)

## Configuration
Instead of hardcoding this setting, we could also make it a chart option. This may be a safer, less intrusive way to support this functionality. However, I personally think -1 is a better default than 15.

## Versioning
I didn't bump any version numbers; will leave to maintainers to advise on how to proceed here