### PR TITLE
Update poetry.lock after PR 6469

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4972,4 +4972,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "29c4a67709a27738a0f0913fab0764fb14b8d0c488bffc752098ee17c090e1f2"
+content-hash = "9a77f82eaf257108607dd75c4da9e8f58120936ed7b57f43b6566b551c85a2ba"


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This PR fixes a warning from poetry after PR #6469 was merged:

```
$ poetry check
Error: poetry.lock is not consistent with pyproject.toml. Run `poetry lock [--no-update]` to fix it.
```

It was created using `poetry lock --no-update`.

## How is this tested?

- [x] N/A