### PR TITLE
Remove pygridgain so Trino data source shows up

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3145,36 +3145,6 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
-name = "pygridgain"
-version = "1.4.0"
-description = "GridGain binary client Python API"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pygridgain-1.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:490abb76e639d675eacb3560c0145f53f8fb7ddf6034d888baf761adeee352a5"},
-    {file = "pygridgain-1.4.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e64c2c205a669a47666abec34e1fefe937202d9e8dfa396a6a2c90bdcd69f722"},
-    {file = "pygridgain-1.4.0-cp310-cp310-win32.whl", hash = "sha256:4c2dff46fedf57b9963957f78c1f87acaa39cb668bc1b31418b5b42aff7c4ae0"},
-    {file = "pygridgain-1.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:2697392444ff15dca08668b2aef2d219aa749cfd2eb6602757e1bbf2ee843197"},
-    {file = "pygridgain-1.4.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:40f5ea3f709c23e9f02a43d2a422f18f9f4655a5d9174a4904ba271792229b9b"},
-    {file = "pygridgain-1.4.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f48aef7141938599923ee8df01685038fc2603bc48b194c7e9ec435b69d3a33"},
-    {file = "pygridgain-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:bf036d2547eb4487fa7383ca22a06060136b4880b4a354af57526a5790d3a9f2"},
-    {file = "pygridgain-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7918a1a117171ce4cc4573581f7c91d145b36bbc1de1bb5106734ed28163dbb6"},
-    {file = "pygridgain-1.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:92d2d235a50288cf80f140ddf46ac8936dcf803aee22001e27939c905b6fb12f"},
-    {file = "pygridgain-1.4.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fa3473273f6a4bd16980b0bcc3f5c90893c48df01225af5205596e5cf80b97b4"},
-    {file = "pygridgain-1.4.0-cp38-cp38-win32.whl", hash = "sha256:ec6f3b5e1685cd97405d368ac361ae205c4a14769cdc0627a7b343f6838b5bfe"},
-    {file = "pygridgain-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:7d28f56408be71de0dbfb351f3228a3e19ada81f1a60d01d0069371711919cd7"},
-    {file = "pygridgain-1.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:772e7333f4c06e94e2ae60d66ecc71e5faeeb6105b0f277a85511a515e3b13eb"},
-    {file = "pygridgain-1.4.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8a1b562c23a75fd9bf20556bfc1a7107c873225a344b3f0b75adbacd49d9606c"},
-    {file = "pygridgain-1.4.0-cp39-cp39-win32.whl", hash = "sha256:c6b8b5307bf686f958b8cd7848e233a212d67229d5b4b54040d8c5ff61e5431c"},
-    {file = "pygridgain-1.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:abbf3720b4bf437e7a79265218d198da24eb70f0f613dad77fb752f424b494ae"},
-    {file = "pygridgain-1.4.0.tar.gz", hash = "sha256:6c106faff495f7edb5c4f804ff54e896010363da0bfd8dcf542f221b19ee0416"},
-]
-
-[package.dependencies]
-attrs = ">=20.3.0"
-tzlocal = "2.1"
-
-[[package]]
 name = "pyhive"
 version = "0.6.1"
 description = "Python interface to Hive"
@@ -3654,6 +3624,21 @@ files = [
     {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
     {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
 ]
+
+[[package]]
+name = "pytz-deprecation-shim"
+version = "0.1.0.post0"
+description = "Shims to make deprecation of pytz easier"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "pytz_deprecation_shim-0.1.0.post0-py2.py3-none-any.whl", hash = "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6"},
+    {file = "pytz_deprecation_shim-0.1.0.post0.tar.gz", hash = "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"},
+]
+
+[package.dependencies]
+"backports.zoneinfo" = {version = "*", markers = "python_version >= \"3.6\" and python_version < \"3.9\""}
+tzdata = {version = "*", markers = "python_version >= \"3.6\""}
 
 [[package]]
 name = "pyyaml"
@@ -4615,18 +4600,34 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2023.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
+    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
+]
+
+[[package]]
 name = "tzlocal"
-version = "2.1"
+version = "4.3.1"
 description = "tzinfo object for the local timezone"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},
-    {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
+    {file = "tzlocal-4.3.1-py3-none-any.whl", hash = "sha256:67d7e7f4ce0a98e9dfde2e02474c60fe846ed032d78b555c554c2e9cba472d84"},
+    {file = "tzlocal-4.3.1.tar.gz", hash = "sha256:ee32ef8c20803c19a96ed366addd3d4a729ef6309cb5c7359a0cc2eeeb7fa46a"},
 ]
 
 [package.dependencies]
-pytz = "*"
+"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
+pytz-deprecation-shim = "*"
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["black", "check-manifest", "flake8", "pyroma", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "ua-parser"
@@ -5057,4 +5058,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "a672fb6765aa482dc59e31a49cd9d96d6d3a5c2d2da864e9e7f8448550cb3439"
+content-hash = "9f1d5df53645dc946144c9c957d52f84ea5eb28964749f2f1040af5cd8135c57"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ user-agents = "2.0"
 werkzeug = "2.3.6"
 wtforms = "2.2.1"
 xlsxwriter = "1.2.2"
+tzlocal = "4.3.1"
 
 [tool.poetry.group.all_ds]
 optional = true
@@ -118,7 +119,6 @@ pyathena = ">=1.5.0,<=1.11.5"
 pydgraph = "2.0.2"
 pydruid = "0.5.7"
 pyexasol = "0.12.0"
-pygridgain = "1.4.0"
 pyhive = "0.6.1"
 pyignite = "0.6.1"
 pymongo = { version = "4.3.3", extras = ["srv", "tls"] }


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This PR updates some dependency pieces so that Trino shows up in the data sources list again.

* Updates the python `tzlocal` dependency to the 4.x series, as seems to be required for Trino to work
* Removes the `pygridgain` dependency, as that has a hard dependency on `tzlocal` 2.1 and therefore breaks Trino

## How is this tested?

- [x] Manually

With a newly built docker container on my local pc, I confirmed that the Trino data source is not available without this PR, but *is* available after this PR is applied.

## Related Tickets & Documents

* https://github.com/getredash/redash/discussions/6483
* https://github.com/getredash/redash/pull/5767#issuecomment-1775067985