### PR TITLE
Add the asdf .tool-versions file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ client/dist
 _build
 .vscode
 .env
+.tool-versions
 
 dump.rdb
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

The [asdf]() runtime version manager stores tool version info in `.tool-versions`, so lets add it to `.gitignore` for now.

## How is this tested?

- [x] Manually

In theory (!), this shouldn't impact anything, though lets see what our CI says.
