### PR TITLE
BigQuery: add date, datetime type mapping

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 from redash import settings
 from redash.query_runner import (
     TYPE_BOOLEAN,
+    TYPE_DATE,
     TYPE_DATETIME,
     TYPE_FLOAT,
     TYPE_INTEGER,
@@ -37,6 +38,8 @@ types_map = {
     "BOOLEAN": TYPE_BOOLEAN,
     "STRING": TYPE_STRING,
     "TIMESTAMP": TYPE_DATETIME,
+    "DATETIME": TYPE_DATETIME,
+    "DATE": TYPE_DATE,
 }
 
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [*] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

On BigQuery, DATE and DATETIME type are not mapped to specific type, so it sometimes handled as "string" type and shown as number.

This PR add mapping for DATETIME/DATE in addition to TIMESTAMP.

## How is this tested?

- [*] Manually

<!-- If Manually, please describe. -->

I just run the query below and confirmed that the column is displayed in date format instead of number.

```
select DATETIME("2022-01-01") as t
union all 
select NULL as t
```


