### PR TITLE
Added ssh tunnel support to mssql and mssql-odbc query runners

### DIFF
--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -67,6 +67,16 @@ class SqlServer(BaseSQLQueryRunner):
     def type(cls):
         return "mssql"
 
+    # Override the base class's host property to alias 'server'. 
+    # Host is used when ssh tunneling (it's set to the tunnel)
+    @property
+    def host(self):
+        return self.configuration.get("server")
+
+    @host.setter
+    def host(self, host):
+        self.configuration["server"] = host
+
     def _get_tables(self, schema):
         query = """
         SELECT table_schema, table_name, column_name

--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -69,6 +69,16 @@ class SQLServerODBC(BaseSQLQueryRunner):
     def type(cls):
         return "mssql_odbc"
 
+    # Override the base class's host property to alias 'server'. 
+    # Host is used when ssh tunneling (it's set to the tunnel)
+    @property
+    def host(self):
+        return self.configuration.get("server")
+
+    @host.setter
+    def host(self, host):
+        self.configuration["server"] = host
+
     def _get_tables(self, schema):
         query = """
         SELECT table_schema, table_name, column_name


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Added support for ssh tunneling to the mssql and mssql-odbc query runners. Prior to this change they would throw a `NotImplementedError` when configured to tunnel over ssh. 

A similar implementation can be found here for ClickHouse: 
https://github.com/getredash/redash/blob/965db26cabfc0de83f65c91439092ed94db4de4a/redash/query_runner/clickhouse.py#L55

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
