### PR TITLE
Use exclude list with flake8 pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,5 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        exclude: "migration/.*|.git|viz-lib|node_modules|migrations|bin/upgrade"
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

It turns out the `flake8` pre-commit hook is NOT using the existing configuration in `setup.cfg`.  So it automatically fails on our existing source code.

This PR copies and extends the `exclude` line from our `setup.cfg`, so that `flake8` will skip the things we don't want it touching.

This should get things working again for now, and we can improve it later on.

## How is this tested?

- [x] Manually

With this change in place, manually running the pre-commit check works again:

```
$ make format
pre-commit run --all-files
isort....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
```
