### PR TITLE
Add MS teams support for Alert Webhook

### DIFF
--- a/redash/destinations/webhook.py
+++ b/redash/destinations/webhook.py
@@ -33,8 +33,14 @@ class Webhook(BaseDestination):
                 "url_base": host,
             }
 
-            data["alert"]["description"] = alert.custom_body
-            data["alert"]["title"] = alert.custom_subject
+            destination_url = options.get("url")
+
+            if 'webhook.office.com' in destination_url:
+                data = {'text' : alert.custom_body,
+                        'title' : alert.custom_subject}
+            else:
+                data["alert"]["description"] = alert.custom_body
+                data["alert"]["title"] = alert.custom_subject
 
             headers = {"Content-Type": "application/json"}
             auth = (
@@ -43,7 +49,7 @@ class Webhook(BaseDestination):
                 else None
             )
             resp = requests.post(
-                options.get("url"),
+                destination_url,
                 data=json_dumps(data),
                 auth=auth,
                 headers=headers,


### PR DESCRIPTION
## What type of PR is this? 
This PR adds support for Microsoft Teams Web Hooks via a "Teams Connector Card"-object.  

- [x] Feature
- [x] New Alert Destination (Sortof)

## Description
The technique used "detects" if a Redash Admin has provided a Microsoft Teams webhook via inspecting the URL.  It assumes microsoft hosts all teams' deployments with the same top-level FQDN (`webhook.office.com`).  Seems pretty safe.  I believe each enterprise deployment get a sub-domain prepended to the URL, so this technique should work for at least all english speaking domains, or maybe for all north america or whatever region is served.

A more strategic implementation of this feature might fork `webhook.py` or maybe add a check-box option on the UI so the user could "declare".

## How is this tested?
- [x] Manually

<!-- If Manually, please describe. -->
I just edited the `webhook.py` python file, `cp`'d into a running production container of the `worker` and it worked fine on the second try.

## Related Tickets & Documents
This feature request has been open and updated.
https://discuss.redash.io/t/microsoft-teams-integration/852/9

## References
- [MS Teams Connectors Spec](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL)
- [pymsteams showing a reference client pushing a notification via HTTPS](https://github.com/rveachkc/pymsteams/blob/master/pymsteams/__init__.py#L175)


