### PR TITLE
Fix webpack error in viz-lib

### DIFF
--- a/viz-lib/webpack.config.js
+++ b/viz-lib/webpack.config.js
@@ -39,8 +39,10 @@ module.exports = {
           {
             loader: "less-loader",
             options: {
-              plugins: [new LessPluginAutoPrefix({ browsers: ["last 3 versions"] })],
-              javascriptEnabled: true,
+              lessOptions: {
+                plugins: [new LessPluginAutoPrefix({ browsers: ["last 3 versions"] })],
+                javascriptEnabled: true,
+	      },
             },
           },
         ],


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

The config file format for webpack has changed slightly, so webpack was throwing this fatal error:

```
$ yarn watch
...
ERROR in ./src/components/ColorPicker/index.less
Module build failed (from ./node_modules/less-loader/dist/cjs.js):
ValidationError: Invalid options object. Less Loader has been initialized using an options object that does
not match the API schema.
```

This commit updates the config file format so webpack works again.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)