### PR TITLE
Fix persisting datasource selection choice

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -137,10 +137,7 @@ function QuerySource(props) {
       const selectedDataSourceId = parseInt(localStorage.getItem("lastSelectedDataSourceId")) || null;
 
       handleDataSourceChange(
-        chooseDataSourceId(
-          [query.data_source_id, selectedDataSourceId, firstDataSourceId],
-          dataSources
-        )
+        chooseDataSourceId([query.data_source_id, selectedDataSourceId, firstDataSourceId], dataSources)
       );
     }
   }, [query.data_source_id, queryFlags.isNew, dataSourcesLoaded, dataSources, handleDataSourceChange]);

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -134,9 +134,11 @@ function QuerySource(props) {
     // choose data source id for new queries
     if (dataSourcesLoaded && queryFlags.isNew) {
       const firstDataSourceId = dataSources.length > 0 ? dataSources[0].id : null;
+      const selectedDataSourceId = parseInt(localStorage.getItem("lastSelectedDataSourceId")) || null;
+
       handleDataSourceChange(
         chooseDataSourceId(
-          [query.data_source_id, localStorage.getItem("lastSelectedDataSourceId"), firstDataSourceId],
+          [query.data_source_id, selectedDataSourceId, firstDataSourceId],
           dataSources
         )
       );


### PR DESCRIPTION
Closes getredash/redash#5646.

We were already storing this in localStorage, however we weren't accounting for the fact that it was stored as a string, rather than an integer.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

We were already storing this in localStorage, however we weren't accounting for the fact that it was stored as a string, rather than an integer.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

Ran redash locally, verified this fixes the issue.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
