### PR TITLE
Add color options tab for FunnelBar

### DIFF
--- a/viz-lib/src/visualizations/funnel/Editor/ColorsSettings.tsx
+++ b/viz-lib/src/visualizations/funnel/Editor/ColorsSettings.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useDebouncedCallback } from "use-debounce";
+import { Section, ColorPicker } from "@/components/visualizations/editor";
+import { EditorPropTypes } from "@/visualizations/prop-types";
+import ColorPalette from "../../ColorPalette";
+
+export default function ColorsSettings({ options, onOptionsChange }: any) {
+  const [onOptionsChangeDebounced] = useDebouncedCallback(onOptionsChange, 200);
+
+  return (
+    <React.Fragment>
+      {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+      <Section>
+        <ColorPicker
+          layout="horizontal"
+          label="Color"
+          interactive
+          presetColors={ColorPalette}
+          placement="topRight"
+          color={options.color}
+          triggerProps={{ "data-test": "Funnel.Editor.Colors.color" }}
+          onChange={(color: any) => onOptionsChange({ color: color })}
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'Label' does not exist on type '({ classN... Remove this comment to see the full error message
+          addonAfter={<ColorPicker.Label color={options.color} presetColors={ColorPalette} />}
+        />
+      </Section>
+    </React.Fragment>
+  );
+}
+
+ColorsSettings.propTypes = EditorPropTypes;

--- a/viz-lib/src/visualizations/funnel/Editor/index.ts
+++ b/viz-lib/src/visualizations/funnel/Editor/index.ts
@@ -2,8 +2,10 @@ import createTabbedEditor from "@/components/visualizations/editor/createTabbedE
 
 import GeneralSettings from "./GeneralSettings";
 import AppearanceSettings from "./AppearanceSettings";
+import ColorsSettings from "./ColorsSettings";
 
 export default createTabbedEditor([
   { key: "General", title: "General", component: GeneralSettings },
   { key: "Appearance", title: "Appearance", component: AppearanceSettings },
+  { key: "Colors", title: "Colors", component: ColorsSettings },
 ]);

--- a/viz-lib/src/visualizations/funnel/Renderer/index.tsx
+++ b/viz-lib/src/visualizations/funnel/Renderer/index.tsx
@@ -60,7 +60,7 @@ export default function Renderer({ data, options }: any) {
         align: "center",
         render: (value: any, item: any) => (
           // @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-          <FunnelBar align="center" color={ColorPalette.Cyan} value={item.pctMax}>
+          <FunnelBar align="center" color={options.color} value={item.pctMax}>
             {formatValue(value)}
           </FunnelBar>
         ),


### PR DESCRIPTION
This will allow choosing a background color for the data bars when using the Funnel visualization.

## What type of PR is this? 
- [x] Feature
- [x] Quality of life

## Description
Add an option to choose a color for the Funnel visualization.  
Up until now, you could only have funnels with the `cyan` color, without an ability to change it.

## TODO
List of tasks to complete:

- [ ] Decide on a default color (keep the original cyan?)
- [ ] Handle text color on dark backgrounds.
- [ ] Support different color palettes?

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Tested manually - tweaked the colors in the visualization editor and saw the expected change.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://github.com/user-attachments/assets/c02bd9c9-c46d-4fb1-bcd9-f4701569e0d6)
![image](https://github.com/user-attachments/assets/56b07ac3-6458-436d-89b8-3fa62afe142c)
![image](https://github.com/user-attachments/assets/6822a3ba-062d-43b6-8369-036cefb94846)
(still need to fix contrast issues)
![image](https://github.com/user-attachments/assets/317da2ab-e689-4410-84ab-d5617d33b2cc)

