### PR TITLE
Use staticPath var to fetch unsupportedRedirect.js

### DIFF
--- a/client/app/multi_org.html
+++ b/client/app/multi_org.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <base href="{{base_href}}" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <script src="/static/unsupportedRedirect.js" async></script>
+    <script src="<%= htmlWebpackPlugin.options.staticPath %>unsupportedRedirect.js" async></script>
 
     <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="96x96" href="/static/images/favicon-96x96.png" />


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Use Webpack configuration for locating this asset in the same way that `client/app/index.html` does.

## How is this tested?

- [x] Manually

(1) Enable MULTI_ORG in .env

```
REDASH_MULTI_ORG=true
```

(2) Update the slug for the default organization

```
$ psql -h localhost -p 15432 -U postgres
postgres=# UPDATE organizations SET slug ='redash';
```

(3) change `baseHref and staticPath` in `webpack.config.js`

(4) run `make build`

(5) verify that accessing the site at `http://localhost:5001/redash/` works
