### PR TITLE
pgautoupgrade now does multi-arch builds

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: postgres:16-alpine
+    image: pgautoupgrade/pgautoupgrade:latest
     ports:
       - "${POSTGRES_PORT:-15432}:5432"
     # The following turns the DB into less durable, but gains significant performance improvements for the tests run (x3


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

Thanks to substantial efforts by @andyundso, the Docker Hub images for pgautoupgrade are now multi-arch (x86_64 and ARM64), so lets switch back to them. :smile:

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
