### PR TITLE
Automatically remove orphans when running make up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ compose_build: .env
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose build
 
 up:
-	docker compose up -d redis postgres
+	docker compose up -d redis postgres --remove-orphans
 	docker compose exec -u postgres postgres psql postgres --csv \
 		-1tqc "SELECT table_name FROM information_schema.tables WHERE table_name = 'organizations'" 2> /dev/null \
 		| grep -q "organizations" || make create_database
-	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose up -d --build
+	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose up -d --build --remove-orphans
 
 test_db:
 	@for i in `seq 1 5`; do \


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

This is just a trivial quality of life improvement PR for Redash developers.

It adds the `--remove-orphans` option to the `make up` docker compose commands, to automatically remove orphaned containers from previous runs.

Without this option `make up` will commonly display a warning about orphaned containers:

```
WARN[0000] Found orphan containers ([redash-server-run-9d298b8fca7f]) for this project. If you
removed or renamed this service in your compose file, you can run this command with the
--remove-orphans flag to clean it up.
```

## How is this tested?

- [x] Manually

Seems to work fine in my local development environment, and doesn't change any of our build nor running code.  In theory (!), this shouldn't cause any issues.