### PR TITLE
Update SQLAlchemy to highest 1.3.x release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pytz>=2019.3
 PyYAML==5.4
 redis==4.4.4
 requests==2.31.0
-SQLAlchemy==1.3.10
+SQLAlchemy==1.3.24
 # We can't upgrade SQLAlchemy-Searchable version as newer versions require PostgreSQL > 9.6, but we target older versions at the moment.
 SQLAlchemy-Searchable==0.10.6
 # We need to pin the version of pyparsing, as newer versions break SQLAlchemy-Searchable-10.0.6 (newer versions no longer depend on it)


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This moves us to the latest SQLAlchemy 1.3.x series release for the Python backend.

That being said, that release was in July 2021.

Moving to SQLAlchemy 1.4 / 2.0 seems like it'll be a substantial project.

From skimming over the migration information, it seems like SQLAlchemy 1.4 is intended to ease migration to SQLAlchemy 2.0:

  * https://docs.sqlalchemy.org/en/14/changelog/migration_14.html
  * https://docs.sqlalchemy.org/en/14/changelog/migration_20.html

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)

This PR is passing both the unit and Cypress tests on my local desktop.