### PR TITLE
Bump mini-css-extract-plugin to 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "less-loader": "^5.0.0",
     "less-plugin-autoprefix": "^2.0.0",
     "lodash": "^4.17.21",
-    "mini-css-extract-plugin": "^0.4.4",
+    "mini-css-extract-plugin": "^1.6.2",
     "mockdate": "^2.0.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10083,13 +10083,13 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mini-css-extract-plugin@^0.4.4:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz#c99e9e78d54f3fa775633aee5933aeaa4e80719a"
-  integrity sha512-dqBanNfktnp2hwL2YguV9Jh91PFX7gu7nRLs4TGsbAfAG6WOtlynFRYzwDwmmeSb5uIwHo9nx1ta0f7vAZVp2w==
+mini-css-extract-plugin@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz#83172b4fd812f8fc4a09d6f6d16f924f53990ca8"
+  integrity sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==
   dependencies:
-    loader-utils "^1.1.0"
-    schema-utils "^1.0.0"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
 
 mini-store@^3.0.1:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR bumps mini-css-extract-plugin to 1.6.2, to help reduce the number of blockers for Dependabot updates.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)