### PR TITLE
Fixed notification template

### DIFF
--- a/redash/destinations/discord.py
+++ b/redash/destinations/discord.py
@@ -43,7 +43,7 @@ class Discord(BaseDestination):
             },
         ]
         if alert.options.get("custom_body"):
-            fields.append({"name": "Description", "value": alert.options["custom_body"]})
+            fields.append({"name": "Description", "value": alert.custom_body})
         if new_state == Alert.TRIGGERED_STATE:
             if alert.options.get("custom_subject"):
                 text = alert.options["custom_subject"]

--- a/redash/destinations/discord.py
+++ b/redash/destinations/discord.py
@@ -42,7 +42,7 @@ class Discord(BaseDestination):
                 "inline": True,
             },
         ]
-        if alert.options.get("custom_body"):
+        if alert.custom_body:
             fields.append({"name": "Description", "value": alert.custom_body})
         if new_state == Alert.TRIGGERED_STATE:
             if alert.options.get("custom_subject"):

--- a/tests/handlers/test_destinations.py
+++ b/tests/handlers/test_destinations.py
@@ -97,7 +97,7 @@ class TestDestinationResource(BaseTestCase):
 
 
 def test_discord_notify_calls_requests_post():
-    alert = mock.Mock(spec_set=["id", "name", "options", "render_template"])
+    alert = mock.Mock(spec_set=["id", "name", "options", "custom_body", "render_template"])
     alert.id = 1
     alert.name = "Test Alert"
     alert.options = {

--- a/tests/handlers/test_destinations.py
+++ b/tests/handlers/test_destinations.py
@@ -104,6 +104,7 @@ def test_discord_notify_calls_requests_post():
         "custom_subject": "Test custom subject",
         "custom_body": "Test custom body",
     }
+    alert.custom_body = alert.options["custom_body"]
     alert.render_template = mock.Mock(return_value={"Rendered": "template"})
     query = mock.Mock()
     query.id = 1


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
This PR fixed non-rendered template for the Discord notification.

Old situation: `"Alert threshold: {{ ALERT_THRESHOLD }}."`
New situationL `"Alert threshold: 1."`

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [X] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
This issue is decribed in #6676

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N.A.