### PR TITLE
Update development and CI docker image to use NodeJS 16.20.1

### DIFF
--- a/.ci/Dockerfile.cypress
+++ b/.ci/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node14.17.0-chrome91-ff89
+FROM cypress/browsers:node16.18.0-chrome90-ff88
 
 ENV APP /usr/src/app
 WORKDIR $APP

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17 as frontend-builder
+FROM node:16.20.1 as frontend-builder
 
 RUN npm install --global --force yarn@1.22.19
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This updates the docker image we're using for development from NodeJS 14.17 to 16.20.1 (the latest 16.x available right now).

NodeJS 16 has been working for people fine for a while now, so lets make it official. :smile:

We can look at newer NodeJS (18, 20, etc) later on, once we're sure it works ok.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
