### PR TITLE
Fix a display order bug in MongoDB Query Runner

### DIFF
--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -137,7 +137,7 @@ def _sorted_fields(fields):
         if isinstance(v, int):
             ord[k] = v
         else:
-            ord[k] = len(fields) + 1
+            ord[k] = len(fields)
 
     return sorted(ord, key=ord.get)
 

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -131,6 +131,17 @@ def parse_results(results: list, flatten: bool = False) -> list:
     return rows, columns
 
 
+def _sorted_fields(fields):
+    ord = {}
+    for k, v in fields.items():
+        if isinstance(v, int):
+            ord[k] = v
+        else:
+            ord[k] = len(fields) + 1
+
+    return sorted(ord, key=ord.get)
+
+
 class MongoDB(BaseQueryRunner):
     should_annotate_query = False
 
@@ -365,7 +376,7 @@ class MongoDB(BaseQueryRunner):
 
         if f:
             ordered_columns = []
-            for k in sorted(f, key=f.get):
+            for k in _sorted_fields(f):
                 column = _get_column_by_name(columns, k)
                 if column:
                     ordered_columns.append(column)

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -39,18 +39,8 @@ class TestMongoDB(TestCase):
         self.assertNotIn("password", mongo_client.call_args.kwargs)
 
     def test_run_query_with_fields(self, mongo_client):
-        config = {
-            "connectionString": "mongodb://localhost:27017/test",
-            "username": "test_user",
-            "password": "test_pass",
-            "dbName": "test",
-        }
-        mongo_qr = MongoDB(config)
-
         query = {"collection": "test", "query": {"age": 10}, "fields": {"_id": 1, "name": 2}}
-
         return_value = [{"_id": "6569ee53d53db7930aaa0cc0", "name": "test2"}]
-
         expected = {
             "columns": [
                 {"name": "_id", "friendly_name": "_id", "type": TYPE_STRING},
@@ -60,20 +50,28 @@ class TestMongoDB(TestCase):
         }
 
         mongo_client().__getitem__().__getitem__().find.return_value = return_value
-        result, err = mongo_qr.run_query(json_dumps(query), None)
+        self._test_query(query, return_value, expected)
 
-        self.assertIsNone(err)
-        self.assertEqual(expected, result)
+    def test_run_query_with_func(self, mongo_client):
+        query = {
+            "collection": "test",
+            "query": {"age": 10},
+            "fields": {"_id": 1, "name": 2, "link": {"$concat": ["hoge_", "$name"]}},
+        }
+        return_value = [{"_id": "6569ee53d53db7930aaa0cc0", "name": "test2", "link": "hoge_test2"}]
+        expected = {
+            "columns": [
+                {"name": "_id", "friendly_name": "_id", "type": TYPE_STRING},
+                {"name": "name", "friendly_name": "name", "type": TYPE_STRING},
+                {"name": "link", "friendly_name": "link", "type": TYPE_STRING},
+            ],
+            "rows": return_value,
+        }
+
+        mongo_client().__getitem__().__getitem__().find.return_value = return_value
+        self._test_query(query, return_value, expected)
 
     def test_run_query_with_aggregate(self, mongo_client):
-        config = {
-            "connectionString": "mongodb://localhost:27017/test",
-            "username": "test_user",
-            "password": "test_pass",
-            "dbName": "test",
-        }
-        mongo_qr = MongoDB(config)
-
         query = {
             "collection": "test",
             "aggregate": [
@@ -82,9 +80,7 @@ class TestMongoDB(TestCase):
                 {"$sort": [{"name": "count", "direction": -1}, {"name": "_id", "direction": -1}]},
             ],
         }
-
         return_value = [{"_id": "foo", "count": 10}, {"_id": "bar", "count": 9}]
-
         expected = {
             "columns": [
                 {"name": "_id", "friendly_name": "_id", "type": TYPE_STRING},
@@ -94,6 +90,17 @@ class TestMongoDB(TestCase):
         }
 
         mongo_client().__getitem__().__getitem__().aggregate.return_value = return_value
+        self._test_query(query, return_value, expected)
+
+    def _test_query(self, query, return_value, expected):
+        config = {
+            "connectionString": "mongodb://localhost:27017/test",
+            "username": "test_user",
+            "password": "test_pass",
+            "dbName": "test",
+        }
+        mongo_qr = MongoDB(config)
+
         result, err = mongo_qr.run_query(json_dumps(query), None)
         self.assertIsNone(err)
         self.assertEqual(expected, result)

--- a/tests/query_runner/test_mongodb.py
+++ b/tests/query_runner/test_mongodb.py
@@ -56,14 +56,14 @@ class TestMongoDB(TestCase):
         query = {
             "collection": "test",
             "query": {"age": 10},
-            "fields": {"_id": 1, "name": 2, "link": {"$concat": ["hoge_", "$name"]}},
+            "fields": {"_id": 1, "name": 4, "link": {"$concat": ["hoge_", "$name"]}},
         }
         return_value = [{"_id": "6569ee53d53db7930aaa0cc0", "name": "test2", "link": "hoge_test2"}]
         expected = {
             "columns": [
                 {"name": "_id", "friendly_name": "_id", "type": TYPE_STRING},
-                {"name": "name", "friendly_name": "name", "type": TYPE_STRING},
                 {"name": "link", "friendly_name": "link", "type": TYPE_STRING},
+                {"name": "name", "friendly_name": "name", "type": TYPE_STRING},
             ],
             "rows": return_value,
         }


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This error will occur when setting a non-numeric value to `fields`:

### Qyery
```
{
	"collection": "hoge",
	"query": {
		"age": {
		    "$lt": 100
		}
	},
	"fields": {
		"_id": 1,
		"name": 4,
		"link": {
		    "$concat": ["hoge_", "$name"]
		}
	}
}
```

### Error

```
Traceback (most recent call last):
  File "/app/redash/tasks/queries/execution.py", line 182, in run
    data, error = query_runner.run_query(annotated_query, self.user)
  File "/app/redash/query_runner/mongodb.py", line 338, in run_query
    for k in sorted(f, key=f.get):
TypeError: '<' not supported between instances of 'dict' and 'int'
```

### How to fix

A value of `fields` means the display order. In this case, the value of `link` in fields is a non-numeric value, so the above error occurs.

I fixed this by setting the display order to `len(fields)` implicitly if non-numeric is specified.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

## Related Tickets & Documents
Closes #5768

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before

![issue-5768_before](https://github.com/user-attachments/assets/1b9def99-5c59-464e-8dc5-89ad30210182)

### After

![issue-5768_after](https://github.com/user-attachments/assets/73490bbd-ccca-420d-91fd-0db88791834a)
