### PR TITLE
Bump bootstrap to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "antd": "^4.4.3",
     "axios": "0.27.2",
     "axios-auth-refresh": "3.3.6",
-    "bootstrap": "^3.3.7",
+    "bootstrap": "^3.4.1",
     "classnames": "^2.2.6",
     "d3": "^3.5.17",
     "debug": "^3.2.7",
@@ -179,8 +179,8 @@
     ]
   },
   "browser": {
-      "fs": false,
-      "path": false
+    "fs": false,
+    "path": false
   },
   "//": "browserslist set to 'Async functions' compatibility",
   "browserslist": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,7 +3592,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^3.3.7:
+bootstrap@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This closes a moderate Dependabot XSS vulnerability alert:

  https://github.com/getredash/redash/security/dependabot/291

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)


## Related Tickets & Documents

https://github.com/getredash/redash/security/dependabot/291

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
