### PR TITLE
Downgrade 'codecov-action' version from v4 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           docker cp tests:/app/coverage.xml ./coverage.xml
           docker cp tests:/app/junit.xml /tmp/test-results/unit-tests/results.xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Store Test Results


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
The 'codecov-action@v4' requires an organization-level upload token, not a single repo upload token,
so we're temporarily downgrading it until we can generate an organization-level upload token.

## How is this tested?
- [x] N/A

## Related Tickets & Documents
> https://github.com/codecov/codecov-action/issues/1273

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- N/A
