### PR TITLE
Extend `make up` to automatically initialise the database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ compose_build: .env
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose build
 
 up:
+	docker compose up -d redis postgres
+	docker compose exec -u postgres postgres psql postgres --csv \
+		-1tqc "SELECT table_name FROM information_schema.tables WHERE table_name = 'organizations'" 2> /dev/null \
+		| grep -q "organizations" || make create_database
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose up -d --build
 
 test_db:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This PR updates `make up` to automatically initialise the database if that hasn't already been done.

It does this by (very quickly) checking if the organization table is present, then running `make create_database` if not.

This is a re-application of https://github.com/getredash/redash/pull/6855, that was caught up in the large revert a while back.


## How is this tested?

- [x] Manually

This shouldn't affect anything with the running code, and seems to work fine (!) in my local development environment.


## Related Tickets & Documents

https://github.com/getredash/redash/pull/6855