### PR TITLE
Bump style-loader to 3.3.3 in viz-lib

### DIFF
--- a/viz-lib/package.json
+++ b/viz-lib/package.json
@@ -64,7 +64,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "prop-types": "^15.7.2",
-    "style-loader": "^1.1.4",
+    "style-loader": "^3.3.3",
     "ts-migrate": "^0.1.35",
     "typescript": "^4.1.2",
     "webpack": "^5.88.2",

--- a/viz-lib/yarn.lock
+++ b/viz-lib/yarn.lock
@@ -6834,7 +6834,7 @@ json5@^2.1.1:
   dependencies:
     minimist "^1.2.5"
 
-json5@^2.1.2, json5@^2.2.2:
+json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -6982,15 +6982,6 @@ loader-utils@^1.2.3, loader-utils@^1.4.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
-
-loader-utils@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
-  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -9768,13 +9759,10 @@ strongly-connected-components@^1.0.1:
   resolved "https://registry.yarnpkg.com/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz#0920e2b4df67c8eaee96c6b6234fe29e873dba99"
   integrity sha1-CSDitN9nyOrulsa2I0/inoc9upk=
 
-style-loader@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.1.4.tgz#1ad81283cefe51096756fd62697258edad933230"
-  integrity sha512-SbBHRD8fwK3pX+4UDF4ETxUF0+rCvk29LWTTI7Rt0cgsDjAj3SWM76ByTe6u2+4IlJ/WwluB7wuslWETCoPQdg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^2.6.5"
+style-loader@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.3.tgz#bba8daac19930169c0c9c96706749a597ae3acff"
+  integrity sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==
 
 supercluster@^7.0.0:
   version "7.1.5"


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This bumps style-loader to 3.3.3 in viz-lib, to remove yet another blocker for a Dependabot warning.

## How is this tested?

- [x] Manually

Very lightly tested on my personal system, but in theory it should work ok.  Lets find out using the CI here... :smile: