### PR TITLE
Update to upload-artifact@v4 in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,12 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
       - name: Store Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: /tmp/test-results
       - name: Store Coverage Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.xml
@@ -93,7 +93,7 @@ jobs:
       - name: Run Lint
         run: yarn lint:ci
       - name: Store Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: /tmp/test-results
@@ -168,7 +168,7 @@ jobs:
       - name: Copy Code Coverage Results
         run: docker cp cypress:/usr/src/app/coverage ./coverage || true
       - name: Store Coverage Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR updates our CI workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`.  This is due to several of the workflows showing this warning during their runs:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js
20: actions/upload-artifact@v3.

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```


## How is this tested?

- [x] N/A

Untested so far, that's what this PR is for. :smile: