### PR TITLE
Autoformat hyperlinks in Slack alerts

### DIFF
--- a/redash/destinations/slack.py
+++ b/redash/destinations/slack.py
@@ -26,13 +26,13 @@ class Slack(BaseDestination):
         fields = [
             {
                 "title": "Query",
+                "type": "mrkdwn",
                 "value": "{host}/queries/{query_id}".format(host=host, query_id=query.id),
-                "short": True,
             },
             {
                 "title": "Alert",
+                "type": "mrkdwn",
                 "value": "{host}/alerts/{alert_id}".format(host=host, alert_id=alert.id),
-                "short": True,
             },
         ]
         if alert.custom_body:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

Format the Slack message using the "mrkdwn" type, which will make hyperlinks clickable.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

Created alert destination using webhook url, verified in Slack channel.

## Related Tickets & Documents

https://github.com/getredash/redash/issues/6821

## Screenshot

![slack-alert](https://github.com/getredash/redash/assets/1175398/681d28b1-29a1-4eb8-b1ff-a637640cc0f1)
