### PR TITLE
Update "make clean" to remove Redash dev Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compose_build up test_db create_database clean down tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
+.PHONY: compose_build up test_db create_database clean clean-all down tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
 
 compose_build: .env
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose build
@@ -17,7 +17,21 @@ create_database: .env
 	docker compose run server create_db
 
 clean:
-	docker compose down && docker compose rm
+	docker compose down
+	docker compose --project-name cypress down
+	docker compose rm --stop --force
+	docker compose --project-name cypress rm --stop --force
+	docker image rm --force \
+		cypress-server:latest cypress-worker:latest cypress-scheduler:latest \
+		redash-server:latest redash-worker:latest redash-scheduler:latest
+	docker container prune --force
+	docker image prune --force
+	docker volume prune --force
+
+clean-all: clean
+	docker image rm --force \
+		redash/redash:10.1.0.b50633 redis:7-alpine maildev/maildev:latest \
+		pgautoupgrade/pgautoupgrade:15-alpine3.8 pgautoupgrade/pgautoupgrade:latest
 
 down:
 	docker compose down


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

At present, when a Redash developer wants to remove the locally built Redash Docker images, they need to do it manually.

This PR extends the existing `make clean` command to remove those images as well.

For example, here is the list of local Redash docker images after building and testing Redash:

```
$ docker image ls
REPOSITORY                    TAG            IMAGE ID       CREATED         SIZE
cypress-server                latest         886733b012fe   6 minutes ago   1.86GB
cypress-worker                latest         0c2ae5331bc2   6 minutes ago   1.86GB
cypress-scheduler             latest         56c23cf1e0e5   6 minutes ago   1.86GB
redash-server                 latest         fa489f5321f3   6 minutes ago   1.86GB
redash-worker                 latest         af38f423e314   6 minutes ago   1.86GB
redash-scheduler              latest         adebad4fd82a   6 minutes ago   1.86GB
redis                         7-alpine       435993df2c8d   2 months ago    41MB
pgautoupgrade/pgautoupgrade   15-alpine3.8   1834e13b7bda   4 months ago    365MB
maildev/maildev               latest         8a920dba53d6   8 months ago    199MB
```

With this PR, the `make clean` command will remove the Redash ones:

```
$ make clean
docker compose down && docker compose rm && \
docker image rm --force \
        cypress-server:latest cypress-worker:latest cypress-scheduler:latest \
        redash-server:latest redash-worker:latest redash-scheduler:latest
No stopped containers
Untagged: cypress-server:latest
Deleted: sha256:886733b012fec29a0fe1f7f04b2d12e8fe2710201956dcfc50e2187265c71ac0
Untagged: cypress-worker:latest
Deleted: sha256:0c2ae5331bc257e4f2e70ff03f27afefd2906378aa89312b97a4eeb753ff0cd8
Untagged: cypress-scheduler:latest
Deleted: sha256:56c23cf1e0e5ed1dc1118a2ba676714b917dde61fc75cefc07ae2d33c727867b
Untagged: redash-server:latest
Deleted: sha256:fa489f5321f3aaff9f27ef848bdc8cb577756f0bca83789f61fd6c64bd46ef77
Untagged: redash-worker:latest
Deleted: sha256:af38f423e3140172f3658a33bfc512d75b6b46f764be15bc3c8828a7b5c4afcd
Untagged: redash-scheduler:latest
Deleted: sha256:adebad4fd82a999a9650f11960c206478fdb266b1c147e8bc59f7421fd4d4e21
```

With the result:

```
$ docker image ls
REPOSITORY                    TAG            IMAGE ID       CREATED        SIZE
redis                         7-alpine       435993df2c8d   2 months ago   41MB
pgautoupgrade/pgautoupgrade   15-alpine3.8   1834e13b7bda   4 months ago   365MB
maildev/maildev               latest         8a920dba53d6   8 months ago   199MB
```

---

Also added a `make clean-all` command, which also removes the above redis, pgautoupgrade, and maildev images too.  That one's probably only rarely useful however. :smile:

## How is this tested?

- [x] Manually

This was tested by building the Redash images (`make compose_build`, `yarn cypress build`), then running the updated `make clean` command and verifying the result.
