### PR TITLE
Bump elliptic to version 6.5.7 to fix a Dependabot warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "d3": "^3.5.17",
     "debug": "^3.2.7",
     "dompurify": "^2.0.17",
+    "elliptic": "^6.5.7",
     "font-awesome": "^4.7.0",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5531,10 +5531,10 @@ elementary-circuits-directed-graph@^1.0.4:
   dependencies:
     strongly-connected-components "^1.0.1"
 
-elliptic@^6.0.0, elliptic@^6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+elliptic@^6.0.0, elliptic@^6.5.4, elliptic@^6.5.7:
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
+  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR fixes 3 "Low" severity Dependabot warnings:

* https://github.com/getredash/redash/security/dependabot/292
* https://github.com/getredash/redash/security/dependabot/293
* https://github.com/getredash/redash/security/dependabot/294

## How is this tested?

- [x] N/A

Untested but it's a very minor change.  Lets see if our CI likes it. :smile:


## Related Tickets & Documents

* https://github.com/indutny/elliptic/pull/317
* https://github.com/indutny/elliptic/issues/319