### PR TITLE
Disable auto limit for mssql query runner

### DIFF
--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -68,6 +68,10 @@ class SQLServerODBC(BaseSQLQueryRunner):
     @classmethod
     def type(cls):
         return "mssql_odbc"
+    
+    @property
+    def supports_auto_limit(self):
+        return False
 
     def _get_tables(self, schema):
         query = """


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->


- [x] Bug Fix


## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Microsoft SQL Server uses TSQL syntax which uses `TOP` rather than `LIMIT` to truncate results. Therefore the default implementation of autolimit in `BaseSQLQueryRunner` doesn't work.

This PR explicits marks auto limit as not supported so that the `LIMIT 1000` tickbox will not appear in the query editor. A subsequent PR should hopefully implement auto limit for the query runner.

## How is this tested?

- [x] Manually


<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

#5773
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

#### Before
![CleanShot 2022-07-02 at 11 11 20@2x](https://user-images.githubusercontent.com/17067911/177008156-bfc9a707-e68e-434c-8983-579df4e94800.png)

#### After


![CleanShot 2022-07-02 at 11 07 06@2x](https://user-images.githubusercontent.com/17067911/177008167-a4461f4e-6c64-4225-b99b-d97691345573.png)

