### PR TITLE
Remove defaults set during schema upgrade/downgrade

### DIFF
--- a/migrations/versions/7205816877ec_change_type_of_json_fields_from_varchar_.py
+++ b/migrations/versions/7205816877ec_change_type_of_json_fields_from_varchar_.py
@@ -24,56 +24,56 @@ def upgrade():
         type_=JSONB(astext_type=sa.Text()),
         nullable=True,
         postgresql_using='options::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('queries', 'schedule',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         nullable=True,
         postgresql_using='schedule::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('events', 'additional_properties',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         nullable=True,
         postgresql_using='additional_properties::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('organizations', 'settings',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         nullable=True,
         postgresql_using='settings::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('alerts', 'options',
         existing_type=JSON(astext_type=sa.Text()),
         type_=JSONB(astext_type=sa.Text()),
         nullable=True,
         postgresql_using='options::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('dashboards', 'options',
         existing_type=JSON(astext_type=sa.Text()),
         type_=JSONB(astext_type=sa.Text()),
         postgresql_using='options::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('dashboards', 'layout',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         postgresql_using='layout::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('changes', 'change',
         existing_type=JSON(astext_type=sa.Text()),
         type_=JSONB(astext_type=sa.Text()),
         postgresql_using='change::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('visualizations', 'options',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         postgresql_using='options::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
     op.alter_column('widgets', 'options',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         postgresql_using='options::jsonb',
-        server_default=sa.text("'{}'::jsonb"))
+        )
 
 
 def downgrade():
@@ -83,53 +83,53 @@ def downgrade():
         type_=sa.Text(),
         postgresql_using='options::text',
         existing_nullable=True,
-        server_default=sa.text("'{}'::text"))
+        )
     op.alter_column('queries', 'schedule',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=sa.Text(),
         postgresql_using='schedule::text',
         existing_nullable=True,
-        server_default=sa.text("'{}'::text"))
+        )
     op.alter_column('events', 'additional_properties',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=sa.Text(),
         postgresql_using='additional_properties::text',
         existing_nullable=True,
-        server_default=sa.text("'{}'::text"))
+        )
     op.alter_column('organizations', 'settings',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=sa.Text(),
         postgresql_using='settings::text',
         existing_nullable=True,
-        server_default=sa.text("'{}'::text"))
+        )
     op.alter_column('alerts', 'options',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=JSON(astext_type=sa.Text()),
         postgresql_using='options::json',
         existing_nullable=True,
-        server_default=sa.text("'{}'::json"))
+        )
     op.alter_column('dashboards', 'options',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=JSON(astext_type=sa.Text()),
         postgresql_using='options::json',
-        server_default=sa.text("'{}'::json"))
+        )
     op.alter_column('dashboards', 'layout',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=sa.Text(),
         postgresql_using='layout::text',
-        server_default=sa.text("'{}'::text"))
+        )
     op.alter_column('changes', 'change',
         existing_type=JSONB(astext_type=sa.Text()),
         type_=JSON(astext_type=sa.Text()),
         postgresql_using='change::json',
-        server_default=sa.text("'{}'::json"))
+        )
     op.alter_column('visualizations', 'options',
         type_=sa.Text(),
         existing_type=JSONB(astext_type=sa.Text()),
         postgresql_using='options::text',
-        server_default=sa.text("'{}'::text"))
+        )
     op.alter_column('widgets', 'options',
         type_=sa.Text(),
         existing_type=JSONB(astext_type=sa.Text()),
         postgresql_using='options::text',
-        server_default=sa.text("'{}'::text"))
+        )

--- a/migrations/versions/fd4fc850d7ea_.py
+++ b/migrations/versions/fd4fc850d7ea_.py
@@ -28,7 +28,7 @@ def upgrade():
                existing_nullable=True,
                existing_server_default=sa.text("'{}'::jsonb"))
     ### end Alembic commands ###
-    
+
     update_query = """
     update users
     set details = details::jsonb || ('{"profile_image_url": "' || profile_image_url || '"}')::jsonb


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->


- [x] Bug Fix


## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

This PR addresses https://github.com/getredash/redash/issues/6836. The fix removes the defaults that are set during schema upgrade/downgrade. 

It looks like defaults are set in redash/models/__init__.py, but it seems like they never actually make it to the database. This could be due to how setting the default parameter works in SQLAlchemy.  

## How is this tested?

- [x] Manually

<!-- If Manually, please describe. -->

Ran `./manage.py db downgrade fd4fc850d7ea` and then `./manage.py db upgrade` just like @wlach did in https://github.com/getredash/redash/issues/6836. The upgrade and downgrade seem to work correctly after making the fix.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

https://github.com/getredash/redash/issues/6836

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
