### PR TITLE
Update rockset.py - replace default API server URL

### DIFF
--- a/redash/query_runner/rockset.py
+++ b/redash/query_runner/rockset.py
@@ -92,7 +92,7 @@ class Rockset(BaseSQLQueryRunner):
         super(Rockset, self).__init__(configuration)
         self.api = RocksetAPI(
             self.configuration.get("api_key"),
-            self.configuration.get("api_server", "https://api.rs2.usw2.rockset.com"),
+            self.configuration.get("api_server", "https://api.usw2a1.rockset.com"),
             self.configuration.get("vi_id"),
         )
 


### PR DESCRIPTION
Replaced default API server URL with new URL in USW2 region

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Just minor edit in the default URL for Rockset API server.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Manually tested by loading Redash and testing the endpoint.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
