### PR TITLE
Update Docker build to Debian 12/Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.8-slim-buster
+FROM python:3.10-slim-bookworm
 
 EXPOSE 5000
 
@@ -69,10 +69,10 @@ RUN apt-get update && \
 ARG TARGETPLATFORM
 ARG databricks_odbc_driver_url=https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.6.26/SimbaSparkODBC-2.6.26.1045-Debian-64bit.zip
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-  curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-  && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+  curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc \
+  && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
   && apt-get update \
-  && ACCEPT_EULA=Y apt-get install  -y --no-install-recommends msodbcsql17 \
+  && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql17 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl "$databricks_odbc_driver_url" --location --output /tmp/simba_odbc.zip \

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ sentry-sdk==1.28.1
 simplejson==3.16.0
 SQLAlchemy==1.3.24
 SQLAlchemy-Searchable==1.2.0
-SQLAlchemy-Utils==0.34.2
+SQLAlchemy-Utils==0.36.6
 sqlparse==0.4.4
 sshtunnel==0.1.5
 statsd==3.3.0


### PR DESCRIPTION
## What type of PR is this? 

- [x] Upgrade

## Description

- Recommended development host may be Ubuntu 20 or Ubuntu 22
- Use Debian 12 instead of Ubuntu 22 for better compatibility with Microsoft's APT repo
- Going forward, Redash may incorporate features and packages designed for Python 3.10
 
## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually