### PR TITLE
FIX : redash docker image TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 
 clean-all: clean
 	docker image rm --force \
-		redash/redash:10.1.0.b50633 redis:7-alpine maildev/maildev:latest \
+		redash/redash:latest redis:7-alpine maildev/maildev:latest \
 		pgautoupgrade/pgautoupgrade:15-alpine3.8 pgautoupgrade/pgautoupgrade:latest
 
 down:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The `clean-all` target in the Makefile still references the Docker image tag from a previous version, which may cause inconsistencies.  

This PR updates the `clean` target to reference the latest version of the Docker image. Alternatively, we could consider referencing a specific version that matches the current TAG for better version control.  

**Changes:**  
- Modified the Docker image tag reference in the `clean-all` target of the Makefile.  

Please review and share your thoughts. Let me know if the current approach or referencing the corresponding TAG is preferred.  



## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
issue : https://github.com/getredash/redash/issues/7279
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
