### PR TITLE
Avoid file locking issue when running CLI test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,7 +132,7 @@ class DataSourceCommandTests(BaseTestCase):
         self.factory.create_data_source(
             name="test1",
             type="sqlite",
-            options=ConfigurationContainer({"dbpath": __file__}),
+            options=ConfigurationContainer({"dbpath": "/notexist.db"}),
         )
         runner = CliRunner()
         result = runner.invoke(manager, ["ds", "test", "test1"])


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix
- [x] Testing

## Description

`__file__` will resolve to `/app/tests/test_cli.py`, which is already opened by Python. When tests are run on a network file system the test runner may deadlock while waiting for an advisory lock to be released on this file.

## How is this tested?

- [x] Unit tests (pytest, jest)
