### PR TITLE
Handle decimal types in query results

### DIFF
--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -1,3 +1,4 @@
+import decimal
 import hashlib
 import logging
 import re
@@ -105,6 +106,8 @@ def fix_column_name(name):
 def flatten(value):
     if isinstance(value, (list, dict)):
         return json_dumps(value)
+    elif isinstance(value, decimal.Decimal):
+        return float(value)
     else:
         return value
 

--- a/tests/query_runner/test_query_results.py
+++ b/tests/query_runner/test_query_results.py
@@ -1,3 +1,4 @@
+import decimal
 import sqlite3
 from unittest import TestCase
 
@@ -102,6 +103,16 @@ class TestCreateTable(TestCase):
         results = {
             "columns": [{"name": "\xe4"}, {"name": "test2"}],
             "rows": [{"\xe4": 1, "test2": 2}],
+        }
+        table_name = "query_123"
+        create_table(connection, table_name, results)
+        connection.execute("SELECT 1 FROM query_123")
+
+    def test_creates_table_with_decimal_in_column_value(self):
+        connection = sqlite3.connect(":memory:")
+        results = {
+            "columns": [{"name": "test1"}, {"name": "test2"}],
+            "rows": [{"test1": 1, "test2": decimal.Decimal(2)}],
         }
         table_name = "query_123"
         create_table(connection, table_name, results)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

Since #6687, we don't serialize query results as JSON before returning them. This is fine, except for the
query results data source which needs to pass the data directly to sqlite3, and doesn't know how to
do that with the decimal types that are occasionally returned by (at least) the PostgreSQL query runner:

https://www.psycopg.org/docs/faq.html#problems-with-type-conversions

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
