### PR TITLE
Bump cryptography to 40.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Jinja2==3.1.2
 itsdangerous==2.1.2
 click==8.1.3
 MarkupSafe==2.1.1
-pyOpenSSL==19.0.0
+pyOpenSSL==23.2.0
 httplib2==0.18.1
 wtforms==2.2.1
 Flask-RESTful==0.3.10
@@ -46,7 +46,7 @@ xlsxwriter==1.2.2
 pystache==0.6.0
 parsedatetime==2.4
 PyJWT==2.4.0
-cryptography==3.4.8
+cryptography==40.0.2
 simplejson==3.16.0
 ua-parser==0.8.0
 user-agents==2.0


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

Due to the difficulty of upgrading cryptography to version 41 (https://github.com/getredash/redash/pull/6076), we can temporarily upgrade to version 40.
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
