### PR TITLE
fix(sec): upgrade werkzeug to 2.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ gevent==1.4.0
 sshtunnel==0.1.5
 supervisor==4.1.0
 supervisor_checks==0.8.1
-werkzeug==0.16.1
+werkzeug==2.2.3
 # Install the dependencies of the bin/bundle-extensions script here.
 # It has its own requirements file to simplify the frontend client build process
 -r requirements_bundles.txt


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in werkzeug 0.16.1
- [CVE-2023-23934](https://www.oscs1024.com/hd/CVE-2023-23934)


### What did I do？
Upgrade werkzeug from 0.16.1 to 2.2.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS