### PR TITLE
Install python dependencies one-by-one. Don't exit on failures.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,8 @@ RUN pip install pip==20.2.4;
 
 # We first copy only the requirements file, to avoid rebuilding on every file change.
 COPY requirements_all_ds.txt ./
-RUN if [ "x$skip_ds_deps" = "x" ] ; then pip install -r requirements_all_ds.txt ; else echo "Skipping pip install -r requirements_all_ds.txt" ; fi
+RUN if [ "x$skip_ds_deps" = "x" ] ; then cat requirements_all_ds.txt | sed -e '/^\s*#.*$/d' -e '/^\s*$/d' | xargs -n 1 pip install || true ; else echo "Skipping pip install -r requirements_all_ds.txt" ; fi
+
 
 COPY requirements_dev.txt ./
 RUN if [ "x$skip_dev_deps" = "x" ] ; then pip install -r requirements_dev.txt ; fi


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor


## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

`docker-compose build` fails while installing `requirements_all_ds.txt` on Apple Silicon because some data source dependencies are pinned to versions incompatible with the ARM architecture. This blocks users from running / developing Redash on our fancy new Macs unless we selectively remove the incompatible lines of `requirements_all_ds.txt` (`pymapd` for example).

Long-term we should ensure that all dependencies are compatible across platforms. This PR implements an effective, hands-free solution until then.

#### Benefits

This change allows the build to continue even if a data source dependency cannot be installed. It works by using `xargs` to feed `requirements_all_ds.txt` to `pip install` line-by-line. The final command `|| true` suppresses the exit code from `xargs` (which will be code `123` if any of the calls to `pip install` returns a non-zero code) so that Docker will continue building.

Since query_runners wrap their imports in `try...` blocks, any query runner that depends on a package that wasn't installed will fail gracefully without crashing the app.

#### Risks

Calling `pip install` line-by-line slows down `docker-compose build`.

Because we catch all non-zero exit codes, a user will need to run `docker-compose build --progress=plain` to see whether or not all dependencies were installed.


## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A
