### PR TITLE
Fix dockerhub image building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       - frontend-unit-tests
       - frontend-e2e-tests
       - build-skip-check
-    if: ${{ needs.build-skip-check.outputs.skip == false}}
+    if: ${{ needs.build-skip-check.outputs.skip }} == false
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Our build-image-and-push step in the CI wasn't running. This change makes it work again :) the comparison operator for the previous step's output had to be outside the jinja placeholder clause.

## How is this tested?

- [x] Manually

I changed the `on:` line on the CI file and pushed the branch. [This GHA run](https://github.com/getredash/redash/actions/runs/6438205061) demonstrates that the build-and-push started executing, though I later canceled it.

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
