### PR TITLE
fix: preventing down app when request post with un-realize entry point

### DIFF
--- a/redash/security.py
+++ b/redash/security.py
@@ -40,13 +40,13 @@ def init_app(app):
                 return
 
             # Prevent un-official request entry point
-            if (request.endpoint is None):
+            if request.endpoint is None:
                 return
 
             view = app.view_functions.get(request.endpoint)
 
             # Prevent un-official request entry point
-            if (view is None):
+            if view is None:
                 return
 
             dest = f"{view.__module__}.{view.__name__}"


### PR DESCRIPTION
## Preventing down app when request post with un-realize entry point

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
While using Redash, we faced the 502 case Bad Gateway with the log
```
server_1     | [2022-03-26 08:27:00,660][PID:14][INFO][werkzeug] 135.125.217.54 - - [26/Mar/2022 08:27:00] "POST / HTTP/1.1" 500 -
server_1     | Traceback (most recent call last):
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
server_1     |     return self.wsgi_app(environ, start_response)
server_1     |   File "/usr/local/lib/python3.7/site-packages/werkzeug/middleware/proxy_fix.py", line 232, in __call__
server_1     |     return self.app(environ, start_response)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app
server_1     |     response = self.handle_exception(e)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask_restful/__init__.py", line 269, in error_router
server_1     |     return original_handler(e)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1866, in handle_exception
server_1     |     reraise(exc_type, exc_value, tb)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
server_1     |     raise value
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
server_1     |     response = self.full_dispatch_request()
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
server_1     |     rv = self.handle_user_exception(e)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask_restful/__init__.py", line 269, in error_router
server_1     |     return original_handler(e)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
server_1     |     reraise(exc_type, exc_value, tb)
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
server_1     |     raise value
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1947, in full_dispatch_request
server_1     |     rv = self.preprocess_request()
server_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2241, in preprocess_request
server_1     |     rv = func()
server_1     |   File "/app/redash/security.py", line 45, in check_csrf
server_1     |     dest = f'{view.__module__}.{view.__name__}'
server_1     | AttributeError: 'NoneType' object has no attribute '__module__'
```
We detected there are some request using method POST to an un-realized entry point. This lead to the lead to case 500 Internal Server Error in service server, causing down application and case 502 Bad Gateway.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

We tested it by CURL as following 
```
curl 'https://localhost:5000/api/events/abc' \
  -H 'authority: redash.poti-poti.io' \
  -H 'accept: application/json, text/plain, */*' \
  -H 'accept-language: en-US,en;q=0.9' \
  -H 'content-type: application/json;charset=UTF-8' \
  -H 'cookie: remember_token=<rememeber_token>; csrf_token=<csrf_token>' \
  -H 'origin: https://localhost:5000' \
  -H 'referer: https://localhost:5000/data_sources' \
  -H 'sec-ch-ua: " Not A;Brand";v="99", "Chromium";v="100", "Google Chrome";v="100"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-origin' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36' \
  -H 'x-csrf-token: <x-csrf-token>' \
  --data-raw '[{"action":"view","object_type":"page","object_id":"data_sources/new","timestamp":1651830468.954,"screen_resolution":"1440x900"}]' \
  --compressed
```
With these change the un-realize entry point with return 405 instead of 500 and not causing down app

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
