### PR TITLE
Change new data source group attachment

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -152,7 +152,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
     def create_with_group(cls, *args, **kwargs):
         data_source = cls(*args, **kwargs)
         data_source_group = DataSourceGroup(
-            data_source=data_source, group=data_source.org.default_group
+            data_source=data_source, group=data_source.org.admin_group
         )
         db.session.add_all([data_source, data_source_group])
         return data_source


### PR DESCRIPTION
## What type of PR is this? 

- [x] Refactor

## Description
As both data sources and  new users are automatically added to the default group (at least when using SAML authentication), the creation of more groups would be silly as everyone would have access to all data sources anyway. So an idea would be to attach new data sources to the admin group instead.

## How is this tested?

- [x] Manually

Created a new data source and checked to which group it was assigned to.