### PR TITLE
Have `make compose_build` create .env if its missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: compose_build up test_db create_database clean down tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
 
-compose_build:
+compose_build: .env
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
 
 up:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

This PR is super simple.  It just updates `make compose_build` to create the required `.env` file first (if its missing).

## How is this tested?

- [x] Manually

It works as intended.  With the `.env` file being missing, it gets created:

```
$ cat .env
cat: .env: No such file or directory
$ make compose_build
printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
redis uses an image, skipping
...
```

And with the `.env` file already in place, things proceed as expected:

```
$ make compose_build
COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
redis uses an image, skipping
...
```