### PR TITLE
Add new text pattern parameter

### DIFF
--- a/client/app/components/EditParameterSettingsDialog.jsx
+++ b/client/app/components/EditParameterSettingsDialog.jsx
@@ -12,6 +12,7 @@ import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
 import QuerySelector from "@/components/QuerySelector";
 import { Query } from "@/services/query";
 import { useUniqueId } from "@/lib/hooks/useUniqueId";
+import "./EditParameterSettingsDialog.less";
 
 const { Option } = Select;
 const formItemProps = { labelCol: { span: 6 }, wrapperCol: { span: 16 } };
@@ -71,6 +72,8 @@ function EditParameterSettingsDialog(props) {
   const [param, setParam] = useState(clone(props.parameter));
   const [isNameValid, setIsNameValid] = useState(true);
   const [initialQuery, setInitialQuery] = useState();
+  const [userInput, setUserInput] = useState(param.regex || "");
+  const [isValidRegex, setIsValidRegex] = useState(true);
 
   const isNew = !props.parameter.name;
 
@@ -114,6 +117,17 @@ function EditParameterSettingsDialog(props) {
 
   const paramFormId = useUniqueId("paramForm");
 
+  const handleRegexChange = e => {
+    setUserInput(e.target.value);
+    try {
+      new RegExp(e.target.value);
+      setParam({ ...param, regex: e.target.value });
+      setIsValidRegex(true);
+    } catch (error) {
+      setIsValidRegex(false);
+    }
+  };
+
   return (
     <Modal
       {...props.dialog.props}
@@ -155,6 +169,7 @@ function EditParameterSettingsDialog(props) {
             <Option value="text" data-test="TextParameterTypeOption">
               Text
             </Option>
+            <Option value="text-pattern">Text Pattern</Option>
             <Option value="number" data-test="NumberParameterTypeOption">
               Number
             </Option>
@@ -180,6 +195,19 @@ function EditParameterSettingsDialog(props) {
             <Option value="datetime-range-with-seconds">Date and Time Range (with seconds)</Option>
           </Select>
         </Form.Item>
+        {param.type === "text-pattern" && (
+          <Form.Item
+            label="Regex"
+            help={!isValidRegex ? "Invalid Regex Pattern" : "Valid Regex Pattern"}
+            {...formItemProps}>
+            <Input
+              value={userInput}
+              onChange={handleRegexChange}
+              className={!isValidRegex ? "input-error" : ""}
+              data-test="RegexPatternInput"
+            />
+          </Form.Item>
+        )}
         {param.type === "enum" && (
           <Form.Item label="Values" help="Dropdown list values (newline delimited)" {...formItemProps}>
             <Input.TextArea

--- a/client/app/components/EditParameterSettingsDialog.jsx
+++ b/client/app/components/EditParameterSettingsDialog.jsx
@@ -27,7 +27,7 @@ function isTypeDateRange(type) {
 
 function joinExampleList(multiValuesOptions) {
   const { prefix, suffix } = multiValuesOptions;
-  return ["value1", "value2", "value3"].map(value => `${prefix}${value}${suffix}`).join(",");
+  return ["value1", "value2", "value3"].map((value) => `${prefix}${value}${suffix}`).join(",");
 }
 
 function NameInput({ name, type, onChange, existingNames, setValidation }) {
@@ -55,7 +55,7 @@ function NameInput({ name, type, onChange, existingNames, setValidation }) {
 
   return (
     <Form.Item required label="Keyword" help={helpText} validateStatus={validateStatus} {...formItemProps}>
-      <Input onChange={e => onChange(e.target.value)} autoFocus />
+      <Input onChange={(e) => onChange(e.target.value)} autoFocus />
     </Form.Item>
   );
 }
@@ -117,7 +117,7 @@ function EditParameterSettingsDialog(props) {
 
   const paramFormId = useUniqueId("paramForm");
 
-  const handleRegexChange = e => {
+  const handleRegexChange = (e) => {
     setUserInput(e.target.value);
     try {
       new RegExp(e.target.value);
@@ -143,15 +143,17 @@ function EditParameterSettingsDialog(props) {
           disabled={!isFulfilled()}
           type="primary"
           form={paramFormId}
-          data-test="SaveParameterSettings">
+          data-test="SaveParameterSettings"
+        >
           {isNew ? "Add Parameter" : "OK"}
         </Button>,
-      ]}>
+      ]}
+    >
       <Form layout="horizontal" onFinish={onConfirm} id={paramFormId}>
         {isNew && (
           <NameInput
             name={param.name}
-            onChange={name => setParam({ ...param, name })}
+            onChange={(name) => setParam({ ...param, name })}
             setValidation={setIsNameValid}
             existingNames={props.existingParams}
             type={param.type}
@@ -160,12 +162,12 @@ function EditParameterSettingsDialog(props) {
         <Form.Item required label="Title" {...formItemProps}>
           <Input
             value={isNull(param.title) ? getDefaultTitle(param.name) : param.title}
-            onChange={e => setParam({ ...param, title: e.target.value })}
+            onChange={(e) => setParam({ ...param, title: e.target.value })}
             data-test="ParameterTitleInput"
           />
         </Form.Item>
         <Form.Item label="Type" {...formItemProps}>
-          <Select value={param.type} onChange={type => setParam({ ...param, type })} data-test="ParameterTypeSelect">
+          <Select value={param.type} onChange={(type) => setParam({ ...param, type })} data-test="ParameterTypeSelect">
             <Option value="text" data-test="TextParameterTypeOption">
               Text
             </Option>
@@ -199,7 +201,8 @@ function EditParameterSettingsDialog(props) {
           <Form.Item
             label="Regex"
             help={!isValidRegex ? "Invalid Regex Pattern" : "Valid Regex Pattern"}
-            {...formItemProps}>
+            {...formItemProps}
+          >
             <Input
               value={userInput}
               onChange={handleRegexChange}
@@ -213,7 +216,7 @@ function EditParameterSettingsDialog(props) {
             <Input.TextArea
               rows={3}
               value={param.enumOptions}
-              onChange={e => setParam({ ...param, enumOptions: e.target.value })}
+              onChange={(e) => setParam({ ...param, enumOptions: e.target.value })}
             />
           </Form.Item>
         )}
@@ -221,7 +224,7 @@ function EditParameterSettingsDialog(props) {
           <Form.Item label="Query" help="Select query to load dropdown values from" {...formItemProps}>
             <QuerySelector
               selectedQuery={initialQuery}
-              onChange={q => setParam({ ...param, queryId: q && q.id })}
+              onChange={(q) => setParam({ ...param, queryId: q && q.id })}
               type="select"
             />
           </Form.Item>
@@ -230,7 +233,7 @@ function EditParameterSettingsDialog(props) {
           <Form.Item className="m-b-0" label=" " colon={false} {...formItemProps}>
             <Checkbox
               defaultChecked={!!param.multiValuesOptions}
-              onChange={e =>
+              onChange={(e) =>
                 setParam({
                   ...param,
                   multiValuesOptions: e.target.checked
@@ -242,7 +245,8 @@ function EditParameterSettingsDialog(props) {
                     : null,
                 })
               }
-              data-test="AllowMultipleValuesCheckbox">
+              data-test="AllowMultipleValuesCheckbox"
+            >
               Allow multiple values
             </Checkbox>
           </Form.Item>
@@ -255,10 +259,11 @@ function EditParameterSettingsDialog(props) {
                 Placed in query as: <code>{joinExampleList(param.multiValuesOptions)}</code>
               </React.Fragment>
             }
-            {...formItemProps}>
+            {...formItemProps}
+          >
             <Select
               value={param.multiValuesOptions.prefix}
-              onChange={quoteOption =>
+              onChange={(quoteOption) =>
                 setParam({
                   ...param,
                   multiValuesOptions: {
@@ -268,7 +273,8 @@ function EditParameterSettingsDialog(props) {
                   },
                 })
               }
-              data-test="QuotationSelect">
+              data-test="QuotationSelect"
+            >
               <Option value="">None (default)</Option>
               <Option value="'">Single Quotation Mark</Option>
               <Option value={'"'} data-test="DoubleQuotationMarkOption">

--- a/client/app/components/EditParameterSettingsDialog.less
+++ b/client/app/components/EditParameterSettingsDialog.less
@@ -1,0 +1,3 @@
+.input-error {
+    border-color: red !important;
+}

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -227,6 +227,7 @@ export class ParameterMappingInput extends React.Component {
         queryId={mapping.param.queryId}
         parameter={mapping.param}
         onSelect={value => this.updateParamMapping({ value })}
+        regex={mapping.param.regex}
       />
     );
   }

--- a/client/app/components/ParameterMappingInput.jsx
+++ b/client/app/components/ParameterMappingInput.jsx
@@ -33,10 +33,10 @@ export const MappingType = {
 };
 
 export function parameterMappingsToEditableMappings(mappings, parameters, existingParameterNames = []) {
-  return map(mappings, mapping => {
+  return map(mappings, (mapping) => {
     const result = extend({}, mapping);
     const alreadyExists = includes(existingParameterNames, mapping.mapTo);
-    result.param = find(parameters, p => p.name === mapping.name);
+    result.param = find(parameters, (p) => p.name === mapping.name);
     switch (mapping.type) {
       case ParameterMappingType.DashboardLevel:
         result.type = alreadyExists ? MappingType.DashboardMapToExisting : MappingType.DashboardAddNew;
@@ -62,7 +62,7 @@ export function editableMappingsToParameterMappings(mappings) {
     map(
       // convert to map
       mappings,
-      mapping => {
+      (mapping) => {
         const result = extend({}, mapping);
         switch (mapping.type) {
           case MappingType.DashboardAddNew:
@@ -95,11 +95,11 @@ export function editableMappingsToParameterMappings(mappings) {
 export function synchronizeWidgetTitles(sourceMappings, widgets) {
   const affectedWidgets = [];
 
-  each(sourceMappings, sourceMapping => {
+  each(sourceMappings, (sourceMapping) => {
     if (sourceMapping.type === ParameterMappingType.DashboardLevel) {
-      each(widgets, widget => {
+      each(widgets, (widget) => {
         const widgetMappings = widget.options.parameterMappings;
-        each(widgetMappings, widgetMapping => {
+        each(widgetMappings, (widgetMapping) => {
           // check if mapped to the same dashboard-level parameter
           if (
             widgetMapping.type === ParameterMappingType.DashboardLevel &&
@@ -140,7 +140,7 @@ export class ParameterMappingInput extends React.Component {
     className: "form-item",
   };
 
-  updateSourceType = type => {
+  updateSourceType = (type) => {
     let {
       mapping: { mapTo },
     } = this.props;
@@ -155,7 +155,7 @@ export class ParameterMappingInput extends React.Component {
     this.updateParamMapping({ type, mapTo });
   };
 
-  updateParamMapping = update => {
+  updateParamMapping = (update) => {
     const { onChange, mapping } = this.props;
     const newMapping = extend({}, mapping, update);
     if (newMapping.value !== mapping.value) {
@@ -175,7 +175,7 @@ export class ParameterMappingInput extends React.Component {
   renderMappingTypeSelector() {
     const noExisting = isEmpty(this.props.existingParamNames);
     return (
-      <Radio.Group value={this.props.mapping.type} onChange={e => this.updateSourceType(e.target.value)}>
+      <Radio.Group value={this.props.mapping.type} onChange={(e) => this.updateSourceType(e.target.value)}>
         <Radio className="radio" value={MappingType.DashboardAddNew} data-test="NewDashboardParameterOption">
           New dashboard parameter
         </Radio>
@@ -205,16 +205,16 @@ export class ParameterMappingInput extends React.Component {
       <Input
         value={mapTo}
         aria-label="Parameter name (key)"
-        onChange={e => this.updateParamMapping({ mapTo: e.target.value })}
+        onChange={(e) => this.updateParamMapping({ mapTo: e.target.value })}
       />
     );
   }
 
   renderDashboardMapToExisting() {
     const { mapping, existingParamNames } = this.props;
-    const options = map(existingParamNames, paramName => ({ label: paramName, value: paramName }));
+    const options = map(existingParamNames, (paramName) => ({ label: paramName, value: paramName }));
 
-    return <Select value={mapping.mapTo} onChange={mapTo => this.updateParamMapping({ mapTo })} options={options} />;
+    return <Select value={mapping.mapTo} onChange={(mapTo) => this.updateParamMapping({ mapTo })} options={options} />;
   }
 
   renderStaticValue() {
@@ -226,7 +226,7 @@ export class ParameterMappingInput extends React.Component {
         enumOptions={mapping.param.enumOptions}
         queryId={mapping.param.queryId}
         parameter={mapping.param}
-        onSelect={value => this.updateParamMapping({ value })}
+        onSelect={(value) => this.updateParamMapping({ value })}
         regex={mapping.param.regex}
       />
     );
@@ -285,12 +285,12 @@ class MappingEditor extends React.Component {
     };
   }
 
-  onVisibleChange = visible => {
+  onVisibleChange = (visible) => {
     if (visible) this.show();
     else this.hide();
   };
 
-  onChange = mapping => {
+  onChange = (mapping) => {
     let inputError = null;
 
     if (mapping.type === MappingType.DashboardAddNew) {
@@ -352,7 +352,8 @@ class MappingEditor extends React.Component {
         trigger="click"
         content={this.renderContent()}
         visible={visible}
-        onVisibleChange={this.onVisibleChange}>
+        onVisibleChange={this.onVisibleChange}
+      >
         <Button size="small" type="dashed" data-test={`EditParamMappingButton-${mapping.param.name}`}>
           <EditOutlinedIcon />
         </Button>
@@ -377,14 +378,14 @@ class TitleEditor extends React.Component {
     title: "", // will be set on editing
   };
 
-  onPopupVisibleChange = showPopup => {
+  onPopupVisibleChange = (showPopup) => {
     this.setState({
       showPopup,
       title: showPopup ? this.getMappingTitle() : "",
     });
   };
 
-  onEditingTitleChange = event => {
+  onEditingTitleChange = (event) => {
     this.setState({ title: event.target.value });
   };
 
@@ -461,7 +462,8 @@ class TitleEditor extends React.Component {
         trigger="click"
         content={this.renderPopover()}
         visible={this.state.showPopup}
-        onVisibleChange={this.onPopupVisibleChange}>
+        onVisibleChange={this.onPopupVisibleChange}
+      >
         <Button size="small" type="dashed">
           <EditOutlinedIcon />
         </Button>
@@ -509,7 +511,7 @@ export class ParameterMappingListInput extends React.Component {
 
     // just to be safe, array or object
     if (typeof value === "object") {
-      return map(value, v => this.getStringValue(v)).join(", ");
+      return map(value, (v) => this.getStringValue(v)).join(", ");
     }
 
     // rest
@@ -575,7 +577,7 @@ export class ParameterMappingListInput extends React.Component {
 
   render() {
     const { existingParams } = this.props; // eslint-disable-line react/prop-types
-    const dataSource = this.props.mappings.map(mapping => ({ mapping }));
+    const dataSource = this.props.mappings.map((mapping) => ({ mapping }));
 
     return (
       <div className="parameters-mapping-list">
@@ -584,11 +586,11 @@ export class ParameterMappingListInput extends React.Component {
             title="Title"
             dataIndex="mapping"
             key="title"
-            render={mapping => (
+            render={(mapping) => (
               <TitleEditor
                 existingParams={existingParams}
                 mapping={mapping}
-                onChange={newMapping => this.updateParamMapping(mapping, newMapping)}
+                onChange={(newMapping) => this.updateParamMapping(mapping, newMapping)}
               />
             )}
           />
@@ -597,19 +599,19 @@ export class ParameterMappingListInput extends React.Component {
             dataIndex="mapping"
             key="keyword"
             className="keyword"
-            render={mapping => <code>{`{{ ${mapping.name} }}`}</code>}
+            render={(mapping) => <code>{`{{ ${mapping.name} }}`}</code>}
           />
           <Table.Column
             title="Default Value"
             dataIndex="mapping"
             key="value"
-            render={mapping => this.constructor.getDefaultValue(mapping, this.props.existingParams)}
+            render={(mapping) => this.constructor.getDefaultValue(mapping, this.props.existingParams)}
           />
           <Table.Column
             title="Value Source"
             dataIndex="mapping"
             key="source"
-            render={mapping => {
+            render={(mapping) => {
               const existingParamsNames = existingParams
                 .filter(({ type }) => type === mapping.param.type) // exclude mismatching param types
                 .map(({ name }) => name); // keep names only

--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -14,7 +14,7 @@ import Tooltip from "./Tooltip";
 const multipleValuesProps = {
   maxTagCount: 3,
   maxTagTextLength: 10,
-  maxTagPlaceholder: num => `+${num.length} more`,
+  maxTagPlaceholder: (num) => `+${num.length} more`,
 };
 
 class ParameterValueInput extends React.Component {
@@ -48,7 +48,7 @@ class ParameterValueInput extends React.Component {
     };
   }
 
-  componentDidUpdate = prevProps => {
+  componentDidUpdate = (prevProps) => {
     const { value, parameter } = this.props;
     // if value prop updated, reset dirty state
     if (prevProps.value !== value || prevProps.parameter !== parameter) {
@@ -59,7 +59,7 @@ class ParameterValueInput extends React.Component {
     }
   };
 
-  onSelect = value => {
+  onSelect = (value) => {
     const isDirty = !isEqual(value, this.props.value);
     this.setState({ value, isDirty });
     this.props.onSelect(value, isDirty);
@@ -96,9 +96,9 @@ class ParameterValueInput extends React.Component {
   renderEnumInput() {
     const { enumOptions, parameter } = this.props;
     const { value } = this.state;
-    const enumOptionsArray = enumOptions.split("\n").filter(v => v !== "");
+    const enumOptionsArray = enumOptions.split("\n").filter((v) => v !== "");
     // Antd Select doesn't handle null in multiple mode
-    const normalize = val => (parameter.multiValuesOptions && val === null ? [] : val);
+    const normalize = (val) => (parameter.multiValuesOptions && val === null ? [] : val);
 
     return (
       <SelectWithVirtualScroll
@@ -106,7 +106,7 @@ class ParameterValueInput extends React.Component {
         mode={parameter.multiValuesOptions ? "multiple" : "default"}
         value={normalize(value)}
         onChange={this.onSelect}
-        options={map(enumOptionsArray, opt => ({ label: String(opt), value: opt }))}
+        options={map(enumOptionsArray, (opt) => ({ label: String(opt), value: opt }))}
         showSearch
         showArrow
         notFoundContent={isEmpty(enumOptionsArray) ? "No options available" : null}
@@ -136,14 +136,14 @@ class ParameterValueInput extends React.Component {
     const { className } = this.props;
     const { value } = this.state;
 
-    const normalize = val => (isNaN(val) ? undefined : val);
+    const normalize = (val) => (isNaN(val) ? undefined : val);
 
     return (
       <InputNumber
         className={className}
         value={normalize(value)}
         aria-label="Parameter number value"
-        onChange={val => this.onSelect(normalize(val))}
+        onChange={(val) => this.onSelect(normalize(val))}
       />
     );
   }
@@ -159,7 +159,7 @@ class ParameterValueInput extends React.Component {
             className={className}
             value={value}
             aria-label="Parameter text pattern value"
-            onChange={e => this.onSelect(e.target.value)}
+            onChange={(e) => this.onSelect(e.target.value)}
           />
         </Tooltip>
       </React.Fragment>
@@ -176,7 +176,7 @@ class ParameterValueInput extends React.Component {
         value={value}
         aria-label="Parameter text value"
         data-test="TextParamInput"
-        onChange={e => this.onSelect(e.target.value)}
+        onChange={(e) => this.onSelect(e.target.value)}
       />
     );
   }

--- a/client/app/components/ParameterValueInput.jsx
+++ b/client/app/components/ParameterValueInput.jsx
@@ -9,6 +9,7 @@ import DateRangeParameter from "@/components/dynamic-parameters/DateRangeParamet
 import QueryBasedParameterInput from "./QueryBasedParameterInput";
 
 import "./ParameterValueInput.less";
+import Tooltip from "./Tooltip";
 
 const multipleValuesProps = {
   maxTagCount: 3,
@@ -25,6 +26,7 @@ class ParameterValueInput extends React.Component {
     parameter: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     onSelect: PropTypes.func,
     className: PropTypes.string,
+    regex: PropTypes.string,
   };
 
   static defaultProps = {
@@ -35,6 +37,7 @@ class ParameterValueInput extends React.Component {
     parameter: null,
     onSelect: () => {},
     className: "",
+    regex: "",
   };
 
   constructor(props) {
@@ -145,6 +148,24 @@ class ParameterValueInput extends React.Component {
     );
   }
 
+  renderTextPatternInput() {
+    const { className } = this.props;
+    const { value } = this.state;
+
+    return (
+      <React.Fragment>
+        <Tooltip title={`Regex to match: ${this.props.regex}`} placement="right">
+          <Input
+            className={className}
+            value={value}
+            aria-label="Parameter text pattern value"
+            onChange={e => this.onSelect(e.target.value)}
+          />
+        </Tooltip>
+      </React.Fragment>
+    );
+  }
+
   renderTextInput() {
     const { className } = this.props;
     const { value } = this.state;
@@ -177,6 +198,8 @@ class ParameterValueInput extends React.Component {
         return this.renderQueryBasedInput();
       case "number":
         return this.renderNumberInput();
+      case "text-pattern":
+        return this.renderTextPatternInput();
       default:
         return this.renderTextInput();
     }

--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -14,7 +14,7 @@ import "./Parameters.less";
 
 function updateUrl(parameters) {
   const params = extend({}, location.search);
-  parameters.forEach(param => {
+  parameters.forEach((param) => {
     extend(params, param.toUrlParams());
   });
   location.setSearch(params, true);
@@ -43,7 +43,7 @@ export default class Parameters extends React.Component {
     appendSortableToParent: true,
   };
 
-  toCamelCase = str => {
+  toCamelCase = (str) => {
     if (isEmpty(str)) {
       return "";
     }
@@ -59,10 +59,10 @@ export default class Parameters extends React.Component {
     }
     const hideRegex = /hide_filter=([^&]+)/g;
     const matches = window.location.search.matchAll(hideRegex);
-    this.hideValues = Array.from(matches, match => match[1]);
+    this.hideValues = Array.from(matches, (match) => match[1]);
   }
 
-  componentDidUpdate = prevProps => {
+  componentDidUpdate = (prevProps) => {
     const { parameters, disableUrlUpdate } = this.props;
     const parametersChanged = prevProps.parameters !== parameters;
     const disableUrlUpdateChanged = prevProps.disableUrlUpdate !== disableUrlUpdate;
@@ -74,7 +74,7 @@ export default class Parameters extends React.Component {
     }
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     // Cmd/Ctrl/Alt + Enter
     if (e.keyCode === 13 && (e.ctrlKey || e.metaKey || e.altKey)) {
       e.stopPropagation();
@@ -109,8 +109,8 @@ export default class Parameters extends React.Component {
   applyChanges = () => {
     const { onValuesChange, disableUrlUpdate } = this.props;
     this.setState(({ parameters }) => {
-      const parametersWithPendingValues = parameters.filter(p => p.hasPendingValue);
-      forEach(parameters, p => p.applyPendingValue());
+      const parametersWithPendingValues = parameters.filter((p) => p.hasPendingValue);
+      forEach(parameters, (p) => p.applyPendingValue());
       if (!disableUrlUpdate) {
         updateUrl(parameters);
       }
@@ -121,7 +121,7 @@ export default class Parameters extends React.Component {
 
   showParameterSettings = (parameter, index) => {
     const { onParametersEdit } = this.props;
-    EditParameterSettingsDialog.showModal({ parameter }).onClose(updated => {
+    EditParameterSettingsDialog.showModal({ parameter }).onClose((updated) => {
       this.setState(({ parameters }) => {
         const updatedParameter = extend(parameter, updated);
         parameters[index] = createParameter(updatedParameter, updatedParameter.parentQueryId);
@@ -132,7 +132,7 @@ export default class Parameters extends React.Component {
   };
 
   renderParameter(param, index) {
-    if (this.hideValues.some(value => this.toCamelCase(value) === this.toCamelCase(param.name))) {
+    if (this.hideValues.some((value) => this.toCamelCase(value) === this.toCamelCase(param.name))) {
       return null;
     }
     const { editable } = this.props;
@@ -149,7 +149,8 @@ export default class Parameters extends React.Component {
               aria-label="Edit"
               onClick={() => this.showParameterSettings(param, index)}
               data-test={`ParameterSettings-${param.name}`}
-              type="button">
+              type="button"
+            >
               <i className="fa fa-cog" aria-hidden="true" />
             </PlainButton>
           )}
@@ -179,20 +180,22 @@ export default class Parameters extends React.Component {
         useDragHandle
         lockToContainerEdges
         helperClass="parameter-dragged"
-        helperContainer={containerEl => (appendSortableToParent ? containerEl : document.body)}
+        helperContainer={(containerEl) => (appendSortableToParent ? containerEl : document.body)}
         updateBeforeSortStart={this.onBeforeSortStart}
         onSortEnd={this.moveParameter}
         containerProps={{
           className: "parameter-container",
           onKeyDown: dirtyParamCount ? this.handleKeyDown : null,
-        }}>
+        }}
+      >
         {parameters &&
           parameters.map((param, index) => (
             <SortableElement key={param.name} index={index}>
               <div
                 className="parameter-block"
                 data-editable={sortable || null}
-                data-test={`ParameterBlock-${param.name}`}>
+                data-test={`ParameterBlock-${param.name}`}
+              >
                 {sortable && <DragHandle data-test={`DragHandle-${param.name}`} />}
                 {this.renderParameter(param, index)}
               </div>

--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -162,6 +162,7 @@ export default class Parameters extends React.Component {
           enumOptions={param.enumOptions}
           queryId={param.queryId}
           onSelect={(value, isDirty) => this.setPendingValue(param, value, isDirty)}
+          regex={param.regex}
         />
       </div>
     );

--- a/client/app/services/parameters/TextPatternParameter.js
+++ b/client/app/services/parameters/TextPatternParameter.js
@@ -1,0 +1,29 @@
+import { toString, isNull } from "lodash";
+import Parameter from "./Parameter";
+
+class TextPatternParameter extends Parameter {
+  constructor(parameter, parentQueryId) {
+    super(parameter, parentQueryId);
+    this.regex = parameter.regex;
+    this.setValue(parameter.value);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  normalizeValue(value) {
+    const normalizedValue = toString(value);
+    if (isNull(normalizedValue)) {
+      return null;
+    }
+
+    var re = new RegExp(this.regex);
+
+    if (re !== null) {
+      if (re.test(normalizedValue)) {
+        return normalizedValue;
+      }
+    }
+    return null;
+  }
+}
+
+export default TextPatternParameter;

--- a/client/app/services/parameters/index.js
+++ b/client/app/services/parameters/index.js
@@ -5,6 +5,7 @@ import EnumParameter from "./EnumParameter";
 import QueryBasedDropdownParameter from "./QueryBasedDropdownParameter";
 import DateParameter from "./DateParameter";
 import DateRangeParameter from "./DateRangeParameter";
+import TextPatternParameter from "./TextPatternParameter";
 
 function createParameter(param, parentQueryId) {
   switch (param.type) {
@@ -22,6 +23,8 @@ function createParameter(param, parentQueryId) {
     case "datetime-range":
     case "datetime-range-with-seconds":
       return new DateRangeParameter(param, parentQueryId);
+    case "text-pattern":
+      return new TextPatternParameter({ ...param, type: "text-pattern" }, parentQueryId);
     default:
       return new TextParameter({ ...param, type: "text" }, parentQueryId);
   }
@@ -34,6 +37,7 @@ function cloneParameter(param) {
 export {
   Parameter,
   TextParameter,
+  TextPatternParameter,
   NumberParameter,
   EnumParameter,
   QueryBasedDropdownParameter,

--- a/client/app/services/parameters/tests/Parameter.test.js
+++ b/client/app/services/parameters/tests/Parameter.test.js
@@ -1,6 +1,7 @@
 import {
   createParameter,
   TextParameter,
+  TextPatternParameter,
   NumberParameter,
   EnumParameter,
   QueryBasedDropdownParameter,
@@ -12,6 +13,7 @@ describe("Parameter", () => {
   describe("create", () => {
     const parameterTypes = [
       ["text", TextParameter],
+      ["text-pattern", TextPatternParameter],
       ["number", NumberParameter],
       ["enum", EnumParameter],
       ["query", QueryBasedDropdownParameter],

--- a/client/app/services/parameters/tests/TextPatternParameter.test.js
+++ b/client/app/services/parameters/tests/TextPatternParameter.test.js
@@ -1,0 +1,21 @@
+import { createParameter } from "..";
+
+describe("TextPatternParameter", () => {
+  let param;
+
+  beforeEach(() => {
+    param = createParameter({ name: "param", title: "Param", type: "text-pattern", regex: "a+" });
+  });
+
+  describe("noramlizeValue", () => {
+    test("converts matching strings", () => {
+      const normalizedValue = param.normalizeValue("art");
+      expect(normalizedValue).toBe("art");
+    });
+
+    test("returns null when string does not match pattern", () => {
+      const normalizedValue = param.normalizeValue("brt");
+      expect(normalizedValue).toBeNull();
+    });
+  });
+});

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -60,6 +60,71 @@ describe("Parameter", () => {
     });
   });
 
+  describe("Text Pattern Parameter", () => {
+    beforeEach(() => {
+      const queryData = {
+        name: "Text Pattern Parameter",
+        query: "SELECT '{{test-parameter}}' AS parameter",
+        options: {
+          parameters: [{ name: "test-parameter", title: "Test Parameter", type: "text-pattern", regex: "a+" }],
+        },
+      };
+
+      cy.createQuery(queryData, false).then(({ id }) => cy.visit(`/queries/${id}/source`));
+    });
+
+    it("updates the results after clicking Apply", () => {
+      cy.getByTestId("ParameterName-test-parameter")
+        .find("input")
+        .type("{selectall}art");
+
+      cy.getByTestId("ParameterApplyButton").click();
+
+      cy.getByTestId("TableVisualization").should("contain", "art");
+
+      cy.getByTestId("ParameterName-test-parameter")
+        .find("input")
+        .type("{selectall}around");
+
+      cy.getByTestId("ParameterApplyButton").click();
+
+      cy.getByTestId("TableVisualization").should("contain", "around");
+    });
+
+    it("throws error message with invalid query request", () => {
+      cy.getByTestId("ParameterName-test-parameter")
+        .find("input")
+        .type("{selectall}art");
+
+      cy.getByTestId("ParameterApplyButton").click();
+
+      cy.getByTestId("ParameterName-test-parameter")
+        .find("input")
+        .type("{selectall}test");
+
+      cy.getByTestId("ParameterApplyButton").click();
+
+      cy.getByTestId("QueryExecutionStatus").should("exist");
+    });
+
+    it("sets dirty state when edited", () => {
+      expectDirtyStateChange(() => {
+        cy.getByTestId("ParameterName-test-parameter")
+          .find("input")
+          .type("{selectall}art");
+      });
+    });
+
+    it("doesn't let user save invalid regex", () => {
+      cy.get(".fa-cog").click();
+      cy.getByTestId("RegexPatternInput").type("{selectall}[");
+      cy.contains("Invalid Regex Pattern").should("exist");
+      cy.getByTestId("SaveParameterSettings").click();
+      cy.get(".fa-cog").click();
+      cy.getByTestId("RegexPatternInput").should("not.equal", "[");
+    });
+  });
+
   describe("Number Parameter", () => {
     beforeEach(() => {
       const queryData = {

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -2,16 +2,14 @@ import { dragParam } from "../../support/parameters";
 import dayjs from "dayjs";
 
 function openAndSearchAntdDropdown(testId, paramOption) {
-  cy.getByTestId(testId)
-    .find(".ant-select-selection-search-input")
-    .type(paramOption, { force: true });
+  cy.getByTestId(testId).find(".ant-select-selection-search-input").type(paramOption, { force: true });
 }
 
 describe("Parameter", () => {
-  const expectDirtyStateChange = edit => {
+  const expectDirtyStateChange = (edit) => {
     cy.getByTestId("ParameterName-test-parameter")
       .find(".parameter-input")
-      .should($el => {
+      .should(($el) => {
         assert.isUndefined($el.data("dirty"));
       });
 
@@ -19,7 +17,7 @@ describe("Parameter", () => {
 
     cy.getByTestId("ParameterName-test-parameter")
       .find(".parameter-input")
-      .should($el => {
+      .should(($el) => {
         assert.isTrue($el.data("dirty"));
       });
   };
@@ -42,9 +40,7 @@ describe("Parameter", () => {
     });
 
     it("updates the results after clicking Apply", () => {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("Redash");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("Redash");
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -53,9 +49,7 @@ describe("Parameter", () => {
 
     it("sets dirty state when edited", () => {
       expectDirtyStateChange(() => {
-        cy.getByTestId("ParameterName-test-parameter")
-          .find("input")
-          .type("Redash");
+        cy.getByTestId("ParameterName-test-parameter").find("input").type("Redash");
       });
     });
   });
@@ -74,17 +68,13 @@ describe("Parameter", () => {
     });
 
     it("updates the results after clicking Apply", () => {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("{selectall}art");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}art");
 
       cy.getByTestId("ParameterApplyButton").click();
 
       cy.getByTestId("TableVisualization").should("contain", "art");
 
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("{selectall}around");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}around");
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -92,15 +82,11 @@ describe("Parameter", () => {
     });
 
     it("throws error message with invalid query request", () => {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("{selectall}art");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}art");
 
       cy.getByTestId("ParameterApplyButton").click();
 
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("{selectall}test");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}test");
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -109,9 +95,7 @@ describe("Parameter", () => {
 
     it("sets dirty state when edited", () => {
       expectDirtyStateChange(() => {
-        cy.getByTestId("ParameterName-test-parameter")
-          .find("input")
-          .type("{selectall}art");
+        cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}art");
       });
     });
 
@@ -139,17 +123,13 @@ describe("Parameter", () => {
     });
 
     it("updates the results after clicking Apply", () => {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("{selectall}42");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}42");
 
       cy.getByTestId("ParameterApplyButton").click();
 
       cy.getByTestId("TableVisualization").should("contain", 42);
 
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .type("{selectall}31415");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}31415");
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -158,9 +138,7 @@ describe("Parameter", () => {
 
     it("sets dirty state when edited", () => {
       expectDirtyStateChange(() => {
-        cy.getByTestId("ParameterName-test-parameter")
-          .find("input")
-          .type("{selectall}42");
+        cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}42");
       });
     });
   });
@@ -184,10 +162,7 @@ describe("Parameter", () => {
       openAndSearchAntdDropdown("ParameterName-test-parameter", "value2"); // asserts option filter prop
 
       // only the filtered option should be on the DOM
-      cy.get(".ant-select-item-option")
-        .should("have.length", 1)
-        .and("contain", "value2")
-        .click();
+      cy.get(".ant-select-item-option").should("have.length", 1).and("contain", "value2").click();
 
       cy.getByTestId("ParameterApplyButton").click();
       // ensure that query is being executed
@@ -205,12 +180,10 @@ describe("Parameter", () => {
         SaveParameterSettings
       `);
 
-      cy.getByTestId("ParameterName-test-parameter")
-        .find(".ant-select-selection-search")
-        .click();
+      cy.getByTestId("ParameterName-test-parameter").find(".ant-select-selection-search").click();
 
       // select all unselected options
-      cy.get(".ant-select-item-option").each($option => {
+      cy.get(".ant-select-item-option").each(($option) => {
         if (!$option.hasClass("ant-select-item-option-selected")) {
           cy.wrap($option).click();
         }
@@ -225,9 +198,7 @@ describe("Parameter", () => {
 
     it("sets dirty state when edited", () => {
       expectDirtyStateChange(() => {
-        cy.getByTestId("ParameterName-test-parameter")
-          .find(".ant-select")
-          .click();
+        cy.getByTestId("ParameterName-test-parameter").find(".ant-select").click();
 
         cy.contains(".ant-select-item-option", "value2").click();
       });
@@ -241,7 +212,7 @@ describe("Parameter", () => {
           name: "Dropdown Query",
           query: "",
         };
-        cy.createQuery(dropdownQueryData, true).then(dropdownQuery => {
+        cy.createQuery(dropdownQueryData, true).then((dropdownQuery) => {
           const queryData = {
             name: "Query Based Dropdown Parameter",
             query: "SELECT '{{test-parameter}}' AS parameter",
@@ -273,7 +244,7 @@ describe("Parameter", () => {
                   SELECT 'value2' AS name, 2 AS value UNION ALL
                   SELECT 'value3' AS name, 3 AS value`,
         };
-        cy.createQuery(dropdownQueryData, true).then(dropdownQuery => {
+        cy.createQuery(dropdownQueryData, true).then((dropdownQuery) => {
           const queryData = {
             name: "Query Based Dropdown Parameter",
             query: "SELECT '{{test-parameter}}' AS parameter",
@@ -299,10 +270,7 @@ describe("Parameter", () => {
         openAndSearchAntdDropdown("ParameterName-test-parameter", "value2"); // asserts option filter prop
 
         // only the filtered option should be on the DOM
-        cy.get(".ant-select-item-option")
-          .should("have.length", 1)
-          .and("contain", "value2")
-          .click();
+        cy.get(".ant-select-item-option").should("have.length", 1).and("contain", "value2").click();
 
         cy.getByTestId("ParameterApplyButton").click();
         // ensure that query is being executed
@@ -320,12 +288,10 @@ describe("Parameter", () => {
           SaveParameterSettings
         `);
 
-        cy.getByTestId("ParameterName-test-parameter")
-          .find(".ant-select")
-          .click();
+        cy.getByTestId("ParameterName-test-parameter").find(".ant-select").click();
 
         // make sure all options are unselected and select all
-        cy.get(".ant-select-item-option").each($option => {
+        cy.get(".ant-select-item-option").each(($option) => {
           expect($option).not.to.have.class("ant-select-dropdown-menu-item-selected");
           cy.wrap($option).click();
         });
@@ -339,14 +305,10 @@ describe("Parameter", () => {
     });
   });
 
-  const selectCalendarDate = date => {
-    cy.getByTestId("ParameterName-test-parameter")
-      .find("input")
-      .click();
+  const selectCalendarDate = (date) => {
+    cy.getByTestId("ParameterName-test-parameter").find("input").click();
 
-    cy.get(".ant-picker-panel")
-      .contains(".ant-picker-cell-inner", date)
-      .click();
+    cy.get(".ant-picker-panel").contains(".ant-picker-cell-inner", date).click();
   };
 
   describe("Date Parameter", () => {
@@ -368,10 +330,10 @@ describe("Parameter", () => {
     });
 
     afterEach(() => {
-      cy.clock().then(clock => clock.restore());
+      cy.clock().then((clock) => clock.restore());
     });
 
-    it("updates the results after selecting a date", function() {
+    it("updates the results after selecting a date", function () {
       selectCalendarDate("15");
 
       cy.getByTestId("ParameterApplyButton").click();
@@ -379,12 +341,10 @@ describe("Parameter", () => {
       cy.getByTestId("TableVisualization").should("contain", dayjs(this.now).format("15/MM/YY"));
     });
 
-    it("allows picking a dynamic date", function() {
+    it("allows picking a dynamic date", function () {
       cy.getByTestId("DynamicButton").click();
 
-      cy.getByTestId("DynamicButtonMenu")
-        .contains("Today/Now")
-        .click();
+      cy.getByTestId("DynamicButtonMenu").contains("Today/Now").click();
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -415,14 +375,11 @@ describe("Parameter", () => {
     });
 
     afterEach(() => {
-      cy.clock().then(clock => clock.restore());
+      cy.clock().then((clock) => clock.restore());
     });
 
-    it("updates the results after selecting a date and clicking in ok", function() {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .as("Input")
-        .click();
+    it("updates the results after selecting a date and clicking in ok", function () {
+      cy.getByTestId("ParameterName-test-parameter").find("input").as("Input").click();
 
       selectCalendarDate("15");
 
@@ -433,27 +390,20 @@ describe("Parameter", () => {
       cy.getByTestId("TableVisualization").should("contain", dayjs(this.now).format("YYYY-MM-15 HH:mm"));
     });
 
-    it("shows the current datetime after clicking in Now", function() {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .as("Input")
-        .click();
+    it("shows the current datetime after clicking in Now", function () {
+      cy.getByTestId("ParameterName-test-parameter").find("input").as("Input").click();
 
-      cy.get(".ant-picker-panel")
-        .contains("Now")
-        .click();
+      cy.get(".ant-picker-panel").contains("Now").click();
 
       cy.getByTestId("ParameterApplyButton").click();
 
       cy.getByTestId("TableVisualization").should("contain", dayjs(this.now).format("YYYY-MM-DD HH:mm"));
     });
 
-    it("allows picking a dynamic date", function() {
+    it("allows picking a dynamic date", function () {
       cy.getByTestId("DynamicButton").click();
 
-      cy.getByTestId("DynamicButtonMenu")
-        .contains("Today/Now")
-        .click();
+      cy.getByTestId("DynamicButtonMenu").contains("Today/Now").click();
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -462,31 +412,20 @@ describe("Parameter", () => {
 
     it("sets dirty state when edited", () => {
       expectDirtyStateChange(() => {
-        cy.getByTestId("ParameterName-test-parameter")
-          .find("input")
-          .click();
+        cy.getByTestId("ParameterName-test-parameter").find("input").click();
 
-        cy.get(".ant-picker-panel")
-          .contains("Now")
-          .click();
+        cy.get(".ant-picker-panel").contains("Now").click();
       });
     });
   });
 
   describe("Date Range Parameter", () => {
     const selectCalendarDateRange = (startDate, endDate) => {
-      cy.getByTestId("ParameterName-test-parameter")
-        .find("input")
-        .first()
-        .click();
+      cy.getByTestId("ParameterName-test-parameter").find("input").first().click();
 
-      cy.get(".ant-picker-panel")
-        .contains(".ant-picker-cell-inner", startDate)
-        .click();
+      cy.get(".ant-picker-panel").contains(".ant-picker-cell-inner", startDate).click();
 
-      cy.get(".ant-picker-panel")
-        .contains(".ant-picker-cell-inner", endDate)
-        .click();
+      cy.get(".ant-picker-panel").contains(".ant-picker-cell-inner", endDate).click();
     };
 
     beforeEach(() => {
@@ -507,10 +446,10 @@ describe("Parameter", () => {
     });
 
     afterEach(() => {
-      cy.clock().then(clock => clock.restore());
+      cy.clock().then((clock) => clock.restore());
     });
 
-    it("updates the results after selecting a date range", function() {
+    it("updates the results after selecting a date range", function () {
       selectCalendarDateRange("15", "20");
 
       cy.getByTestId("ParameterApplyButton").click();
@@ -522,12 +461,10 @@ describe("Parameter", () => {
       );
     });
 
-    it("allows picking a dynamic date range", function() {
+    it("allows picking a dynamic date range", function () {
       cy.getByTestId("DynamicButton").click();
 
-      cy.getByTestId("DynamicButtonMenu")
-        .contains("Last month")
-        .click();
+      cy.getByTestId("DynamicButtonMenu").contains("Last month").click();
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -544,15 +481,10 @@ describe("Parameter", () => {
   });
 
   describe("Apply Changes", () => {
-    const expectAppliedChanges = apply => {
-      cy.getByTestId("ParameterName-test-parameter-1")
-        .find("input")
-        .as("Input")
-        .type("Redash");
+    const expectAppliedChanges = (apply) => {
+      cy.getByTestId("ParameterName-test-parameter-1").find("input").as("Input").type("Redash");
 
-      cy.getByTestId("ParameterName-test-parameter-2")
-        .find("input")
-        .type("Redash");
+      cy.getByTestId("ParameterName-test-parameter-2").find("input").type("Redash");
 
       cy.location("search").should("not.contain", "Redash");
 
@@ -588,10 +520,7 @@ describe("Parameter", () => {
     it("shows and hides according to parameter dirty state", () => {
       cy.getByTestId("ParameterApplyButton").should("not.be", "visible");
 
-      cy.getByTestId("ParameterName-test-parameter-1")
-        .find("input")
-        .as("Param")
-        .type("Redash");
+      cy.getByTestId("ParameterName-test-parameter-1").find("input").as("Param").type("Redash");
 
       cy.getByTestId("ParameterApplyButton").should("be.visible");
 
@@ -601,21 +530,13 @@ describe("Parameter", () => {
     });
 
     it("updates dirty counter", () => {
-      cy.getByTestId("ParameterName-test-parameter-1")
-        .find("input")
-        .type("Redash");
+      cy.getByTestId("ParameterName-test-parameter-1").find("input").type("Redash");
 
-      cy.getByTestId("ParameterApplyButton")
-        .find(".ant-badge-count p.current")
-        .should("contain", "1");
+      cy.getByTestId("ParameterApplyButton").find(".ant-badge-count p.current").should("contain", "1");
 
-      cy.getByTestId("ParameterName-test-parameter-2")
-        .find("input")
-        .type("Redash");
+      cy.getByTestId("ParameterName-test-parameter-2").find("input").type("Redash");
 
-      cy.getByTestId("ParameterApplyButton")
-        .find(".ant-badge-count p.current")
-        .should("contain", "2");
+      cy.getByTestId("ParameterApplyButton").find(".ant-badge-count p.current").should("contain", "2");
     });
 
     it('applies changes from "Apply Changes" button', () => {
@@ -625,16 +546,13 @@ describe("Parameter", () => {
     });
 
     it('applies changes from "alt+enter" keyboard shortcut', () => {
-      expectAppliedChanges(input => {
+      expectAppliedChanges((input) => {
         input.type("{alt}{enter}");
       });
     });
 
     it('disables "Execute" button', () => {
-      cy.getByTestId("ParameterName-test-parameter-1")
-        .find("input")
-        .as("Input")
-        .type("Redash");
+      cy.getByTestId("ParameterName-test-parameter-1").find("input").as("Input").type("Redash");
       cy.getByTestId("ExecuteButton").should("be.disabled");
 
       cy.get("@Input").clear();
@@ -659,15 +577,12 @@ describe("Parameter", () => {
 
       cy.createQuery(queryData, false).then(({ id }) => cy.visit(`/queries/${id}/source`));
 
-      cy.get(".parameter-block")
-        .first()
-        .invoke("width")
-        .as("paramWidth");
+      cy.get(".parameter-block").first().invoke("width").as("paramWidth");
 
       cy.get("body").type("{alt}D"); // hide schema browser
     });
 
-    it("is possible to rearrange parameters", function() {
+    it("is possible to rearrange parameters", function () {
       cy.server();
       cy.route("POST", "**/api/queries/*").as("QuerySave");
 

--- a/client/cypress/integration/query/parameter_spec.js
+++ b/client/cypress/integration/query/parameter_spec.js
@@ -60,7 +60,7 @@ describe("Parameter", () => {
         name: "Text Pattern Parameter",
         query: "SELECT '{{test-parameter}}' AS parameter",
         options: {
-          parameters: [{ name: "test-parameter", title: "Test Parameter", type: "text-pattern", regex: "a+" }],
+          parameters: [{ name: "test-parameter", title: "Test Parameter", type: "text-pattern", regex: "a.*a" }],
         },
       };
 
@@ -68,25 +68,25 @@ describe("Parameter", () => {
     });
 
     it("updates the results after clicking Apply", () => {
-      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}art");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}arta");
 
       cy.getByTestId("ParameterApplyButton").click();
 
-      cy.getByTestId("TableVisualization").should("contain", "art");
+      cy.getByTestId("TableVisualization").should("contain", "arta");
 
-      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}around");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}arounda");
 
       cy.getByTestId("ParameterApplyButton").click();
 
-      cy.getByTestId("TableVisualization").should("contain", "around");
+      cy.getByTestId("TableVisualization").should("contain", "arounda");
     });
 
     it("throws error message with invalid query request", () => {
-      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}art");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}arta");
 
       cy.getByTestId("ParameterApplyButton").click();
 
-      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}test");
+      cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}abcab");
 
       cy.getByTestId("ParameterApplyButton").click();
 
@@ -95,7 +95,7 @@ describe("Parameter", () => {
 
     it("sets dirty state when edited", () => {
       expectDirtyStateChange(() => {
-        cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}art");
+        cy.getByTestId("ParameterName-test-parameter").find("input").type("{selectall}arta");
       });
     });
 

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -1,3 +1,4 @@
+import re
 from functools import partial
 from numbers import Number
 
@@ -88,6 +89,16 @@ def _is_number(string):
         return True
 
 
+def _is_regex_pattern(value, regex):
+    try:
+        if re.compile(regex).fullmatch(value):
+            return True
+        else:
+            return False
+    except re.error:
+        return False
+
+
 def _is_date(string):
     parse(string)
     return True
@@ -135,6 +146,7 @@ class ParameterizedQuery:
 
         enum_options = definition.get("enumOptions")
         query_id = definition.get("queryId")
+        regex = definition.get("regex")
         allow_multiple_values = isinstance(definition.get("multiValuesOptions"), dict)
 
         if isinstance(enum_options, str):
@@ -142,6 +154,7 @@ class ParameterizedQuery:
 
         validators = {
             "text": lambda value: isinstance(value, str),
+            "text-pattern": lambda value: _is_regex_pattern(value, regex),
             "number": _is_number,
             "enum": lambda value: _is_value_within_options(value, enum_options, allow_multiple_values),
             "query": lambda value: _is_value_within_options(

--- a/tests/models/test_parameterized_query.py
+++ b/tests/models/test_parameterized_query.py
@@ -73,6 +73,21 @@ class TestParameterizedQuery(TestCase):
 
         self.assertEqual("foo baz", query.text)
 
+    def test_validates_text_pattern_parameters(self):
+        schema = [{"name": "bar", "type": "text-pattern", "regex": "a+"}]
+        query = ParameterizedQuery("foo {{bar}}", schema)
+
+        query.apply({"bar": "a"})
+
+        self.assertEqual("foo a", query.text)
+
+    def test_raises_on_invalid_text_pattern_parameters(self):
+        schema = schema = [{"name": "bar", "type": "text-pattern", "regex": "a+"}]
+        query = ParameterizedQuery("foo {{bar}}", schema)
+
+        with pytest.raises(InvalidParameterError):
+            query.apply({"bar": "b"})
+
     def test_raises_on_invalid_number_parameters(self):
         schema = [{"name": "bar", "type": "number"}]
         query = ParameterizedQuery("foo", schema)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
This PR adds in a new "Text Pattern" parameter input type. This input type allows a creator to specify a regex pattern, and the query will only run if the input matches the regex pattern. Since this parameter input type is not "Text," users can share dashboards that have this parameter input type, therefore addressing (https://github.com/getredash/redash/discussions/6785).

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
(https://github.com/getredash/redash/discussions/6785)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

https://github.com/getredash/redash/assets/97199317/e644fd75-634c-49f8-809e-9af6dc792720

