### PR TITLE
Update requirements_all_ds.txt. Bump snowflake-connector to 3.0.4

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -27,7 +27,7 @@ qds-sdk>=1.9.6
 # ibm-db>=2.0.9
 pydruid==0.5.7
 requests_aws_sign==0.1.5
-snowflake-connector-python==2.1.3
+snowflake-connector-python==3.0.4
 phoenixdb==0.7
 # certifi is needed to support MongoDB and SSL:
 certifi>=2019.9.11


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [X] Other

## Description
Version 2.1.3 of snowflake connector is long obsolete. The minimum supported version by snowflake is 2.5.0.
This PR bumps this to the latest

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [X] Manually
- [ ] N/A

- build an docker image
- create a SF datasource
- execute a number of queries

