### PR TITLE
Make the database reencrypt script safer

### DIFF
--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -1,7 +1,9 @@
 import time
+import logging
 
 import sqlalchemy
 from click import argument, option
+from cryptography.fernet import InvalidToken
 from flask.cli import AppGroup
 from flask_migrate import stamp
 from sqlalchemy.exc import DatabaseError
@@ -81,8 +83,6 @@ def reencrypt(old_secret, new_secret, show_sql):
     _wait_for_db_connection(db)
 
     if show_sql:
-        import logging
-
         logging.basicConfig()
         logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 
@@ -109,10 +109,15 @@ def reencrypt(old_secret, new_secret, show_sql):
         update = table_for_update.update()
         selected_items = db.session.execute(select([table_for_select]))
         for item in selected_items:
-            stmt = update.where(table_for_update.c.id == item["id"]).values(
-                encrypted_options=item["encrypted_options"]
-            )
-            db.session.execute(stmt)
+            try:
+                stmt = update.where(table_for_update.c.id == item["id"]).values(
+                    encrypted_options=item["encrypted_options"]
+                )
+                db.session.execute(stmt)
+            except InvalidToken:
+                logging.error(
+                    f'Invalid Decryption Key for id {item["id"]} in table {table_for_select}'
+                )
 
         selected_items.close()
         db.session.commit()

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -113,10 +113,14 @@ def reencrypt(old_secret, new_secret, show_sql):
                 stmt = update.where(table_for_update.c.id == item["id"]).values(
                     encrypted_options=item["encrypted_options"]
                 )
-                db.session.execute(stmt)
             except InvalidToken:
                 logging.error(
                     f'Invalid Decryption Key for id {item["id"]} in table {table_for_select}'
+                )
+            else:
+                db.session.execute(stmt)
+                logging.info(
+                    f'Successfully updated encryption for id {item["id"]} in table {table_for_select}'
                 )
 
         selected_items.close()

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -1,5 +1,5 @@
-import time
 import logging
+import time
 
 import sqlalchemy
 from click import argument, option
@@ -114,14 +114,9 @@ def reencrypt(old_secret, new_secret, show_sql):
                     encrypted_options=item["encrypted_options"]
                 )
             except InvalidToken:
-                logging.error(
-                    f'Invalid Decryption Key for id {item["id"]} in table {table_for_select}'
-                )
+                logging.error(f'Invalid Decryption Key for id {item["id"]} in table {table_for_select}')
             else:
                 db.session.execute(stmt)
-                logging.info(
-                    f'Successfully updated encryption for id {item["id"]} in table {table_for_select}'
-                )
 
         selected_items.close()
         db.session.commit()


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The current `reencrypt` script (`manage database reencrypt old_key new_key`, [as described in the docs](https://redash.io/help/open-source/admin-guide/secrets)) works nicely when databases are consistent.

However, there are some scenarios where a database encryption may become inconsistent, and this script can be really helpful with just some minor adjustments.

For exemple, in our case, we were upgrading from V8 directly to V10. As we saw there was a new `REDASH_SECRET_KEY`, we set this new key with a new value. However, during the db migration, only one table was migrated (we're still not sure how that happened).

The result was that the encryption key used in the `data_sources` table became different from the `notification_destinations` table in production. Hence, we could not access our Alert Destinations page in the browser.

It is also not hard to think of other inconsistency cases, such as different rows inside those tables having different encryption keys.

In our case, if we ran this script as it was, it would break immediately because the `data_sources` table runs first, making it impossible to fix the `notification_destinations` rows. Also, we were not sure if running this with a possibly invalid token could somehow break our data sources.

With the small proposed change, we make the `reencrypt` script safer to run. This way, it will run row by row, and only change the encryption if `old_key` is able to decrypt the data in the first place. If it isn't, then the script simply skips that row.

What do you think? If approved, I can also update the docs [here](https://redash.io/help/open-source/admin-guide/secrets).

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

It is just a small update to a script that had no automatic testing in the first place.

The way I tested was simply building redash locally and playing with different encryption keys in the env vars.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

I'll update the docs if you agree with the changes :)

The idea is to just to make it clearer in the docs that the `reencrypt` script is safe to use, even if you are not sure about the decryption key.

