### PR TITLE
Use SSH deployment key to bump version and tag release candiate

### DIFF
--- a/.github/workflows/periodic-snapshot.yml
+++ b/.github/workflows/periodic-snapshot.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{secrets.ACTION_PUSH_KEY}}
       - run: |
           date="$(date +%y.%m).0-dev"
           gawk -i inplace -F: -v q=\" -v tag=$date '/^  "version": / { print $1 FS, q tag q ","; next} { print }' package.json


### PR DESCRIPTION
To allow this workflow to run even though normal contributors are required to create a pull request.

## What type of PR is this? 

- [x] Feature
- [x] Bug Fix

## Description

Steps:

1. Generate SSH key pair: ssh-keygen -t ed25519. No need for passphrases etc.
2. Add public key (.pub one) as a deploy key at Your repo -> Settings -> Security -> Deploy keys, check "Allow write access".
3. Add private key as a secret at Your repo -> Settings -> Security -> Secrets and variables -> Actions

Based on  https://stackoverflow.com/a/76135647/1809872

## How is this tested?

- [x] Manually

## Related Tickets & Documents

https://github.com/getredash/redash/pull/6416