### PR TITLE
Add pkg-config to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN useradd --create-home redash
 # Ubuntu packages
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+  pkg-config \
   curl \
   gnupg \
   build-essential \


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

While investigating a different problem with our Docker builds, it turns out the MySQL client install doesn't always work.

```
Collecting mysqlclient<3.0,>=1.4 (from memsql==3.2.0)
#22 55.46   Downloading mysqlclient-2.2.0.tar.gz (89 kB)
#22 55.46      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 89.5/89.5 kB 131.2 MB/s eta 0:00:00
#22 55.49   Installing build dependencies: started
#22 57.66   Installing build dependencies: finished with status 'done'
#22 57.67   Getting requirements to build wheel: started
#22 57.87   Getting requirements to build wheel: finished with status 'error'
#22 57.88   error: subprocess-exited-with-error
#22 57.88   
#22 57.88   × Getting requirements to build wheel did not run successfully.
#22 57.88   │ exit code: 1
#22 57.88   ╰─> [24 lines of output]
#22 57.88       /bin/sh: 1: pkg-config: not found
#22 57.88       /bin/sh: 1: pkg-config: not found
```

Adding the `pkg-config` Ubuntu package seems to fix the problem.

## How is this tested?

- [x] Manually

I've only tested the Docker build process with this, not the full CI tests.  They should (in theory) all work unchanged however.