### PR TITLE
Fix: Query results in public dashboard not loading when query ends with semicolon

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -308,16 +308,14 @@ class BaseSQLQueryRunner(BaseQueryRunner):
         return str(parsed_query)
 
     def apply_auto_limit(self, query_text, should_apply_auto_limit):
+        queries = split_sql_statements(query_text)
         if should_apply_auto_limit:
-            queries = split_sql_statements(query_text)
             # we only check for last one in the list because it is the one that we show result
             last_query = queries[-1]
             if self.query_is_select_no_limit(last_query):
                 queries[-1] = self.add_limit_to_query(last_query)
-            return combine_sql_statements(queries)
-        else:
-            return query_text
-
+        return combine_sql_statements(queries)
+        
 
 class BaseHTTPQueryRunner(BaseQueryRunner):
     should_annotate_query = False

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -315,7 +315,7 @@ class BaseSQLQueryRunner(BaseQueryRunner):
             if self.query_is_select_no_limit(last_query):
                 queries[-1] = self.add_limit_to_query(last_query)
         return combine_sql_statements(queries)
-        
+
 
 class BaseHTTPQueryRunner(BaseQueryRunner):
     should_annotate_query = False


### PR DESCRIPTION
## What type of PR is this? 
This PR fixes the formatting flake8 error resulting in the build failure and also includes the cherry-picked commit of the below PR:
https://github.com/getredash/redash/pull/5809 

Dashboards accessed using the public url use the cached query result mechanism to fetch results after a query job is finished.
When using parameterized queries, the frontend requests the data usually 2 times: one time after changing the parameter, and one time after the job is finished. The second request relies on the caching mechanism to find the cached result of the first request. The second request does not request auto_limit, which causes a lack of splitting and merging of sql statements. Because of that, the two sql queries differ in whitespacing and a trailing semicolon, which causes the query_hashes of both requests to differ.

That results in another job invocation and an empty query result in the second response in the frontend, which causes an endless loading spinner in the frontend and no fetched data.

By splitting the statements each time, you prevent these differences in the 2 sql queries.
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Splitting and merging statements should/can not break anything, otherwise the auto limiting would be buggy. Ran pre-commit to make sure no flake8 errors

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
