### PR TITLE
update widget_spec.js test to pass on 380 or 381 vizheight

### DIFF
--- a/client/cypress/integration/dashboard/widget_spec.js
+++ b/client/cypress/integration/dashboard/widget_spec.js
@@ -177,7 +177,7 @@ describe("Widget", () => {
       cy.visit(this.dashboardUrl);
       cy.getByTestId("TableVisualization")
         .its("0.offsetHeight")
-        .should("eq", 381);
+        .should("be.oneOf", [380, 381]);
       cy.percySnapshot("Shows correct height of table visualization");
     });
   });


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other (test fix)

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

This test doesn't seem to pass consistently, sometimes returning 380 and sometimes 381, which might be an architecture/OS thing. See [Discord message 1](https://discord.com/channels/1029619790563790848/1029619790563790851/1124653072002584597), [Discord message 2](https://discord.com/channels/1029619790563790848/1029619790563790851/1125920087740784731).

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A