### PR TITLE
Create sqlalchemy_searchable expressions

### DIFF
--- a/migrations/versions/7ce5925f832b_create_sqlalchemy_searchable_expressions.py
+++ b/migrations/versions/7ce5925f832b_create_sqlalchemy_searchable_expressions.py
@@ -1,0 +1,25 @@
+"""create sqlalchemy_searchable expressions
+
+Revision ID: 7ce5925f832b
+Revises: 1038c2174f5d
+Create Date: 2023-09-29 16:48:29.517762
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy_searchable import sql_expressions
+
+
+# revision identifiers, used by Alembic.
+revision = '7ce5925f832b'
+down_revision = '1038c2174f5d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(sql_expressions)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
The required sql expressions for sqlalchemy_searchable are only created on the sqlalchemy pre_create hook. When upgrading from a previous redash version, there may be no CREATE statements in any applicable migrations, so these sql expressions are never created.

In a fresh install the hook runs properly so there's no issue with the search functionality.

Add a migration to manually execute the sql_expressions DDL from sqlalchemy_searchable.

## What type of PR is this? 

- [x] Bug Fix

## Description

The required sql expressions for sqlalchemy_searchable are only created on the sqlalchemy pre_create hook. When upgrading from a previous redash version no CREATE statements may be run, so these expressions are never created.

## How is this tested?

- [x] Manually

1. Created a fresh install of redash from the current master branch and deleted the custom sql expressions created by sqlalchemy_searchable. This mimics the state of an installation that was upgraded from a version prior to the version bump of sqlalchemy_searchable.
2. Confirmed that search is broken.
3. Deployed fix and ran migrations.
4. Confirmed search is fixed.

## Related Tickets & Documents

Fixes https://github.com/getredash/redash/issues/6381
