### PR TITLE
Render counter widgets using relative font size

### DIFF
--- a/client/app/components/dashboards/dashboard-grid.less
+++ b/client/app/components/dashboards/dashboard-grid.less
@@ -123,7 +123,6 @@
       right: 10px;
       bottom: 15px;
       height: auto;
-      overflow: hidden;
       padding: 0;
     }
   }

--- a/viz-lib/src/visualizations/counter/Renderer.tsx
+++ b/viz-lib/src/visualizations/counter/Renderer.tsx
@@ -10,17 +10,18 @@ import "./render.less";
 
 function getCounterStyles(scale: any) {
   return {
-    msTransform: `scale(${scale})`,
-    MozTransform: `scale(${scale})`,
-    WebkitTransform: `scale(${scale})`,
-    transform: `scale(${scale})`,
+    fontSize: `${scale}px`,
   };
 }
 
 function getCounterScale(container: any) {
-  const inner = container.firstChild;
-  const scale = Math.min(container.offsetWidth / inner.offsetWidth, container.offsetHeight / inner.offsetHeight);
-  return Number(isFinite(scale) ? scale : 1).toFixed(2); // keep only two decimal places
+  // size of font in base container
+  // children use a relative font size (em)
+  if (container.closest('.visualization-preview')) {
+    return "60";
+  }
+  const fontSize = container.clientHeight / 4.5;
+  return fontSize > 60 ? "60" : fontSize < 12 ? "12" : fontSize.toFixed();
 }
 
 export default function Renderer({ data, options, visualizationName }: any) {

--- a/viz-lib/src/visualizations/counter/render.less
+++ b/viz-lib/src/visualizations/counter/render.less
@@ -2,15 +2,13 @@
   display: block;
   text-align: center;
   padding: 15px 10px;
-  overflow: hidden;
   position: relative;
 
   .counter-visualization-content {
     margin: 0;
     padding: 0;
-    font-size: 80px;
+    font-size: 2em;
     line-height: normal;
-    overflow: hidden;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## What type of PR is this? 

- [x] Adjustment to the UI

## Description

Using `transform` scales contents in in height and width, resulting in text wrapping even if there is horizontal space.

## How is this tested?

- [x] Manually

<!-- If Manually, please describe. -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Screen shot for master**

![counter_display_orig](https://github.com/getredash/redash/assets/1175398/df23ceea-667a-437d-9d7e-60b45e5a553c)

**Screen shot for this PR**

![counter_display_new](https://github.com/getredash/redash/assets/1175398/ab070e22-8dbc-4071-b69a-3bf581516e7f)

