### PR TITLE
Update README to point at wiki based dev guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Redash supports more than 35 SQL and NoSQL [data sources](https://redash.io/help
 ## Reporting Bugs and Contributing Code
 
 * Want to report a bug or request a feature? Please open [an issue](https://github.com/getredash/redash/issues/new).
-* Want to help us build **_Redash_**? Fork the project, edit in a [dev environment](https://redash.io/help-onpremise/dev/guide.html) and make a pull request. We need all the help we can get!
+* Want to help us build **_Redash_**? Fork the project, edit in a [dev environment](https://github.com/getredash/redash/wiki/Local-development-setup) and make a pull request. We need all the help we can get!
 
 ## Security
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

The existing readme point to the old developer documentation in the Knowledge Base, which is known to not work (yet).

This PR updates the README to point at our new, working, wiki based developer documentation.

## How is this tested?

- [x] Manually

Tested the rendered page locally in my IDE (Jetbrains IntelliJ), then clicked the link to ensure I didn't make a typo.  It loaded the web page fine. :smile: