### PR TITLE
Fix: don't accept password login requests if password auth is disabled

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -198,7 +198,8 @@ def login(org_slug=None):
     if current_user.is_authenticated:
         return redirect(next_path)
 
-    if request.method == "POST":
+
+    if request.method == "POST" and current_org.get_setting("auth_password_login_enabled"):
         try:
             org = current_org._get_current_object()
             user = models.User.get_by_email_and_org(request.form["email"], org)
@@ -214,6 +215,10 @@ def login(org_slug=None):
                 flash("Wrong email or password.")
         except NoResultFound:
             flash("Wrong email or password.")
+    elif request.method == "POST" and not current_org.get_setting("auth_password_login_enabled"):
+        flash("Password login is not enabled for your organization.")
+
+
 
     google_auth_url = get_google_auth_url(next_path)
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -230,6 +230,22 @@ class TestLogin(BaseTestCase):
             self.assertEqual(rv.status_code, 302)
             self.assertFalse(login_user_mock.called)
 
+    def test_correct_user_and_password_when_password_login_disabled(self):
+        user = self.factory.user
+        user.hash_password("password")
+
+        self.db.session.add(user)
+        self.db.session.commit()
+
+        self.factory.org.set_setting("auth_password_login_enabled", False)
+
+        with patch("redash.handlers.authentication.login_user") as login_user_mock:
+            rv = self.client.post(
+                "/default/login", data={"email": user.email, "password": "password"}
+            )
+            self.assertEqual(rv.status_code, 200)
+            self.assertIn("Password login is not enabled for your organization", str(rv.data))
+
 
 class TestLogout(BaseTestCase):
     def test_logout_when_not_loggedin(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

**Before**: When an organisation disables password auth, `login.html` will not render the username and password inputs. But if a user submits a valid login request with correct username and password in the POST data, Redash logs in the user.

**After**: A valid login request including correct username and password will not succeed if the organisation has disabled password login. A warning will be flashed instead.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Example of the response a user will see if they make a password login attempt when password auth has been disabled.

<img width="665" alt="CleanShot 2022-01-26 at 11 33 46@2x" src="https://user-images.githubusercontent.com/17067911/151216010-872a8986-84c4-4a66-a9bf-084800b59e59.png">

