### PR TITLE
Add limit option for MSSQL query runner

### DIFF
--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -119,6 +119,7 @@ class BaseQueryRunner:
     noop_query = None
     limit_query = " LIMIT 1000"
     limit_keywords = ["LIMIT", "OFFSET"]
+    limit_after_select = False
 
     def __init__(self, configuration):
         self.syntax = "sql"
@@ -301,10 +302,17 @@ class BaseSQLQueryRunner(BaseQueryRunner):
         parsed_query = sqlparse.parse(query)[0]
         limit_tokens = sqlparse.parse(self.limit_query)[0].tokens
         length = len(parsed_query.tokens)
-        if parsed_query.tokens[length - 1].ttype == sqlparse.tokens.Punctuation:
-            parsed_query.tokens[length - 1 : length - 1] = limit_tokens
+        if not self.limit_after_select:
+            if parsed_query.tokens[length - 1].ttype == sqlparse.tokens.Punctuation:
+                parsed_query.tokens[length - 1 : length - 1] = limit_tokens
+            else:
+                parsed_query.tokens += limit_tokens
         else:
-            parsed_query.tokens += limit_tokens
+            for i in range(length - 1, -1, -1):
+                if parsed_query[i].value.upper() == 'SELECT':
+                    index = parsed_query.token_index(parsed_query[i + 1])
+                    parsed_query = sqlparse.sql.Statement(parsed_query.tokens[:index] + limit_tokens + parsed_query.tokens[index:])
+                    break
         return str(parsed_query)
 
     def apply_auto_limit(self, query_text, should_apply_auto_limit):

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -309,9 +309,11 @@ class BaseSQLQueryRunner(BaseQueryRunner):
                 parsed_query.tokens += limit_tokens
         else:
             for i in range(length - 1, -1, -1):
-                if parsed_query[i].value.upper() == 'SELECT':
+                if parsed_query[i].value.upper() == "SELECT":
                     index = parsed_query.token_index(parsed_query[i + 1])
-                    parsed_query = sqlparse.sql.Statement(parsed_query.tokens[:index] + limit_tokens + parsed_query.tokens[index:])
+                    parsed_query = sqlparse.sql.Statement(
+                        parsed_query.tokens[:index] + limit_tokens + parsed_query.tokens[index:]
+                    )
                     break
         return str(parsed_query)
 

--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -34,6 +34,10 @@ class SqlServer(BaseSQLQueryRunner):
     should_annotate_query = False
     noop_query = "SELECT 1"
 
+    limit_query = " TOP 1000"
+    limit_keywords = ["TOP"]
+    limit_after_select = True
+
     @classmethod
     def configuration_schema(cls):
         return {

--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -21,6 +21,10 @@ class SQLServerODBC(BaseSQLQueryRunner):
     should_annotate_query = False
     noop_query = "SELECT 1"
 
+    limit_query = " TOP 1000"
+    limit_keywords = ["TOP"]
+    limit_after_select = True
+
     @classmethod
     def configuration_schema(cls):
         return {


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
The limit query adds ` LIMIT 1000` to the end of the query, but this isn't working for MSSQL queries.
This change adds the possibility to add the query runner specified limit text after the `SELECT` statement, based on the `limit_after_select` variable.

## How is this tested?

- [X] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
This issue is also discussed in #5773. No other issues 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A