### PR TITLE
Fixes #7272: Error in rehash DB migration with Elasticsearch queries

### DIFF
--- a/redash/query_runner/elasticsearch.py
+++ b/redash/query_runner/elasticsearch.py
@@ -92,7 +92,7 @@ class BaseElasticSearch(BaseQueryRunner):
             logger.setLevel(logging.DEBUG)
 
         self.server_url = self.configuration.get("server", "")
-        if self.server_url[-1] == "/":
+        if self.server_url and self.server_url[-1] == "/":
             self.server_url = self.server_url[:-1]
 
         basic_auth_user = self.configuration.get("basic_auth_user", None)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

When migrating from Redash 10.1.0 to 25.1.0, the initialization of the Elasticsearch query runner is triggered, causing an error to be thrown. In addition to the measures implemented in #7258, the current fix ensures that the migration proceeds successfully.


## How is this tested?

- [x] Manually

The same issue as #7272 occurred in the current environment. After applying this fix, running `docker-compose run --rm server manage db upgrade` completed the migration successfully, and it was confirmed that Elasticsearch queries can now be executed.

## Related Tickets & Documents

- https://github.com/getredash/redash/issues/7272#issuecomment-2599636306
- #7258
