### PR TITLE
Revert "aggregate Y column values rather than displaying last Y value (#6908)"

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/pie/without-x.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareData/pie/without-x.json
@@ -28,19 +28,19 @@
     "series": [
       {
         "visible": true,
-        "values": [200],
-        "labels": ["Slice 0"],
+        "values": [10, 60, 100, 30],
+        "labels": ["Slice 0", "Slice 0", "Slice 0", "Slice 0"],
         "type": "pie",
         "hole": 0.4,
         "marker": {
-          "colors": ["#356AFF"]
+          "colors": ["#356AFF", "#E92828", "#3BD973", "#604FE9"]
         },
         "hoverinfo": "text+label",
         "hover": [],
-        "text": ["100% (200)"],
+        "text": ["15% (30)", "15% (30)", "15% (30)", "15% (30)"],
         "textinfo": "percent",
         "textposition": "inside",
-        "textfont": { "color": ["#ffffff"] },
+        "textfont": { "color": ["#ffffff", "#ffffff", "#333333", "#ffffff"] },
         "name": "a",
         "direction": "counterclockwise",
         "domain": { "x": [0, 0.98], "y": [0, 0.9] }

--- a/viz-lib/src/visualizations/chart/plotly/prepareDefaultData.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareDefaultData.ts
@@ -91,38 +91,26 @@ function prepareSeries(series: any, options: any, additionalOptions: any) {
       };
 
   const sourceData = new Map();
-
-  //we hold the labels and values in a dictionary so that we can aggregate multiple values for a single label
-  //once we reach the end of the data, we'll convert the dictionary to separate arrays for labels and values
-  const labelsValuesDict: { [key: string]: any } = {};
-
+  const xValues: any = [];
+  const yValues: any = [];
   const yErrorValues: any = [];
   each(data, row => {
     const x = normalizeValue(row.x, options.xAxis.type); // number/datetime/category
     const y = cleanYValue(row.y, seriesYAxis === "y2" ? options.yAxis[1].type : options.yAxis[0].type); // depends on series type!
     const yError = cleanNumber(row.yError); // always number
     const size = cleanNumber(row.size); // always number
-    if (x in labelsValuesDict){
-      labelsValuesDict[x] += y;
-    }
-    else{
-      labelsValuesDict[x] = y;
-    }
-    const aggregatedY = labelsValuesDict[x];
-
     sourceData.set(x, {
       x,
-      y: aggregatedY,
+      y,
       yError,
       size,
       yPercent: null, // will be updated later
       row,
     });
+    xValues.push(x);
+    yValues.push(y);
     yErrorValues.push(yError);
   });
-
-  const xValues = Object.keys(labelsValuesDict);
-  const yValues = Object.values(labelsValuesDict);
 
   const plotlySeries = {
     visible: true,

--- a/viz-lib/src/visualizations/chart/plotly/preparePieData.ts
+++ b/viz-lib/src/visualizations/chart/plotly/preparePieData.ts
@@ -41,10 +41,8 @@ function prepareSeries(series: any, options: any, additionalOptions: any) {
   const xPosition = (index % cellsInRow) * cellWidth;
   const yPosition = Math.floor(index / cellsInRow) * cellHeight;
 
-  //we hold the labels and values in a dictionary so that we can aggregate multiple values for a single label
-  //once we reach the end of the data, we'll convert the dictionary to separate arrays for labels and values
-  const labelsValuesDict: { [key: string]: any } = {};
-
+  const labels: any = [];
+  const values: any = [];
   const sourceData = new Map();
   const seriesTotal = reduce(
     series.data,
@@ -57,28 +55,18 @@ function prepareSeries(series: any, options: any, additionalOptions: any) {
   each(series.data, row => {
     const x = hasX ? normalizeValue(row.x, options.xAxis.type) : `Slice ${index}`;
     const y = cleanNumber(row.y);
-
-    if (x in labelsValuesDict){
-      labelsValuesDict[x] += y;
-    }
-    else{
-      labelsValuesDict[x] = y;
-    }
-    const aggregatedY = labelsValuesDict[x];
-
+    labels.push(x);
+    values.push(y);
     sourceData.set(x, {
       x,
-      y: aggregatedY,
-      yPercent: (aggregatedY / seriesTotal) * 100,
+      y,
+      yPercent: (y / seriesTotal) * 100,
       row,
     });
   });
 
-  const markerColors = map(Array.from(sourceData.values()), data => getValueColor(data.row.x));
+  const markerColors = map(series.data, row => getValueColor(row.x));
   const textColors = map(markerColors, c => chooseTextColorForBackground(c));
-
-  const labels = Object.keys(labelsValuesDict);
-  const values = Object.values(labelsValuesDict);
 
   return {
     visible: true,


### PR DESCRIPTION
This reverts commit f09760389aa95002a5845c4186648c3ab33a3283 since it broke data labels for bar charts.

## What type of PR is this? 

- [x] Revert Regression

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually
- [x] N/A

## Related Tickets & Documents

https://github.com/getredash/redash/issues/6996
