### PR TITLE
Update Netlify to NodeJS 16.20.1 and Yarn 1.22.19

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,12 +3,12 @@
   publish = "client/dist"
   # Netlify doesn't seem to install Yarn even though NETLIFY_USE_YARN is set below
   # command = "cd ../ && npm i -g yarn@1.22.19 && yarn --frozen-lockfile --force && cd viz-lib && yarn build:babel && cd .. && rm -r ./node_modules/@redash/viz && cp -r ./viz-lib/. ./node_modules/@redash/viz && yarn build && cd ./client"
-  command = "cd ../ && npm i -g yarn@1.22.19 && yarn cache clean && yarn --frozen-lockfile --network-concurrency 1 && yarn build && cd ./client"
+  command = "cd ../ && yarn cache clean && yarn --frozen-lockfile --network-concurrency 1 && yarn build && cd ./client"
 
 [build.environment]
-  NODE_VERSION = "14.16.1"
+  NODE_VERSION = "16.20.1"
   NETLIFY_USE_YARN = "true"
-  YARN_VERSION = "1.22.10"
+  YARN_VERSION = "1.22.19"
   CYPRESS_INSTALL_BINARY = "0"
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = "1"
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR updates our Netlify builds to use NodeJS 16.20.1, and Yarn 1.22.19

## How is this tested?

- [x] N/A

This PR needs to be tested by running the CI on GitHub.