### PR TITLE
Add data type info into schemas of Trino tables (Recreated)

### DIFF
--- a/redash/query_runner/trino.py
+++ b/redash/query_runner/trino.py
@@ -84,7 +84,7 @@ class Trino(BaseQueryRunner):
 
     def get_schema(self, get_stats=False):
         query = """
-            SELECT table_schema, table_name, column_name
+            SELECT table_schema, table_name, column_name, data_type
             FROM information_schema.columns
             WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
         """
@@ -101,7 +101,8 @@ class Trino(BaseQueryRunner):
             if table_name not in schema:
                 schema[table_name] = {"name": table_name, "columns": []}
 
-            schema[table_name]["columns"].append(row["column_name"])
+            column = {"name": row["column_name"], "type": row["data_type"]}
+            schema[table_name]["columns"].append(column)
 
         return list(schema.values())
 


### PR DESCRIPTION
The current get_schema method of Trino query runner is missing table columns' data types information, so these data types won't be seen in Queries editing GUI. After the modification, these info are back.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
