### PR TITLE
Show an error message on "Test Connection" failure for Google Spreadsheet Query Runner

### DIFF
--- a/redash/query_runner/google_spreadsheets.py
+++ b/redash/query_runner/google_spreadsheets.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 try:
     import google.auth
     import gspread
+    from google.auth.exceptions import GoogleAuthError
     from google.oauth2.service_account import Credentials
     from gspread.exceptions import APIError
     from gspread.exceptions import WorksheetNotFound as GSWorksheetNotFound
@@ -230,13 +231,17 @@ class GoogleSpreadsheet(BaseQueryRunner):
         return spreadsheetservice
 
     def test_connection(self):
-        service = self._get_spreadsheet_service()
         test_spreadsheet_key = "1S0mld7LMbUad8LYlo13Os9f7eNjw57MqVC0YiCd1Jis"
         try:
+            service = self._get_spreadsheet_service()
             service.open_by_key(test_spreadsheet_key).worksheets()
         except APIError as e:
+            logger.exception(e)
             message = parse_api_error(e)
             raise Exception(message)
+        except GoogleAuthError as e:
+            logger.exception(e)
+            raise Exception(str(e))
 
     def run_query(self, query, user):
         logger.debug("Spreadsheet is about to execute query: %s", query)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
This PR is for showing an error message on "Test Connection" failure for Google Spreadsheet Query Runner. In addition to that, logging a traceback for an error by redash-worker.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
Closes #6636

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### When a service account for Google Spreadsheet is disabled
#### Error message on Test Connection Failure
![20231209_sheet_api_disable](https://github.com/getredash/redash/assets/36331/2dadc3aa-5ea8-4a12-a489-fe7a3cdc5884)
#### Logs on Test Connection Failure
![20231209_sheet_api_disable_log](https://github.com/getredash/redash/assets/36331/fb4e7811-0365-472f-915c-e8cb8eeb68be)
### When a connection is refused and so on
####  Error message on Test Connection Failure
![20231209_transport_error](https://github.com/getredash/redash/assets/36331/af66758b-a814-423c-a3d0-71c44d57916f)
#### Logs on Test Connection Failure
![20231209_transport_error_log](https://github.com/getredash/redash/assets/36331/060450fd-6a1a-4bea-bc01-35ce5bc6c510)

