### PR TITLE
Update PyMongo to version 4.3.3

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -6,7 +6,7 @@ influxdb==5.2.3
 mysqlclient==2.1.1
 oauth2client==4.1.3
 pyhive==0.6.1
-pymongo[tls,srv]==3.9.0
+pymongo[tls,srv]==4.3.3
 vertica-python==0.9.5
 td-client==1.0.0
 pymssql==2.1.5


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This updates the PyMongo library so people can use MongoDB 6.0

## How is this tested?

- [x] Manually

@Adityak4201 was asking for this in https://github.com/RedashCommunity/redash/issues/59, so should be ok to test this.
