### PR TITLE
Allow the X and Y tick format to be customized

### DIFF
--- a/client/cypress/support/visualizations/chart.js
+++ b/client/cypress/support/visualizations/chart.js
@@ -80,6 +80,10 @@ export function assertAxesAndAddLabels(xaxisLabel, yaxisLabel) {
     .clear()
     .type(yaxisLabel);
 
+  cy.getByTestId("Chart.LeftYAxis.TickFormat")
+    .clear()
+    .type("+");
+
   cy.getByTestId("VisualizationEditor.Tabs.General").click();
 }
 

--- a/viz-lib/src/components/visualizations/editor/ContextHelp.tsx
+++ b/viz-lib/src/components/visualizations/editor/ContextHelp.tsx
@@ -53,5 +53,18 @@ function DateTimeFormatSpecs() {
   );
 }
 
+function TickFormatSpecs() {
+  const { HelpTriggerComponent } = visualizationsSettings;
+  return (
+    <HelpTriggerComponent
+      title="Tick Formatting"
+      href="https://redash.io/help/user-guide/visualizations/formatting-axis"
+      className="visualization-editor-context-help">
+      {ContextHelp.defaultIcon}
+    </HelpTriggerComponent>
+  );
+}
+
 ContextHelp.NumberFormatSpecs = NumberFormatSpecs;
 ContextHelp.DateTimeFormatSpecs = DateTimeFormatSpecs;
+ContextHelp.TickFormatSpecs = TickFormatSpecs;

--- a/viz-lib/src/visualizations/chart/Editor/AxisSettings.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/AxisSettings.tsx
@@ -2,7 +2,7 @@ import { isString, isObject, isFinite, isNumber, merge } from "lodash";
 import React from "react";
 import { useDebouncedCallback } from "use-debounce";
 import * as Grid from "antd/lib/grid";
-import { Section, Select, Input, InputNumber } from "@/components/visualizations/editor";
+import { Section, Select, Input, InputNumber, ContextHelp } from "@/components/visualizations/editor";
 
 function toNumber(value: any) {
   value = isNumber(value) ? value : parseFloat(value);
@@ -18,6 +18,7 @@ type OwnProps = {
     };
     rangeMin?: number;
     rangeMax?: number;
+    tickFormat?: string;
   };
   features?: {
     autoDetectType?: boolean;
@@ -39,6 +40,8 @@ export default function AxisSettings({ id, options, features, onChange }: Props)
   }, 200);
 
   const [handleMinMaxChange] = useDebouncedCallback(opts => optionsChanged(opts), 200);
