### PR TITLE
Change default webUI port back to 5001

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -66,7 +66,7 @@ services:
       - worker
       - scheduler
     environment:
-      CYPRESS_baseUrl: http://server:5001
+      CYPRESS_baseUrl: http://server:5000
       PERCY_TOKEN: ${PERCY_TOKEN:-""}
       PERCY_BRANCH: ${PERCY_BRANCH:-""}
       PERCY_COMMIT: ${PERCY_COMMIT:-""}

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
       - postgres
       - redis
     ports:
-      - "${REDASH_PORT:-5000}:5000"
+      - "${REDASH_PORT:-5001}:5000"
       - "5678:5678"
     environment:
       PYTHONUNBUFFERED: 0
@@ -66,7 +66,7 @@ services:
       - worker
       - scheduler
     environment:
-      CYPRESS_baseUrl: http://server:5000
+      CYPRESS_baseUrl: http://server:5001
       PERCY_TOKEN: ${PERCY_TOKEN:-""}
       PERCY_BRANCH: ${PERCY_BRANCH:-""}
       PERCY_COMMIT: ${PERCY_COMMIT:-""}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jest": "TZ=Africa/Khartoum jest",
     "test": "run-s type-check jest",
     "test:watch": "jest --watch",
-    "cypress": "node client/cypress/cypress.js",
+    "cypress": "COMPOSE_PROFILES=local node client/cypress/cypress.js",
     "preinstall": "cd viz-lib && yarn link --link-folder ../.yarn",
     "postinstall": "(cd viz-lib && yarn --frozen-lockfile && yarn build:babel) && yarn link --link-folder ./.yarn @redash/viz"
   },


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This PR changes the default (tcp) port for the web user interface back to port 5001.

The recent change to port 5000 (to match an old default) turned out to be more painful than it's worth.

So, lets keep using port 5001 after all. :smile:

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
