### PR TITLE
fix(sec): upgrade ua-parser to 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ parsedatetime==2.4
 PyJWT==2.4.0
 cryptography==40.0.2
 simplejson==3.16.0
-ua-parser==0.8.0
+ua-parser==0.15.0
 user-agents==2.0
 maxminddb-geolite2==2018.703
 pypd==1.1.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ua-parser 0.8.0
- [CVE-2021-21317](https://www.oscs1024.com/hd/CVE-2021-21317)


### What did I do？
Upgrade ua-parser from 0.8.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS