### PR TITLE
Fix `FEATURE_POLICY` to initialize from `REDASH_FEATURE_POLICY` envvar, not `REDASH_REFERRER_POLICY`

### DIFF
--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -163,7 +163,7 @@ REFERRER_POLICY = os.environ.get(
 # an empty value.
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
 # for more information.
-FEATURE_POLICY = os.environ.get("REDASH_REFERRER_POLICY", "")
+FEATURE_POLICY = os.environ.get("REDASH_FEATURE_POLICY", "")
 
 MULTI_ORG = parse_boolean(os.environ.get("REDASH_MULTI_ORG", "false"))
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Problem: setting the `REDASH_REFERRER_POLICY` environment variable also sets the feature policy in addition to the referrer policy. Conversely, there is no way to set the feature policy on its own.

It looks like a copy/paste error from the line above.

Solution: change the feature policy to be set by a `REDASH_FEATURE_POLICY` environment variable.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
