### PR TITLE
Add "set -e" to docker_build

### DIFF
--- a/.circleci/docker_build
+++ b/.circleci/docker_build
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 VERSION=$(jq -r .version package.json)
 VERSION_TAG=$VERSION.b$CIRCLE_BUILD_NUM
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description

The status of the build-preview-docker-image test in the master branch is Success, but it actually fails.

https://app.circleci.com/pipelines/github/getredash/redash/5861/workflows/fb449a05-b96c-4e5a-b45b-433c1eac3c9c/jobs/52018?invite=true#step-109-4956

![スクリーンショット 2023-02-20 12 16 59](https://user-images.githubusercontent.com/117768/220001644-135e0689-5b58-4df1-a6fe-ba155c9cab18.png)

Add `set -e` to the bash script to set the status to Failed if the docker build fails.

<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

I didn't know how to write a docker build test, so I checked the operation manually.
The `pip install -r requirements_all_ds.txt` seems to fail now on the master branch.
I set `--build-arg skip_ds_deps=true` and the docker build succeeded.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
