### PR TITLE
Add new connection options in MySQL

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -67,8 +67,19 @@ class Mysql(BaseSQLQueryRunner):
                 "connect_timeout": {"type": "number", "default": 60, "title": "Connection Timeout"},
                 "charset": {"type": "string", "default": "utf8"},
                 "use_unicode": {"type": "boolean", "default": True},
+                "autocommit": {"type": "boolean", "default": False},
             },
-            "order": ["host", "port", "user", "passwd", "db", "connect_timeout", "charset", "use_unicode"],
+            "order": [
+                "host",
+                "port",
+                "user",
+                "passwd",
+                "db",
+                "connect_timeout",
+                "charset",
+                "use_unicode",
+                "autocommit",
+            ],
             "required": ["db"],
             "secret": ["passwd"],
         }
@@ -76,6 +87,18 @@ class Mysql(BaseSQLQueryRunner):
         if show_ssl_settings:
             schema["properties"].update(
                 {
+                    "ssl_mode": {
+                        "type": "string",
+                        "title": "SSL Mode",
+                        "default": "preferred",
+                        "extendedEnum": [
+                            {"value": "disabled", "name": "Disabled"},
+                            {"value": "preferred", "name": "Preferred"},
+                            {"value": "required", "name": "Required"},
+                            {"value": "verify-ca", "name": "Verify CA"},
+                            {"value": "verify-identity", "name": "Verify Identity"},
+                        ],
+                    },
                     "use_ssl": {"type": "boolean", "title": "Use SSL"},
                     "ssl_cacert": {
                         "type": "string",
@@ -112,6 +135,7 @@ class Mysql(BaseSQLQueryRunner):
             charset=self.configuration.get("charset", "utf8"),
             use_unicode=self.configuration.get("use_unicode", True),
             connect_timeout=self.configuration.get("connect_timeout", 60),
+            autocommit=self.configuration.get("autocommit", True),
         )
 
         ssl_options = self._get_ssl_parameters()
@@ -216,7 +240,7 @@ class Mysql(BaseSQLQueryRunner):
         ssl_params = {}
 
         if self.configuration.get("use_ssl"):
-            config_map = {"ssl_cacert": "ca", "ssl_cert": "cert", "ssl_key": "key"}
+            config_map = {"ssl_mode": "preferred", "ssl_cacert": "ca", "ssl_cert": "cert", "ssl_key": "key"}
             for key, cfg in config_map.items():
                 val = self.configuration.get(key)
                 if val:


### PR DESCRIPTION
## What type of PR is this? 

- [X] Other

## Description
This PR adds some new connection options to the MySQL query runner, I added this because when trying to connect to a PlanetScale instance, I got some errors and it required to use these extra options to work.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [X] E2E Tests (Cypress)
- [X] Manually

I changed the query runner, so we had some small changes in the UI when adding a MySQL database which I tested and I also tried to connect to a PlanetScale instance using it and it worked. I also ran unit tests and E2E tests to ensure nothing broke, however not all tests with Cypress passed (at least locally using my MacBook Air M1), but I don't think it's related to the changes I made.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img src="https://github.com/getredash/redash/assets/26484303/eec2eca8-0176-4816-a522-be2ed67529bc" alt="drawing" width="200"/>


