### PR TITLE
Use headers instead of URL params for ClickHouse credentials

### DIFF
--- a/redash/query_runner/clickhouse.py
+++ b/redash/query_runner/clickhouse.py
@@ -99,10 +99,13 @@ class ClickHouse(BaseSQLQueryRunner):
         timeout = self.configuration.get("timeout", 30)
 
         params = {
-            "user": self.configuration.get("user", "default"),
-            "password": self.configuration.get("password", ""),
             "database": self.configuration["dbname"],
             "default_format": "JSON",
+        }
+
+        headers = {
+            "x-clickhouse-user": self.configuration.get("user", "default"),
+            "x-clickhouse-key": self.configuration.get("password", ""),
         }
 
         if session_id:
@@ -119,6 +122,7 @@ class ClickHouse(BaseSQLQueryRunner):
                 timeout=timeout,
                 params=params,
                 verify=verify,
+                headers=headers,
             )
 
             if not r.ok:

--- a/tests/query_runner/test_clickhouse.py
+++ b/tests/query_runner/test_clickhouse.py
@@ -104,10 +104,15 @@ class TestClickHouse(TestCase):
         self.assertEqual(
             kwargs["params"],
             {
-                "user": "default",
-                "password": "",
                 "database": "system",
                 "default_format": "JSON",
+            },
+        )
+        self.assertEqual(
+            kwargs["headers"],
+            {
+                "x-clickhouse-user": "default",
+                "x-clickhouse-key": "",
             },
         )
         self.assertEqual(kwargs["timeout"], 60)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other (Security/Improvement)

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The ClickHouse driver was passing the credentials via URL query parameters.
This not a good practice because URLs tend to get included in logs.
This PR changes this to use the `x-clickhouse-user` and `x-clickhouse-key` headers instead.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

Add a ClickHouse DB as datasource. Observe connecting and querying still works as before.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A