### PR TITLE
Better Heatmap Annotation Color

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/default.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/default.json
@@ -26,7 +26,10 @@
         "z": [[3, 1], [4, 2]],
         "type": "heatmap",
         "name": "",
-        "colorscale": "Bluered"
+        "colorscale": [
+          [ 0, "rgb(0,0,255)" ],
+          [ 1, "rgb(255,0,0)" ]
+        ]
       }
     ]
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/reversed.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/reversed.json
@@ -28,7 +28,10 @@
         "z": [[2, 4], [1, 3]],
         "type": "heatmap",
         "name": "",
-        "colorscale": "Bluered"
+        "colorscale": [
+          [ 0, "rgb(0,0,255)" ],
+          [ 1, "rgb(255,0,0)" ]
+        ]
       }
     ]
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/sorted-reversed.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/sorted-reversed.json
@@ -30,7 +30,10 @@
         "z": [[4, 2], [3, 1]],
         "type": "heatmap",
         "name": "",
-        "colorscale": "Bluered"
+        "colorscale": [
+          [ 0, "rgb(0,0,255)" ],
+          [ 1, "rgb(255,0,0)" ]
+        ]
       }
     ]
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/sorted.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/sorted.json
@@ -28,7 +28,10 @@
         "z": [[1, 3], [2, 4]],
         "type": "heatmap",
         "name": "",
-        "colorscale": "Bluered"
+        "colorscale": [
+          [ 0, "rgb(0,0,255)" ],
+          [ 1, "rgb(255,0,0)" ]
+        ]
       }
     ]
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/with-labels.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/heatmap/with-labels.json
@@ -2,7 +2,7 @@
   "input": {
     "options": {
       "globalSeriesType": "heatmap",
-      "colorScheme": "Bluered",
+      "colorScheme": "Greys",
       "seriesOptions": {},
       "showDataLabels": true
     },
@@ -26,7 +26,10 @@
         "z": [[3, 1], [4, 2]],
         "type": "heatmap",
         "name": "",
-        "colorscale": "Bluered"
+        "colorscale": [
+          [ 0, "rgb(0,0,0)" ],
+          [ 1, "rgb(255,255,255)" ]
+        ]
       },
       {
         "x": [12, 11, 12, 11],
@@ -36,7 +39,7 @@
         "showlegend": false,
         "text": ["3", "1", "4", "2"],
         "textfont": {
-          "color": ["black", "black", "black", "black"]
+          "color": ["#333333", "#ffffff", "#333333", "#ffffff"]
         }
       }
     ]


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
- [x] Bug Fix

## Description
Gives you more legible annotations for heatmap. (Closes #5729)
Now annotation color will be calculated based on cell color.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A

## Related Tickets & Documents
#5729 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before (left) and After (right):
![image](https://github.com/getredash/redash/assets/1698635/ddc25c0f-42cc-47ec-b7a9-251dcb1c311d)

Before (left) and After (right):
![image](https://github.com/getredash/redash/assets/1698635/39a78eba-7075-47bc-b130-b2e8b4689e7e)

