### PR TITLE
fix MySQL multi statement support

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -3,7 +3,7 @@ protobuf==3.17.3
 gspread==3.1.0
 impyla==0.16.0
 influxdb==5.2.3
-mysqlclient==1.3.14
+mysqlclient==2.1.1
 oauth2client==4.1.3
 pyhive==0.6.1
 pymongo[tls,srv]==3.9.0
@@ -18,7 +18,7 @@ sasl>=0.1.3
 thrift>=0.8.0
 thrift_sasl>=0.1.0
 cassandra-driver==3.21.0
-memsql==3.0.0
+memsql==3.2.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
 PyAthena>=1.5.0,<=1.11.5


### PR DESCRIPTION
Bump `mysqlclient` from `1.3.14` to `2.1.1`, `memsql` from `3.0.0` to `3.2.0` to fix MySQL multi statement support.

## What type of PR is this? 

- [x] Bug Fix

## Description
The version string returned from `_mysql.get_client_info()` is different, and is lower than 4 in the latest Docker image.
It maybe due to Maridb client connector changed their version number naming policy.
The new version of `mysqlclient` no longer check client version number to enable `MULTI_STATEMENTS` and `MULTI_RESULTS` flags. So updating `mysqlclient` to a newer version could fix the issue.
`memsql` also need to be updated to be compatible with new version of mysqlclient.

## How is this tested?

- [x] Manually

## Related Tickets & Documents

Fixes #5925.
