### PR TITLE
Always push images to hub.docker.com/u/redash

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -71,8 +71,8 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ github.repository_owner }}/redash:preview
-            ${{ github.repository_owner }}/preview:${{ steps.version.outputs.VERSION_TAG }}
+            redash/redash:preview
+            redash/preview:${{ steps.version.outputs.VERSION_TAG }}
           context: .
           build-args: |
             test_all_deps=true


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix (CI)

## Description

Using `github.repository_owner` name was convenient for testing this action, but is not correct since account names do not match.

Git Hub: getredash/
Docker Hub: redash/