### PR TITLE
convert query result back to text

### DIFF
--- a/migrations/versions/7205816877ec_change_type_of_json_fields_from_varchar_.py
+++ b/migrations/versions/7205816877ec_change_type_of_json_fields_from_varchar_.py
@@ -59,12 +59,6 @@ def upgrade():
         type_=JSONB(astext_type=sa.Text()),
         postgresql_using='layout::jsonb',
         server_default=sa.text("'{}'::jsonb"))
-    op.alter_column('query_results', 'data',
-        existing_type=sa.Text(),
-        type_=JSONB(astext_type=sa.Text()),
-        nullable=True,
-        postgresql_using='data::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
     op.alter_column('changes', 'change',
         existing_type=JSON(astext_type=sa.Text()),
         type_=JSONB(astext_type=sa.Text()),
@@ -123,11 +117,6 @@ def downgrade():
         existing_type=JSONB(astext_type=sa.Text()),
         type_=sa.Text(),
         postgresql_using='layout::text',
-        server_default=sa.text("'{}'::text"))
-    op.alter_column('query_results', 'data',
-        existing_type=JSONB(astext_type=sa.Text()),
-        type_=sa.Text(),
-        postgresql_using='data::text',
         server_default=sa.text("'{}'::text"))
     op.alter_column('changes', 'change',
         existing_type=JSONB(astext_type=sa.Text()),

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -48,6 +48,7 @@ from redash.models.parameterized_query import (
 from redash.models.types import (
     Configuration,
     EncryptedConfiguration,
+    JSONText,
     MutableDict,
     MutableList,
     json_cast_property,
@@ -315,7 +316,7 @@ class QueryResult(db.Model, BelongsToOrgMixin):
     data_source = db.relationship(DataSource, backref=backref("query_results"))
     query_hash = Column(db.String(32), index=True)
     query_text = Column("query", db.Text)
-    data = Column(MutableDict.as_mutable(JSONB), nullable=True)
+    data = Column(JSONText, nullable=True)
     runtime = Column(DOUBLE_PRECISION)
     retrieved_at = Column(db.DateTime(True))
 


### PR DESCRIPTION
## What type of PR is this? 
Convert QueryResult data column back to text due to a limit of JSON(10MB) and JSONB(255MB) column type size

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Removed from migrations conversion of QueryResult.data to JSONB, and added custom JsonText type, which is actually a copy of removed PseudoJson type

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
