### PR TITLE
Wait for query change to propagate on pivot spec

### DIFF
--- a/client/cypress/integration/visualizations/pivot_spec.js
+++ b/client/cypress/integration/visualizations/pivot_spec.js
@@ -99,6 +99,10 @@ describe("Pivot", () => {
         .focus()
         .type(" UNION ALL {enter}SELECT 'c' AS stage1, 'c5' AS stage2, 55 AS value");
 
+      // wait for the query text change to propagate (it's debounced in QuerySource.jsx)
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(200);
+
       cy.getByTestId("SaveButton").click();
       cy.getByTestId("ExecuteButton")
         .should("be.enabled")


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Checked what's happening for the Pivot spec in [this run](https://cloud.cypress.io/projects/924cka/runs/7c62599b-ead0-473d-aadd-443eab109b91/test-results/18b0354a-312f-4ef0-9ce9-3ee6e21865e7/video):
1. Query text is updated to include a new line
2. Save button is triggered, if for some reason the debounce we do didn't finish by then text will be saved with older values
3. Same for execution
4. New query object is received from the backend, the query text is updated on the frontend. The new value will revert in this case
5. Query is asserted with the older results, so it fails


For reference, the delay we do is in https://github.com/getredash/redash/blob/84c2abed59bace2f2b9d1e31d512a60ba8c8ac47/client/app/pages/queries/QuerySource.jsx#L84-L86

In the future it's possible to do some refactor on the query page state for that not to be needed, but left the wait as a short term to fix the flaky test.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
