### PR TITLE
Excel and CSV Query Runner fix

### DIFF
--- a/redash/query_runner/csv.py
+++ b/redash/query_runner/csv.py
@@ -80,7 +80,7 @@ class CSV(BaseQueryRunner):
                     "to_redash": lambda x: x.strftime("%Y-%m-%d %H:%M:%S"),
                 },
                 {"pandas_type": np.bool_, "redash_type": "boolean"},
-                {"pandas_type": np.object, "redash_type": "string"},
+                {"pandas_type": np.object_, "redash_type": "string"},
             ]
             labels = []
             for dtype, label in zip(df.dtypes, df.columns):

--- a/redash/query_runner/excel.py
+++ b/redash/query_runner/excel.py
@@ -78,7 +78,7 @@ class Excel(BaseQueryRunner):
                     "to_redash": lambda x: x.strftime("%Y-%m-%d %H:%M:%S"),
                 },
                 {"pandas_type": np.bool_, "redash_type": "boolean"},
-                {"pandas_type": np.object, "redash_type": "string"},
+                {"pandas_type": np.object_, "redash_type": "string"},
             ]
             labels = []
             for dtype, label in zip(df.dtypes, df.columns):


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Running a CSV or Excel query throws an error in the current master branch.

`Error running query: Error reading https://people.sc.fsu.edu/~jburkardt/data/csv/addresses.csv. module 'numpy' has no attribute 'object'. 'np.object' was a deprecated alias for the builtin 'object'. To avoid this error in existing code, use 'object' by itself. Doing this will not modify any behavior and is safe. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations`

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [X] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
Error
![image](https://github.com/getredash/redash/assets/2754353/6b9edaa9-4155-4b23-b5bc-4a181f9c43af)


After fix
![image](https://github.com/getredash/redash/assets/2754353/dc6d7e6f-9a1c-4a32-85ed-d700a3cb283e)


## Related Tickets & Documents
Similar to [https://github.com/getredash/redash/pull/6371](url)
