### PR TITLE
Revert arm64 docker image building in CI (for now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
             test_all_deps=true
           cache-from: type=ghq
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
         env:
           DOCKER_CONTENT_TRUST: true
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-network-timeout 600000


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR reverts PRs #6525 and #6531, due to problems building the arm64 images with GitHub Actions.

## How is this tested?

- [x] N/A