### PR TITLE
Update development workflow for Apple Silicon, Node version, default port, and maildev image

### DIFF
--- a/client/cypress/cypress.js
+++ b/client/cypress/cypress.js
@@ -13,7 +13,7 @@ try {
   cypressConfigBaseUrl = cypressConfig.baseUrl;
 } catch (e) {}
 
-const baseUrl = process.env.CYPRESS_baseUrl || cypressConfigBaseUrl || "http://localhost:5000";
+const baseUrl = process.env.CYPRESS_baseUrl || cypressConfigBaseUrl || "http://localhost:5001";
 
 function seedDatabase(seedValues) {
   get(baseUrl + "/login", (_, { headers }) => {

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:5000",
+  "baseUrl": "http://localhost:5001",
   "video": true,
   "videoUploadOnPasses": false,
   "fixturesFolder": "client/cypress/fixtures",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - postgres
       - redis
     ports:
-      - "5000:5000"
+      - "5001:5000"
       - "5678:5678"
     environment:
       <<: *redash-environment
@@ -53,17 +53,17 @@ services:
     restart: unless-stopped
   postgres:
     image: postgres:9.5-alpine
+    ports:
+      - "15432:5432"
     # The following turns the DB into less durable, but gains significant performance improvements for the tests run (x3
     # improvement on my personal machine). We should consider moving this into a dedicated Docker Compose configuration for
     # tests.
-    ports:
-      - "15432:5432"
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
   email:
-    image: djfarrelly/maildev
+    image: maildev/maildev
     ports:
       - "1080:80"
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "git+https://github.com/getredash/redash.git"
   },
   "engines": {
-    "node": "^14.16.1",
+    "node": ">14.16.0 <17.0.0",
     "yarn": "^1.22.10"
   },
   "author": "Redash Contributors",

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -9,7 +9,7 @@ pyhive==0.6.1
 pymongo[tls,srv]==3.9.0
 vertica-python==0.9.5
 td-client==1.0.0
-pymssql==2.1.4
+pymssql==2.1.5
 dql==0.5.26
 dynamo3==0.4.10
 boto3>=1.10.0,<1.11.0
@@ -24,7 +24,7 @@ simple_salesforce==0.74.3
 PyAthena>=1.5.0,<=1.11.5
 pymapd==0.19.0
 qds-sdk>=1.9.6
-ibm-db>=2.0.9
+# ibm-db>=2.0.9
 pydruid==0.5.7
 requests_aws_sign==0.1.5
 snowflake-connector-python==2.1.3
@@ -47,3 +47,4 @@ nzpy>=1.15
 nzalchemy
 python-arango==6.1.0
 pinotdb>=0.4.5
+pyarrow==10.0.0

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ const isDevelopment = !isProduction;
 const isHotReloadingEnabled =
   isDevelopment && process.env.HOT_RELOAD === "true";
 
-const redashBackend = process.env.REDASH_BACKEND || "http://localhost:5000";
+const redashBackend = process.env.REDASH_BACKEND || "http://localhost:5001";
 const baseHref = CONFIG.baseHref || "/";
 const staticPath = CONFIG.staticPath || "/static/";
 const htmlTitle = CONFIG.title || "Redash";


### PR DESCRIPTION
## Description

This PR includes a few fixes for the development workflow:

1. Fix issues with Apple Silicon (M1, M2) processors: applied suggestions from #5805 to remove/update dependencies that aren't ARM compatible.
2. Update supported Node versions. I bumped the supported engines up to Node v16. When I tried with v19 I had a few issues, so will wait with it until we update the Node modules.
3. Updated the default port from `5000` to `5001` as port `5000` seems to be used by the system on MacOS now.
4. Updated the maildev image to the latest one.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

Closes #5805, closes #5804.