### PR TITLE
Bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
       - name: Store Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: backend-test-results
           path: /tmp/test-results
       - name: Store Coverage Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.xml
@@ -94,9 +94,9 @@ jobs:
       - name: Run Lint
         run: yarn lint:ci
       - name: Store Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: frontend-test-results
           path: /tmp/test-results
 
   frontend-unit-tests:
@@ -169,7 +169,7 @@ jobs:
       - name: Copy Code Coverage Results
         run: docker cp cypress:/usr/src/app/coverage ./coverage || true
       - name: Store Coverage Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage


### PR DESCRIPTION
## What type of PR is this? 
- [x] Other

## Description
> https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The artifact actions will be deprecated on January 30th. Therefore, I am upading the versions of these actions.
In the new version, artifacts with the same name are not supported, so I'm adding a prefix to each artifact name.
Additionall,y as some of you may know, this patch was previously applied but was reverted: #6674, #6876

## How is this tested?
- [x] Manually

Tested on personal fork: https://github.com/lucydodo/redash/actions/runs/12532753927

## Related Tickets & Documents
Not applicable.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Not applicable.