### PR TITLE
Reset Redis pipeline at end of enqueue_query

### DIFF
--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -112,6 +112,8 @@ def enqueue_query(query, data_source, user_id, is_api_key=False, scheduled_query
 
         except redis.WatchError:
             continue
+        finally:
+            pipe.reset()
 
     if not job:
         logger.error("[Manager][%s] Failed adding job for query.", query_hash)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
Discovered while investigating https://github.com/getredash/redash/issues/6424

enqueue_query is using a Redis pipeline, which it should reset once it is complete. See
https://redis-py.readthedocs.io/en/stable/advanced_features.html.

This shouldn't lead to any behaviour change in Redash, but does ensure it is following recommendations.

I haven't looked if this is missing elsewhere in the codebase - this was just one I noticed while investigating another issue.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A
