### PR TITLE
Fix Elasticsearch query runner error: 'str' object has no attribute 'pop' error when parsing query

### DIFF
--- a/redash/query_runner/elasticsearch2.py
+++ b/redash/query_runner/elasticsearch2.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Optional, Tuple
 
@@ -64,6 +65,7 @@ class ElasticSearch2(BaseHTTPQueryRunner):
         return data, error
 
     def _build_query(self, query: str) -> Tuple[dict, str, Optional[list]]:
+        query = json.loads(query)
         index_name = query.pop("index", "")
         result_fields = query.pop("result_fields", None)
         url = "/{}/_search".format(index_name)

--- a/tests/query_runner/test_elasticsearch2.py
+++ b/tests/query_runner/test_elasticsearch2.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from redash.query_runner.elasticsearch2 import (
     ElasticSearch2,
@@ -137,3 +137,14 @@ class TestXPackSQL(TestCase):
             ],
         }
         self.assertDictEqual(XPackSQLElasticSearch._parse_results(None, response), expected)
+
+
+class TestElasticSearch2(TestCase):
+    @mock.patch("redash.query_runner.elasticsearch2.ElasticSearch2.__init__", return_value=None)
+    def test_build_query(self, mock_init):
+        query_runner = ElasticSearch2()
+        query_str = '{"index": "test_index", "result_fields": ["field1", "field2"]}'
+        query_dict, url, result_fields = query_runner._build_query(query_str)
+        self.assertEqual(query_dict, {})
+        self.assertEqual(url, "/test_index/_search")
+        self.assertEqual(result_fields, ["field1", "field2"])


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Fix Elasticsearch query runner (refactored version not yet released)

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

I needed redash to work with elasticsearch 7.10, but the current v10.1.0 release does not support it. There was a major refactor of the elasticsearch query runner in #5794, but that code has not yet been released. So, I got the latest from master and tried it out.

I'm not sure how this code was tested originally, but it doesn't work because of a very minor bug. When building the elasticsearch query, it's trying to call `pop()` on the `query` parameter which is of type `str`, and there is no `pop()` method on `str`. Any attempt to run an elasticsearch query results in the error:

`'str' object has no attribute 'pop' error when parsing query`

It needs to be converted to a dictionary, which is a one line change. Then it works fine.

Not sure how this wasn't caught earlier. Maybe no one has tried it out yet? I do appreciate all the hard work that @NicolasLM, @susodapop, and @wwl717195673 put into the refactor. It's been working well for us after this fix.


## Related Tickets & Documents
#5794
