### PR TITLE
fix pyathena version

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -21,7 +21,7 @@ cassandra-driver==3.21.0
 memsql==3.0.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
-PyAthena>=1.5.0
+PyAthena>=1.5.0,<=1.11.5
 pymapd==0.19.0
 qds-sdk>=1.9.6
 ibm-db>=2.0.9


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix


## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
When I build redash with latest version of PyAthena, it seems not to be run query to Athena( including test connection ).
So I'd like to lock it  in the use within same major version.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/18380243/162450660-5732f95b-3a03-44c1-ade1-032ee469d893.png">

<img width="680" alt="image" src="https://user-images.githubusercontent.com/18380243/162450953-06b4898a-ebbe-4d65-9f00-2a5712be25cc.png">


## How is this tested?

- [x] Manually

<!-- If Manually, please describe. -->

- Build locally
- Add DataSource using Athena
- Run Test connection and confirm success
- Run some query and confirm success


## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

I found the same error log as the link below.

- https://discuss.redash.io/t/redash-datasource-connection-test-fails/9989

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
