### PR TITLE
Have `make create_database` create .env if its missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test_db:
 	done
 	docker-compose exec postgres sh -c 'psql -U postgres -c "drop database if exists tests;" && psql -U postgres -c "create database tests;"'
 
-create_database:
+create_database: .env
 	docker-compose run server create_db
 
 clean:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

This PR is super simple. It just updates `make create_database` to create the required `.env` file first (if its missing).

## How is this tested?

- [x] Manually

When the `.env` file isn't present, it will be automatically created (with this PR):

```
$ cat .env
cat: .env: No such file or directory
$ make create_database
printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
docker-compose run server create_db
Creating network "redash_default" with the default driver
Creating redash_redis_1 ... 
Creating redash_postgres_1 ... 
...
```

When the `.env` file already exists, the `make create_database` will proceed without creating it:

```
$ make create_database
docker-compose run server create_db
Starting redash_postgres_1 ... 
Starting redash_redis_1    ... 
...
```