### PR TITLE
[add] sql-formatter params

### DIFF
--- a/client/app/lib/formatterConfig.js
+++ b/client/app/lib/formatterConfig.js
@@ -1,0 +1,2 @@
+export const formatterConfig = {
+}

--- a/client/app/lib/formatterConfig.js
+++ b/client/app/lib/formatterConfig.js
@@ -1,2 +1,1 @@
-export const formatterConfig = {
-}
+export const formatterConfig = {}

--- a/client/app/lib/formatterConfig.js.example
+++ b/client/app/lib/formatterConfig.js.example
@@ -1,0 +1,8 @@
+export const formatterConfig = {
+    language: "bigquery",
+    dialect: "bigquery",
+    tabWidth: 4,
+    keywordCase: "upper",
+    dataTypeCase: "upper",
+    functionCase: "upper"
+}

--- a/client/app/lib/queryFormat.ts
+++ b/client/app/lib/queryFormat.ts
@@ -1,12 +1,13 @@
 import { trim } from "lodash";
-import sqlFormatter from "sql-formatter";
+import { format as sqlFormatter } from "sql-formatter";
+import { formatterConfig } from './formatterConfig';
 
 interface QueryFormatterMap {
   [syntax: string]: (queryText: string) => string;
 }
 
 const QueryFormatters: QueryFormatterMap = {
-  sql: queryText => sqlFormatter.format(trim(queryText)),
+  sql: queryText => sqlFormatter(trim(queryText), formatterConfig),
   json: queryText => JSON.stringify(JSON.parse(queryText), null, 4),
 };
 

--- a/client/app/lib/queryFormat.ts
+++ b/client/app/lib/queryFormat.ts
@@ -1,5 +1,5 @@
 import { trim } from "lodash";
-import { format as sqlFormatter } from "sql-formatter";
+import { format } from "sql-formatter";
 import { formatterConfig } from './formatterConfig';
 
 interface QueryFormatterMap {
@@ -7,7 +7,7 @@ interface QueryFormatterMap {
 }
 
 const QueryFormatters: QueryFormatterMap = {
-  sql: queryText => sqlFormatter(trim(queryText), formatterConfig),
+  sql: queryText => format(trim(queryText), formatterConfig),
   json: queryText => JSON.stringify(JSON.parse(queryText), null, 4),
 };
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@types/prop-types": "^15.7.3",
     "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.10",
-    "@types/sql-formatter": "^2.3.0",
+    "@types/sql-formatter": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^2.10.0",
     "@typescript-eslint/parser": "^2.10.0",
     "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-grid-layout": "^0.18.2",
     "react-resizable": "^1.10.1",
     "react-virtualized": "^9.21.2",
-    "sql-formatter": "git+https://github.com/getredash/sql-formatter.git",
+    "sql-formatter": "^15.0.2",
     "universal-router": "^8.3.0",
     "use-debounce": "^3.1.0",
     "use-media": "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6968,6 +6968,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@=8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
@@ -9773,7 +9778,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.16.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10275,6 +10280,11 @@ moo@^0.4.3:
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
   integrity sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==
 
+moo@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 mouse-change@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mouse-change/-/mouse-change-1.4.0.tgz#c2b77e5bfa34a43ce1445c8157a4e4dc9895c14f"
@@ -10463,6 +10473,16 @@ ndarray@^1.0.11, ndarray@^1.0.13, ndarray@^1.0.14, ndarray@^1.0.15, ndarray@^1.0
   dependencies:
     iota-array "^1.0.0"
     is-buffer "^1.0.2"
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 nearley@^2.7.10:
   version "2.16.0"
@@ -13820,11 +13840,14 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-"sql-formatter@git+https://github.com/getredash/sql-formatter.git":
-  version "2.3.3"
-  resolved "git+https://github.com/getredash/sql-formatter.git#b61a6dce3b451e38e87090b0675a43be1638e5b6"
+sql-formatter@^15.0.2:
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-15.0.2.tgz#302b8846c347d5a3d1dd858306727cfeb36d7d0c"
+  integrity sha512-B8FTRc1dhb36lfuwSdiLhwrhkvT3PU/3es7YDPPQBOhbGHdXKlweAXTRS+QfCWk06ufAh118yFja6NcukBS4gg==
   dependencies:
-    lodash "^4.16.0"
+    argparse "^2.0.1"
+    get-stdin "=8.0.0"
+    nearley "^2.20.1"
 
 sshpk@^1.14.1, sshpk@^1.7.0:
   version "1.17.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,12 @@
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
 
-"@types/sql-formatter@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@types/sql-formatter/-/sql-formatter-2.3.0.tgz#d2584c54f865fd57a7fe7e88ee8ed3623b23da33"
-  integrity sha512-Xh9kEOaKWhm3vYD5lUjYFFiSfpN4y3/iQCJUAVwFaQ1rVvHs4WXTa5C8E7gyF3kxwsMS8KgttW7WBAPtFlsvAg==
+"@types/sql-formatter@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sql-formatter/-/sql-formatter-4.0.1.tgz#3c15dc3e50335e7909d6c01f1a4fd66da05e82a3"
+  integrity sha512-WLSHjarjiUz4GtQivyaDbagqJNHcFA1XOAvrgXmWLl1OeTCP0RuiFB1PtUIH4ArOqZX1Hk6ANzABWe6nw9nKpg==
+  dependencies:
+    sql-formatter "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -13840,7 +13842,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sql-formatter@^15.0.2:
+sql-formatter@*, sql-formatter@^15.0.2:
   version "15.0.2"
   resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-15.0.2.tgz#302b8846c347d5a3d1dd858306727cfeb36d7d0c"
   integrity sha512-B8FTRc1dhb36lfuwSdiLhwrhkvT3PU/3es7YDPPQBOhbGHdXKlweAXTRS+QfCWk06ufAh118yFja6NcukBS4gg==


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
This pull request introduces significant improvements to the query editor's formatting functionality in Redash. Previously, the query editor's format feature was limited to default settings. With this update, users can now utilize custom formatting settings defined in a configuration file, allowing for greater flexibility and personalization.

Key Changes:

1. **Upgraded sql-formatter and @types/sql-formatter**  

The versions of sql-formatter and its corresponding TypeScript type definitions have been updated. This upgrade ensures better performance and compatibility with the new formatting features.

2. **Loading Custom Settings from Configuration File in queryFormat.js** 
Implemented new functionality in queryFormat.js to read formatting settings from an external configuration file. This allows users to define their preferred formatting options, such as indentation style, keyword casing, and other SQL formatting standards.

This enhancement aims to provide a more user-friendly and customizable experience in the query editor, catering to diverse coding styles and preferences.  

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
