### PR TITLE
added clear button for query-based parameter inputs

### DIFF
--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -122,6 +122,7 @@ class ParameterValueInput extends React.Component {
         parameter={parameter}
         value={value}
         queryId={queryId}
+        allowClear={true}
         onSelect={this.onSelect}
         style={{ minWidth: 60 }}
         {...multipleValuesProps}

--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -122,7 +122,6 @@ class ParameterValueInput extends React.Component {
         parameter={parameter}
         value={value}
         queryId={queryId}
-        allowClear={true}
         onSelect={this.onSelect}
         style={{ minWidth: 60 }}
         {...multipleValuesProps}

--- a/client/app/components/SelectWithVirtualScroll.tsx
+++ b/client/app/components/SelectWithVirtualScroll.tsx
@@ -36,6 +36,7 @@ function SelectWithVirtualScroll({ options, ...props }: VirtualScrollSelectProps
     <AntdSelect<string>
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       options={options}
+      allowClear={true}
       optionFilterProp="label" // as this component expects "options" prop
       {...props}
     />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Added a clear button to these multi-select inputs, its handy to clear everything at once rather than 'backspace' through possibly dozens of values to reset the input.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/708914/156200025-3add9d3d-a2cd-4346-a7d7-51d5088b5e1f.png)