### PR TITLE
Dynamodb can assume AWS IAM role

### DIFF
--- a/redash/query_runner/dynamodb_sql.py
+++ b/redash/query_runner/dynamodb_sql.py
@@ -1,13 +1,16 @@
 import logging
-import sys
+import os
 
 from redash.query_runner import *
+from redash.settings import parse_boolean
 from redash.utils import json_dumps
 
 logger = logging.getLogger(__name__)
+ASSUME_ROLE = parse_boolean(os.environ.get("DYNAMODB_SQL_ASSUME_ROLE", "false"))
 
 try:
-    from dql import Engine, FragmentEngine
+    import boto3
+    from dql import FragmentEngine
     from dynamo3 import DynamoDBError
     from pyparsing import ParseException
 
@@ -38,16 +41,33 @@ class DynamoDBSQL(BaseSQLQueryRunner):
 
     @classmethod
     def configuration_schema(cls):
-        return {
+        schema = {
             "type": "object",
             "properties": {
                 "region": {"type": "string", "default": "us-east-1"},
                 "access_key": {"type": "string"},
                 "secret_key": {"type": "string"},
             },
-            "required": ["access_key", "secret_key"],
             "secret": ["secret_key"],
         }
+
+        if ASSUME_ROLE:
+            del schema["properties"]["access_key"]
+            del schema["properties"]["secret_key"]
+            schema["secret"] = []
+            schema["properties"].update(
+                {
+                    "iam_role": {"type": "string", "title": "IAM role to assume"},
+                    "external_id": {
+                        "type": "string",
+                        "title": "External ID to be used while STS assume role",
+                    },
+                }
+            )
+        else:
+            schema["required"] = ["access_key", "secret_key"]
+
+        return schema
 
     def test_connection(self):
         engine = self._connect()
@@ -61,9 +81,37 @@ class DynamoDBSQL(BaseSQLQueryRunner):
     def name(cls):
         return "DynamoDB (with DQL)"
 
+    def _get_iam_credentials(self, user=None):
+        if ASSUME_ROLE:
+            role_session_name = "redash" if user is None else user.email
+            sts = boto3.client("sts")
+            creds = sts.assume_role(
+                RoleArn=self.configuration["iam_role"],
+                RoleSessionName=role_session_name,
+                ExternalId=self.configuration.get("external_id"),
+            )
+            return {
+                "aws_access_key_id": creds["Credentials"]["AccessKeyId"],
+                "aws_secret_access_key": creds["Credentials"]["SecretAccessKey"],
+                "aws_session_token": creds["Credentials"]["SessionToken"],
+                "region_name": self.configuration["region"],
+            }
+        else:
+            return {
+                "aws_access_key_id": self.configuration.get("access_key", None),
+                "aws_secret_access_key": self.configuration.get("secret_key", None),
+                "region_name": self.configuration["region"],
+            }
+
     def _connect(self):
         engine = FragmentEngine()
         config = self.configuration.to_dict()
+
+        config["session"] = boto3.Session(**self._get_iam_credentials())._session
+
+        if ASSUME_ROLE:
+            del config["iam_role"]
+            del config["external_id"]
 
         if not config.get("region"):
             config["region"] = "us-east-1"

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -21,7 +21,7 @@ cassandra-driver==3.21.0
 memsql==3.0.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
-PyAthena>=1.5.0
+PyAthena>=1.5.0,<=1.11.5
 pymapd==0.19.0
 qds-sdk>=1.9.6
 ibm-db>=2.0.9

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ mock==3.0.5
 # (this is not perfect and we should resolve this in a different way)
 pymongo[srv,tls]==3.9.0
 botocore>=1.13,<1.14.0
-PyAthena>=1.5.0
+PyAthena>=1.5.0,<=1.11.5
 ptvsd==4.3.2
 freezegun==0.3.12
 watchdog==0.9.0


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [X] Feature

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

DynamoDB data source can use only AWS credentials.\
This PR adds ability for DynamoDBSQL class to assume AWS IAM role in addition.

To allow DynamoDBSQL use AWS IAM role instead of AWS credentials, `DYNAMODB_SQL_ASSUME_ROLE=true` must be set in `env` file for redash.

## How is this tested?

- [X] Manually

<!-- If Manually, please describe. -->

1. added `DYNAMODB_SQL_ASSUME_ROLE=true` into the `env` file.
2. restarted docker containers
3. In Redash UI, `Settings` -> `New Data Source` -> chose `DynamoDB (with DQL)`
4. Entered `DynamoDB (with DQL)` settings

<img width="517" alt="redash-dynamodb-assume-role" src="https://user-images.githubusercontent.com/17691337/169475954-acb195ac-7ab3-4730-bc40-3628ad2f59b9.png">
