### PR TITLE
Avoid updating query result for archived queries

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -738,6 +738,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         queries = Query.query.filter(
             Query.query_hash == query_result.query_hash,
             Query.data_source == query_result.data_source,
+            Query.is_archived.is_(False),
         )
 
         for q in queries:

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -462,7 +462,7 @@ class TestQueryUpdateLatestResult(BaseTestCase):
     def test_updates_existing_queries(self):
         query1 = self.factory.create_query(query_text=self.query)
         query2 = self.factory.create_query(query_text=self.query)
-        query3 = self.factory.create_query(query_text=self.query)
+        query3 = self.factory.create_query(query_text=self.query, is_archived=True)
 
         query_result = QueryResult.store_result(
             self.data_source.org_id,
@@ -478,7 +478,7 @@ class TestQueryUpdateLatestResult(BaseTestCase):
 
         self.assertEqual(query1.latest_query_data, query_result)
         self.assertEqual(query2.latest_query_data, query_result)
-        self.assertEqual(query3.latest_query_data, query_result)
+        self.assertEqual(query3.latest_query_data, None)
 
     def test_doesnt_update_queries_with_different_hash(self):
         query1 = self.factory.create_query(query_text=self.query)


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix
- [x] Optimization

## Description

Refreshing an active query inadvertently updates archived queries with the same `query_hash`. On installations with many archived queries this increases the load on the database and consumes space that may never be reclaimed.

## How is this tested?

- [x] Unit tests (pytest, jest)