### PR TITLE
Fix invalid comparison causing excessive parameter updates

### DIFF
--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -1,4 +1,4 @@
-import { size, filter, forEach, extend } from "lodash";
+import { size, filter, forEach, extend, isEqual } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { SortableContainer, SortableElement, DragHandle } from "@redash/viz/lib/components/sortable";
@@ -54,7 +54,7 @@ export default class Parameters extends React.Component {
 
   componentDidUpdate = prevProps => {
     const { parameters, disableUrlUpdate } = this.props;
-    const parametersChanged = prevProps.parameters !== parameters;
+    const parametersChanged = !isEqual(prevProps.parameters, parameters);
     const disableUrlUpdateChanged = prevProps.disableUrlUpdate !== disableUrlUpdate;
     if (parametersChanged) {
       this.setState({ parameters });


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This caused Safari to block the page where the history.pushState was called too many times in large dashboards.

The component was updated many times, and this wrong comparison was always true, causing the code to eventually call "`history.replaceState()` more than 100 times per 30 seconds".

## How is this tested?

- [x] Manually

While the bug itself is a componentDidUpdate that compares the wrong thing, the manifestation of it is not that terrible. I checked and verified that it does not reproduce in Safari.