### PR TITLE
Use correct names for Apache projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Redash supports more than 35 SQL and NoSQL [data sources](https://redash.io/help
 - Amazon DynamoDB
 - Amazon Redshift
 - Axibase Time Series Database
-- Cassandra
+- Apache Cassandra
 - ClickHouse
 - CockroachDB
 - CSV
 - Databricks (Apache Spark)
 - DB2 by IBM
-- Druid
+- Apache Druid
 - Elasticsearch
 - Firebolt
 - Google Analytics
@@ -49,8 +49,8 @@ Redash supports more than 35 SQL and NoSQL [data sources](https://redash.io/help
 - Google Spreadsheets
 - Graphite
 - Greenplum
-- Hive
-- Impala
+- Apache Hive
+- Apache Impala
 - InfluxDB
 - JIRA
 - JSON


### PR DESCRIPTION
Apache's trademark policy says to use the full name for these products on their first mention, on a page.

I did not re-sort the list, as Apache Kylin is sorted by "Kylin" and figured you intend to retain that sort style.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [X] Other
  - README.md typo fix

## Description
Fix Apache product names.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [X] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
