### PR TITLE
Bump Cypress to 11.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^1.0.1",
-    "cypress": "^10.11.0",
+    "cypress": "^11.2.0",
     "dayjs": "^1.11.9",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4780,10 +4780,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.2.tgz#673b5f233bf34d8e602b949429f8171d9121bea3"
   integrity sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==
 
-cypress@^10.11.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.11.0.tgz#e9fbdd7638bae3d8fb7619fd75a6330d11ebb4e8"
-  integrity sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==
+cypress@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
+  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR bumps Cypress to 11.2.0.  This is the most recent version of Cypress we can move to without needing to update many tests due to `cy.server()`, and `cy.route()`, [being been removed in Cypress 12.x](https://docs.cypress.io/guides/references/migration-guide#Command--Cypress-API-Changes).

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)