### PR TITLE
ci: use docker/build-push-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Skip?
         id: skip-check
         run: |
-          if [[ ${{ vars.DOCKER_USER }} == '' ]] || [[ ${{ secrets.DOCKER_PASS }} == '' ]]; then
+          if [[ "${{ vars.DOCKER_USER }}" == '' ]] || [[ "${{ secrets.DOCKER_PASS }}" == '' ]]; then
             echo skip=true >> "$GITHUB_OUTPUT"
           else
             echo skip=false >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,28 @@ jobs:
           name: coverage
           path: coverage
 
+  build-skip-check:
+    runs-on: ubuntu-22.04
+    outputs:
+      skip: ${{ steps.skip-check.outputs.skip }}
+    steps:
+      - name: Skip?
+        id: skip-check
+        run: |
+          if [[ ${{ vars.DOCKER_USER }} == '' ]] || [[ ${{ secrets.DOCKER_PASS }} == '' ]]; then
+            echo skip=true >> "$GITHUB_OUTPUT"
+          else
+            echo skip=false >> "$GITHUB_OUTPUT"
+          fi
+
   build-docker-image:
     runs-on: ubuntu-22.04
     needs:
       - backend-unit-tests
       - frontend-unit-tests
       - frontend-e2e-tests
+      - build-skip-check
+    if: ${{ needs.build-skip-check.outputs.skip == false}}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Enable Code Coverage Report For Master Branch
         if: endsWith(github.ref, '/master')
         run: |
-          echo "CODE_COVERAGE=true" >> $GITHUB_ENV
+          echo "CODE_COVERAGE=true" >> "$GITHUB_ENV"
       - name: Install Dependencies
         run: |
           npm install --global --force yarn@1.22.19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,14 +170,44 @@ jobs:
         run: |
           npm install --global --force yarn@1.22.19
           yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
-      - name: Build and push preview image to Docker Hub
-        env:
-          DOCKER_USER: ${{ vars.DOCKER_USER }}
-          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+
+      - name: Set up QEMU
+        timeout-minutes: 1
+        uses: docker/setup-qemu-action@v2.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Bump version
+        id: version
         run: |
           set -x
           .ci/update_version
-          .ci/docker_build
+          VERSION=$(jq -r .version package.json)
+          VERSION_TAG="${VERSION}.b${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}"
+          echo "VERSION_TAG=$VERSION_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push preview image to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            redash/redash:preview
+            redash/preview:${{ steps.version.outputs.VERSION_TAG }}
+          context: .
+          build-args: |
+            test_all_deps=true
+          cache-from: type=ghq
+          cache-to: type=gha,mode=max
+        env:
+          DOCKER_CONTENT_TRUST: true
+
       - name: "Failure: output container logs to console"
         if: failure()
         run: docker-compose logs


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

https://discord.com/channels/1029619790563790848/1029619790563790851/1148007830805282958
>sid (gh:guidopetri) — 2023/09/04 06:33
@JustinClift i think we can simplify the .ci/docker_build file away. there's a build-and-push github action that we can use, e.g. https://github.com/stringer-rss/stringer/blob/main/.github/workflows/build.yml#L44-L56 , which can a) run conditionally on branches b) build across platforms and c) use caching automatically, which will improve our build times dramatically. i'd also be surprised if we couldn't set it to only build / push if the docker secrets are available
(i wrote that CI yaml recently, but i'm not super familiar with gh actions)

sid's idea is very good, I want to new preview docker image.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
