### PR TITLE
the widget height should be accurate if set auto-height

### DIFF
--- a/client/app/components/dashboards/DashboardGrid.jsx
+++ b/client/app/components/dashboards/DashboardGrid.jsx
@@ -201,7 +201,8 @@ class DashboardGrid extends React.Component {
       const item = find(layout, { i: widgetId.toString() });
       if (item) {
         // update widget height
-        item.h = Math.ceil((newHeight + cfg.margins) / cfg.rowHeight);
+        // if widget set auto-height, the height should be accurate
+        item.h = (newHeight + cfg.margins) / cfg.rowHeight;
       }
 
       return { layouts: { [MULTI]: layout } };


### PR DESCRIPTION
## Bug Fix
If you use Math.ceil, there will be more blank space on the mobile.