### PR TITLE
Add a make target to generate .env file for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ clean:
 down:
 	docker-compose down
 
+env:
+	printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
+
 tests:
 	docker-compose run server tests
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

This PR adds a new `make env` command, which generates a development oriented `.env` file.

```
$ make env
```

It's just a small quality-of-life improvement for developers, and helps reduce confusion as to what values are needed.

At present it only generates the `REDASH_COOKIE_SECRET` and `REDASH_SECRET_KEY` environment variables, but we can easily add more as needed.


## How is this tested?

- [x] Manually

Tested (using bash) by running `make env` then confirming it worked using `cat .env`.

```
$ make env
printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
$ cat .env
REDASH_COOKIE_SECRET=9GWB4pw54flMmfTLEhJMcUYKW9nWgUmZ
REDASH_SECRET_KEY=KV86JIFs2V3lDjXIXU6KWShJy1auGCm4
```

## Related Tickets & Documents

We should update the [Local development setup wiki page](https://github.com/getredash/redash/wiki/Local-development-setup) with this command when merged. :smile: