### PR TITLE
Added new Env Variable REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES and updated include_drafts param to get value from REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ x-redash-environment: &redash-environment
   REDASH_MAIL_SERVER: "email"
   REDASH_ENFORCE_CSRF: "true"
   REDASH_GUNICORN_TIMEOUT: 60
+  REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES: "false"
   # Set secret keys in the .env file
 services:
   server:

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -124,12 +124,12 @@ class BaseQueryListResource(BaseResource):
                 search_term,
                 self.current_user.group_ids,
                 self.current_user.id,
-                include_drafts=True,
+                include_drafts=settings.FEATURE_VIEW_DRAFT_QUERIES,
                 multi_byte_search=current_org.get_setting("multi_byte_search_enabled"),
             )
         else:
             results = models.Query.all_queries(
-                self.current_user.group_ids, self.current_user.id, include_drafts=True
+                self.current_user.group_ids, self.current_user.id, include_drafts=settings.FEATURE_VIEW_DRAFT_QUERIES,
             )
         return filter_by_tags(results, models.Query.tags)
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -482,6 +482,7 @@ VERSION_CHECK = parse_boolean(os.environ.get("REDASH_VERSION_CHECK", "true"))
 FEATURE_DISABLE_REFRESH_QUERIES = parse_boolean(
     os.environ.get("REDASH_FEATURE_DISABLE_REFRESH_QUERIES", "false")
 )
+
 FEATURE_SHOW_QUERY_RESULTS_COUNT = parse_boolean(
     os.environ.get("REDASH_FEATURE_SHOW_QUERY_RESULTS_COUNT", "true")
 )
@@ -491,6 +492,7 @@ FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS = parse_boolean(
 FEATURE_AUTO_PUBLISH_NAMED_QUERIES = parse_boolean(
     os.environ.get("REDASH_FEATURE_AUTO_PUBLISH_NAMED_QUERIES", "true")
 )
+FEATURE_VIEW_DRAFT_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES", "false"))
 FEATURE_EXTENDED_ALERT_OPTIONS = parse_boolean(
     os.environ.get("REDASH_FEATURE_EXTENDED_ALERT_OPTIONS", "false")
 )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Added new Env Variable REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES and updated include_drafts param to get value from REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES

1. Application shows all the unpublished queries from other users on the UI by default, which is due to Hard coded value with `True` for the include_draft param.
2. Added new Env Variable `REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES` (boolean) through which application can be configured to view unpublished queries
3. By Default `REDASH_FEATURE_VIEW_UNPUBLISH_QUERIES`  will be `true` and can be configure through to `false` by adding the variable to env file.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
