### PR TITLE
Python query runner: fixed `dataframe_to_result` function

### DIFF
--- a/redash/query_runner/python.py
+++ b/redash/query_runner/python.py
@@ -274,7 +274,7 @@ class Python(BaseQueryRunner):
         result["rows"] = df.to_dict("records")
 
         for column_name, column_type in df.dtypes.items():
-            if column_type == np.bool:
+            if column_type == np.bool_:
                 redash_type = TYPE_BOOLEAN
             elif column_type == np.inexact:
                 redash_type = TYPE_FLOAT


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Bug Fix


## Description

On current master branch, if you run `dataframe_to_result` function, you will receive the following error:

> Error running query: <class 'AttributeError'> module 'numpy' has no attribute 'bool'. `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

This request fixes that.

## How is this tested?

- [ ] Manually

<!-- If Manually, please describe. -->
