### PR TITLE
Default to not allow HTML content in tables

### DIFF
--- a/viz-lib/src/visualizations/table/Editor/__snapshots__/ColumnsSettings.test.tsx.snap
+++ b/viz-lib/src/visualizations/table/Editor/__snapshots__/ColumnsSettings.test.tsx.snap
@@ -5,7 +5,7 @@ Object {
   "columns": Array [
     Object {
       "alignContent": "right",
-      "allowHTML": true,
+      "allowHTML": false,
       "allowSearch": false,
       "booleanValues": Array [
         "false",
@@ -38,7 +38,7 @@ Object {
   "columns": Array [
     Object {
       "alignContent": "left",
-      "allowHTML": true,
+      "allowHTML": false,
       "allowSearch": false,
       "booleanValues": Array [
         "false",
@@ -71,7 +71,7 @@ Object {
   "columns": Array [
     Object {
       "alignContent": "left",
-      "allowHTML": true,
+      "allowHTML": false,
       "allowSearch": false,
       "booleanValues": Array [
         "false",
@@ -104,7 +104,7 @@ Object {
   "columns": Array [
     Object {
       "alignContent": "left",
-      "allowHTML": true,
+      "allowHTML": false,
       "allowSearch": true,
       "booleanValues": Array [
         "false",
@@ -137,7 +137,7 @@ Object {
   "columns": Array [
     Object {
       "alignContent": "left",
-      "allowHTML": true,
+      "allowHTML": false,
       "allowSearch": false,
       "booleanValues": Array [
         "false",

--- a/viz-lib/src/visualizations/table/getOptions.ts
+++ b/viz-lib/src/visualizations/table/getOptions.ts
@@ -54,7 +54,7 @@ function getDefaultColumnsOptions(columns: any) {
     allowSearch: false,
     alignContent: getColumnContentAlignment(col.type),
     // `string` cell options
-    allowHTML: true,
+    allowHTML: false,
     highlightLinks: false,
   }));
 }


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Change the default for each column in a table to not allow HTML. This addresses a potential security issue.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

Verified that the default behavior changes when a table is created.

## Related Tickets & Documents

https://github.com/getredash/redash/discussions/6615

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
