### PR TITLE
chore: inherit BaseSQLQueryRunner in Snowflake query runner

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -6,7 +6,7 @@ except ImportError:
     enabled = False
 
 
-from redash.query_runner import BaseQueryRunner, register
+from redash.query_runner import BaseSQLQueryRunner, register
 from redash.query_runner import (
     TYPE_STRING,
     TYPE_DATE,
@@ -31,7 +31,7 @@ TYPES_MAP = {
 }
 
 
-class Snowflake(BaseQueryRunner):
+class Snowflake(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
 
     @classmethod


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Modify `Snowflake` query runner to inherit `BaseSQLQueryRunner` instead of `BaseQueryRunner`. Primary intention was to add auto-limit query support, but rather than add those methods to the `Snowflake` query runner, I think we can refactor it to inherit from BaseSQLQueryRunner and get it for free.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
Added snowflake connection, ran queries and created dashboards successfully.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
