### PR TITLE
fix(sec): upgrade cryptography to 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ xlsxwriter==1.2.2
 pystache==0.5.4
 parsedatetime==2.4
 PyJWT==1.7.1
-cryptography==2.8
+cryptography==3.3.2
 simplejson==3.16.0
 ua-parser==0.8.0
 user-agents==2.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in cryptography 2.8
- [CVE-2020-25659](https://www.oscs1024.com/hd/CVE-2020-25659)


### What did I do？
Upgrade cryptography from 2.8 to 3.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS