### PR TITLE
Use 'urllib.parse.quote' instead 'werkzeug.urls.url_quote'

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,9 +1,9 @@
 import unicodedata
+from urllib.parse import quote
 
 from flask import make_response, request
 from flask_login import current_user
 from flask_restful import abort
-from werkzeug.urls import url_quote
 
 from redash import models, settings
 from redash.handlers.base import BaseResource, get_object_or_404, record_event
@@ -126,7 +126,7 @@ def content_disposition_filenames(attachment_filename):
     except UnicodeEncodeError:
         filenames = {
             "filename": unicodedata.normalize("NFKD", attachment_filename).encode("ascii", "ignore"),
-            "filename*": "UTF-8''%s" % url_quote(attachment_filename, safe=b""),
+            "filename*": "UTF-8''%s" % quote(attachment_filename, safe=b""),
         }
     else:
         filenames = {"filename": attachment_filename}


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
Use 'urllib.parse.quote' instead 'werkzeug.urls.url_quote'

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
