### PR TITLE
Fix: Query result datetime column type check in frontend (#5369)

### DIFF
--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -113,6 +113,10 @@ export function fetchDataFromJob(jobId, interval = 1000) {
   });
 }
 
+export function isDateTime(v) {
+  return isString(v) && moment(v).isValid() && /^\d{4}-\d{2}-\d{2}T/.test(v);
+}
+
 class QueryResult {
   constructor(props) {
     this.deferred = defer();
@@ -147,7 +151,7 @@ class QueryResult {
           let newType = null;
           if (isNumber(v)) {
             newType = "float";
-          } else if (isString(v) && v.match(/^\d{4}-\d{2}-\d{2}T/)) {
+          } else if (isDateTime(v)) {
             row[k] = moment.utc(v);
             newType = "datetime";
           } else if (isString(v) && v.match(/^\d{4}-\d{2}-\d{2}$/)) {

--- a/client/app/services/query-result.test.js
+++ b/client/app/services/query-result.test.js
@@ -1,0 +1,17 @@
+import { isDateTime } from "@/services/query-result";
+
+describe("isDateTime", () => {
+  it.each([
+    ["2022-01-01T00:00:00", true],
+    ["2022-01-01T00:00:00+09:00", true],
+    ["2021-01-27T00:00:01.733983944+03:00 stderr F {", false],
+    ["2021-01-27Z00:00:00+09:00", false],
+    ["2021-01-27", false],
+    ["foo bar", false],
+    [2022, false],
+    [null, false],
+    ["", false],
+  ])("isDateTime('%s'). expected '%s'.", (value, expected) => {
+    expect(isDateTime(value)).toBe(expected);
+  });
+});


### PR DESCRIPTION
[Note, this is PR #5819, but rebased onto `master` branch)

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
This PR fix colum type check bug in frontend (#5369) due to fuzzy datetime type checking. 
Text which starts with datetime (YYYY-MM-DDT) followed by some string will be detected as a string by this fix.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
We have tested run query and view results in browser by prepare sqlite database which contains bug causes text.

before
![image](https://user-images.githubusercontent.com/19401388/187896647-56a46104-18cf-4472-9d21-9217841276e4.png)

after
![image](https://user-images.githubusercontent.com/19401388/187896560-c914d767-a317-4527-a4d7-8de0f725c623.png)

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
