### PR TITLE
Use REDASH_CSV_WRITER_ENCODING for downloading CSV

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 import unicodedata
@@ -37,6 +38,7 @@ from redash.serializers import (
     serialize_job,
 )
 
+WRITER_ENCODING = os.environ.get("REDASH_CSV_WRITER_ENCODING", "utf-8")
 
 def error_response(message, http_status=400):
     return {"job": {"status": 4, "error": message}}, http_status
@@ -431,9 +433,9 @@ class QueryResultResource(BaseResource):
 
     @staticmethod
     def make_csv_response(query_result):
-        headers = {"Content-Type": "text/csv; charset=UTF-8"}
+        headers = {"Content-Type": f"text/csv; charset={WRITER_ENCODING.upper()}"}
         return make_response(
-            serialize_query_result_to_dsv(query_result, ","), 200, headers
+            serialize_query_result_to_dsv(query_result, ",").encode(WRITER_ENCODING), 200, headers
         )
 
     @staticmethod

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -3,7 +3,7 @@ import csv
 import xlsxwriter
 from funcy import rpartial, project
 from dateutil.parser import isoparse as parse_date
-from redash.utils import json_loads, UnicodeWriter
+from redash.utils import json_loads
 from redash.query_runner import TYPE_BOOLEAN, TYPE_DATE, TYPE_DATETIME
 from redash.authentication.org_resolving import current_org
 

--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -135,42 +135,6 @@ def build_url(request, host, path):
     return "{}://{}{}".format(request.scheme, host, path)
 
 
-class UnicodeWriter:
-    """
-    A CSV writer which will write rows to CSV file "f",
-    which is encoded in the given encoding.
-    """
-
-    def __init__(self, f, dialect=csv.excel, encoding=WRITER_ENCODING, **kwds):
-        # Redirect output to a queue
-        self.queue = io.StringIO()
-        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
-        self.stream = f
-        self.encoder = codecs.getincrementalencoder(encoding)()
-
-    def _encode_utf8(self, val):
-        if isinstance(val, str):
-            return val.encode(WRITER_ENCODING, WRITER_ERRORS)
-
-        return val
-
-    def writerow(self, row):
-        self.writer.writerow([self._encode_utf8(s) for s in row])
-        # Fetch UTF-8 output from the queue ...
-        data = self.queue.getvalue()
-        data = data.decode(WRITER_ENCODING)
-        # ... and reencode it into the target encoding
-        data = self.encoder.encode(data)
-        # write to the target stream
-        self.stream.write(data)
-        # empty queue
-        self.queue.truncate(0)
-
-    def writerows(self, rows):
-        for row in rows:
-            self.writerow(row)
-
-
 def collect_parameters_from_request(args):
     parameters = {}
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

`REDASH_CSV_WRITER_ENCODING` environment variable is ignored and always downloads as UTF-8.
We, engineers may not understand what the problem is that.

The administrative staffs in Japan like to edit the CSV directly in Excel and upload it to another system. Excel needs to be encoded in CP932(Shift-JIS) to edit it directly, so we need to be able to set the character encoding.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents

Sorry for the Japanese documentation. There are people who are having the same problem as I am.
https://qiita.com/koike_moyashi/items/d0d5dc37a93b398f0aaa

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
