### PR TITLE
Improve visibility of error message during schema retrieval

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -234,6 +234,13 @@ class BaseQueryRunner(object):
     def get_schema(self, get_stats=False):
         raise NotSupported()
 
+    def _handle_run_query_error(self, error):
+        if error is None:
+            return
+
+        logger.error(error)
+        raise Exception(f"Error during query execution. Reason: {error}")
+
     def _run_query_internal(self, query):
         results, error = self.run_query(query, None)
 

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -206,7 +206,7 @@ class Athena(BaseQueryRunner):
 
         results, error = self.run_query(query, None)
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
         for row in results["rows"]:

--- a/redash/query_runner/azure_kusto.py
+++ b/redash/query_runner/azure_kusto.py
@@ -138,7 +138,7 @@ class AzureKusto(BaseQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -305,7 +305,7 @@ class BigQuery(BaseQueryRunner):
         query = '\nUNION ALL\n'.join(queries)
         results, error = self.run_query(query, None)
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
         for row in results["rows"]:
@@ -341,7 +341,7 @@ class BigQuery(BaseQueryRunner):
             json_data = json_dumps(data, ignore_nan=True)
         except apiclient.errors.HttpError as e:
             json_data = None
-            if e.resp.status == 400:
+            if e.resp.status in [400, 404]:
                 error = json_loads(e.content)["error"]["message"]
             else:
                 error = e.content

--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -79,7 +79,7 @@ class ClickHouse(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -154,7 +154,7 @@ class Databricks(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/db2.py
+++ b/redash/query_runner/db2.py
@@ -65,7 +65,7 @@ class DB2(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/drill.py
+++ b/redash/query_runner/drill.py
@@ -135,7 +135,7 @@ class Drill(BaseHTTPQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/druid.py
+++ b/redash/query_runner/druid.py
@@ -77,7 +77,7 @@ class Druid(BaseQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         schema = {}
         results = json_loads(results)

--- a/redash/query_runner/firebolt.py
+++ b/redash/query_runner/firebolt.py
@@ -76,7 +76,7 @@ class Firebolt(BaseQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         schema = {}
         results = json_loads(results)

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -80,7 +80,7 @@ class SqlServer(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -68,7 +68,7 @@ class SQLServerODBC(BaseSQLQueryRunner):
     @classmethod
     def type(cls):
         return "mssql_odbc"
-    
+
     @property
     def supports_auto_limit(self):
         return False
@@ -86,7 +86,7 @@ class SQLServerODBC(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -137,7 +137,7 @@ class Mysql(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -85,7 +85,7 @@ class Oracle(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -186,7 +186,7 @@ class PostgreSQL(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/phoenix.py
+++ b/redash/query_runner/phoenix.py
@@ -72,7 +72,7 @@ class Phoenix(BaseQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -78,7 +78,7 @@ class Presto(BaseQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -173,7 +173,7 @@ class Snowflake(BaseQueryRunner):
         results, error = self._run_query_without_warehouse(query)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         schema = {}
         for row in results["rows"]:

--- a/redash/query_runner/sqlite.py
+++ b/redash/query_runner/sqlite.py
@@ -43,7 +43,7 @@ class Sqlite(BaseSQLQueryRunner):
             schema[table_name] = {"name": table_name, "columns": []}
             results_table, error = self.run_query(query_columns % (table_name,), None)
             if error is not None:
-                raise Exception("Failed getting schema.")
+                self._handle_run_query_error(error)
 
             results_table = json_loads(results_table)
             for row_column in results_table["rows"]:

--- a/redash/query_runner/trino.py
+++ b/redash/query_runner/trino.py
@@ -85,7 +85,7 @@ class Trino(BaseQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
         schema = {}

--- a/redash/query_runner/vertica.py
+++ b/redash/query_runner/vertica.py
@@ -75,7 +75,7 @@ class Vertica(BaseSQLQueryRunner):
         results, error = self.run_query(query, None)
 
         if error is not None:
-            raise Exception("Failed getting schema.")
+            self._handle_run_query_error(error)
 
         results = json_loads(results)
 

--- a/redash/tasks/general.py
+++ b/redash/tasks/general.py
@@ -85,8 +85,8 @@ def get_schema(data_source_id, refresh):
                 "message": "Data source type does not support retrieving schema",
             }
         }
-    except Exception:
-        return {"error": {"code": 2, "message": "Error retrieving schema."}}
+    except Exception as e:
+        return {"error": {"code": 2, "message": f"Error retrieving schema: {e}"}}
 
 
 def sync_user_details():


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x ] Other

## Description
Right now it is impossible to debug the error during schema update. There is not logs in worker logs as well as response from the server is useless in chrome dev tools: 
![image](https://user-images.githubusercontent.com/2346916/209062586-0d5b5743-34f5-495f-8390-1630a646b4bf.png)


With the current change we: 
1. Pass the real error message back to the task response:
![image](https://user-images.githubusercontent.com/2346916/209062722-acfe32ca-8139-4e0b-95e8-43a35f9de89c.png)

2. Reduce code duplication by consolidating error handling in one place for future improvements.
3. improve bigQuery error handling to parse json for 404 errors as well as for 400th.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
I tested this behavior by reproducing the error during schema update operation. With this new change I can clearly see the issue in dev tools as well as in logs.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
