### PR TITLE
Display catalog information on the schema pane when connecting to Trino

### DIFF
--- a/redash/query_runner/trino.py
+++ b/redash/query_runner/trino.py
@@ -103,9 +103,7 @@ class Trino(BaseQueryRunner):
             results = json_loads(results)
 
             for row in results["rows"]:
-                table_name = f'{row["table_schema"]}.{row["table_name"]}'
-                if not self.configuration.get("catalog"):
-                    table_name = f"{catalog}." + table_name
+                table_name = f'{catalog}.{row["table_schema"]}.{row["table_name"]}'
 
                 if table_name not in schema:
                     schema[table_name] = {"name": table_name, "columns": []}

--- a/tests/query_runner/test_trino.py
+++ b/tests/query_runner/test_trino.py
@@ -17,34 +17,25 @@ class TestTrino(TestCase):
     @patch.object(Trino, "_get_catalogs")
     @patch.object(Trino, "run_query")
     def test_get_schema_no_catalog_set(self, mock_run_query, mock__get_catalogs):
-        mock_run_query.return_value = (
-            f'{{"rows": [{{"table_schema": "{TestTrino.schema_name}", "table_name": "{TestTrino.table_name}", "column_name": "{TestTrino.column_name}", "data_type": "{TestTrino.column_type}"}}]}}',
-            None,
-        )
-        mock__get_catalogs.return_value = [TestTrino.catalog_name]
         runner = Trino({})
-        schema = runner.get_schema()
-        expected_schema = [
-            {
-                "name": f"{TestTrino.catalog_name}.{TestTrino.schema_name}.{TestTrino.table_name}",
-                "columns": [{"name": f"{TestTrino.column_name}", "type": f"{TestTrino.column_type}"}],
-            }
-        ]
-        self.assertEqual(schema, expected_schema)
+        self._assert_schema_catalog(mock_run_query, mock__get_catalogs, runner)
 
     @patch.object(Trino, "_get_catalogs")
     @patch.object(Trino, "run_query")
     def test_get_schema_catalog_set(self, mock_run_query, mock__get_catalogs):
+        runner = Trino({"catalog": TestTrino.catalog_name})
+        self._assert_schema_catalog(mock_run_query, mock__get_catalogs, runner)
+
+    def _assert_schema_catalog(self, mock_run_query, mock__get_catalogs, runner):
         mock_run_query.return_value = (
             f'{{"rows": [{{"table_schema": "{TestTrino.schema_name}", "table_name": "{TestTrino.table_name}", "column_name": "{TestTrino.column_name}", "data_type": "{TestTrino.column_type}"}}]}}',
             None,
         )
         mock__get_catalogs.return_value = [TestTrino.catalog_name]
-        runner = Trino({"catalog": TestTrino.catalog_name})
         schema = runner.get_schema()
         expected_schema = [
             {
-                "name": f"{TestTrino.schema_name}.{TestTrino.table_name}",
+                "name": f"{TestTrino.catalog_name}.{TestTrino.schema_name}.{TestTrino.table_name}",
                 "columns": [{"name": f"{TestTrino.column_name}", "type": f"{TestTrino.column_type}"}],
             }
         ]


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
When connecting to Trino, if you specify Catalog, the name is not displayed on the left side of Redash's Query Editor. However, the query must be specified in the format `catalog.schema.table` (below). 

![image](https://user-images.githubusercontent.com/33893308/280184645-6cffdfaf-fc29-472c-8fca-e10980490cfd.png)

Therefore, even if you connect to Trino with Catalog specified, it should display `catalog.schema.table`.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

## Related Tickets & Documents
Closes https://github.com/getredash/redash/issues/6574

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://github.com/getredash/redash/assets/36331/18419ebc-339c-4708-8a11-36d537a805be)
![image](https://github.com/getredash/redash/assets/36331/60abb7e7-6eb1-4302-9c8c-f30bb1c6a06c)
