### PR TITLE
Add support for MongoDB 6.0 data sources

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -6,7 +6,7 @@ influxdb==5.2.3
 mysqlclient==1.3.14
 oauth2client==4.1.3
 pyhive==0.6.1
-pymongo[tls,srv]==3.9.0
+pymongo[tls,srv]==4.3.2
 vertica-python==0.9.5
 td-client==1.0.0
 pymssql==2.1.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ mock==3.0.5
 
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
-pymongo[srv,tls]==3.9.0
+pymongo[srv,tls]==4.3.2
 botocore>=1.13,<1.14.0
 PyAthena>=1.5.0
 ptvsd==4.3.2


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
Because of the use of an outdated of the pymongo lib, Redash is not compatible with the latest stable release of MongoDB: MongoDB 6.0+

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
