### PR TITLE
Pin importlib-metadata to 4.13.0

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,5 +4,5 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata>=1.6  # remove when on 3.8
+importlib-metadata==4.12.0  # 5.0.0 removed compatibility shims
 importlib_resources==1.5  # remove when on 3.9


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

importlib-metadata-5.0.0 removed SelectableGroups which Redash 10 depends on

See https://github.com/python/importlib_metadata/issues/409

## How is this tested?

- [x] Manually

```
docker-compose run --rm server create_db
```

## Related Tickets & Documents

Solves https://discuss.redash.io/t/docker-installation-problem/11190