### PR TITLE
Allow CSV/TSV/Excel download from shared dashboards

### DIFF
--- a/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/VisualizationWidget.jsx
@@ -27,8 +27,12 @@ function visualizationWidgetMenuOptions({ widget, canEditDashboard, onParameters
   const canEditParameters = canEditDashboard && !isEmpty(invoke(widget, "query.getParametersDefs"));
   const widgetQueryResult = widget.getQueryResult();
   const isQueryResultEmpty = !widgetQueryResult || !widgetQueryResult.isEmpty || widgetQueryResult.isEmpty();
-
-  const downloadLink = fileType => widgetQueryResult.getLink(widget.getQuery().id, fileType);
+  const parts = window.location.pathname.split('/').reverse()
+  var apiKey = null;
+  if (parts.length > 3 && parts[2] === 'public' && parts[0].length === 40) {
+    apiKey = parts[0];
+  }
+  const downloadLink = fileType => widgetQueryResult.getLink(widget.getQuery().id, fileType, apiKey);
   const downloadName = fileType => widgetQueryResult.getName(widget.getQuery().name, fileType);
   return compact([
     <Menu.Item key="download_csv" disabled={isQueryResultEmpty}>

--- a/client/app/components/dashboards/dashboard-widget/Widget.jsx
+++ b/client/app/components/dashboards/dashboard-widget/Widget.jsx
@@ -69,7 +69,6 @@ class Widget extends React.Component {
     header: PropTypes.node,
     footer: PropTypes.node,
     canEdit: PropTypes.bool,
-    isPublic: PropTypes.bool,
     refreshStartedAt: Moment,
     menuOptions: PropTypes.node,
     tileProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -82,7 +81,6 @@ class Widget extends React.Component {
     header: null,
     footer: null,
     canEdit: false,
-    isPublic: false,
     refreshStartedAt: null,
     menuOptions: null,
     tileProps: {},
@@ -109,8 +107,8 @@ class Widget extends React.Component {
   };
 
   render() {
-    const { className, children, header, footer, canEdit, isPublic, menuOptions, tileProps } = this.props;
-    const showDropdownButton = !isPublic && (canEdit || !isEmpty(menuOptions));
+    const { className, children, header, footer, canEdit, menuOptions, tileProps } = this.props;
+    const showDropdownButton = (canEdit || !isEmpty(menuOptions));
     return (
       <div className="widget-wrapper">
         <div className={cx("tile body-container", className)} {...tileProps}>

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -328,7 +328,11 @@ class QueryResultResource(BaseResource):
                     abort(404, message="No cached result found for this query.")
 
         if query_result:
-            require_access(query_result.data_source, self.current_user, view_only)
+            api_key = request.args.get("api_key")
+            if query and api_key in query.dashboard_api_keys:
+                pass  # shared dashboard
+            else:
+                require_access(query_result.data_source, self.current_user, view_only)
 
             if isinstance(self.current_user, models.ApiUser):
                 event = {

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -74,7 +74,7 @@ def _get_column_lists(columns):
 
 def serialize_query_result(query_result, is_api_user):
     if is_api_user:
-        publicly_needed_keys = ["data", "retrieved_at"]
+        publicly_needed_keys = ["data", "id", "retrieved_at"]
         return project(query_result.to_dict(), publicly_needed_keys)
     else:
         return query_result.to_dict()

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -294,6 +294,36 @@ class TestQueryResultAPI(BaseTestCase):
         )
         self.assertEqual(rv.status_code, 200)
 
+    def test_access_query_using_dashboard_api_key(self):
+        query = self.factory.create_query()
+        query_result = self.factory.create_query_result(query_text=query.query_text)
+
+        dashboard1 = self.factory.create_dashboard()
+        visualization1 = self.factory.create_visualization(query_rel=query)
+        self.factory.create_widget(visualization=visualization1, dashboard=dashboard1)
+        api_key = self.factory.create_api_key(object=dashboard1).api_key
+
+        rv = self.make_request(
+            "get",
+            "/api/queries/{}/results/{}.json?api_key={}".format(query.id, query_result.id, api_key),
+            user=False,
+        )
+        self.assertEqual(rv.status_code, 200)
+
+    def test_reject_query_using_unrelated_dashboard_api_key(self):
+        query = self.factory.create_query()
+        query_result = self.factory.create_query_result(query_text=query.query_text)
+
+        dashboard1 = self.factory.create_dashboard()
+        api_key = self.factory.create_api_key(object=dashboard1).api_key
+
+        rv = self.make_request(
+            "get",
+            "/api/queries/{}/results/{}.json?api_key={}".format(query.id, query_result.id, api_key),
+            user=False,
+        )
+        self.assertEqual(rv.status_code, 403)
+
     def test_access_with_query_api_key_without_query_result_id(self):
         ds = self.factory.create_data_source(group=self.factory.org.default_group, view_only=False)
         query = self.factory.create_query()

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -32,7 +32,7 @@ class QueryResultSerializationTest(BaseTestCase):
     def test_doesnt_serialize_sensitive_keys_for_unauthenticated_users(self):
         query_result = self.factory.create_query_result(data={})
         serialized = serialize_query_result(query_result, True)
-        self.assertSetEqual(set(["data", "retrieved_at"]), set(serialized.keys()))
+        self.assertSetEqual(set(["data", "id", "retrieved_at"]), set(serialized.keys()))
 
 
 class DsvSerializationTest(BaseTestCase):


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

- Always show dropdown menu for tables on shared dashboards
- Append `?api_key` for dashboards using the path `/public/`
- Compare `api_key` with dashboard API keys associated with the requested query

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

https://github.com/user-attachments/assets/b56c0686-f718-436b-90eb-7c79f645ebc7