### PR TITLE
Readme: add MariaDB to supported data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Redash supports more than 35 SQL and NoSQL [data sources](https://redash.io/help
 - JSON
 - Apache Kylin
 - OmniSciDB (Formerly MapD)
+- MariaDB
 - MemSQL
 - Microsoft Azure Data Warehouse / Synapse
 - Microsoft Azure SQL Database


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

As per [this pull request](https://github.com/getredash/redash/pull/4061)[1] and also [this developer comment](https://github.com/getredash/redash/issues/5754#issuecomment-1173147163)[2] it seems that MariaDB support is something Redash has already had for years. The current list in `README.md` shows only MySQL which, being from Oracle and often just being an alias for MariaDB, is maybe not the thing most people will actually be using going forward.

This pull request explicitly adds MariaDB to the list of supported data sources. For the commit message I've used the style from [this other recent commit](https://github.com/getredash/redash/commit/0712abb3590046d96d7252e7e4575875aefe5b84).

[1] (2019) "Switch to mysqlclient from Python-MySQL" for py3 compatibility and MariaDB compatibility
[2] (2022) Redash contributor validating a bug report with both mysql and mariadb
