### PR TITLE
Update to formatSimpleTemplate to allow input in any case for Snowflake users

### DIFF
--- a/viz-lib/src/lib/value-format.tsx
+++ b/viz-lib/src/lib/value-format.tsx
@@ -89,8 +89,9 @@ export function formatSimpleTemplate(str: any, data: any) {
     return "";
   }
   return str.replace(/{{\s*([^\s]+?)\s*}}/g, (match, prop) => {
-    if (hasOwnProperty.call(data, prop) && !isUndefined(data[prop])) {
-      return data[prop];
+    const propUpper = prop.toUpperCase();
+    if (hasOwnProperty.call(data, propUpper) && !isUndefined(data[propUpper])) {
+      return data[propUpper];
     }
     return match;
   });

--- a/viz-lib/src/lib/value-format.tsx
+++ b/viz-lib/src/lib/value-format.tsx
@@ -90,7 +90,9 @@ export function formatSimpleTemplate(str: any, data: any) {
   }
   return str.replace(/{{\s*([^\s]+?)\s*}}/g, (match, prop) => {
     const propUpper = prop.toUpperCase();
-    if (hasOwnProperty.call(data, propUpper) && !isUndefined(data[propUpper])) {
+    if (hasOwnProperty.call(data, prop) && !isUndefined(data[prop])) {
+      return data[prop];
+    } else if (hasOwnProperty.call(data, propUpper) && !isUndefined(data[propUpper])) {
       return data[propUpper];
     }
     return match;


### PR DESCRIPTION
## What type of PR is this? 
- [X] Bug Fix

## Description
In the chart builder, the user is instructed that they may reference any column value with `{{ column_name }}` syntax:

<img src="https://user-images.githubusercontent.com/11794347/163636236-73f47571-97e0-472c-b100-62cabdf19275.png" width="60%" border-weight="1px">

However, since our company uses Redash on top of Snowflake the input must be capitalized, or it will not work:

**Doesn't work:**
<img src="https://user-images.githubusercontent.com/11794347/163636240-ade57784-e100-4091-aaa2-edf07941f39d.png" width="60%">

**Works:**
<img src="https://user-images.githubusercontent.com/11794347/163636243-1bb01192-27c9-4740-95be-642e95390942.png" width="60%">

This update to the formatSimpleTemplate() attempts to retrieve a column value with `prop` as before, and as a backup tries with `propUpper`, a capitalized version. This should fix the issue for any other users who use Snowflake.

## How is this tested?
- [X] N/A

