### PR TITLE
Add REDASH_HOST to the development docker compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ x-redash-service: &redash-service
   env_file:
     - .env
 x-redash-environment: &redash-environment
+  REDASH_HOST: http://localhost:5001
   REDASH_LOG_LEVEL: "INFO"
   REDASH_REDIS_URL: "redis://redis:6379/0"
   REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix


## Description

Adding the full host and port to the compose file in our repository ensures emails generated in the development environment have the port number included in their urls.


## How is this tested?

- [x] Manually

Screenshot of a generated invite email that includes this fix:

![Screenshot 2024-09-12 at 3 48 58 PM](https://github.com/user-attachments/assets/9155849a-4d64-466b-80f9-519f92a43d4d)


## Related Tickets & Documents

https://github.com/getredash/redash/discussions/7153