### PR TITLE
Account for devicePixelRatio when scaling counter widgets

### DIFF
--- a/viz-lib/src/visualizations/counter/Renderer.tsx
+++ b/viz-lib/src/visualizations/counter/Renderer.tsx
@@ -20,7 +20,7 @@ function getCounterScale(container: any) {
   if (container.closest('.visualization-preview') || container.closest('.ant-tabs-tabpane')) {
     return "60";
   }
-  const fontSize = 12 + container.clientHeight / 5;
+  const fontSize = 12 + (container.clientHeight / window.devicePixelRatio / 5);
   return fontSize > 60 ? "60" : fontSize.toFixed();
 }
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Manually

## Related Tickets & Documents

https://github.com/getredash/redash/issues/6521

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

devicePixelRatio=1

![10scale](https://github.com/getredash/redash/assets/1175398/e08f5d85-ab21-4df8-bce3-47753e79f8b2)

devicePixelRatio=1.8

![18scale](https://github.com/getredash/redash/assets/1175398/1548904c-d98d-4df8-bc79-ed5f4082c3b5)

