### PR TITLE
Bump request to 2.88.2 in viz-lib

### DIFF
--- a/viz-lib/yarn.lock
+++ b/viz-lib/yarn.lock
@@ -6681,7 +6681,7 @@ jsdom@^11.5.1:
     nwsapi "^2.0.7"
     parse5 "4.0.0"
     pn "^1.1.0"
-    request "^2.87.0"
+    request "^2.88.2"
     request-promise-native "^1.0.5"
     sax "^1.2.4"
     symbol-tree "^3.2.2"
@@ -6870,7 +6870,7 @@ less@^3.11.1:
     mime "^1.4.1"
     mkdirp "^0.5.0"
     promise "^7.1.1"
-    request "^2.83.0"
+    request "^2.88.2"
     source-map "~0.6.0"
 
 leven@^3.1.0:
@@ -8819,7 +8819,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.83.0, request@^2.87.0:
+request@^2.83.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR attempts to bump request to 2.88.2 in viz-lib.

Had to hand edit the yarn.lock file (!), because I couldn't get the yarn command to do what I was trying to do.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)