### PR TITLE
Update to paramiko-3.4.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2791,13 +2791,13 @@ test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "paramiko"
-version = "3.4.0"
+version = "3.4.1"
 description = "SSH2 protocol library"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "paramiko-3.4.0-py3-none-any.whl", hash = "sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7"},
-    {file = "paramiko-3.4.0.tar.gz", hash = "sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3"},
+    {file = "paramiko-3.4.1-py3-none-any.whl", hash = "sha256:8e49fd2f82f84acf7ffd57c64311aa2b30e575370dc23bdb375b10262f7eac32"},
+    {file = "paramiko-3.4.1.tar.gz", hash = "sha256:8b15302870af7f6652f2e038975c1d2973f06046cb5d7d65355668b3ecbece0c"},
 ]
 
 [package.dependencies]
@@ -5452,4 +5452,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "02293766776027e8d1d72d7649c9775d1a01d465cd5d585d9d1596f69905f946"
+content-hash = "60b16b87265062c99c3c69b0d00995264dfae8ba231e9802496858e98aa61c1b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ xlsxwriter = "1.2.2"
 tzlocal = "4.3.1"
 pyodbc = "5.1.0"
 debugpy = "^1.8.9"
+paramiko = "3.4.1"
 
 [tool.poetry.group.all_ds]
 optional = true


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Solves the deprecation warning for TripleDES

```
$ docker compose exec server ./manage.py
/usr/local/lib/python3.10/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/usr/local/lib/python3.10/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
```

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

## Related Tickets & Documents

https://github.com/paramiko/paramiko/issues/2419
