### PR TITLE
fix falsey comparison to determine whether a dashboard is archived. closes #6560

### DIFF
--- a/redash/handlers/organization.py
+++ b/redash/handlers/organization.py
@@ -15,7 +15,7 @@ def organization_status(org_slug=None):
         "data_sources": models.DataSource.all(current_org, group_ids=current_user.group_ids).count(),
         "queries": models.Query.all_queries(current_user.group_ids, current_user.id, include_drafts=True).count(),
         "dashboards": models.Dashboard.query.filter(
-            models.Dashboard.org == current_org, models.Dashboard.is_archived is False
+            models.Dashboard.org == current_org, models.Dashboard.is_archived.is_(False)
         ).count(),
     }
 


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
When `black` updated our code, it removed a falsey comparison that was using `==`, but that was an overloaded operator from SQLAlchemy. Instead of using the `is` operator, which cannot be overloaded, we need to use the `.is_()` method to compare properly and achieve the same behavior.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

## Related Tickets & Documents

Closes #6560

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
