### PR TITLE
Use rq_redis_connection when listing RQ jobs in remove_ghost_locks maintenance task

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -59,7 +59,7 @@ def get_status():
 
 
 def rq_job_ids():
-    queues = Queue.all(connection=redis_connection)
+    queues = Queue.all(connection=rq_redis_connection)
 
     started_jobs = [StartedJobRegistry(queue=q).get_job_ids() for q in queues]
     queued_jobs = [q.job_ids for q in queues]


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Fix for UnicodeDecodeError in remove_ghost_locks mainentance task.

Redash has two connections to Redis - one for RQ, which does not support decode_responses in it's connection string, and one for Redash direct access to Redis, which expects decode_responses to be set. There is one place in the remove_ghost_locks call stack where the Redash connection is used in place of the RQ one, causing UnicodeDecodeErrors.

Discovered while investigating https://github.com/getredash/redash/issues/6424

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

* Modified the docker-compose file - set the worker command to `worker` instead of `dev_worker` (to make the healthcheck tasks run)
* Started a long-running query (`SELECT pg_sleep(300)`)
* Before change - observe several `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9c in position 1: invalid start byte` in docker logs of `redash-worker-1` during query execution
* After change - query completes without `UnicodeDecodeError` in `redash-worker-1` logs
