### PR TITLE
Bump ua-parser to 0.18.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ parsedatetime==2.4
 PyJWT==2.4.0
 cryptography==40.0.2
 simplejson==3.16.0
-ua-parser==0.15.0
+ua-parser==0.18.0
 user-agents==2.0
 maxminddb-geolite2==2018.703
 pypd==1.1.0


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

Straight forward bump of ua-parser from 0.15.0 to 0.18.0.  This newer version is passing both link and Cypress tests on my computer, so seems ok.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)