### PR TITLE
Use precompiled psycopg2-binary package instead of psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Flask-WTF==0.14.3
 passlib==1.7.1
 aniso8601==8.0.0
 blinker==1.4
-psycopg2==2.8.3
+psycopg2-binary==2.9.6
 python-dateutil==2.8.0
 pytz>=2019.3
 PyYAML==5.4


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This replaces our use of psycopg2 with the pre-compiled version, psycopg2-binary

In theory, we should be able to simplify our development dependencies a bit through
using this.


## How is this tested?

- [x] Manually

It's reportedly working for others, and seems to pass initial testing on my desktop here.  Haven't yet run our full CI tests on it though, thus this PR to make that happen.


## Related Tickets & Documents

https://github.com/RedashCommunity/redash/pull/77