### PR TITLE
Update docker-compose.yml: Mount postgresql/data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
   email:
     image: djfarrelly/maildev
     ports:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Current `docker-compose.yml` doesn't mount `postgresql/data`.  So we hit by accidents like as follows.

1. I deploy Redash with docker compose.
1. My co-workers add queries.
1. (A few days after) I execute `docker comopse down` to maintain Redash.
1. We lost all queries and settings.

We think that would be very dangerous for people who don't know that.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

Sorry for the Japanese documentation. There are people who are having the same problem as I am.
https://kuchitama.hateblo.jp/entry/redash_on_docker_trouble

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
