### PR TITLE
Prevent the use of importlib-metadata==5.0.0

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,5 +4,5 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata>=1.6  # remove when on 3.8
+importlib-metadata==4.13.0  # remove when on 3.8
 importlib_resources==1.5  # remove when on 3.9

--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,5 +4,5 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata==4.13.0  # remove when on 3.8
+importlib-metadata>=1.6,<5.0  # remove when on 3.8
 importlib_resources==1.5  # remove when on 3.9


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The recent release of `importlib-metadata==5.0.0` removed the deprecated endpoint, resulting error of `'EntryPoints' object has no attribute 'get'` while creating the redash service.

```
redash-worker-1     | Traceback (most recent call last):                                                                                
redash-worker-1     |   File "./manage.py", line 9, in <module>                                                                         
redash-worker-1     |     manager()                                                                                                     
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/core.py", line 722, in __call__                              
redash-worker-1     |     return self.main(*args, **kwargs)                                                                             
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 586, in main                                   
redash-worker-1     |     return super(FlaskGroup, self).main(*args, **kwargs)                                                          
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/core.py", line 697, in main                                  
redash-worker-1     |     rv = self.invoke(ctx)                                                                                         
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke                               
redash-worker-1     |     return _process_result(sub_ctx.command.invoke(sub_ctx))                                                       
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke                               
redash-worker-1     |     return _process_result(sub_ctx.command.invoke(sub_ctx))                                                       
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/core.py", line 895, in invoke                                
redash-worker-1     |     return ctx.invoke(self.callback, **ctx.params)                                                                
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/core.py", line 535, in invoke                                
redash-worker-1     |     return callback(*args, **kwargs)                                                                              
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func                         
redash-worker-1     |     return f(get_current_context(), *args, **kwargs)                                                              
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 425, in decorator                              
redash-worker-1     |     with __ctx.ensure_object(ScriptInfo).load_app().app_context():                                                
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 381, in load_app                               
redash-worker-1     |     app = call_factory(self, self.create_app)                                                                     
redash-worker-1     |   File "/usr/local/lib/python3.7/site-packages/flask/cli.py", line 117, in call_factory                           
redash-worker-1     |     return app_factory(script_info)                                                                               
redash-worker-1     |   File "/app/redash/cli/__init__.py", line 13, in create                                                          
redash-worker-1     |     app = current_app or create_app()                                                                             
redash-worker-1     |   File "/app/redash/app.py", line 57, in create_app                                                               
redash-worker-1     |     extensions.init_app(app)                                                                                      
redash-worker-1     |   File "/app/redash/extensions.py", line 107, in init_app                                                         
redash-worker-1     |     load_extensions(app)                                                                                          
redash-worker-1     |   File "/app/redash/extensions.py", line 69, in load_extensions                                                   
redash-worker-1     |     entry_point_loader("redash.extensions", extensions, logger=app.logger, app=app)                               
redash-worker-1     |   File "/app/redash/extensions.py", line 30, in entry_point_loader                                                
redash-worker-1     |     for entry_point in entry_points().get(group_name, []):                                                        
redash-worker-1     | AttributeError: 'EntryPoints' object has no attribute 'get'                                                       
```

This PR sets the version range of `importlib-metadata` as `>=1.6,<5.0` to prevent this issue.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
