### PR TITLE
Change autocomplete token limit to 1000000

### DIFF
--- a/client/app/pages/queries/hooks/useAutocompleteFlags.js
+++ b/client/app/pages/queries/hooks/useAutocompleteFlags.js
@@ -7,7 +7,7 @@ function calculateTokensCount(schema) {
 }
 
 export default function useAutocompleteFlags(schema) {
-  const isAvailable = useMemo(() => calculateTokensCount(schema) <= 5000, [schema]);
+  const isAvailable = useMemo(() => calculateTokensCount(schema) <= 1000000, [schema]);
   const [isEnabled, setIsEnabled] = useState(localOptions.get("liveAutocomplete", true));
 
   const toggleAutocomplete = useCallback(state => {

--- a/client/app/pages/queries/hooks/useAutocompleteFlags.js
+++ b/client/app/pages/queries/hooks/useAutocompleteFlags.js
@@ -10,7 +10,7 @@ export default function useAutocompleteFlags(schema) {
   const isAvailable = useMemo(() => calculateTokensCount(schema) <= 1000000, [schema]);
   const [isEnabled, setIsEnabled] = useState(localOptions.get("liveAutocomplete", true));
 
-  const toggleAutocomplete = useCallback(state => {
+  const toggleAutocomplete = useCallback((state) => {
     setIsEnabled(state);
     localOptions.set("liveAutocomplete", state);
   }, []);


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
Before this PR, autocomplete is disabled for tokens more than 5000. That is too small for us, and probably the most of dataware house.

And, anyway, each user can disable autocomplete if they want.
I think it should be up to user to decide whether to use autocomplete or not, and it is better to make hard-coded limit large enough to most user.

This PR changes the limit of the token from 5000 to 1000000. There is no change on memory consumption as the tokens are anyway stored on memory even if autocomplete is disabled.


## How is this tested?
- [x] Manually

I confirmed that there is no problem for token more than 700000, and there is no CPU/memory exhausting.

