### PR TITLE
Allow RSA key used for JWT to be specified as a file path

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -187,6 +187,10 @@ def jwt_token_load_user_from_request(request):
     if not payload:
         return
 
+    if "email" not in payload:
+        logger.info("No email field in token, refusing to login")
+        return
+
     try:
         user = models.User.get_by_email_and_org(payload["email"], org)
     except models.NoResultFound:

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -6,6 +6,34 @@ import simplejson
 
 logger = logging.getLogger("jwt_auth")
 
+FILE_SCHEME_PREFIX = "file://"
+
+
+def get_public_key_from_file(url):
+    file_path = url[len(FILE_SCHEME_PREFIX) :]
+    with open(file_path) as key_file:
+        key_str = key_file.read()
+
+    get_public_keys.key_cache[url] = [key_str]
+    return key_str
+
+
+def get_public_key_from_net(url):
+    r = requests.get(url)
+    r.raise_for_status()
+    data = r.json()
+    if "keys" in data:
+        public_keys = []
+        for key_dict in data["keys"]:
+            public_key = jwt.algorithms.RSAAlgorithm.from_jwk(simplejson.dumps(key_dict))
+            public_keys.append(public_key)
+
+        get_public_keys.key_cache[url] = public_keys
+        return public_keys
+    else:
+        get_public_keys.key_cache[url] = data
+        return data
+
 
 def get_public_keys(url):
     """
@@ -13,23 +41,15 @@ def get_public_keys(url):
         List of RSA public keys usable by PyJWT.
     """
     key_cache = get_public_keys.key_cache
+    keys = {}
     if url in key_cache:
-        return key_cache[url]
+        keys = key_cache[url]
     else:
-        r = requests.get(url)
-        r.raise_for_status()
-        data = r.json()
-        if "keys" in data:
-            public_keys = []
-            for key_dict in data["keys"]:
-                public_key = jwt.algorithms.RSAAlgorithm.from_jwk(simplejson.dumps(key_dict))
-                public_keys.append(public_key)
-
-            get_public_keys.key_cache[url] = public_keys
-            return public_keys
+        if url.startswith(FILE_SCHEME_PREFIX):
+            keys = [get_public_key_from_file(url)]
         else:
-            get_public_keys.key_cache[url] = data
-            return data
+            keys = get_public_key_from_net(url)
+    return keys
 
 
 get_public_keys.key_cache = {}
@@ -58,4 +78,5 @@ def verify_jwt_token(jwt_token, expected_issuer, expected_audience, algorithms, 
             break
         except Exception as e:
             logging.exception(e)
+
     return payload, valid_token

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+jwcrypto==1.5.0
 pytest==7.4.0
 pytest-cov==4.1.0
 coverage==7.2.7


### PR DESCRIPTION
- `auth_jwt_auth_public_certs_url` may file:// in addition to http/https
- Log an error if payload does not contain an email address

## What type of PR is this? 
- [x] Refactor
- [x] Feature

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Unit tests (pytest, jest)

## Background

This feature allows another application to craft a JWT token to automatically log into redash.

Formerly this was possible, but the RSA public key had to be on an HTTP server. A file path is less complex and easier to secure.

