### PR TITLE
Commit version update and tag together

### DIFF
--- a/.github/workflows/periodic-snapshot.yml
+++ b/.github/workflows/periodic-snapshot.yml
@@ -12,7 +12,7 @@ jobs:
   bump-version-and-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           date="$(date +%y.%m).0-dev"
           gawk -i inplace -F: -v q=\" -v tag=$date '/^  "version": / { print $1 FS, q tag q ","; next} { print }' package.json
@@ -22,6 +22,5 @@ jobs:
           git config user.email github-actions@github.com
           git add package.json redash/__init__.py pyproject.toml
           git commit -m "Snapshot: ${date}"
-          git push origin
           git tag $date
-          git push origin $date
+          git push --atomic origin master refs/tags/$date


### PR DESCRIPTION
Also update to checkout v4

## What type of PR is this? 

- [x] Other

## Description

This is an effort to make this action more reliable, and possibly solve this error

> error: failed to push some refs to 'https://github.com/getredash/redash'
> hint: Updates were rejected because the remote contains work that you do not
> hint: have locally. This is usually caused by another repository pushing to
> hint: the same ref. If you want to integrate the remote changes, use

## How is this tested?

- [x] Manually

Create private repo, manually trigger after setting `on: workflow_dispatch`