### PR TITLE
Remove importlib-resources from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ gevent==22.10.1
 greenlet==1.1.3
 gunicorn==20.0.4
 httplib2==0.19.0
-importlib-resources==5.13.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 jsonschema==3.1.1


### PR DESCRIPTION
This is not required for Python >= 3.8 since the goal of this project is to back port functionality.  Also the version specified is not compatible with later versions of Python.

## What type of PR is this? 

- [x] Upgrade

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Unit tests (pytest, jest)

## Related Tickets & Documents

https://pypi.org/project/importlib-resources/
