### PR TITLE
fix: Support importlib_metadata v5.0.0

### DIFF
--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -65,7 +65,7 @@ def load_bundles():
 
     """
     bundles = odict()
-    for entry_point in importlib_metadata.entry_points().get("redash.bundles", []):
+    for entry_point in importlib_metadata.entry_points(group="redash.bundles"):
         logger.info('Loading Redash bundle "%s".', entry_point.name)
         module = entry_point_module(entry_point)
         # Try to get a list of bundle files

--- a/bin/bundle-extensions
+++ b/bin/bundle-extensions
@@ -65,7 +65,18 @@ def load_bundles():
 
     """
     bundles = odict()
-    for entry_point in importlib_metadata.entry_points(group="redash.bundles"):
+    # HACK:
+    #   bin/bundle-extensions is tested in different versions.
+    #   circleci frontend-unit-tests: python 3.5 and importlib-metadata-2.1.3
+    #   circleci backend-unit-tests: python 3.7 and importlib-metadata-5.0.0
+    if importlib_metadata.version("importlib_metadata") >= "5.0.0":
+        bundles_entry_points = importlib_metadata.entry_points(group="redash.bundles")
+    else:
+        bundles_entry_points = importlib_metadata.entry_points().get(
+            "redash.bundles", []
+        )
+
+    for entry_point in bundles_entry_points:
         logger.info('Loading Redash bundle "%s".', entry_point.name)
         module = entry_point_module(entry_point)
         # Try to get a list of bundle files

--- a/redash/extensions.py
+++ b/redash/extensions.py
@@ -27,7 +27,7 @@ def entry_point_loader(group_name, mapping, logger=None, *args, **kwargs):
     if logger is None:
         logger = extension_logger
 
-    for entry_point in entry_points().get(group_name, []):
+    for entry_point in entry_points(group=group_name):
         logger.info('Loading entry point "%s".', entry_point.name)
         try:
             # Then try to load the entry point (import and getattr)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

importlib_metadata removed compatibility shims for deprecated entry point interfaces.
see: https://github.com/python/importlib_metadata/blob/main/CHANGES.rst#v500

Filter result of entry_points function by group parameter.
see: https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.entry_points

It seems https://github.com/getredash/redash/pull/5831 fix problem by using old version, but supporting new version should be encouraged.

redash support Nodejs v14.17 and test frontend in circleci with circleci/node:14.17.
This include old python v3.5 and require some dirty hack. https://github.com/getredash/redash/pull/5840/commits/034fcc23a1cf9269007e65e26a970b05abfb66c4
If changing image used in circleci is better, I prefer to handle it in another pull request.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
percy in CI is failed but it is caused by https://github.com/getredash/redash/pull/5691 and it seems OK.