### PR TITLE
Fix: Under 'Data Sources' enable 'Test Connection' button after Save …

### DIFF
--- a/client/app/components/dynamic-form/DynamicForm.jsx
+++ b/client/app/components/dynamic-form/DynamicForm.jsx
@@ -151,6 +151,7 @@ export default function DynamicForm({
   onSubmit,
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isTouched, setIsTouched] = useState(false);
   const [showExtraFields, setShowExtraFields] = useState(defaultShowExtraFields);
   const [form] = Form.useForm();
   const extraFields = filter(fields, { extra: true });
@@ -163,9 +164,8 @@ export default function DynamicForm({
       onSubmit(
         values,
         msg => {
-          const { setFieldsValue, getFieldsValue } = form;
           setIsSubmitting(false);
-          setFieldsValue(getFieldsValue()); // reset form touched state
+          setIsTouched(false); // reset form touched state
           notification.success(msg);
         },
         msg => {
@@ -174,7 +174,7 @@ export default function DynamicForm({
         }
       );
     },
-    [form, fields, onSubmit]
+    [fields, onSubmit]
   );
 
   const handleFinishFailed = useCallback(
@@ -187,6 +187,9 @@ export default function DynamicForm({
   return (
     <Form
       form={form}
+      onFieldsChange={() => {
+        setIsTouched(true);
+      }}
       id={id}
       className="dynamic-form"
       layout="vertical"
@@ -216,7 +219,7 @@ export default function DynamicForm({
           {saveText}
         </Button>
       )}
-      <DynamicFormActions actions={actions} isFormDirty={form.isFieldsTouched()} />
+      <DynamicFormActions actions={actions} isFormDirty={isTouched} />
     </Form>
   );
 }


### PR DESCRIPTION
…#5455

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

### What is the issue ?
As per Redash, under 'Data sources' page, if input fields are updated then 'Test Connection' button have to be disabled. And on saving the change, 'Test Connection' button have to be ENABLED back. But due to a bug, 'Test Connection' button is disabled even after save. Currently after saving the changes, users are refreshing the page to use 'Test Connection' option which is not a good user experience.

> Why we must disable the test connection button ? - We should disable the test button when a user has not saved changes because the Test operation always uses the most recently saved details.

### Fix details:
This change will fix the above mentioned issue i.e. Under 'Data sources' page, 'Test Connection' button will be enabled back after user save the changes.

### Technical details:
As per [ant doc](https://ant.design/components/form/#setFieldsValue-do-not-trigger-onFieldsChange-or-onValuesChange), `setFieldsValue` do not rest the form touched state, which is why button is still in disable state even after values are reset on save (see line number 168). Also we cannot reset `isFieldsTouched` directly. So using a `touched` state to track `onFieldsChange` and reseting `touched` state on save to enable 'Test Connection' button. 

## Related Tickets & Documents

Closes #5455

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

https://user-images.githubusercontent.com/12841596/144880207-aba8ed76-b71f-4489-bd08-c8aff1b7da86.mov



