### PR TITLE
Support a python-table-object string in query_results query-runner

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import re
 import sqlite3
+import os
 from urllib.parse import parse_qs
 
 from redash import models
@@ -14,6 +15,11 @@ from redash.query_runner import (
     register,
 )
 from redash.utils import json_dumps, json_loads
+
+from redash.settings.helpers import (
+    parse_boolean,
+)
+ 
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +45,8 @@ def extract_cached_query_ids(query):
     queries = re.findall(r"(?:join|from)\s+cached_query_(\d+)", query, re.IGNORECASE)
     return [int(q) for q in queries]
 
+def extract_query_tables(query):
+    return re.findall(r"(?:join|from)\s+query_table_start_({.*?})_query_table_end", query, re.IGNORECASE)
 
 def _load_query(user, query_id):
     query = models.Query.get_by_id(query_id)
@@ -82,7 +90,7 @@ def get_query_results(user, query_id, bring_from_cache, params=None):
     return results
 
 
-def create_tables_from_query_ids(user, connection, query_ids, query_params, cached_query_ids=[]):
+def create_tables_from_query_ids(user, connection, query_ids, query_params, cached_query_ids=[], query_tables=[]):
     for query_id in set(cached_query_ids):
         results = get_query_results(user, query_id, True)
         table_name = "cached_query_{query_id}".format(query_id=query_id)
@@ -97,6 +105,12 @@ def create_tables_from_query_ids(user, connection, query_ids, query_params, cach
     for query_id in set(query_ids):
         results = get_query_results(user, query_id, False)
         table_name = "query_{query_id}".format(query_id=query_id)
+        create_table(connection, table_name, results)
+
+    for query_table in set(query_tables):
+        results = eval(query_table)
+        table_hash = hashlib.md5("query_{hash}".format(hash=query_table).encode()).hexdigest()
+        table_name = "query_table_{param_hash}".format(param_hash=table_hash)
         create_table(connection, table_name, results)
 
 
@@ -144,6 +158,13 @@ def prepare_parameterized_query(query, query_params):
         query = query.replace(key, value)
     return query
 
+def prepare_table_query(query, query_tables):
+    for query_table in query_tables:
+        table_hash = hashlib.md5("query_{hash}".format(hash=query_table).encode()).hexdigest()
+        table_name = "query_table_{param_hash}".format(param_hash=table_hash)
+        key = "query_table_start_{table}_query_table_end".format(table=query_table)
+        query = query.replace(key, table_name)
+    return query
 
 class Results(BaseQueryRunner):
     should_annotate_query = False
@@ -165,12 +186,21 @@ class Results(BaseQueryRunner):
         query_params = extract_query_params(query)
 
         cached_query_ids = extract_cached_query_ids(query)
-        create_tables_from_query_ids(user, connection, query_ids, query_params, cached_query_ids)
+
+        query_tables = []
+        
+        if parse_boolean(os.environ.get("REDASH_QUERY_RESULTS_ALLOW_PYTHON_TABLE_STRING", "false")):
+            query_tables = extract_query_tables(query)
+
+        create_tables_from_query_ids(user, connection, query_ids, query_params, cached_query_ids, query_tables)
 
         cursor = connection.cursor()
 
         if query_params is not None:
             query = prepare_parameterized_query(query, query_params)
+
+        if query_tables is not None:
+            query = prepare_table_query(query, query_tables)
 
         try:
             cursor.execute(query)


### PR DESCRIPTION
Allow to add a table in python-string format in the sqlite command to extend the possibilities of the query_results, especially in combination with the python query runner.


## What type of PR is this? 
- [x] Feature

## Description
The query_results runner is modified to accept python stringified result tables. This should be especially useful, when executed from python query runner, where you have intermediate result tables that you can then give to the query_results runner to refine further.

The table-string has to be preceded by "query_table_start_" and followed by "_query_table_end"
Example:
`select * from query_table_start_{'rows': [{'id': 1040}, {'id': 4711}], 'columns': [{'name': 'id', 'friendly_name': 'id', 'type': 'integer'}]}_query_table_end where id = 4711`

I assume that this is not a secure feature as the table might contain strings that: 
 * are interpreted as table ends and then add additional SQL commands, 
 * dangerous non-table objects that are created when using the python eval() command to convert the string to an object

Because of the security concerns, this feature is not enabled by default. It can be enabled by setting the environment variable REDASH_QUERY_RESULTS_ALLOW_PYTHON_TABLE_STRING to "true"

I assume it has no special redash-version requirements. It was tested on redash:10.1.0.b50633 container.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [X] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
Done some request with and without new string-table, also joined with another query_X table
Tested on redash:10.1.0.b50633 container, by replacing the query_results.py file.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
