### PR TITLE
Automatically tag release candidates

### DIFF
--- a/.github/workflows/periodic-snapshot.yml
+++ b/.github/workflows/periodic-snapshot.yml
@@ -1,0 +1,26 @@
+name: Periodic Snapshot
+
+# 10 minutes after midnight on the first of every month
+on:
+  schedule:
+  - cron: "10 0 1 * *"
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version-and-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          date="$(date +%y.%m).0-dev"
+          gawk -i inplace -F: -v q=\" -v tag=$date '/^  "version": / { print $1 FS, q tag q ","; next} { print }' package.json
+          gawk -i inplace -F= -v q=\" -v tag=$date '/^__version__ =/ { print $1 FS, q tag q; next} { print }' redash/__init__.py
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add package.json redash/__init__.py
+          git commit -m "Shapshot: ${date}"
+          git push origin
+          git tag $date
+          git push origin $date

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redash-client",
-  "version": "11.0.0-dev",
+  "version": "23.09.0-dev",
   "description": "The frontend part of Redash.",
   "main": "index.js",
   "scripts": {

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -14,7 +14,7 @@ from redash.app import create_app  # noqa
 from redash.destinations import import_destinations
 from redash.query_runner import import_query_runners
 
-__version__ = "11.0.0-dev"
+__version__ = "23.09.0-dev"
 
 
 if os.environ.get("REMOTE_DEBUG"):


### PR DESCRIPTION
Format similar to Ubuntu: _YY.MM.N_

Discussion thread: https://github.com/getredash/redash/discussions/6411

## What type of PR is this? 

- [x] Feature

## How is this tested?

Replace github `schedule` with `workflow_dispatch` to trigger manually

```yaml
on: workflow_dispatch
```
