### PR TITLE
Update snowflake-connector-python

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -27,7 +27,7 @@ qds-sdk>=1.9.6
 ibm-db>=2.0.9
 pydruid==0.5.7
 requests_aws_sign==0.1.5
-snowflake-connector-python==2.1.3
+snowflake-connector-python==2.9.0
 phoenixdb==0.7
 # certifi is needed to support MongoDB and SSL:
 certifi>=2019.9.11


### PR DESCRIPTION
The Snowflake parameter MULTI_STATEMENT_COUNT can be altered in this version, which will solve the "Multiple SQL statements in a single API call are not supported; use one API call per statement instead." error

## What type of PR is this? 
- [x] Refactor

## Description
Update requirements for snowflake-connector-python

## How is this tested?
- [x] N/A
