### PR TITLE
Allow Query.options to be None

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -264,7 +264,7 @@ class DataSource(BelongsToOrgMixin, db.Model):
 
     @property
     def uses_ssh_tunnel(self):
-        return "ssh_tunnel" in self.options
+        return self.options and "ssh_tunnel" in self.options
 
     @property
     def query_runner(self):

--- a/viz-lib/src/visualizations/counter/Renderer.tsx
+++ b/viz-lib/src/visualizations/counter/Renderer.tsx
@@ -17,11 +17,11 @@ function getCounterStyles(scale: any) {
 function getCounterScale(container: any) {
   // size of font in base container
   // children use a relative font size (em)
-  if (container.closest('.visualization-preview')) {
+  if (container.closest('.visualization-preview') || container.closest('.ant-tabs-tabpane')) {
     return "60";
   }
   const fontSize = container.clientHeight / 4.5;
-  return fontSize > 60 ? "60" : fontSize < 12 ? "12" : fontSize.toFixed();
+  return fontSize > 60 ? "60" : fontSize < 14 ? "14" : fontSize.toFixed();
 }
 
 export default function Renderer({ data, options, visualizationName }: any) {


### PR DESCRIPTION
Query.options may not have a value on a database created by 10.1.0

## What type of PR is this? 

- [x] Bug Fix

## Description

This incompatibility was introduced in https://github.com/getredash/redash/pull/4797

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually
