### PR TITLE
Webpack-dev-server seems to require the dev-middleware config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -240,14 +240,18 @@ const config = {
     ignored: /\.sw.$/
   },
   devServer: {
-    inline: true,
-    index: "/static/index.html",
+    devMiddleware: {
+      index: "/static/index.html",
+      publicPath: staticPath,
+      stats: {
+        modules: false,
+        chunkModules: false
+      },
+    },
     historyApiFallback: {
       index: "/static/index.html",
       rewrites: [{ from: /./, to: "/static/index.html" }]
     },
-    contentBase: false,
-    publicPath: staticPath,
     proxy: [
       {
         context: [
@@ -273,10 +277,6 @@ const config = {
         secure: false
       }
     ],
-    stats: {
-      modules: false,
-      chunkModules: false
-    },
     hot: isHotReloadingEnabled
   },
   performance: {


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This PR updates the configuration for webpack-dev-server, to avoid a fatal error when trying to start it:

```
$ yarn webpack-dev-server
yarn run v1.22.19
$ webpack-dev-server
[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not
match the API schema.
 - options has an unknown property 'stats'. These properties are valid:
   object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?,
hot?, http2?, https?, ipc?, liveReload?, magicHtml?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?,
onListening?, open?, port?, proxy?, server?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?,
webSocketServer? }
error Command failed with exit code 2.
```

## How is this tested?

- [x] Manually

With the updated configuration in this PR, webpack-dev-server works again:

```
$ yarn webpack-dev-server
yarn run v1.22.19
$ webpack-dev-server
<i> [webpack-dev-server] [HPM] Proxy created: /login,/logout,/invite,/setup,/status.json,/api,/oauth  -> http://localhost:5001/
<i> [webpack-dev-server] [HPM] Proxy created: path => {
<i>           // CSS/JS for server-rendered pages should be served from backend
<i>           return /^\/static\/[a-z]+\.[0-9a-fA-F]+\.(css|js)$/.test(path);
<i>         }  -> http://localhost:5001/
<i> [webpack-dev-server] Project is running at:
<i> [webpack-dev-server] Loopback: http://localhost:8080/
<i> [webpack-dev-server] On Your Network (IPv4): http://111.222.333.444:8080/
<i> [webpack-dev-server] Content not from webpack is served from '/some/path/redash/redash/public' directory
<i> [webpack-dev-server] 404s will fallback to '/static/index.html'
```