### PR TITLE
Use correct redis connection

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -59,7 +59,7 @@ def get_status():
 
 
 def rq_job_ids():
-    queues = Queue.all(connection=redis_connection)
+    queues = Queue.all(connection=rq_redis_connection)
 
     started_jobs = [StartedJobRegistry(queue=q).get_job_ids() for q in queues]
     queued_jobs = [q.job_ids for q in queues]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch, MagicMock
+from redash import rq_redis_connection
+from redash.monitor import rq_job_ids
+
+
+def test_rq_job_ids_uses_rq_redis_connection():
+    mock_queue = MagicMock()
+    mock_queue.job_ids = []
+
+    mock_registry = MagicMock()
+    mock_registry.get_job_ids.return_value = []
+
+    with patch('redash.monitor.Queue') as mock_Queue, patch('redash.monitor.StartedJobRegistry') as mock_StartedJobRegistry:
+        mock_Queue.all.return_value = [mock_queue]
+        mock_StartedJobRegistry.return_value = mock_registry
+
+        rq_job_ids()
+
+        mock_Queue.all.assert_called_once_with(connection=rq_redis_connection)
+        mock_StartedJobRegistry.assert_called_once_with(queue=mock_queue)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from redash import rq_redis_connection
 from redash.monitor import rq_job_ids
 
@@ -10,7 +11,9 @@ def test_rq_job_ids_uses_rq_redis_connection():
     mock_registry = MagicMock()
     mock_registry.get_job_ids.return_value = []
 
-    with patch('redash.monitor.Queue') as mock_Queue, patch('redash.monitor.StartedJobRegistry') as mock_StartedJobRegistry:
+    with patch("redash.monitor.Queue") as mock_Queue, patch(
+        "redash.monitor.StartedJobRegistry"
+    ) as mock_StartedJobRegistry:
         mock_Queue.all.return_value = [mock_queue]
         mock_StartedJobRegistry.return_value = mock_registry
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

The normal Redis connection uses the parameter [`decode_responses=True`](https://github.com/getredash/redash/blob/a69f7fb2fe41af23eec99b5c5d92d6ee6044c532/redash/settings/__init__.py#L22) and that's not supported by [python-rq](https://python-rq.org/docs/connections/#encoding--decoding).

The other monitor functions were already using the correct `rq_redis_connection` but the `rq_job_ids`


## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A
