### PR TITLE
Handle the case when query runner configuration is an empty dict

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -91,7 +91,7 @@ class BaseElasticSearch(BaseQueryRunner):
 
             logger.setLevel(logging.DEBUG)
 
-        self.server_url = self.configuration["server"]
+        self.server_url = self.configuration.get("server", "")
         if self.server_url[-1] == "/":
             self.server_url = self.server_url[:-1]
 

--- a/redash/query_runner/mongodb.py
+++ b/redash/query_runner/mongodb.py
@@ -188,7 +188,7 @@ class MongoDB(BaseQueryRunner):
 
         self.syntax = "json"
 
-        self.db_name = self.configuration["dbName"]
+        self.db_name = self.configuration.get("dbName", "")
 
         self.is_replica_set = (
             True if "replicaSetName" in self.configuration and self.configuration["replicaSetName"] else False

--- a/redash/query_runner/script.py
+++ b/redash/query_runner/script.py
@@ -55,12 +55,13 @@ class Script(BaseQueryRunner):
     def __init__(self, configuration):
         super(Script, self).__init__(configuration)
 
+        path = self.configuration.get("path", "")
         # If path is * allow any execution path
-        if self.configuration["path"] == "*":
+        if path == "*":
             return
 
         # Poor man's protection against running scripts from outside the scripts directory
-        if self.configuration["path"].find("../") > -1:
+        if path.find("../") > -1:
             raise ValueError("Scripts can only be run from the configured scripts directory")
 
     def test_connection(self):

--- a/redash/query_runner/sqlite.py
+++ b/redash/query_runner/sqlite.py
@@ -28,7 +28,7 @@ class Sqlite(BaseSQLQueryRunner):
     def __init__(self, configuration):
         super(Sqlite, self).__init__(configuration)
 
-        self._dbpath = self.configuration["dbpath"]
+        self._dbpath = self.configuration.get("dbpath", "")
 
     def _get_tables(self, schema):
         query_table = "select tbl_name from sqlite_master where type='table'"


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The migration introduced in #7184 creates query runners with an empty configuration dictionary. Some query runners raise an exception if the configuration dictionary doesn't contain some keys. This PR updates the implementation to use `get` instead of direct access.

Fixes #7221.

## How is this tested?

- [x] Manually