### PR TITLE
use default docker repo name if variable is not defined

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -81,6 +81,9 @@ jobs:
           if [[ "${{ vars.DOCKER_REPO }}" != "" ]]; then
             echo "DOCKER_REPO=${{ vars.DOCKER_REPO }}" >> $GITHUB_ENV
             echo "DOCKER_REPO=${{ vars.DOCKER_REPO }}" >> $GITHUB_OUTPUT
+          else
+            echo "DOCKER_REPO=${DOCKER_REPO}" >> $GITHUB_ENV
+            echo "DOCKER_REPO=${DOCKER_REPO}" >> $GITHUB_OUTPUT
           fi
       - name: Build and push preview image to Docker Hub
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## What type of PR is this? 
Fallback to default DOCKER_REPO env variable in case if DOCKER_REPO actions variable is not defined

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
