### PR TITLE
Use a fixed older version of databend-py, due to problem with 0.4.7

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -6,6 +6,7 @@ cassandra-driver==3.21.0
 # certifi is needed to support MongoDB and SSL:
 certifi>=2019.9.11
 cmem-cmempy==21.2.3
+databend-py==0.4.6
 databend-sqlalchemy==0.2.4
 google-api-python-client==1.7.11
 gspread==3.1.0


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This PR introduces a backend dependency on `databend-py` 0.4.6, as the newer 0.4.7 release has an error which causes it to always fail.  Guessing they don't (yet) have any kind of CI on their repo for this. :frowning:

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A

Not yet tested at all, as I'm wanting to see how our CI goes with this change.