### PR TITLE
fixed importlib-resources==5.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ werkzeug==2.3.3
 Authlib==0.15.5
 advocate==1.0.0
 urllib3==1.25.11
+importlib-resources==5.13.0


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
A few hours ago, importlib-resources was [updated](https://github.com/python/importlib_resources/issues/80), which resulted in a CI [failure](https://github.com/getredash/redash/actions/runs/5490556738/jobs/10006155533). It seems that there is no locked version of importlib-resources in Python 3.8.

Although the error originates from [pysaml2](https://github.com/IdentityPython/pysaml2), we are unable to upgrade to 7.4.1 as it relies on Python 3.9.

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
