### PR TITLE
Pymongo version upgrade changes

### DIFF
--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -302,19 +302,20 @@ class MongoDB(BaseQueryRunner):
 
         cursor = None
         if q or (not q and not aggregate):
-            if s:
-                cursor = db[collection].find(q, f).sort(s)
-            else:
-                cursor = db[collection].find(q, f)
-
-            if "skip" in query_data:
-                cursor = cursor.skip(query_data["skip"])
-
-            if "limit" in query_data:
-                cursor = cursor.limit(query_data["limit"])
-
             if "count" in query_data:
-                cursor = len(list(cursor))
+                options = {opt: query_data[opt] for opt in ("skip", "limit") if opt in query_data}
+                cursor = db[collection].count_documents(q, **options)
+            else:
+                if s:
+                    cursor = db[collection].find(q, f).sort(s)
+                else:
+                    cursor = db[collection].find(q, f)
+
+                if "skip" in query_data:
+                    cursor = cursor.skip(query_data["skip"])
+
+                if "limit" in query_data:
+                    cursor = cursor.limit(query_data["limit"])
 
         elif aggregate:
             allow_disk_use = query_data.get("allowDiskUse", False)

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -15,7 +15,7 @@ try:
     from bson.timestamp import Timestamp
     from bson.decimal128 import Decimal128
     from bson.son import SON
-    from bson.json_util import object_hook as bson_object_hook
+    from bson.json_util import object_hook as bson_object_hook, JSONOptions
 
     enabled = True
 
@@ -67,7 +67,8 @@ def datetime_parser(dct):
     if "$oids" in dct:
         return parse_oids(dct["$oids"])
 
-    return bson_object_hook(dct)
+    opts = JSONOptions(tz_aware=True)
+    return bson_object_hook(dct, json_options=opts)
 
 
 def parse_query_json(query):
@@ -244,7 +245,7 @@ class MongoDB(BaseQueryRunner):
     def get_schema(self, get_stats=False):
         schema = {}
         db = self._get_db()
-        for collection_name in db.collection_names():
+        for collection_name in db.list_collection_names():
             if collection_name.startswith("system."):
                 continue
             columns = self._get_collection_fields(db, collection_name)
@@ -313,7 +314,7 @@ class MongoDB(BaseQueryRunner):
                 cursor = cursor.limit(query_data["limit"])
 
             if "count" in query_data:
-                cursor = cursor.count()
+                cursor = len(list(cursor))
 
         elif aggregate:
             allow_disk_use = query_data.get("allowDiskUse", False)

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -6,7 +6,7 @@ influxdb==5.2.3
 mysqlclient==2.1.1
 oauth2client==4.1.3
 pyhive==0.6.1
-pymongo[tls,srv]==3.9.0
+pymongo[tls,srv]==4.3.3
 vertica-python==0.9.5
 td-client==1.0.0
 pymssql==2.1.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ mock==3.0.5
 
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
-pymongo[srv,tls]==3.9.0
+pymongo[srv,tls]==4.3.3
 boto3>=1.10.0,<1.11.0
 botocore>=1.13,<1.14.0
 PyAthena>=1.5.0,<=1.11.5


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

- The pymongo version has been updated to 4.3.3
- The default `JSONOption` from `bson.json_utils` sets `tz_aware` to `False` from 4.0 (https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#tz-aware-defaults-to-false), so setting value to `True` explicitly in `datetime_parser`
- `collection_names` method has been changed to `list_collection_names` (https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#database-collection-names-is-removed)
- `count` method has been changed and using `len` to get the length from `cursor` since `count` method has been removed from 4.0 (https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-count-and-cursor-count-is-removed)

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
