### PR TITLE
New cypress test: sorting dashboard list does not crash page.

### DIFF
--- a/client/cypress/integration/dashboard/dashboard_list.js
+++ b/client/cypress/integration/dashboard/dashboard_list.js
@@ -1,27 +1,24 @@
 describe("Dashboard list sort", () => {
-    beforeEach(() => {
-      cy.login();
-    });
-  
-    it("creates one dashboard", () => {
-      cy.visit("/dashboards");
-      cy.getByTestId("CreateButton").click();
-      cy.getByTestId("CreateDashboardMenuItem").click();
-      cy.getByTestId("CreateDashboardDialog").within(() => {
-        cy.get("input").type("A Foo Bar");
-        cy.getByTestId("DashboardSaveButton").click();
-      });
-    });
-
-    describe('Sorting table does not crash page ', () => {
-      it('sorts', () => {
-        cy.visit('/dashboards')
-        cy.contains('Name').click()
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-        cy.getByTestId("ErrorMessage").should("not.exist")
-
-      })
-    })
-  
+  beforeEach(() => {
+    cy.login();
   });
 
+  it("creates one dashboard", () => {
+    cy.visit("/dashboards");
+    cy.getByTestId("CreateButton").click();
+    cy.getByTestId("CreateDashboardMenuItem").click();
+    cy.getByTestId("CreateDashboardDialog").within(() => {
+      cy.get("input").type("A Foo Bar");
+      cy.getByTestId("DashboardSaveButton").click();
+    });
+  });
+
+  describe("Sorting table does not crash page ", () => {
+    it("sorts", () => {
+      cy.visit("/dashboards");
+      cy.contains("Name").click();
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.getByTestId("ErrorMessage").should("not.exist");
+    });
+  });
+});

--- a/client/cypress/integration/dashboard/dashboard_list.js
+++ b/client/cypress/integration/dashboard/dashboard_list.js
@@ -1,0 +1,27 @@
+describe("Dashboard list sort", () => {
+    beforeEach(() => {
+      cy.login();
+    });
+  
+    it("creates one dashboard", () => {
+      cy.visit("/dashboards");
+      cy.getByTestId("CreateButton").click();
+      cy.getByTestId("CreateDashboardMenuItem").click();
+      cy.getByTestId("CreateDashboardDialog").within(() => {
+        cy.get("input").type("A Foo Bar");
+        cy.getByTestId("DashboardSaveButton").click();
+      });
+    });
+
+    describe('Sorting table does not crash page ', () => {
+      it('sorts', () => {
+        cy.visit('/dashboards')
+        cy.contains('Name').click()
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.getByTestId("ErrorMessage").should("not.exist")
+
+      })
+    })
+  
+  });
+


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->


- [x] Other

## Description

Follow up to #5645 which adds a cypress test verifying the dashboard page won't crash during sort.

## Related Tickets & Documents

Protect against duplication of #5119 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
