### PR TITLE
multi-filter defaults to all values selected, instead of first value selected

### DIFF
--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -318,6 +318,9 @@ class QueryResult {
         }
         return v;
       });
+      if (filter.values.length > 1 && filter.multiple) {
+        filter.current = filter.values.slice();
+      }
     });
 
     return filters;

--- a/client/cypress/integration/query/filters_spec.js
+++ b/client/cypress/integration/query/filters_spec.js
@@ -69,6 +69,7 @@ describe("Query Filters", () => {
 
     it("filters rows in a Table Visualization", () => {
       // Defaults to All Options Selected
+      
       expectSelectedOptionsToHaveMembers(["a", "b", "c"]);
       expectTableToHaveLength(11);
       expectFirstColumnToHaveMembers(["a", "a", "a", "a", "b", "b", "b", "c", "c", "c", "c"]);
@@ -84,6 +85,7 @@ describe("Query Filters", () => {
       cy.getByTestId("TableVisualization").should("not.exist");
 
       // Single Option selected
+
       cy.getByTestId("FilterName-stage1::multi-filter")
         .find(".ant-select-selector")
         .click();

--- a/client/cypress/integration/query/filters_spec.js
+++ b/client/cypress/integration/query/filters_spec.js
@@ -69,7 +69,7 @@ describe("Query Filters", () => {
 
     it("filters rows in a Table Visualization", () => {
       // Defaults to All Options Selected
-      
+
       expectSelectedOptionsToHaveMembers(["a", "b", "c"]);
       expectTableToHaveLength(11);
       expectFirstColumnToHaveMembers(["a", "a", "a", "a", "b", "b", "b", "c", "c", "c", "c"]);

--- a/client/cypress/integration/query/filters_spec.js
+++ b/client/cypress/integration/query/filters_spec.js
@@ -68,19 +68,10 @@ describe("Query Filters", () => {
     }
 
     it("filters rows in a Table Visualization", () => {
-      expectSelectedOptionsToHaveMembers(["a"]);
-      expectTableToHaveLength(4);
-      expectFirstColumnToHaveMembers(["a", "a", "a", "a"]);
-
-      cy.getByTestId("FilterName-stage1::multi-filter")
-        .find(".ant-select-selector")
-        .click();
-      cy.contains(".ant-select-item-option-content", "b").click();
-      cy.getByTestId("FilterName-stage1::multi-filter").click(); // close dropdown
-
-      expectSelectedOptionsToHaveMembers(["a", "b"]);
-      expectTableToHaveLength(7);
-      expectFirstColumnToHaveMembers(["a", "a", "a", "a", "b", "b", "b"]);
+      // Defaults to All Options Selected
+      expectSelectedOptionsToHaveMembers(["a", "b", "c"]);
+      expectTableToHaveLength(11);
+      expectFirstColumnToHaveMembers(["a", "a", "a", "a", "b", "b", "b", "c", "c", "c", "c"]);
 
       // Clear Option
 
@@ -91,6 +82,29 @@ describe("Query Filters", () => {
       cy.getByTestId("FilterName-stage1::multi-filter").click(); // close dropdown
 
       cy.getByTestId("TableVisualization").should("not.exist");
+
+      // Single Option selected
+      cy.getByTestId("FilterName-stage1::multi-filter")
+        .find(".ant-select-selector")
+        .click();
+      cy.contains(".ant-select-item-option-content", "a").click();
+      cy.getByTestId("FilterName-stage1::multi-filter").click(); // close dropdown
+
+      expectSelectedOptionsToHaveMembers(["a"]);
+      expectTableToHaveLength(4);
+      expectFirstColumnToHaveMembers(["a", "a", "a", "a"]);
+
+      // Two Options selected
+
+      cy.getByTestId("FilterName-stage1::multi-filter")
+        .find(".ant-select-selector")
+        .click();
+      cy.contains(".ant-select-item-option-content", "b").click();
+      cy.getByTestId("FilterName-stage1::multi-filter").click(); // close dropdown
+
+      expectSelectedOptionsToHaveMembers(["a", "b"]);
+      expectTableToHaveLength(7);
+      expectFirstColumnToHaveMembers(["a", "a", "a", "a", "b", "b", "b"]);
 
       // Select All Option
 

--- a/client/cypress/integration/query/filters_spec.js
+++ b/client/cypress/integration/query/filters_spec.js
@@ -89,7 +89,7 @@ describe("Query Filters", () => {
       cy.getByTestId("FilterName-stage1::multi-filter")
         .find(".ant-select-selector")
         .click();
-      cy.contains(".ant-select-item-option-content", "a").click();
+      cy.contains(".ant-select-item-option-grouped > .ant-select-item-option-content", "a").click();
       cy.getByTestId("FilterName-stage1::multi-filter").click(); // close dropdown
 
       expectSelectedOptionsToHaveMembers(["a"]);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

As discussed here: https://discuss.redash.io/t/make-multi-filters-show-all-values-by-default/3133

> Multi-filters are really useful. But right now their behavior is not intuitive. I expect the filter to show me all the data by default. Only filtering out values when I intentionally select a values in the dropdown. Right now, Redash does this opposite: it shows no data until a filter value is selected.
> I propose that a multi-filter should do nothing until the user chooses which values to filter. Or alternatively, allow the user to set and save a default value for a multi-filter in the query editor.

The current behavior (which has changed since the initial discussion thread was opened) is that multi-filters default to a single value instead of showing no data. In some situations, this is arguably worse than showing no data at all, since users may not notice the presence of the filter at all and draw incorrect conclusions from looking at only a subset of the data.

This PR implements the suggested default behavior of multi-filter: All data shown by default.

I haven't tested this yet and will be checking the autodeploy to validate correctness. The code change is a bit messy and I'd be happy to clean it up if the maintainers approve of the general spirit of this change.

## Related Tickets & Documents
- https://github.com/getredash/redash/pull/3905:
This was a previous attempt at solving this problem by adding configurable defaults for multi-filters. It seems to have been closed because the introduction of query parameters was hypothesized to make filters and multi-filters more or less obsolete.

- https://github.com/getredash/redash/issues/1952
- https://github.com/getredash/redash/pull/2155
- https://github.com/getredash/redash/pull/2262

These other two referenced PR's are from 2018 and seem to have been auto-closed due to staleness (not a deliberate rejection). As far as I can tell the community & maintainers are still warm to the idea of multi-filters defaulting to displaying all data. Please let me know if I'm missing something!

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

https://deploy-preview-5676--redash-preview.netlify.app/queries/491/source Using the Demo source,
```
select substr(month, 1, 4) "year::multi-filter", month,  mrr from saas_metrics
```

![image](https://user-images.githubusercontent.com/1988030/146271738-c9e3d0dd-1d13-44f2-a2e3-1fee653192e1.png)

Compared to an earlier preview [5675](https://deploy-preview-5676--redash-preview.netlify.app/queries/491/source), this query autopopulates all values of the multifilter upon load. Unfortunately there's some issues with the preview deployment setup and I often run into this `It seems like we encountered an error. Try refreshing this page or contact your administrator.` message, but I don't think that's related to this PR.