### PR TITLE
Support comma separated RedashGroups

### DIFF
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -1,4 +1,5 @@
 import logging
+from itertools import chain
 
 from flask import Blueprint, flash, redirect, request, url_for
 from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT, entity
@@ -138,7 +139,7 @@ def idp_initiated(org_slug=None):
         return logout_and_redirect_to_index()
 
     if "RedashGroups" in authn_response.ava:
-        group_names = authn_response.ava.get("RedashGroups")
+        group_names = chain(*[name.split(",") for name in authn_response.ava.get("RedashGroups")])
         user.update_group_assignments(group_names)
 
     url = url_for("redash.index", org_slug=org_slug)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

Modify SAML RedashGroups to allow multiple groups to be written separated by commas, since writing multiple groups in SAML RedashGroups does not change the groups.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

I applied the following patch to `redash/redash:10.1.0.b50633` and confirmed that it works correctly with SAML of Azure AD (Entra ID).

<details>

```diff
diff --git a/redash/authentication/saml_auth.py b/redash/authentication/saml_auth.py
index 1c52bf1a..116dd76a 100644
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -1,3 +1,4 @@
+from itertools import chain
 import logging

 from flask import Blueprint, flash, redirect, request, url_for
@@ -138,7 +139,7 @@ def idp_initiated(org_slug=None):
         return logout_and_redirect_to_index()

     if "RedashGroups" in authn_response.ava:
-        group_names = authn_response.ava.get("RedashGroups")
+        group_names = chain(*[name.split(",") for name in authn_response.ava.get("RedashGroups")])
         user.update_group_assignments(group_names)

     url = url_for("redash.index", org_slug=org_slug)
```

</details>

## Related Tickets & Documents

- https://discuss.redash.io/t/redashgroups-parameter-comma-separated-list-of-groups/6426
- https://github.com/getredash/redash/issues/4963
- https://discuss.redash.io/t/redashgroups-paramenter-only-accepting-1-value-for-group-push-via-okta/8586

<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A
