### PR TITLE
Patch: jira jql query result - Error running query: sequence item 0: expected str instance, int found

### DIFF
--- a/redash/query_runner/jql.py
+++ b/redash/query_runner/jql.py
@@ -74,7 +74,7 @@ def parse_issue(issue, field_mapping):
                     if len(listValues) > 0:
                         result[
                             field_mapping.get_dict_output_field_name(k, member_name)
-                        ] = ",".join(listValues)
+                        ] = ",".join(str(x) for x in listValues)
 
             else:
                 # otherwise support list values only for non-dict items


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other



## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
 This pull request for patching error in Jira as Datasource  while querying with JQL. This error occured when query data from jira contains `int` in query result array. The error said `Error running query: sequence item 0: expected str instance, int found`

![image](https://user-images.githubusercontent.com/3032793/218040835-7852a739-92b1-495c-bd98-c1248bf135eb.png)

The solution for this error, I convert all values from `listValues` variable into string.

## How is this tested?

- [X] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
