### PR TITLE
Move to Redis 7 for our development and CI docker compose

### DIFF
--- a/.ci/docker-compose.ci.yml
+++ b/.ci/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
       REDASH_DATABASE_URL: "postgresql://postgres:FmTKs5vX52ufKR1rd8tn4MoSP7zvCJwb@postgres/postgres"
       REDASH_COOKIE_SECRET: "2H9gNG9obnAQ9qnR9BDTQUph6CbXKCzF"
   redis:
-    image: redis:3.0-alpine
+    image: redis:7-alpine
     restart: unless-stopped
   postgres:
     image: pgautoupgrade/pgautoupgrade:dev

--- a/.ci/docker-compose.cypress.yml
+++ b/.ci/docker-compose.cypress.yml
@@ -65,7 +65,7 @@ services:
       CYPRESS_PROJECT_ID: ${CYPRESS_PROJECT_ID}
       CYPRESS_RECORD_KEY: ${CYPRESS_RECORD_KEY}
   redis:
-    image: redis:3.0-alpine
+    image: redis:7-alpine
     restart: unless-stopped
   postgres:
     image: pgautoupgrade/pgautoupgrade:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       <<: *redash-environment
       PYTHONUNBUFFERED: 0
   redis:
-    image: redis:3-alpine
+    image: redis:7-alpine
     restart: unless-stopped
   postgres:
     image: pgautoupgrade/pgautoupgrade:dev


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR updates our development and CI docker-compose files to use Redis 7, bringing us back to using a current, supported version of Redis.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)


## Related Tickets & Documents

I've run our backend unit test and Cypress with this, and it's not shown any problems.