### PR TITLE
Update to latest in yarn 1.22.x series

### DIFF
--- a/.ci/Dockerfile.cypress
+++ b/.ci/Dockerfile.cypress
@@ -5,7 +5,7 @@ WORKDIR $APP
 
 COPY package.json yarn.lock .yarnrc $APP/
 COPY viz-lib $APP/viz-lib
-RUN npm install yarn@1.22.10 -g && yarn --frozen-lockfile --network-concurrency 1 > /dev/null
+RUN npm install yarn@1.22.19 -g && yarn --frozen-lockfile --network-concurrency 1 > /dev/null
 
 COPY . $APP
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           cache: 'yarn'
       - name: Install Dependencies
         run: |
-          npm install --global --force yarn@1.22.10
+          npm install --global --force yarn@1.22.19
           yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
       - name: Run Lint
         run: yarn lint:ci
@@ -94,7 +94,7 @@ jobs:
           cache: 'yarn'
       - name: Install Dependencies
         run: |
-          npm install --global --force yarn@1.22.10
+          npm install --global --force yarn@1.22.19
           yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
       - name: Run App Tests
         run: yarn test
@@ -127,7 +127,7 @@ jobs:
           echo "CODE_COVERAGE=true" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
-          npm install --global --force yarn@1.22.10
+          npm install --global --force yarn@1.22.19
           yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
       - name: Setup Redash Server
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14.17 as frontend-builder
 
-RUN npm install --global --force yarn@1.22.10
+RUN npm install --global --force yarn@1.22.19
 
 # Controls whether to build the frontend assets
 ARG skip_frontend_build

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,8 @@
   base    = "client"
   publish = "client/dist"
   # Netlify doesn't seem to install Yarn even though NETLIFY_USE_YARN is set below
-  # command = "cd ../ && npm i -g yarn@1.22.10 && yarn --frozen-lockfile --force && cd viz-lib && yarn build:babel && cd .. && rm -r ./node_modules/@redash/viz && cp -r ./viz-lib/. ./node_modules/@redash/viz && yarn build && cd ./client"
-  command = "cd ../ && npm i -g yarn@1.22.10 && yarn cache clean && yarn --frozen-lockfile --network-concurrency 1 && yarn build && cd ./client"
+  # command = "cd ../ && npm i -g yarn@1.22.19 && yarn --frozen-lockfile --force && cd viz-lib && yarn build:babel && cd .. && rm -r ./node_modules/@redash/viz && cp -r ./viz-lib/. ./node_modules/@redash/viz && yarn build && cd ./client"
+  command = "cd ../ && npm i -g yarn@1.22.19 && yarn cache clean && yarn --frozen-lockfile --network-concurrency 1 && yarn build && cd ./client"
 
 [build.environment]
   NODE_VERSION = "14.16.1"


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

We're using an old version of yarn's 1.22.x releases.  This PR updates to the latest one, 1.22.19.


## How is this tested?

- [x] Manually

I've been using yarn 1.22.19 for several months across multiple projects, and it also seems to be working fine in Redash over the last week in my local setup.  Thus this PR.