### PR TITLE
fixed all aws query runners auth

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -421,41 +421,44 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.28.8"
+version = "1.34.89"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.28.8-py3-none-any.whl", hash = "sha256:7132ac3f3a9c28b84dcc344cfb439d37d2c5ab45f6b577358fc9aeba5d5aab63"},
-    {file = "boto3-1.28.8.tar.gz", hash = "sha256:cf88309d9b8cd9a2fb0c8049cb4b217b4e9dcb55bf670d6054b0bbe2eef25e57"},
+    {file = "boto3-1.34.89-py3-none-any.whl", hash = "sha256:f9166f485d64b012d46acd212fb29a45b195a85ff66a645b05b06d9f7572af36"},
+    {file = "boto3-1.34.89.tar.gz", hash = "sha256:e0940e43810fe82f5b77442c751491fcc2768af7e7c3e8c15ea158e1ca9b586c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.8,<1.32.0"
+botocore = ">=1.34.89,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.6.0,<0.7.0"
+s3transfer = ">=0.10.0,<0.11.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.8"
+version = "1.34.89"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.31.8-py3-none-any.whl", hash = "sha256:61ba7efaa6305c1928b9b3fbb6f780cbfbd762e19008d20c11ba52b47f20e1b0"},
-    {file = "botocore-1.31.8.tar.gz", hash = "sha256:092baa2168ae78080b0c28011527bfc11d8debd3767aa1e9a4ce8a91fd9943a2"},
+    {file = "botocore-1.34.89-py3-none-any.whl", hash = "sha256:35205ed7db13058a3f7114c28e93058a8ff1490dfc6a5b5dff9c581c738fbf59"},
+    {file = "botocore-1.34.89.tar.gz", hash = "sha256:6624b69bcdf2c5d0568b7bc9cbac13e605f370e7ea06710c61e2e2dc76831141"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = ">=1.25.4,<1.27"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
 
 [package.extras]
-crt = ["awscrt (==0.16.26)"]
+crt = ["awscrt (==0.20.9)"]
 
 [[package]]
 name = "cachetools"
@@ -4202,20 +4205,20 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.6.2"
+version = "0.10.1"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">= 3.8"
 files = [
-    {file = "s3transfer-0.6.2-py3-none-any.whl", hash = "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084"},
-    {file = "s3transfer-0.6.2.tar.gz", hash = "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"},
+    {file = "s3transfer-0.10.1-py3-none-any.whl", hash = "sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d"},
+    {file = "s3transfer-0.10.1.tar.gz", hash = "sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19"},
 ]
 
 [package.dependencies]
-botocore = ">=1.12.36,<2.0a.0"
+botocore = ">=1.33.2,<2.0a.0"
 
 [package.extras]
-crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "sasl"
@@ -5300,4 +5303,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "e7985ee5c3ca3a4389b4e85fda033a9b3b867dbbe4b4a7fca8ea5c35fc401148"
+content-hash = "a50c491f9171d7a63c1f76562a8cca77d37caf686823ef8f227f9a6a3e8d64af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ optional = true
 [tool.poetry.group.all_ds.dependencies]
 atsd-client = "3.0.5"
 azure-kusto-data = "0.0.35"
-boto3 = "1.28.8"
-botocore = "1.31.8"
+boto3 = "1.34.89"
+botocore = "1.34.89"
 cassandra-driver = "3.21.0"
 certifi = ">=2019.9.11"
 cmem-cmempy = "21.2.3"

--- a/redash/query_runner/amazon_elasticsearch.py
+++ b/redash/query_runner/amazon_elasticsearch.py
@@ -2,6 +2,7 @@ from . import register
 from .elasticsearch2 import ElasticSearch2
 
 try:
+    import boto3
     from botocore import credentials, session
     from requests_aws_sign import AWSV4Sign
 
@@ -32,9 +33,10 @@ class AmazonElasticsearchService(ElasticSearch2):
                 "region": {"type": "string"},
                 "access_key": {"type": "string", "title": "Access Key"},
                 "secret_key": {"type": "string", "title": "Secret Key"},
-                "use_aws_iam_profile": {
-                    "type": "boolean",
-                    "title": "Use AWS IAM Profile",
+                "iam_role": {"type": "string", "title": "IAM role to assume"},
+                "external_id": {
+                    "type": "string",
+                    "title": "External ID to be used while STS assume role",
                 },
             },
             "secret": ["secret_key"],
@@ -43,24 +45,35 @@ class AmazonElasticsearchService(ElasticSearch2):
                 "region",
                 "access_key",
                 "secret_key",
-                "use_aws_iam_profile",
+                "iam_role",
+                "external_id",
             ],
             "required": ["server", "region"],
         }
 
     def __init__(self, configuration):
         super(AmazonElasticsearchService, self).__init__(configuration)
-
         region = configuration["region"]
-        cred = None
-        if configuration.get("use_aws_iam_profile", False):
-            cred = credentials.get_credentials(session.Session())
-        else:
-            cred = credentials.Credentials(
-                access_key=configuration.get("access_key", ""),
-                secret_key=configuration.get("secret_key", ""),
+        args = {
+            "region_name": region,
+            "aws_access_key_id": configuration.get("access_key", None),
+            "aws_secret_access_key": configuration.get("secret_key", None),
+        }
+        if configuration.get("iam_role"):
+            role_session_name = "redash"
+            sts = boto3.client("sts", **args)
+            creds = sts.assume_role(
+                RoleArn=configuration.get("iam_role"),
+                RoleSessionName=role_session_name,
+                ExternalId=configuration.get("external_id"),
             )
-
+            args = {
+                "aws_access_key_id": creds["Credentials"]["AccessKeyId"],
+                "aws_secret_access_key": creds["Credentials"]["SecretAccessKey"],
+                "aws_session_token": creds["Credentials"]["SessionToken"],
+                "region_name": region,
+            }
+        cred = credentials.get_credentials(session.Session(**args))
         self.auth = AWSV4Sign(cred, region, "es")
 
     def get_auth(self):


### PR DESCRIPTION
## What type of PR is this? 
Currently Athena supports only a limited amount of auth methods depending on ASSUME_ROLE and OPTIONAL_CREDENTIALS flags values:
 - ASSUME_ROLE: true, OPTIONAL_CREDENTIALS: true - athena client uses assume role credentials retrieved using sts boto client with [aws default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html#credentials-default)
 - ASSUME_ROLE: false, OPTIONAL_CREDENTIALS: true - use athena client with default credentials provider chain
 - ASSUME_ROLE: true, OPTIONAL_CREDENTIALS: false - same as first option
 - ASSUME_ROLE: false, OPTIONAL_CREDENTIALS: false - athena client uses static credentials
 
 These scenarios do not cover cases when:
  - there a need to use different scenarios for different athena datasources, e.g.: one uses static credentials, another one assumes role. ASSUME_ROLE and OPTIONAL_CREDENTIALS flags are global for a whole redash setup
  - when static credentials should be passed to a sts client
  
 In this PR propose do not use ASSUME_ROLE and OPTIONAL_CREDENTIALS flags at all and use the same approach for all aws query runners, which allows to cover all possible scenarios:
 - aws_access_key_id and aws_secret_access_key are set and role_arn is not set - use static credentials for service client
 - aws_access_key_id, aws_secret_access_key and role_arn are all set - use static credentials for sts client and use assume role credentials for service client
 - only role_arn is set - use default credentials provider chain for sts client and assumed role credentials for service client
 - none is set - use default credentials provider chain for service client

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
