### PR TITLE
Improve fixed-column layout

### DIFF
--- a/viz-lib/src/visualizations/table/Renderer.tsx
+++ b/viz-lib/src/visualizations/table/Renderer.tsx
@@ -141,7 +141,7 @@ export default function Renderer({ options, data }: any) {
           showSizeChanger: false,
         }}
         showSorterTooltip={false}
-        scroll = {{x : 'max-content'}}
+        scroll={ (get(options, "fixedColumns", 0) > 0 ? { x : 'max-content' } : {}) }
       />
     </div>
   );

--- a/viz-lib/src/visualizations/table/renderer.less
+++ b/viz-lib/src/visualizations/table/renderer.less
@@ -140,6 +140,10 @@
       .ant-table {
         flex-grow: 1;
       }
+
+      .ant-table-content {
+        overflow: unset !important;
+      }
     }
   }
   /* END */
@@ -157,10 +161,6 @@
   }
 }
 
-.ant-table-cell-fix-left{
-  background-color: #fff !important;
-}
-
 .ant-table-tbody > tr.ant-table-row:hover > .ant-table-cell-fix-left {
-  background-color: rgb(248, 249, 250) !important;
+  background-color: rgb(248, 249, 250);
 }


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Only set `scroll.x` when more than one fixed column is set to preserve text wrapping.  Unset `.ant-table-content` `overflow` property to ensure virtical scrolling works.


## How is this tested?

- [x] Manually

## Related Tickets & Documents

https://github.com/getredash/redash/issues/7127

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

https://github.com/user-attachments/assets/a0e674c7-ed30-4ce4-a0da-b5a8bc2949f7