### PR TITLE
Update maildev path in developer docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
   email:
-    image: djfarrelly/maildev
+    image: maildev/maildev
     ports:
       - "1080:80"
     restart: unless-stopped


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Other

## Description

The docker compose file was using an outdated path for the maildev test mail server.
It's moved to maildev/maildev.
