### PR TITLE
Revert example message for "Custom rule for hiding filter"

### DIFF
--- a/client/app/pages/dashboards/components/ShareDashboardDialog.jsx
+++ b/client/app/pages/dashboards/components/ShareDashboardDialog.jsx
@@ -118,28 +118,9 @@ class ShareDashboardDialog extends React.Component {
             />
           </Form.Item>
           {dashboard.public_url && (
-            <>
-              <Form.Item>
-                <Alert
-                  message={
-                    <div>
-                      Custom rule for hiding filter components when sharing links:
-                      <br />
-                      You can hide filter components by appending `&hide_filter={"{{"} component_name{"}}"}` to the
-                      sharing URL.
-                      <br />
-                      Example: http://{"{{"}ip{"}}"}:{"{{"}port{"}}"}/public/dashboards/{"{{"}id{"}}"}
-                      ?p_country=ghana&p_site=10&hide_filter=country
-                    </div>
-                  }
-                  type="warning"
-                />
-              </Form.Item>
-
-              <Form.Item label="Secret address" {...this.formItemProps}>
-                <InputWithCopy value={dashboard.public_url} data-test="SecretAddress" />
-              </Form.Item>
-            </>
+            <Form.Item label="Secret address" {...this.formItemProps}>
+              <InputWithCopy value={dashboard.public_url} data-test="SecretAddress" />
+            </Form.Item>
           )}
         </Form>
       </Modal>


### PR DESCRIPTION
Rervert UI changes from https://github.com/getredash/redash/pull/6115

## What type of PR is this? 

- [x] Bug Fix

## Description

The "hide_filter" feature is incomplete, and the example text is confusing, adds clutter to the share dashboard dialog.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A
