### PR TITLE
Remove request from the declared dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "raw-loader": "^0.5.1",
     "react-refresh": "^0.14.0",
     "react-test-renderer": "^16.5.2",
-    "request": "^2.88.2",
     "request-cookies": "^1.1.0",
     "style-loader": "^2.0.0",
     "typescript": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12779,7 +12779,7 @@ request-promise@^4.2.2:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@^2.88.2:
+request@^2.87.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR removes `request` from the declared list of JS dependencies, as we don't use it directly ourselves.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)