### PR TITLE
allow ssl connections for impala runner

### DIFF
--- a/redash/query_runner/impala_ds.py
+++ b/redash/query_runner/impala_ds.py
@@ -53,6 +53,7 @@ class Impala(BaseSQLQueryRunner):
                 },
                 "database": {"type": "string"},
                 "use_ldap": {"type": "boolean"},
+                "use_ssl": {"type": "boolean"},
                 "ldap_user": {"type": "string"},
                 "ldap_password": {"type": "string"},
                 "timeout": {"type": "number"},


### PR DESCRIPTION
There is no possibility to use ssl connections for impala runner.
Based on response here: https://discuss.redash.io/t/ssl-for-impala-use-ssl-true-issues-being-added-to-connect/3741/3 adding a ssl parameter in connector config should solve this issue.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
https://discuss.redash.io/t/ssl-for-impala-use-ssl-true-issues-being-added-to-connect/3741/3

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
