### PR TITLE
Add "make format" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ down:
 env:
 	printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
 
+format:
+	pre-commit run --all-files
+
 tests:
 	docker-compose run server tests
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR adds a `make format` command, which runs our pre-commit hook to format our source files.

Should be a bit easier to remember. :smile:

## How is this tested?

- [x] Manually

```
$ make format
pre-commit run --all-files
isort....................................................................Passed
black....................................................................Passed
```