### PR TITLE
feature/add support Athena non default catalog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ python-dateutil==2.8.0
 pytz>=2019.3
 PyYAML==5.1.2
 redis==3.5.0
-requests==2.21.0
+requests==2.27.1
 SQLAlchemy==1.3.10
 # We can't upgrade SQLAlchemy-Searchable version as newer versions require PostgreSQL > 9.6, but we target older versions at the moment.
 SQLAlchemy-Searchable==0.10.6

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -12,8 +12,8 @@ td-client==1.0.0
 pymssql==2.1.4
 dql==0.5.26
 dynamo3==0.4.10
-boto3>=1.10.0,<1.11.0
-botocore>=1.13,<1.14.0
+boto3>=1.21.0,<1.22.0
+botocore>=1.24.0,<1.25.0
 sasl>=0.1.3
 thrift>=0.8.0
 thrift_sasl>=0.1.0
@@ -21,13 +21,13 @@ cassandra-driver==3.21.0
 memsql==3.0.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
-PyAthena>=1.5.0
+PyAthena>=1.5.0,<=1.11.5
 pymapd==0.19.0
 qds-sdk>=1.9.6
 ibm-db>=2.0.9
 pydruid==0.5.7
 requests_aws_sign==0.1.5
-snowflake-connector-python==2.1.3
+snowflake-connector-python==2.7.4
 phoenixdb==0.7
 # certifi is needed to support MongoDB and SSL:
 certifi>=2019.9.11

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,8 +6,8 @@ mock==3.0.5
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
 pymongo[srv,tls]==3.9.0
-botocore>=1.13,<1.14.0
-PyAthena>=1.5.0
+botocore>=1.24.0,<1.25.0
+PyAthena>=1.5.0,<=1.11.5
 ptvsd==4.3.2
 freezegun==0.3.12
 watchdog==0.9.0


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
Athena Federated Query  needs non default catalog_name(AwsDataCatalog). This PR supports another athena catalog_name.
### 1. boto3, botocore version-up
Now, boto3 / botocore freezed very old version. Athena Federated Query GA 12. 2020.
### 2. get_schema from Athena-api
Current implementation use Glue-api. athena's catalog_name != glue's catalog_name, ( glue's catalog_name = aws accont-id).
So, change get_schema from glue to athena's api. There is no performance difference between glue and athena.
When compared with about 2000 tables, only a few seconds difference.
I also implemented via information_schema.
###  3. Keep pyathena 1.x
pyathena 2.x supports non default catalog.But we can set catalog name via sql  e.g.) select * from [catalog].[database].[table]
So, keep pyathena 1.x, I cloud not  find the advantage of connecting by specifying the catalog name.
(Even in redash 8, we can execute Federated Query by specifying the catalog name in SQL.)

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
https://github.com/getredash/redash/pull/5731

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
