### PR TITLE
Redis replace hmset -> hset

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -90,7 +90,7 @@ class ScheduledQueriesExecutions(object):
         self.executions = redis_connection.hgetall(self.KEY_NAME)
 
     def update(self, query_id):
-        redis_connection.hmset(self.KEY_NAME, {query_id: time.time()})
+        redis_connection.hset(self.KEY_NAME, mapping={query_id: time.time()})
 
     def get(self, query_id):
         timestamp = self.executions.get(str(query_id))

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -112,7 +112,7 @@ def refresh_queries():
         "query_ids": json_dumps([q.id for q in enqueued]),
     }
 
-    redis_connection.hmset("redash:status", status)
+    redis_connection.hset("redash:status", mapping=status)
     logger.info("Done refreshing queries: %s" % status)
 
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
https://github.com/redis/redis-py/blob/252c840ea2ade01637b4ed7c834dd83b130041b4/CHANGES#L17
    * HSET command now can accept multiple pairs. HMSET has been marked as deprecated now. Thanks to @laixintao #1271

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
