### PR TITLE
consistent rq status naming and handling

### DIFF
--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -19,6 +19,7 @@ import PlainButton from "@/components/PlainButton";
 import ExpandedWidgetDialog from "@/components/dashboards/ExpandedWidgetDialog";
 import EditParameterMappingsDialog from "@/components/dashboards/EditParameterMappingsDialog";
 import VisualizationRenderer from "@/components/visualizations/VisualizationRenderer";
+import { ExecutionStatus } from "@/services/query-result";
 
 import Widget from "./Widget";
 
@@ -278,7 +279,7 @@ class VisualizationWidget extends React.Component {
     const widgetQueryResult = widget.getQueryResult();
     const widgetStatus = widgetQueryResult && widgetQueryResult.getStatus();
     switch (widgetStatus) {
-      case "failed":
+      case ExecutionStatus.FAILED:
         return (
           <div className="body-row-auto scrollbox">
             {widgetQueryResult.getError() && (
@@ -288,7 +289,7 @@ class VisualizationWidget extends React.Component {
             )}
           </div>
         );
-      case "done":
+      case ExecutionStatus.FINISHED:
         return (
           <div className="body-row-auto scrollbox">
             <VisualizationRenderer

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -380,7 +380,9 @@ function QuerySource(props) {
                     <QueryVisualizationTabs
                       queryResult={queryResult}
                       visualizations={query.visualizations}
-                      showNewVisualizationButton={queryFlags.canEdit && queryResultData.status === ExecutionStatus.DONE}
+                      showNewVisualizationButton={
+                        queryFlags.canEdit && queryResultData.status === ExecutionStatus.FINISHED
+                      }
                       canDeleteVisualizations={queryFlags.canEdit}
                       selectedTab={selectedVisualization}
                       onChangeTab={setSelectedVisualization}

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -165,7 +165,7 @@ function QueryView(props) {
             <QueryVisualizationTabs
               queryResult={queryResult}
               visualizations={query.visualizations}
-              showNewVisualizationButton={queryFlags.canEdit && queryResultData.status === ExecutionStatus.DONE}
+              showNewVisualizationButton={queryFlags.canEdit && queryResultData.status === ExecutionStatus.FINISHED}
               canDeleteVisualizations={queryFlags.canEdit}
               selectedTab={selectedVisualization}
               onChangeTab={setSelectedVisualization}

--- a/client/app/pages/queries/components/QueryExecutionStatus.jsx
+++ b/client/app/pages/queries/components/QueryExecutionStatus.jsx
@@ -4,33 +4,37 @@ import PropTypes from "prop-types";
 import Alert from "antd/lib/alert";
 import Button from "antd/lib/button";
 import Timer from "@/components/Timer";
+import { ExecutionStatus } from "@/services/query-result";
 
 export default function QueryExecutionStatus({ status, updatedAt, error, isCancelling, onCancel }) {
-  const alertType = status === "failed" ? "error" : "info";
-  const showTimer = status !== "failed" && updatedAt;
-  const isCancelButtonAvailable = includes(["waiting", "processing"], status);
+  const alertType = status === ExecutionStatus.FAILED ? "error" : "info";
+  const showTimer = status !== ExecutionStatus.FAILED && updatedAt;
+  const isCancelButtonAvailable = includes([ExecutionStatus.QUEUED, ExecutionStatus.STARTED], status);
   let message = isCancelling ? <React.Fragment>Cancelling&hellip;</React.Fragment> : null;
 
   switch (status) {
-    case "waiting":
+    case ExecutionStatus.QUEUED:
       if (!isCancelling) {
         message = <React.Fragment>Query in queue&hellip;</React.Fragment>;
       }
       break;
-    case "processing":
+    case ExecutionStatus.STARTED:
       if (!isCancelling) {
         message = <React.Fragment>Executing query&hellip;</React.Fragment>;
       }
       break;
-    case "loading-result":
+    case ExecutionStatus.LOADING_RESULT:
       message = <React.Fragment>Loading results&hellip;</React.Fragment>;
       break;
-    case "failed":
+    case ExecutionStatus.FAILED:
       message = (
         <React.Fragment>
           Error running query: <strong>{error}</strong>
         </React.Fragment>
       );
+      break;
+    case ExecutionStatus.CANCELED:
+      message = <React.Fragment>Query was canceled</React.Fragment>;
       break;
     // no default
   }
@@ -66,7 +70,7 @@ QueryExecutionStatus.propTypes = {
 };
 
 QueryExecutionStatus.defaultProps = {
-  status: "waiting",
+  status: ExecutionStatus.QUEUED,
   updatedAt: null,
   error: null,
   isCancelling: true,

--- a/client/app/pages/queries/components/QueryExecutionStatus.jsx
+++ b/client/app/pages/queries/components/QueryExecutionStatus.jsx
@@ -1,4 +1,3 @@
-import { includes } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import Alert from "antd/lib/alert";
@@ -9,7 +8,12 @@ import { ExecutionStatus } from "@/services/query-result";
 export default function QueryExecutionStatus({ status, updatedAt, error, isCancelling, onCancel }) {
   const alertType = status === ExecutionStatus.FAILED ? "error" : "info";
   const showTimer = status !== ExecutionStatus.FAILED && updatedAt;
-  const isCancelButtonAvailable = includes([ExecutionStatus.QUEUED, ExecutionStatus.STARTED], status);
+  const isCancelButtonAvailable = [
+    ExecutionStatus.SCHEDULED,
+    ExecutionStatus.QUEUED,
+    ExecutionStatus.STARTED,
+    ExecutionStatus.DEFERRED,
+  ].includes(status);
   let message = isCancelling ? <React.Fragment>Cancelling&hellip;</React.Fragment> : null;
 
   switch (status) {

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -2,6 +2,7 @@ import moment from "moment";
 import debug from "debug";
 import Mustache from "mustache";
 import { axios } from "@/services/axios";
+import { ExecutionStatus } from "@/services/query-result";
 import {
   zipObject,
   isEmpty,
@@ -103,7 +104,7 @@ export class Query {
       return new QueryResult({
         job: {
           error: `missing ${valuesWord} for ${missingParams.join(", ")} ${paramsWord}.`,
-          status: 4,
+          status: ExecutionStatus.FAILED,
         },
       });
     }
@@ -360,7 +361,7 @@ export class QueryResultError {
 
   // eslint-disable-next-line class-methods-use-this
   getStatus() {
-    return "failed";
+    return ExecutionStatus.FAILED;
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -236,11 +236,11 @@ api.add_org_resource(
 )
 api.add_org_resource(
     QueryResultResource,
-    "/api/query_results/<query_result_id>.<filetype>",
-    "/api/query_results/<query_result_id>",
+    "/api/query_results/<result_id>.<filetype>",
+    "/api/query_results/<result_id>",
     "/api/queries/<query_id>/results",
     "/api/queries/<query_id>/results.<filetype>",
-    "/api/queries/<query_id>/results/<query_result_id>.<filetype>",
+    "/api/queries/<query_id>/results/<result_id>.<filetype>",
     endpoint="query_result",
 )
 api.add_org_resource(

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -5,6 +5,7 @@ import regex
 from flask import make_response, request
 from flask_login import current_user
 from flask_restful import abort
+from rq.job import JobStatus
 
 from redash import models, settings
 from redash.handlers.base import BaseResource, get_object_or_404, record_event
@@ -38,7 +39,7 @@ from redash.utils import (
 
 
 def error_response(message, http_status=400):
-    return {"job": {"status": 4, "error": message}}, http_status
+    return {"job": {"status": JobStatus.FAILED, "error": message}}, http_status
 
 
 error_messages = {
@@ -225,7 +226,7 @@ class QueryResultResource(BaseResource):
                 headers["Access-Control-Allow-Credentials"] = str(settings.ACCESS_CONTROL_ALLOW_CREDENTIALS).lower()
 
     @require_any_of_permission(("view_query", "execute_query"))
-    def options(self, query_id=None, query_result_id=None, filetype="json"):
+    def options(self, query_id=None, result_id=None, filetype="json"):
         headers = {}
         self.add_cors_headers(headers)
 
@@ -285,12 +286,12 @@ class QueryResultResource(BaseResource):
                 return error_messages["no_permission"]
 
     @require_any_of_permission(("view_query", "execute_query"))
-    def get(self, query_id=None, query_result_id=None, filetype="json"):
+    def get(self, query_id=None, result_id=None, filetype="json"):
         """
         Retrieve query results.
 
         :param number query_id: The ID of the query whose results should be fetched
-        :param number query_result_id: the ID of the query result to fetch
+        :param number result_id: the ID of the query result to fetch
         :param string filetype: Format to return. One of 'json', 'xlsx', or 'csv'. Defaults to 'json'.
 
         :<json number id: Query result ID
@@ -305,13 +306,13 @@ class QueryResultResource(BaseResource):
         # This method handles two cases: retrieving result by id & retrieving result by query id.
         # They need to be split, as they have different logic (for example, retrieving by query id
         # should check for query parameters and shouldn't cache the result).
-        should_cache = query_result_id is not None
+        should_cache = result_id is not None
 
         query_result = None
         query = None
 
-        if query_result_id:
-            query_result = get_object_or_404(models.QueryResult.get_by_id_and_org, query_result_id, self.current_org)
+        if result_id:
+            query_result = get_object_or_404(models.QueryResult.get_by_id_and_org, result_id, self.current_org)
 
         if query_id is not None:
             query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
@@ -346,7 +347,7 @@ class QueryResultResource(BaseResource):
                     event["object_id"] = query_id
                 else:
                     event["object_type"] = "query_result"
-                    event["object_id"] = query_result_id
+                    event["object_id"] = result_id
 
                 self.record_event(event)
 

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -43,24 +43,24 @@ def enqueue_query(query, data_source, user_id, is_api_key=False, scheduled_query
             if job_id:
                 logger.info("[%s] Found existing job: %s", query_hash, job_id)
                 job_complete = None
-                job_cancelled = None
 
                 try:
                     job = Job.fetch(job_id)
                     job_exists = True
                     status = job.get_status()
-                    job_complete = status in [JobStatus.FINISHED, JobStatus.FAILED]
-                    job_cancelled = job.is_cancelled
-
+                    job_complete = status in [
+                        JobStatus.FINISHED,
+                        JobStatus.FAILED,
+                        JobStatus.STOPPED,
+                        JobStatus.CANCELED,
+                    ]
                     if job_complete:
                         message = "job found is complete (%s)" % status
-                    elif job_cancelled:
-                        message = "job found has ben cancelled"
                 except NoSuchJobError:
                     message = "job found has expired"
                     job_exists = False
 
-                lock_is_irrelevant = job_complete or job_cancelled or not job_exists
+                lock_is_irrelevant = job_complete or not job_exists
 
                 if lock_is_irrelevant:
                     logger.info("[%s] %s, removing lock", query_hash, message)

--- a/redash/tasks/worker.py
+++ b/redash/tasks/worker.py
@@ -65,10 +65,7 @@ class StatsdRecordingWorker(BaseWorker):
             super().execute_job(job, queue)
         finally:
             statsd_client.decr("rq.jobs.running.{}".format(queue.name))
-            if job.get_status() == JobStatus.FINISHED:
-                statsd_client.incr("rq.jobs.finished.{}".format(queue.name))
-            else:
-                statsd_client.incr("rq.jobs.failed.{}".format(queue.name))
+            statsd_client.incr("rq.jobs.{}.{}".format(job.get_status(), queue.name))
 
 
 class HardLimitingWorker(BaseWorker):
@@ -154,7 +151,7 @@ class HardLimitingWorker(BaseWorker):
         job_status = job.get_status()
         if job_status is None:  # Job completed and its ttl has expired
             return
-        if job_status not in [JobStatus.FINISHED, JobStatus.FAILED]:
+        if job_status not in [JobStatus.FINISHED, JobStatus.FAILED, JobStatus.STOPPED, JobStatus.CANCELED]:
             if not job.ended_at:
                 job.ended_at = utcnow()
 

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -1,3 +1,5 @@
+from rq.job import JobStatus
+
 from redash.handlers.query_results import error_messages, run_query
 from redash.models import db
 from tests import BaseTestCase
@@ -434,8 +436,6 @@ class TestQueryResultExcelResponse(BaseTestCase):
 
 class TestJobResource(BaseTestCase):
     def test_cancels_queued_queries(self):
-        QUEUED = 1
-        FAILED = 4
 
         query = self.factory.create_query()
         job_id = self.make_request(
@@ -447,10 +447,9 @@ class TestJobResource(BaseTestCase):
         ]["id"]
 
         status = self.make_request("get", f"/api/jobs/{job_id}").json["job"]["status"]
-        self.assertEqual(status, QUEUED)
+        self.assertEqual(status, JobStatus.QUEUED)
 
         self.make_request("delete", f"/api/jobs/{job_id}")
 
         job = self.make_request("get", f"/api/jobs/{job_id}").json["job"]
-        self.assertEqual(job["status"], FAILED)
-        self.assertTrue("cancelled" in job["error"])
+        self.assertEqual(job["status"], JobStatus.CANCELED)

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -1,6 +1,7 @@
 from mock import Mock, patch
 from rq import Connection
 from rq.exceptions import NoSuchJobError
+from rq.job import JobStatus
 
 from redash import models, rq_redis_connection
 from redash.query_runner.pg import PostgreSQL
@@ -21,7 +22,7 @@ def fetch_job(*args, **kwargs):
 
     result = Mock()
     result.id = job_id
-    result.is_cancelled = False
+    result.get_status = lambda: JobStatus.STARTED
 
     return result
 
@@ -107,7 +108,7 @@ class TestEnqueueTask(BaseTestCase):
             # "cancel" the previous job
             def cancel_job(*args, **kwargs):
                 job = fetch_job(*args, **kwargs)
-                job.is_cancelled = True
+                job.get_status = lambda: JobStatus.CANCELED
                 return job
 
             my_fetch_job.side_effect = cancel_job


### PR DESCRIPTION
## What type of PR is this? 
- support more RQ statuses (STOPPED, CANCELED, DEFERRED, etc)
- consistent status naming
- replaced deprecated job result handling methods

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
