### PR TITLE
Build and push image to Docker Hub.  pgautoupgrade repo version

### DIFF
--- a/.ci/docker_build
+++ b/.ci/docker_build
@@ -1,21 +1,41 @@
 #!/bin/bash
+
+# This script only needs to run on the main Redash repo
+
+if [ "${GITHUB_REPOSITORY}" != "getredash/redash" ] && [ "${GITHUB_REPOSITORY}" != "justinclift/redash" ]; then # FIXME: Remove justinclift stuff
+	echo "Skipping image build for Docker Hub, as this isn't the main Redash repository"
+	exit 0
+fi
+
+#if [ "${GITHUB_REF_NAME}" != "master" ] && [ "${GITHUB_REF_NAME}" != "preview-image" ]; then
+#	echo "Skipping image build for Docker Hub, as this isn't the 'master' nor 'preview-image' branch"
+#	exit 0
+#fi
+
 set -e
 VERSION=$(jq -r .version package.json)
-VERSION_TAG=$VERSION.b$CIRCLE_BUILD_NUM
+VERSION_TAG="$VERSION.b${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}"
 
 export DOCKER_BUILDKIT=1
 export COMPOSE_DOCKER_CLI_BUILD=1
 
-docker login -u $DOCKER_USER -p $DOCKER_PASS
+docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
 
-if [ $CIRCLE_BRANCH = master ] || [ $CIRCLE_BRANCH = preview-image ]
-then
-    docker build --build-arg skip_dev_deps=true -t redash/redash:preview -t redash/preview:$VERSION_TAG .
-    docker push redash/redash:preview
-    docker push redash/preview:$VERSION_TAG
+if [ "${GITHUB_REPOSITORY}" = "getredash/redash" ]; then # FIXME: Remove pgautoupgrade stuff
+	DOCKERHUB_REPO="redash/redash"
+  DOCKER_TAGS="-t redash/redash:preview -t redash/preview:${VERSION_TAG}"
 else
-    docker build --build-arg skip_dev_deps=true -t redash/redash:$VERSION_TAG .
-    docker push redash/redash:$VERSION_TAG
+	DOCKERHUB_REPO="pgautoupgrade/tempstuff"
+  DOCKER_TAGS="-t pgautoupgrade/tempstuff:preview -t pgautoupgrade/tempstuff:${VERSION_TAG}"
 fi
 
-echo "Built: $VERSION_TAG"
+# Build the docker container
+docker build --build-arg test_all_deps=true ${DOCKER_TAGS} .
+
+# Push the container to the preview build locations
+docker push "${DOCKERHUB_REPO}:preview"
+if [ "${GITHUB_REPOSITORY}" = "getredash/redash" ]; then
+	docker push "redash/preview:${VERSION_TAG}"
+fi
+
+echo "Built: ${VERSION_TAG}"

--- a/.ci/update_version
+++ b/.ci/update_version
@@ -1,6 +1,6 @@
 #!/bin/bash
 VERSION=$(jq -r .version package.json)
-FULL_VERSION=$VERSION+b$CIRCLE_BUILD_NUM
+FULL_VERSION=${VERSION}+b${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}
 
-sed -ri "s/^__version__ = '([A-Za-z0-9.-]*)'/__version__ = '$FULL_VERSION'/" redash/__init__.py
-sed -i "s/dev/$CIRCLE_SHA1/" client/app/version.json
+sed -ri "s/^__version__ = '([A-Za-z0-9.-]*)'/__version__ = '${FULL_VERSION}'/" redash/__init__.py
+sed -i "s/dev/${GITHUB_SHA}/" client/app/version.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,32 @@ jobs:
         with:
           name: coverage
           path: coverage
+  build-docker-image:
+    runs-on: ubuntu-22.04
+    needs:
+      - backend-unit-tests
+      - frontend-unit-tests
+      - frontend-e2e-tests
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+      - name: Install Dependencies
+        run: |
+          npm install --global --force yarn@1.22.19
+          yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
+      - name: Build and push preview image to Docker Hub
+        env:
+          DOCKER_USER: ${{ vars.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        run: |
+          set -x
+          .ci/update_version
+          .ci/docker_build
+      - name: "Failure: output container logs to console"
+        if: failure()
+        run: docker-compose logs


### PR DESCRIPTION
Test that adding the build+push step to the end of the existing workflow... er... works ok.

This one uses the pgautoupgrade docker repo for now, to avoid pushing dev stuff to the proper Redash repo.