### PR TITLE
Update PostgreSQL test image from 9.5 to 14

### DIFF
--- a/.ci/docker-compose.ci.yml
+++ b/.ci/docker-compose.ci.yml
@@ -18,6 +18,6 @@ services:
     image: redis:3.0-alpine
     restart: unless-stopped
   postgres:
-    image: postgres:9.5.6-alpine
+    image: postgres:14.5-alpine
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped

--- a/.ci/docker-compose.cypress.yml
+++ b/.ci/docker-compose.cypress.yml
@@ -67,6 +67,6 @@ services:
     image: redis:3.0-alpine
     restart: unless-stopped
   postgres:
-    image: postgres:9.5.6-alpine
+    image: postgres:14.5-alpine
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     image: redis:3-alpine
     restart: unless-stopped
   postgres:
-    image: postgres:9.5-alpine
+    image: postgres:14-alpine
     ports:
       - "15432:5432"
     # The following turns the DB into less durable, but gains significant performance improvements for the tests run (x3


### PR DESCRIPTION
## What type of PR is this? 

- [x] Build/Test

## Description

PostgreSQL 9.5 end-of-life was February 11, 2021

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)

## Related Tickets & Documents

https://www.postgresql.org/support/versioning/

