### PR TITLE
List pages: move sidebar to the left

### DIFF
--- a/client/app/components/layouts/content-with-sidebar.less
+++ b/client/app/components/layouts/content-with-sidebar.less
@@ -11,7 +11,7 @@
   > .layout-content {
     flex: 1 0 auto;
     width: 75%;
-    order: 0;
+    order: 1;
     margin: 0;
   }
 
@@ -19,7 +19,7 @@
     flex: 0 0 auto;
     width: 25%;
     max-width: 350px;
-    order: 1;
+    order: 0;
     margin: 0;
     padding: 0 0 0 @spacing;
   }

--- a/client/app/components/layouts/content-with-sidebar.less
+++ b/client/app/components/layouts/content-with-sidebar.less
@@ -31,6 +31,7 @@
       width: 100%;
       order: 1;
       margin: 0;
+      padding: 0;
     }
 
     > .layout-sidebar {
@@ -38,7 +39,6 @@
       max-width: none;
       order: 0;
       margin: 0 0 @spacing 0;
-      padding: 0;
     }
   }
 }

--- a/client/app/components/layouts/content-with-sidebar.less
+++ b/client/app/components/layouts/content-with-sidebar.less
@@ -13,6 +13,7 @@
     width: 75%;
     order: 1;
     margin: 0;
+    padding: 0 0 0 @spacing
   }
 
   > .layout-sidebar {
@@ -21,7 +22,6 @@
     max-width: 350px;
     order: 0;
     margin: 0;
-    padding: 0 0 0 @spacing;
   }
 
   @media (max-width: 990px) {

--- a/client/app/pages/dashboards/dashboard-list.css
+++ b/client/app/pages/dashboards/dashboard-list.css
@@ -6,11 +6,6 @@ div.tags-list {
   -ms-user-select: none; /* IE10+ */
 }
 
-.page-dashboard-list .page-header-actions {
-  width: 25%; /* same as sidebar */
-  max-width: 350px; /* same as sidebar */
-}
-
 /* same rule as for sidebar */
 @media (max-width: 990px) {
   .page-dashboard-list .page-header-actions {

--- a/client/app/pages/queries-list/queries-list.css
+++ b/client/app/pages/queries-list/queries-list.css
@@ -3,10 +3,6 @@
   height: 35px;
 }
 
-.page-queries-list .page-header-actions {
-  width: 25%; /* same as sidebar */
-  max-width: 350px; /* same as sidebar */
-}
 
 /* same rule as for sidebar */
 @media (max-width: 990px) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

Now that we use a vertical navbar, it makes sense to place the list view filter sidebar on the same side as the navbar. 

I split this work into small commits, each addressing the particular change. It might be easier to review one-by-one.

## Related Tickets & Documents

N/ A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before
<img width="1463" alt="CleanShot 2022-02-01 at 08 26 58@2x" src="https://user-images.githubusercontent.com/17067911/151986751-dea0a7ed-7847-477d-b9c8-0aa49cde5ef7.png">
<img width="1463" alt="CleanShot 2022-02-01 at 08 26 56@2x" src="https://user-images.githubusercontent.com/17067911/151986768-ae126153-302a-46c2-bb25-74026120f5a6.png">
<img width="1463" alt="CleanShot 2022-02-01 at 08 27 19@2x" src="https://user-images.githubusercontent.com/17067911/151986867-e7e54cf4-c544-4f2e-a477-f1464d80d908.png">
<img width="1463" alt="CleanShot 2022-02-01 at 08 27 25@2x" src="https://user-images.githubusercontent.com/17067911/151986872-cd054fb3-909b-479a-a151-31f2c7dd932b.png">

### After
<img width="1463" alt="CleanShot 2022-02-01 at 08 23 38@2x" src="https://user-images.githubusercontent.com/17067911/151986964-c64b50f6-88d9-40cd-8748-8099efb6744e.png">

<img width="1463" alt="CleanShot 2022-02-01 at 08 24 25@2x" src="https://user-images.githubusercontent.com/17067911/151986992-84f8ab14-1d92-45d9-b308-adf6b633c784.png">

<img width="1463" alt="CleanShot 2022-02-01 at 08 24 00@2x" src="https://user-images.githubusercontent.com/17067911/151987015-900b6024-3344-4af2-80c8-12ac22f6cdb4.png">
<img width="1463" alt="CleanShot 2022-02-01 at 08 24 17@2x" src="https://user-images.githubusercontent.com/17067911/151987045-cef4cc75-fef0-4eae-a29a-3b1d84659b25.png">

