### PR TITLE
Bump snowflake-connector-python to 3.1.0

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -24,7 +24,7 @@ qds-sdk>=1.9.6
 # ibm-db>=2.0.9
 pydruid==0.5.7
 requests_aws_sign==0.1.5
-snowflake-connector-python==3.0.4
+snowflake-connector-python==3.1.0
 phoenixdb==0.7
 # certifi is needed to support MongoDB and SSL:
 certifi>=2019.9.11


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR bumps snowflake-connector-python to 3.1.0 (released today), so we can unblock some Dependabot PRs.

## How is this tested?

Untested thus far, but should be fine.