### PR TITLE
bigquery get schema query add region

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -305,7 +305,7 @@ class BigQuery(BaseQueryRunner):
 
         query_base = """
         SELECT table_schema, table_name, field_path
-        FROM `{dataset_id}`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
+        FROM region-`{dataset_id}`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
         WHERE table_schema NOT IN ('information_schema')
         """
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Feature

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
The query used to retrieve the BigQuery schema requires a region value. This update ensures that the correct region is specified when executing the query to avoid potential errors or inconsistencies.

Related Documents : https://cloud.google.com/bigquery/docs/information-schema-column-field-paths?hl=ko#scope_and_syntax

## How is this tested?

- [x] Manually
