### PR TITLE
Add kerberos development headers to Redash image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update && \
   libffi-dev \
   sudo \
   git-core \
+  # Kerberos, needed for MS SQL Python driver to compile on arm64
+  libkrb5-dev \
   # Postgres client
   libpq-dev \
   # ODBC support:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Without these headers, compiling pymssql on arm64 fails:

```
gcc -pthread -shared build/temp.linux-aarch64-cpython-38/src/pymssql/_mssql.o -L/usr/local/lib -lsybdb
    -lgssapi_krb5 -lkrb5 -lssl -lcrypto
    -o build/lib.linux-aarch64-cpython-38/pymssql/_mssql.cpython-38-aarch64-linux-gnu.so
/usr/bin/ld: cannot find -lgssapi_krb5
/usr/bin/ld: cannot find -lkrb5
collect2: error: ld returned 1 exit status
```

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)

On x86_64, all our tests pass fine.

On arm64 (eg M1 Mac Mini) some of our E2E tests seem to be failing due to an unrelated matter.  That will need looking into at a future point (not today).