### PR TITLE
Replace cx_Oracle with python-oracledb

### DIFF
--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -13,7 +13,7 @@ from redash.query_runner import (
 from redash.utils import json_dumps, json_loads
 
 try:
-    import cx_Oracle
+    import oracledb as cx_Oracle
 
     TYPES_MAP = {
         cx_Oracle.DATETIME: TYPE_DATETIME,

--- a/redash/query_runner/oracle.py
+++ b/redash/query_runner/oracle.py
@@ -13,22 +13,22 @@ from redash.query_runner import (
 from redash.utils import json_dumps, json_loads
 
 try:
-    import oracledb as cx_Oracle
+    import oracledb
 
     TYPES_MAP = {
-        cx_Oracle.DATETIME: TYPE_DATETIME,
-        cx_Oracle.CLOB: TYPE_STRING,
-        cx_Oracle.LOB: TYPE_STRING,
-        cx_Oracle.FIXED_CHAR: TYPE_STRING,
-        cx_Oracle.FIXED_NCHAR: TYPE_STRING,
-        cx_Oracle.INTERVAL: TYPE_DATETIME,
-        cx_Oracle.LONG_STRING: TYPE_STRING,
-        cx_Oracle.NATIVE_FLOAT: TYPE_FLOAT,
-        cx_Oracle.NCHAR: TYPE_STRING,
-        cx_Oracle.NUMBER: TYPE_FLOAT,
-        cx_Oracle.ROWID: TYPE_INTEGER,
-        cx_Oracle.STRING: TYPE_STRING,
-        cx_Oracle.TIMESTAMP: TYPE_DATETIME,
+        oracledb.DATETIME: TYPE_DATETIME,
+        oracledb.CLOB: TYPE_STRING,
+        oracledb.LOB: TYPE_STRING,
+        oracledb.FIXED_CHAR: TYPE_STRING,
+        oracledb.FIXED_NCHAR: TYPE_STRING,
+        oracledb.INTERVAL: TYPE_DATETIME,
+        oracledb.LONG_STRING: TYPE_STRING,
+        oracledb.NATIVE_FLOAT: TYPE_FLOAT,
+        oracledb.NCHAR: TYPE_STRING,
+        oracledb.NUMBER: TYPE_FLOAT,
+        oracledb.ROWID: TYPE_INTEGER,
+        oracledb.STRING: TYPE_STRING,
+        oracledb.TIMESTAMP: TYPE_DATETIME,
     }
 
     ENABLED = True
@@ -46,7 +46,7 @@ class Oracle(BaseSQLQueryRunner):
 
     @classmethod
     def get_col_type(cls, col_type, scale):
-        if col_type == cx_Oracle.NUMBER:
+        if col_type == oracledb.NUMBER:
             if scale is None:
                 return TYPE_INTEGER
             if scale > 0:
@@ -122,16 +122,16 @@ class Oracle(BaseSQLQueryRunner):
 
     @classmethod
     def output_handler(cls, cursor, name, default_type, length, precision, scale):
-        if default_type in (cx_Oracle.CLOB, cx_Oracle.LOB):
-            return cursor.var(cx_Oracle.LONG_STRING, 80000, cursor.arraysize)
+        if default_type in (oracledb.CLOB, oracledb.LOB):
+            return cursor.var(oracledb.LONG_STRING, 80000, cursor.arraysize)
 
-        if default_type in (cx_Oracle.STRING, cx_Oracle.FIXED_CHAR):
+        if default_type in (oracledb.STRING, oracledb.FIXED_CHAR):
             return cursor.var(str, length, cursor.arraysize)
 
-        if default_type == cx_Oracle.NUMBER:
+        if default_type == oracledb.NUMBER:
             if scale <= 0:
                 return cursor.var(
-                    cx_Oracle.STRING,
+                    oracledb.STRING,
                     255,
                     outconverter=Oracle._convert_number,
                     arraysize=cursor.arraysize,
@@ -145,13 +145,13 @@ class Oracle(BaseSQLQueryRunner):
         if self.configuration["host"].lower() == "_useservicename":
             dsn = self.configuration["servicename"]
         else:
-            dsn = cx_Oracle.makedsn(
+            dsn = oracledb.makedsn(
                 self.configuration["host"],
                 self.configuration["port"],
                 service_name=self.configuration["servicename"],
             )
 
-        connection = cx_Oracle.connect(
+        connection = oracledb.connect(
             user=self.configuration["user"],
             password=self.configuration["password"],
             dsn=dsn,
@@ -175,7 +175,7 @@ class Oracle(BaseSQLQueryRunner):
                 data = {"columns": columns, "rows": rows}
                 json_data = json_dumps(data)
                 connection.commit()
-        except cx_Oracle.DatabaseError as err:
+        except oracledb.DatabaseError as err:
             (err_args,) = err.args
             line_number = query.count("\n", 0, err_args.offset) + 1
             column_number = err_args.offset - query.rfind("\n", 0, err_args.offset) - 1

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -45,4 +45,7 @@ python-arango==6.1.0
 pinotdb>=0.4.5
 pygridgain==1.4.0
 pyignite==0.6.1
+# python-oracledb supports Oracle 12c and above without needing the Oracle
+# client libraries installed.  To support Oracle 9.x and above as well,
+# then the Oracle client libraries will need installing first.
 oracledb==1.4.0

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -45,3 +45,4 @@ python-arango==6.1.0
 pinotdb>=0.4.5
 pygridgain==1.4.0
 pyignite==0.6.1
+oracledb==1.4.0

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -1,4 +1,5 @@
-# Requires installation of, or similar versions of:
+# If you want to use thick mode, you need to install the Oracle client library.
+# reference. https://pypi.org/project/oracledb/#description
 #    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
 #    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm
-cx_Oracle==5.3
+oracledb==1.3.2

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -2,4 +2,3 @@
 # reference. https://pypi.org/project/oracledb/#description
 #    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
 #    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm
-oracledb==1.4.0

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -2,4 +2,4 @@
 # reference. https://pypi.org/project/oracledb/#description
 #    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
 #    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm
-oracledb==1.3.2
+oracledb==1.4.0

--- a/requirements_oracle_ds.txt
+++ b/requirements_oracle_ds.txt
@@ -1,4 +1,0 @@
-# If you want to use thick mode, you need to install the Oracle client library.
-# reference. https://pypi.org/project/oracledb/#description
-#    oracle-instantclient12.2-basic_12.2.0.1.0-1_x86_64.rpm
-#    oracle-instantclient12.2-devel_12.2.0.1.0-1_x64_64.rpm


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [x] Feature
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

This is a pull request to switch the Oracle Driver module from cx_Oracle to python-oracledb.

Please note the following points with this change.

- The supported Python version is 3.6 or higher.🐍
- The supported Oracle database version is 12c or higher.
  - Thin mode: 12c or higher.
  - Thick mode: 9.2 or higher. (with Oracle Client library)
- In Thin mode, you do not need the Oracle Client library⭕️
- The ENCODING option has been deprecated. Please set the NLS_LANG environment variable instead.❌ -> `The environment variable "NLS_LANG" is also used now.`
  - https://python-oracledb.readthedocs.io/en/latest/user_guide/globalization.html#setting-the-client-character-set
- For other considerations from cx_Oracle changes, please refer to the following documents.
  - https://oracle.github.io/python-cx_Oracle/#features
  - https://oracle.github.io/python-oracledb/#features
- ~This PR will not include changes to `requirements_all_ds.txt`.~ c5f6aa837cedd580560dfb1a244cfb406e6249a9

Please review and let me know if you have any comments. Thank you.🙇‍♂️

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

#6373
#6380

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

no UI change.