### PR TITLE
fix: dump rows and columns to json

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1007,8 +1007,8 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
             "QUERY_NAME": self.query_rel.name,
             "QUERY_URL": "{host}/queries/{query_id}".format(host=host, query_id=self.query_rel.id),
             "QUERY_RESULT_VALUE": result_value,
-            "QUERY_RESULT_ROWS": data["rows"],
-            "QUERY_RESULT_COLS": data["columns"],
+            "QUERY_RESULT_ROWS": json_dumps(data["rows"]),
+            "QUERY_RESULT_COLS": json_dumps(data["columns"]),
             "QUERY_RESULT_TABLE": result_table,
         }
         return mustache_render_escape(template, context)


### PR DESCRIPTION
## What type of PR is this? 
dump rows and columns for alerts

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
in alert templates rows and columns objects are dumped as binary data

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
