### PR TITLE
Add explicit permission check to postgres schema discovery

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -220,7 +220,7 @@ class PostgreSQL(BaseSQLQueryRunner):
         ON a.attrelid = c.oid
         AND a.attnum > 0
         AND NOT a.attisdropped
-        WHERE c.relkind IN ('m', 'f', 'p')
+        WHERE c.relkind IN ('m', 'f', 'p') AND has_table_privilege(s.nspname || '.' || c.relname, 'select')
 
         UNION
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

Postgres schema discovery code has a flow related permissions of materialized views. If you have a user with permissions restricted to particular schema (not public) it will get all materialized view from the DB instance regardless the permissions. The issue related only to materialized views (and possibly foreign tables and partitioned tables) because tables and views discovered using ``information_schema.columns``  and has implicit permissions check.

To overcome the issue I propose to add explicit permission check using has_table_privilege

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

I configured permissions for the user like this:

```sql
GRANT CONNECT ON DATABASE db_name TO redash_user;
REVOKE USAGE ON SCHEMA public from redash_user;
GRANT USAGE ON SCHEMA s1 TO redash_user;
GRANT SELECT ON ALL TABLES IN schema s1 TO redash_user;
REVOKE CREATE ON SCHEMA s1 FROM redash_user;
REVOKE all ON  ALL TABLES IN schema public FROM redash_user;
REVOKE all privileges  ON schema public FROM redash_user;
ALTER DEFAULT PRIVILEGES IN SCHEMA s1 GRANT SELECT ON TABLES TO redash_user;
```

Afterwards I checked the user has no materialized views from the public schema in the UI.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
