### PR TITLE
add: urlencode selector - space as plus or 20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ npm-debug.log
 
 client/cypress/screenshots
 client/cypress/videos
+
+.yarnrc

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -457,3 +457,6 @@ CSRF_TIME_LIMIT = int(os.environ.get("REDASH_CSRF_TIME_LIMIT", 3600 * 6))
 
 # Email blocked domains, use delimiter comma to separated multiple domains
 BLOCKED_DOMAINS = set_from_string(os.environ.get("REDASH_BLOCKED_DOMAINS", "qq.com"))
+
+# Ability to urlencode spaces as %20, default is plus
+URLENCODE_SPACE_AS_PLUS = parse_boolean(os.environ.get("REDASH_URLENCODE_SPACE_AS_PLUS", "true"))

--- a/redash/utils/requests_session.py
+++ b/redash/utils/requests_session.py
@@ -1,3 +1,7 @@
+# pylint: disable=missing-module-docstring
+from urllib.parse import quote, quote_plus, urlencode
+
+# pylint: disable=unused-import
 from advocate.exceptions import UnacceptableAddressException  # noqa: F401
 
 from redash import settings
@@ -8,10 +12,16 @@ else:
     import requests as requests_or_advocate
 
 
-class ConfiguredSession(requests_or_advocate.Session):
+class ConfiguredSession(requests_or_advocate.Session):  # noqa: E501, pylint: disable=missing-class-docstring
     def request(self, *args, **kwargs):
         if not settings.REQUESTS_ALLOW_REDIRECTS:
             kwargs.update({"allow_redirects": False})
+
+        if "params" in kwargs:
+            quoter = quote_plus if settings.URLENCODE_SPACE_AS_PLUS else quote
+
+            kwargs["params"] = urlencode(kwargs["params"], quote_via=quoter)
+
         return super().request(*args, **kwargs)
 
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
Add ability to change quoter for url encode query parameters from default "space as plus" to "space as %20".
Feature is controlled by env REDASH_URLENCODE_SPACE_AS_PLUS = true|false

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
I have an API that treats space as %20, so default behaviour doesn't work. After REDASH_URLENCODE_SPACE_AS_PLUS set to "false", all parameters passes ok.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
