### PR TITLE
fix: remember recently used datasource

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -1,4 +1,4 @@
-import { extend, find, includes, isEmpty, map } from "lodash";
+import { extend, isEmpty, map } from "lodash";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
@@ -48,7 +48,12 @@ import "./QuerySource.less";
 
 function chooseDataSourceId(dataSourceIds, availableDataSources) {
   availableDataSources = map(availableDataSources, ds => ds.id);
-  return find(dataSourceIds, id => includes(availableDataSources, id)) || null;
+  for (let i = 0; i < dataSourceIds.length; i++) {
+    if (availableDataSources.indexOf(parseInt(dataSourceIds[i]))!==-1) {
+      return dataSourceIds[i];
+    }
+  }
+  return null;
 }
 
 function QuerySource(props) {


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Previously in the redash v10 the UI cannot remember the recently used datasource when we want to create a new query (always back to the first datasource on the list), but in v8 that feature is exist. So now when we want to create a new query, the UI can remember our recently used datasource. 

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

- Try to make a new query using any datasource and don't forget to save the query.
- Try to make another new query, as you can see now the datasource in the dropdown menu is the recently used datasource.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

This bug fix PR related to this issue:
[https://github.com/getredash/redash/issues/6083](https://github.com/getredash/redash/issues/6083)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before: 
![before](https://github.com/getredash/redash/assets/87929380/287c0a70-ea11-4959-9eea-93cdea61ea0a)

After:
![Peek 2023-06-15 15-57](https://github.com/getredash/redash/assets/87929380/5bbd6c3f-bdb5-4a72-9557-db889f686ea1)




