### PR TITLE
Pin boto3 dependencies in dev requirements as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ jobs:
           name: List Enabled Query Runners
           command: docker-compose run --rm redash manage ds list_types
       - run:
+          name: List Installed Python Packages
+          command: docker-compose run --rm redash pip freeze
+      - run:
           name: Run Tests
           command: docker-compose run --name tests redash tests --junitxml=junit.xml --cov-report xml --cov=redash --cov-config .coveragerc tests/
       - run:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ mock==3.0.5
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
 pymongo[srv,tls]==3.9.0
+boto3>=1.10.0,<1.11.0
 botocore>=1.13,<1.14.0
 PyAthena>=1.5.0,<=1.11.5
 ptvsd==4.3.2


### PR DESCRIPTION
This fixes the `backend-unit-tests` job in CI, where a too-recent version of boto3 was getting installed.