### PR TITLE
Update watchdog to version 3.0.0, to workaround reported error

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,5 @@ botocore>=1.13,<1.14.0
 PyAthena>=1.5.0,<=1.11.5
 ptvsd==4.3.2
 freezegun==0.3.12
-watchdog==0.9.0
+watchdog==3.0.0
 ptpython==3.0.23


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Fixes an error reported here:

https://github.com/getredash/redash/discussions/6131#discussioncomment-6399367

```
I updated requirements_dev.txt to install watchdog=3.0.0 instead of 0.0.9 otherwise redash-server-1 would
crash on startup on an issue with /usr/local/lib/python3.8/site-packages/watchdog/events.py
"ImportError: cannot import name 'EVENT_TYPE_OPENED' from 'watchdog.events'"
```


## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)


## Related Tickets & Documents

https://github.com/getredash/redash/discussions/6131#discussioncomment-6399367