### PR TITLE
chore: Fix ci.yml typo: ghq -> gha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
           context: .
           build-args: |
             test_all_deps=true
-          cache-from: type=ghq
+          cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
         env:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Fix `cache-from: type=ghq` in ci.yml.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [x] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents

* https://docs.docker.com/build/cache/backends/gha/
* https://github.com/getredash/redash/actions/runs/6852509945/job/18632439030#step:9:149

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A