+
+  const [handleTickFormatChange] = useDebouncedCallback(opts => optionsChanged(opts), 200);
 
   return (
     <React.Fragment>
@@ -86,6 +89,21 @@ export default function AxisSettings({ id, options, features, onChange }: Props)
           data-test={`Chart.${id}.Name`}
           defaultValue={isObject(options.title) ? options.title.text : null}
           onChange={(event: any) => handleNameChange(event.target.value)}
+        />
+      </Section>
+
+      {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+      <Section>
+        <Input
+          label={
+            <React.Fragment>
+              Tick Format
+              <ContextHelp.TickFormatSpecs />
+            </React.Fragment>
+          }
+          data-test={`Chart.${id}.TickFormat`}
+          defaultValue={options.tickFormat}
+          onChange={(event: any) => handleTickFormatChange({ tickFormat: event.target.value })}
         />
       </Section>
 

--- a/viz-lib/src/visualizations/chart/Editor/XAxisSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/XAxisSettings.test.tsx
@@ -55,6 +55,20 @@ describe("Visualizations -> Chart -> Editor -> X-Axis Settings", () => {
       .simulate("change", { target: { value: "test" } });
   });
 
+  test("Changes axis tick format", done => {
+    const el = mount(
+      {
+        globalSeriesType: "column",
+        xAxis: { },
+      },
+      done
+    );
+
+    findByTestID(el, "Chart.XAxis.TickFormat")
+      .last()
+      .simulate("change", { target: { value: "%B" } });
+  });
+
   test("Sets Show Labels option", done => {
     const el = mount(
       {

--- a/viz-lib/src/visualizations/chart/Editor/YAxisSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/YAxisSettings.test.tsx
@@ -59,6 +59,20 @@ describe("Visualizations -> Chart -> Editor -> Y-Axis Settings", () => {
       .simulate("change", { target: { value: "test" } });
   });
 
+  test("Changes axis tick format", done => {
+    const el = mount(
+      {
+        globalSeriesType: "column",
+        yAxis: [],
+      },
+      done
+    );
+
+    findByTestID(el, "Chart.LeftYAxis.TickFormat")
+      .last()
+      .simulate("change", { target: { value: "s" } });
+  });
+
   test("Changes axis min value", done => {
     const el = mount(
       {

--- a/viz-lib/src/visualizations/chart/Editor/__snapshots__/XAxisSettings.test.tsx.snap
+++ b/viz-lib/src/visualizations/chart/Editor/__snapshots__/XAxisSettings.test.tsx.snap
@@ -14,6 +14,18 @@ Object {
 }
 `;
 
+exports[`Visualizations -> Chart -> Editor -> X-Axis Settings Changes axis tick format 1`] = `
+Object {
+  "xAxis": Object {
+    "labels": Object {
+      "enabled": true,
+    },
+    "tickFormat": "%B",
+    "type": "-",
+  },
+}
+`;
+
 exports[`Visualizations -> Chart -> Editor -> X-Axis Settings Changes axis type 1`] = `
 Object {
   "xAxis": Object {

--- a/viz-lib/src/visualizations/chart/Editor/__snapshots__/YAxisSettings.test.tsx.snap
+++ b/viz-lib/src/visualizations/chart/Editor/__snapshots__/YAxisSettings.test.tsx.snap
@@ -47,6 +47,21 @@ Object {
 }
 `;
 
+exports[`Visualizations -> Chart -> Editor -> Y-Axis Settings Changes axis tick format 1`] = `
+Object {
+  "yAxis": Array [
+    Object {
+      "tickFormat": "s",
+      "type": "linear",
+    },
+    Object {
+      "opposite": true,
+      "type": "linear",
+    },
+  ],
+}
+`;
+
 exports[`Visualizations -> Chart -> Editor -> Y-Axis Settings Changes axis type 1`] = `
 Object {
   "yAxis": Array [

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -21,6 +21,7 @@ function prepareXAxis(axisOptions: any, additionalOptions: any) {
     title: getAxisTitle(axisOptions),
     type: getAxisScaleType(axisOptions),
     automargin: true,
+    tickformat: axisOptions.tickFormat,
   };
 
   if (additionalOptions.sortX && axis.type === "category") {
@@ -48,6 +49,7 @@ function prepareYAxis(axisOptions: any) {
     automargin: true,
     autorange: true,
     range: null,
+    tickformat: axisOptions.tickFormat,
   };
 }
 


### PR DESCRIPTION
Allow the format of each axis to be customzied using a D3 format string

Numbers: https://d3-wiki.readthedocs.io/zh_CN/master/Formatting/
Date/Time: https://d3-wiki.readthedocs.io/zh_CN/master/Time-Formatting/

## What type of PR is this? 

- [x] Feature

## Description

The database will save these in `visualizations.options`

```
    "xAxis": {
        "type": "-",
        "labels": {
            "enabled": true
        },
        "tickFormat": "%B %d"
    },
    "yAxis": [
        {
            "type": "linear",
            "tickFormat": "s"
        },
        {
            "type": "linear",
            "opposite": true,
            "tickFormat": ""
        }
    ],
```

Specifying a D3 format

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually

## Related Tickets & Documents

https://github.com/getredash/redash/issues/3215

Separate documentation needs to be added since there is no numbro/moment.js equivalent translation to D3 syntax.
Plotly does not allow a custom function to be defined for axis formatting.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

_Old Behavior_

![tick_format_x_orig](https://github.com/getredash/redash/assets/1175398/0ade41ae-cf6e-499d-adf8-447c2de9412e)

_New Axis Formatting using_

Y: **s**
X: **%B %d**

![tick_format_x_new](https://github.com/getredash/redash/assets/1175398/6f90eff7-a699-4a62-b041-af26a59a92c2)
