### PR TITLE
Allow WebPack configuration when building in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ USER redash
 WORKDIR /frontend
 COPY --chown=redash package.json yarn.lock .yarnrc /frontend/
 COPY --chown=redash viz-lib /frontend/viz-lib
+COPY --chown=redash scripts /frontend/scripts
 
 # Controls whether to instrument code for coverage information
 ARG code_coverage


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug fix

## Description

Allow webpack to be run inside the container. Facilitates alternate CI builds.

## How is this tested?

- [x] Integration tests
