### PR TITLE
Update `make env` to not run multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,10 @@ clean:
 down:
 	docker-compose down
 
-env:
+.env:
 	printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
+
+env: .env
 
 format:
 	pre-commit run --all-files


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR updates the `make env` Makefile target, so that it will avoid running if the `.env` file already exists.

## How is this tested?

- [x] Manually

```
$ cat .env
cat: .env: No such file or directory
$ make env
printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
$ make env
make: Nothing to be done for 'env'.
$ cat .env
REDASH_COOKIE_SECRET=xuRAOJAsJ0qw5QokFZ9XUd0coSmlmhtR
REDASH_SECRET_KEY=WqrqCXJo75KqYeYKE8W1nvovkW91ZYmD
```