### PR TITLE
BigQueryGCE: return project id as not bytes but str

### DIFF
--- a/redash/query_runner/big_query_gce.py
+++ b/redash/query_runner/big_query_gce.py
@@ -63,7 +63,7 @@ class BigQueryGCE(BigQuery):
         return requests.get(
             "http://metadata/computeMetadata/v1/project/project-id",
             headers={"Metadata-Flavor": "Google"},
-        ).content
+        ).text
 
     def _get_bigquery_service(self):
         credentials = gce.AppAssertionCredentials(scope="https://www.googleapis.com/auth/bigquery")


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

`big_query_gce.py`'s `_get_project_id()` returns `bytes` type. However, this value is expected by Google's client library to be `str`. The library internally converts the value to `str` value `b'your_project_id'`, which is not a valid project id at all.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

My employer company runs a Redash instance. I applied this fix there and verified that BigQueryGCE data source works correctly.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
