### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
     && ACCEPT_EULA=Y apt-get install  -y --no-install-recommends msodbcsql17 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && curl "$databricks_odbc_driver_url" --output /tmp/simba_odbc.zip \
+    && curl "$databricks_odbc_driver_url" --location --output /tmp/simba_odbc.zip \
     && chmod 600 /tmp/simba_odbc.zip \
     && unzip /tmp/simba_odbc.zip -d /tmp/ \
     && dpkg -i /tmp/SimbaSparkODBC-*/*.deb \


### PR DESCRIPTION
curl add --location option to follow redirects

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

wo --locaiton option I had the following output :

#0 5.854   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#0 5.854                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
#0 5.878 Archive:  /tmp/simba_odbc.zip
#0 5.878   End-of-central-directory signature not found.  Either this file is not
#0 5.878   a zipfile, or it constitutes one disk of a multi-part archive.  In the
#0 5.878   latter case the central directory and zipfile comment will be found on
#0 5.878   the last disk(s) of this archive.
#0 5.878 unzip:  cannot find zipfile directory in one of /tmp/simba_odbc.zip or
#0 5.878         /tmp/simba_odbc.zip.zip, and cannot find /tmp/simba_odbc.zip.ZIP, period.
------
failed to solve: executor failed running [/bin/sh -c if [ "$TARGETPLATFORM" = "linux/amd64" ]; then     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -     && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list     && apt-get update     && ACCEPT_EULA=Y apt-get install  -y --no-install-recommends msodbcsql17     && apt-get clean     && rm -rf /var/lib/apt/lists/*     &&    curl  "$databricks_odbc_driver_url" --output /tmp/simba_odbc.zip     && chmod 600 /tmp/simba_odbc.zip     && unzip /tmp/simba_odbc.zip -d /tmp/     && dpkg -i /tmp/SimbaSparkODBC-*/*.deb     && printf "[Simba]\nDriver = /opt/simba/spark/lib/64/libsparkodbc_sb64.so" >> /etc/odbcinst.ini     && rm /tmp/simba_odbc.zip     && rm -rf /tmp/SimbaSparkODBC*; fi]: exit code: 9

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
