### PR TITLE
Only evaluate the next state if there's a valid value

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -969,6 +969,7 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
 
     def evaluate(self):
         data = self.query_rel.latest_query_data.data if self.query_rel.latest_query_data else None
+        new_state = self.UNKNOWN_STATE
 
         if data and data["rows"] and self.options["column"] in data["rows"][0]:
             op = OPERATORS.get(self.options["op"], lambda v, t: False)
@@ -997,9 +998,8 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
 
             threshold = self.options["value"]
 
-            new_state = next_state(op, value, threshold)
-        else:
-            new_state = self.UNKNOWN_STATE
+            if value is not None:
+                new_state = next_state(op, value, threshold)
 
         return new_state
 

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -118,6 +118,10 @@ class TestAlertEvaluate(BaseTestCase):
         )
         self.assertEqual(alert.evaluate(), Alert.UNKNOWN_STATE)
 
+    def test_evaluate_return_unknown_when_value_is_none(self):
+        alert = self.create_alert(get_results(None))
+        self.assertEqual(alert.evaluate(), Alert.UNKNOWN_STATE)
+
 
 class TestNextState(TestCase):
     def test_numeric_value(self):


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix


## Description

I've experience this on my Redash in production. I'm not sure what can cause the value to exist, but be None. I guess it depends on the SQL query.

I followed the same idea of returning a self.UNKNOWN_STATE for cases that we can't know what's happening.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents
Fixes #5618