### PR TITLE
Updated the redash/query_runner/pg.py PostgreSQL _get_tables method

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -221,7 +221,8 @@ class PostgreSQL(BaseSQLQueryRunner):
         AND a.attnum > 0
         AND NOT a.attisdropped
         WHERE c.relkind IN ('m', 'f', 'p')
-
+        AND has_schema_privilege(s.nspname, 'usage')
+        AND has_table_privilege(s.nspname || '.' || c.relname, 'select')
         UNION
 
         SELECT table_schema,


### PR DESCRIPTION
Added the following conditions to the where clause in the query in the _get_tables method:
AND has_schema_privilege(s.nspname, 'usage')
AND has_table_privilege(s.nspname || '.' || c.relname, 'select')

## What type of PR is this? 
- [* ] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?
- [* ] Manually 

<!-- If Manually, please describe. -->
Ug analytics in Redash should only have tables and views associated with the ug_redash user

