### PR TITLE
Add support for 'linux/arm64' platforms

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -44,10 +44,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
 
-      - name: Install Dependencies
-        run: |
-          npm install --global --force yarn@1.22.22
-          yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -58,6 +58,11 @@ jobs:
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
+      - name: Install Dependencies
+        run: |
+          npm install --global --force yarn@1.22.22
+          yarn cache clean && yarn --frozen-lockfile --network-concurrency 1
+
       - name: Set version
         id: version
         run: |
@@ -66,6 +71,7 @@ jobs:
           VERSION_TAG=$(jq -r .version package.json)
           echo "VERSION_TAG=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
+      # TODO: We can use GitHub Actions's matrix option to reduce the build time.
       - name: Build and push preview image to Docker Hub
         uses: docker/build-push-action@v4
         with:
@@ -76,9 +82,9 @@ jobs:
           context: .
           build-args: |
             test_all_deps=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          cache-from: type=gha,scope=multi-platform
+          cache-to: type=gha,mode=max,scope=multi-platform
+          platforms: linux/amd64,linux/arm64
         env:
           DOCKER_CONTENT_TRUST: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ COPY --chown=redash scripts /frontend/scripts
 ARG code_coverage
 ENV BABEL_ENV=${code_coverage:+test}
 
+# Avoid issues caused by lags in disk and network I/O speeds when working on top of QEMU emulation for multi-platform image building.
+RUN yarn config set network-timeout 300000
+
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn --frozen-lockfile --network-concurrency 1; fi
 
 COPY --chown=redash client /frontend/client
@@ -85,6 +88,9 @@ ENV POETRY_VERSION=1.6.1
 ENV POETRY_HOME=/etc/poetry
 ENV POETRY_VIRTUALENVS_CREATE=false
 RUN curl -sSL https://install.python-poetry.org | python3 -
+
+# Avoid crashes, including corrupted cache artifacts, when building multi-platform images with GitHub Actions.
+RUN /etc/poetry/bin/poetry cache clear pypi --all
 
 COPY pyproject.toml poetry.lock ./
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
When we take a snapshot, it also creates a Docker image for the ARM64 platform.

## How is this tested?

- [x] Manually

<!-- If Manually, please describe. -->
- Docker Hub: https://hub.docker.com/layers/seongtaejg/preview/24.07.0-dev/images/sha256-9370a73741542571e8787cc3c7ae807be9c8fb5e4a5ff15d6f162619f76a7763?context=repo
- GitHub Actions CI log: https://github.com/lucydodo/redash/actions/runs/10190456427
- I confirmed it can run via the `setup` script on Ubuntu 24.04 installed on ARM64-based processor 

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
#5765

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Not applicable.

## Notes
Currently, it takes about **3h** to build a docker image.
Of course, I have a new ways in mind to improve this speed(cache, matrix, etc.). But PRs can get too complicated,
so I'm going to make changes to the core functionality first, and then improve the speed with additional PRs.

Any comments or review are welcome. Thank you.