### PR TITLE
Provide stable URL for referencing dashboards

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1128,7 +1128,12 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
 
     @classmethod
     def get_by_slug_and_org(cls, slug, org):
-        return cls.query.filter(cls.slug == slug, cls.org == org).one()
+        pattern = "{}(_[0-9]+)?".format(slug)
+        return (
+            cls.query.filter(cls.slug.op("SIMILAR TO")(pattern), cls.org == org, cls.is_archived.is_(False))
+            .order_by(cls.id.desc())
+            .first()
+        )
 
     @hybrid_property
     def lowercase_name(self):

--- a/tests/handlers/test_dashboards.py
+++ b/tests/handlers/test_dashboards.py
@@ -56,12 +56,15 @@ class TestDashboardResourceGet(BaseTestCase):
 
         self.assertResponseEqual(expected, actual)
 
-    def test_get_dashboard_with_slug(self):
+    def test_get_dashboard_with_id_slug(self):
         d1 = self.factory.create_dashboard()
+        d2 = self.factory.create_dashboard()
+        self.factory.create_dashboard(is_archived=True)
+        # Accessible as /dashboard/{slug}
         rv = self.make_request("get", "/api/dashboards/{0}?legacy".format(d1.slug))
         self.assertEqual(rv.status_code, 200)
 
-        expected = serialize_dashboard(d1, with_widgets=True, with_favorite_state=False)
+        expected = serialize_dashboard(d2, with_widgets=True, with_favorite_state=False)
         actual = json_loads(rv.data)
 
         self.assertResponseEqual(expected, actual)


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

Dashboards may be referenced if their ID is known (`/dashboards/{dashboard_id}-{slug}`), but there was no easy method of linking one dashboard to another by name.

The route `/dashboard/{slug}` already exists, but was useless because the exact slug ID had to be supplied (`slug`, `slug_1`, `slug_2`, ...). This change improves this routes by finding the best match.

This enables dashboar

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

Create several dashboards with the same name, archive the first and test redirects using `/dashboard/{slug}`

## Example Use Case

![redash-markdown-links](https://github.com/getredash/redash/assets/1175398/168f4ba3-0d9d-4247-87ff-d1b2ed262a42)
