### PR TITLE
Switch to automatically upgraded PostgreSQL 15

### DIFF
--- a/.ci/docker-compose.ci.yml
+++ b/.ci/docker-compose.ci.yml
@@ -19,7 +19,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: pgautoupgrade/pgautoupgrade:dev
+    image: pgautoupgrade/pgautoupgrade:15-alpine3.8
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
     environment:

--- a/.ci/docker-compose.cypress.yml
+++ b/.ci/docker-compose.cypress.yml
@@ -68,7 +68,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: pgautoupgrade/pgautoupgrade:dev
+    image: pgautoupgrade/pgautoupgrade:15-alpine3.8
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: pgautoupgrade/pgautoupgrade:dev
+    image: pgautoupgrade/pgautoupgrade:15-alpine3.8
     ports:
       - "15432:5432"
     # The following turns the DB into less durable, but gains significant performance improvements for the tests run (x3


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

The [pgautoupgrade repo on Docker Hub](https://hub.docker.com/r/pgautoupgrade/pgautoupgrade) now has stable version tags, so lets use the PostgreSQL 15.x series.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)