### PR TITLE
Move from oauth2client to google-auth / support ADC

### DIFF
--- a/redash/query_runner/big_query_gce.py
+++ b/redash/query_runner/big_query_gce.py
@@ -1,9 +1,8 @@
-import httplib2
 import requests
 
 try:
+    import google.auth
     from apiclient.discovery import build
-    from oauth2client.contrib import gce
 
     enabled = True
 except ImportError:
@@ -60,17 +59,11 @@ class BigQueryGCE(BigQuery):
         }
 
     def _get_project_id(self):
-        return requests.get(
-            "http://metadata/computeMetadata/v1/project/project-id",
-            headers={"Metadata-Flavor": "Google"},
-        ).text
+        google.auth.default()[1]
 
     def _get_bigquery_service(self):
-        credentials = gce.AppAssertionCredentials(scope="https://www.googleapis.com/auth/bigquery")
-        http = httplib2.Http()
-        http = credentials.authorize(http)
-
-        return build("bigquery", "v2", http=http)
+        creds = google.auth.default(scopes=["https://www.googleapis.com/auth/bigquery"])[0]
+        return build("bigquery", "v2", credentials=creds, cache_discovery=False)
 
 
 register(BigQueryGCE)

--- a/redash/query_runner/google_analytics.py
+++ b/redash/query_runner/google_analytics.py
@@ -17,10 +17,10 @@ from redash.utils import json_dumps, json_loads
 logger = logging.getLogger(__name__)
 
 try:
-    import httplib2
+    import google.auth
     from apiclient.discovery import build
     from apiclient.errors import HttpError
-    from oauth2client.service_account import ServiceAccountCredentials
+    from google.oauth2.service_account import Credentials
 
     enabled = True
 except ImportError:
@@ -105,8 +105,8 @@ class GoogleAnalytics(BaseSQLQueryRunner):
     def configuration_schema(cls):
         return {
             "type": "object",
-            "properties": {"jsonKeyFile": {"type": "string", "title": "JSON Key File"}},
-            "required": ["jsonKeyFile"],
+            "properties": {"jsonKeyFile": {"type": "string", "title": "JSON Key File (ADC is used if omitted)"}},
+            "required": [],
             "secret": ["jsonKeyFile"],
         }
 
@@ -115,10 +115,15 @@ class GoogleAnalytics(BaseSQLQueryRunner):
         self.syntax = "json"
 
     def _get_analytics_service(self):
-        scope = ["https://www.googleapis.com/auth/analytics.readonly"]
-        key = json_loads(b64decode(self.configuration["jsonKeyFile"]))
-        creds = ServiceAccountCredentials.from_json_keyfile_dict(key, scope)
-        return build("analytics", "v3", http=creds.authorize(httplib2.Http()))
+        scopes = ["https://www.googleapis.com/auth/analytics.readonly"]
+
+        try:
+            key = json_loads(b64decode(self.configuration["jsonKeyFile"]))
+            creds = Credentials.from_service_account_info(key, scopes=scopes)
+        except KeyError:
+            creds = google.auth.default(scopes=scopes)[0]
+
+        return build("analytics", "v3", credentials=creds)
 
     def _get_tables(self, schema):
         accounts = self._get_analytics_service().management().accounts().list().execute().get("items")

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -9,14 +9,14 @@ cmem-cmempy==21.2.3
 databend-py==0.4.6
 databend-sqlalchemy==0.2.4
 google-api-python-client==1.7.11
-gspread==3.1.0
+google-auth>=2.22.0
+gspread==5.1.0
 impyla==0.16.0
 influxdb==5.2.3
 memsql==3.2.0
 mysqlclient==2.1.1
 nzalchemy
 nzpy>=1.15
-oauth2client==4.1.3
 openpyxl==3.0.7
 # python-oracledb supports Oracle 12c and above without needing the Oracle
 # client libraries installed.  To support Oracle 9.x and above as well,


### PR DESCRIPTION
## What type of PR is this? 
- [x] Refactor
- [x] Feature

## Description

[oauth2client](https://pypi.org/project/oauth2client/), the library to be used to authenticate with Google services, was deprecated in 2017 and is no longer maintained. This PR rewrites the service account credentials code and replaces it with [google-auth](https://pypi.org/project/google-auth/).

In addition, this makes the JSON key file optional for the data source and uses the application's default credentials (ADC) if the JSON key file is omitted. This enables support for a variety of GCP authentication methods, including the gcloud CLI, GCE metadata servers, and GKE or AWS Workload Identity.
These methods are more secure than manually managing service account keys.

Please see the document for more details about ADC:
https://cloud.google.com/docs/authentication/application-default-credentials

Note that the bigquery_gce functionality is covered by the ADC feature, but is retained for compatibility reasons.

[gspread](https://pypi.org/project/gspread/) library is also updated to latest version to support google-auth. (At least version 3.5.0 is required)

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually

Each modified datasource are tested manually to check weather it can get the google credentials from a service account JSON file and ADC.

## Related Tickets & Documents
https://redash.io/help/data-sources/querying/bigquery : JSON Key file will be optional if ADC can be used.

