### PR TITLE
Match FROM and AS capitalisation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bookworm as frontend-builder
+FROM node:18-bookworm AS frontend-builder
 
 RUN npm install --global --force yarn@1.22.22
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description

This fixes a warning shown when building the docker image:

```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

## How is this tested?

- [x] N/A

It's only changing the capitalisation of a dockerfile keyword.  It's super unlikely to break anything, though CI will show us anyway. :wink:

## Related Tickets & Documents


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
