### PR TITLE
Do not makedsn for query_runner/oracle.py

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -138,8 +138,8 @@ class Oracle(BaseSQLQueryRunner):
         if self.configuration.get("encoding"):
             os.environ["NLS_LANG"] = self.configuration["encoding"]
 
-        # When type "_donotmakedsn" in the host self.configuration["servicename"] is used instead
-        if self.configuration["host"].lower() == "_donotmakedsn":
+        # To use a DSN Service Name instead, use the text string `_useservicename` in the host name field.
+        if self.configuration["host"].lower() == "_useservicename":
             dsn = self.configuration["servicename"]
         else:
             dsn = cx_Oracle.makedsn(

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -66,7 +66,7 @@ class Oracle(BaseSQLQueryRunner):
             "properties": {
                 "user": {"type": "string"},
                 "password": {"type": "string"},
-                "host": {"type": "string", "title": "Host (When type _donotmakedsn, DSN Service Name is used instead.)"},
+                "host": {"type": "string", "title": "Host (To use a DSN Service Name instead, use the text string `_useservicename` in the host name field.)"},
                 "port": {"type": "number"},
                 "servicename": {"type": "string", "title": "DSN Service Name"},
                 "encoding": {"type": "string"},

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -66,7 +66,10 @@ class Oracle(BaseSQLQueryRunner):
             "properties": {
                 "user": {"type": "string"},
                 "password": {"type": "string"},
-                "host": {"type": "string", "title": "Host: To use a DSN Service Name instead, use the text string `_useservicename` in the host name field."},
+                "host": {
+                    "type": "string",
+                    "title": "Host: To use a DSN Service Name instead, use the text string `_useservicename` in the host name field.",
+                },
                 "port": {"type": "number"},
                 "servicename": {"type": "string", "title": "DSN Service Name"},
                 "encoding": {"type": "string"},

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -138,11 +138,14 @@ class Oracle(BaseSQLQueryRunner):
         if self.configuration.get("encoding"):
             os.environ["NLS_LANG"] = self.configuration["encoding"]
 
-        dsn = cx_Oracle.makedsn(
-            self.configuration["host"],
-            self.configuration["port"],
-            service_name=self.configuration["servicename"],
-        )
+        if self.configuration["host"].lower() == "_donotmakedsn":
+            dsn = self.configuration["servicename"]
+        else:
+            dsn = cx_Oracle.makedsn(
+                self.configuration["host"],
+                self.configuration["port"],
+                service_name=self.configuration["servicename"],
+            )
 
         connection = cx_Oracle.connect(
             user=self.configuration["user"],

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -66,7 +66,7 @@ class Oracle(BaseSQLQueryRunner):
             "properties": {
                 "user": {"type": "string"},
                 "password": {"type": "string"},
-                "host": {"type": "string", "title": "Host (To use a DSN Service Name instead, use the text string `_useservicename` in the host name field.)"},
+                "host": {"type": "string", "title": "Host: To use a DSN Service Name instead, use the text string `_useservicename` in the host name field."},
                 "port": {"type": "number"},
                 "servicename": {"type": "string", "title": "DSN Service Name"},
                 "encoding": {"type": "string"},

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -66,7 +66,7 @@ class Oracle(BaseSQLQueryRunner):
             "properties": {
                 "user": {"type": "string"},
                 "password": {"type": "string"},
-                "host": {"type": "string"},
+                "host": {"type": "string", "title": "Host (When type _donotmakedsn, DSN Service Name is used instead.)"},
                 "port": {"type": "number"},
                 "servicename": {"type": "string", "title": "DSN Service Name"},
                 "encoding": {"type": "string"},

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -138,6 +138,7 @@ class Oracle(BaseSQLQueryRunner):
         if self.configuration.get("encoding"):
             os.environ["NLS_LANG"] = self.configuration["encoding"]
 
+        # When type "_donotmakedsn" in the host self.configuration["servicename"] is used instead
         if self.configuration["host"].lower() == "_donotmakedsn":
             dsn = self.configuration["servicename"]
         else:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Feature

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

change for redash/query_runner/oracle.py
Do not makedsn for **Autonomous Database** or **FAILOVER,LOAD_BALANCE**

When type "_useservicename" in the `host`, self.configuration["servicename"] is used instead.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

[Connecting to Oracle Database — cx\_Oracle 8\.3\.0 documentation](https://cx-oracle.readthedocs.io/en/latest/user_guide/connection_handling.html#oracle-net-connect-descriptor-strings)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="312" alt="donotmakedsn02" src="https://github.com/getredash/redash/assets/1247622/b690c28b-2611-44b0-92b3-cb10069f69e7">

