### PR TITLE
Build + push `preview` image only on `master` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,18 @@ jobs:
       - name: Skip?
         id: skip-check
         run: |
-          if [[ "${{ vars.DOCKER_USER }}" == '' ]] || [[ "${{ secrets.DOCKER_PASS }}" == '' ]]; then
+          if [[ "${{ vars.DOCKER_USER }}" == '' ]]; then
+            echo 'Docker user is empty. Skipping build+push'
+            echo skip=true >> "$GITHUB_OUTPUT"
+          elif [[ "${{ secrets.DOCKER_PASS }}" == '' ]]; then
+            echo 'Docker password is empty. Skipping build+push'
+            echo skip=true >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref_name }}" != 'master' ]]; then
+            echo 'Ref name is not `master`. Skipping build+push'
             echo skip=true >> "$GITHUB_OUTPUT"
           else
+            echo 'Docker user and password are set and branch is `master`.'
+            echo 'Building + pushing `preview` image.'
             echo skip=false >> "$GITHUB_OUTPUT"
           fi
 
@@ -172,7 +181,7 @@ jobs:
       - frontend-unit-tests
       - frontend-e2e-tests
       - build-skip-check
-    if: ${{ needs.build-skip-check.outputs.skip }} == false
+    if: needs.build-skip-check.outputs.skip == 'false'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The CI is trying to build + push the `preview` tagged image on PRs, but we only want that to happen on the `master` branch. This change adds a condition to the CI step that runs the build+push, filtering for the ref to be `master` as a condition of the CI step being run.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
Added a test commit that skips the e2e/unit tests (for faster iteration) and verified that the build+push CI step does not run on this PR.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

#6503 , #6505 , #6420
