### PR TITLE
Create workflow trigger for publishing release image

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -4,6 +4,15 @@ on:
     tags:
       - '*-dev'
   workflow_dispatch:
+    inputs:
+      dockerRepository:
+        description: 'Docker repository'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - redash
 
 env:
   NODE_VERSION: 18
@@ -75,11 +84,28 @@ jobs:
       # TODO: We can use GitHub Actions's matrix option to reduce the build time.
       - name: Build and push preview image to Docker Hub
         uses: docker/build-push-action@v4
+        if: ${{ github.event.inputs.dockerRepository == 'preview' || !github.event.workflow_run }}
         with:
           push: true
           tags: |
             redash/redash:preview
             redash/preview:${{ steps.version.outputs.VERSION_TAG }}
+          context: .
+          build-args: |
+            test_all_deps=true
+          cache-from: type=gha,scope=multi-platform
+          cache-to: type=gha,mode=max,scope=multi-platform
+          platforms: linux/amd64,linux/arm64
+        env:
+          DOCKER_CONTENT_TRUST: true
+
+      - name: Build and push release image to Docker Hub
+        uses: docker/build-push-action@v4
+        if: ${{ github.event.inputs.dockerRepository == 'redash' }}
+        with:
+          push: true
+          tags: |
+            redash/redash:${{ steps.version.outputs.VERSION_TAG }}
           context: .
           build-args: |
             test_all_deps=true


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

- If the action was not triggered manually, publish a preview image
- Always select a branch for release image

## How is this tested?

- [x] Manually

Tested on personal Dockerhub account

https://hub.docker.com/repository/docker/eradman/redash/general
https://hub.docker.com/repository/docker/eradman/preview/general

## Related Tickets & Documents

https://github.com/getredash/redash/issues/7251

Preview image from master

![preview-image-1](https://github.com/user-attachments/assets/4b083265-2e4a-4d95-ae2c-4a7a3009eacc)

Publish a release

![preview-image-2](https://github.com/user-attachments/assets/442c3756-19fd-4c00-830f-02cad69a836e)
