### PR TITLE
PG: Only list tables where schema has USAGE permission

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -231,7 +231,9 @@ class PostgreSQL(BaseSQLQueryRunner):
         ON a.attrelid = c.oid
         AND a.attnum > 0
         AND NOT a.attisdropped
-        WHERE c.relkind IN ('m', 'f', 'p') AND has_table_privilege(s.nspname || '.' || c.relname, 'select')
+        WHERE c.relkind IN ('m', 'f', 'p')
+        AND has_table_privilege(s.nspname || '.' || c.relname, 'select')
+        AND has_schema_privilege(s.nspname, 'usage')
 
         UNION
 


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

This covers cases where partitioned tables are part of a schema that is not accessible by the current user.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Create a new schema then set up a data source for Redash with another, non-superuser role

```
CREATE SCHEMA xyz;

CREATE TABLE xyz.tab (
   id bigint GENERATED ALWAYS AS IDENTITY,
   ts timestamp NOT NULL
) PARTITION BY LIST ((ts::date));

CREATE TABLE xyz.tab_default PARTITION OF xyz.tab DEFAULT;
```

## Related Tickets & Documents

https://github.com/getredash/redash/issues/6988