### PR TITLE
Updated rq-scheduler to 0.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ statsd==3.3.0
 greenlet==0.4.16
 gunicorn==20.0.4
 rq==1.5.0
-rq-scheduler==0.9.1
+rq-scheduler==0.10.0
 jsonschema==3.1.1
 RestrictedPython==5.0
 pysaml2==6.1.0


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [X] Bug Fix
- [X] Other

## Description
This upgrades the rq-scheduler package to version 0.10.0 which is less sensitive to disruption and allows for multiple scheduler processes to run. 

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [X] Manually
- [ ] N/A

Built a new docker image and deployed it to our qa environment. Reconfigured QA environment to have two schedulers running and verified logs and that jobs continued to be scheduled. Verified that "There's already an active RQ scheduler" messages were no longer present. 

## Related Tickets & Documents
#5797 

