### PR TITLE
Update package.json so `yarn watch` works again

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:viz": "(cd viz-lib && yarn build:babel)",
     "build": "yarn clean && yarn build:viz && NODE_ENV=production webpack",
     "build:old-node-version": "yarn clean && NODE_ENV=production node --max-old-space-size=4096 node_modules/.bin/webpack",
-    "watch:app": "webpack --watch --progress --colors -d",
+    "watch:app": "webpack watch --progress",
     "watch:viz": "(cd viz-lib && yarn watch:babel)",
     "watch": "npm-run-all --parallel watch:*",
     "webpack-dev-server": "webpack-dev-server",


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

For some unknown reason the `--colors` and `-d` options are no longer recognised by webpack (v4) "watch" in our configuration.

This is likely due to some other non-obvious problem in our configuration, as those options should exist (they're documented).

For now though, this gets things working again.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually

Running `yarn watch` now works again like it should:

```
$ yarn watch
yarn run v1.22.19
$ npm-run-all --parallel watch:*
$ webpack watch --progress
$ (cd viz-lib && yarn watch:babel)
$ yarn build:babel:base --watch
$ babel src --out-dir lib --source-maps --ignore 'src/**/*.test.js'
...
```