### PR TITLE
Add migration to set default alert selector

### DIFF
--- a/migrations/versions/1655999df5e3_default_alert_selector.py
+++ b/migrations/versions/1655999df5e3_default_alert_selector.py
@@ -1,0 +1,26 @@
+"""set default alert selector
+
+Revision ID: 1655999df5e3
+Revises: 9e8c841d1a30
+Create Date: 2024-10-18 11:24:49
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '1655999df5e3'
+down_revision = '9e8c841d1a30'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+    UPDATE alerts
+    SET options = jsonb_set(options, '{selector}', '"first"')
+    WHERE options->>'selector' IS NULL;
+    """)
+
+def downgrade():
+    pass


### PR DESCRIPTION
## What type of PR is this? 

- [x] Migration

## Description

In commits fc1e1f7a and e44fcdb a new Selector option was added to alerts, which may be "first", "min" or "max".  This migration sets the default to "first" for existing alerts.

## How is this tested?

- [x] Manually

```
docker compose exec server ./manage.py db downgrade 9e8c841d1a30
docker compose exec server ./manage.py db upgrade
```
