### PR TITLE
Push by tag name for Docker repository "redash"

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -118,7 +118,7 @@ jobs:
           context: .
           build-args: |
             test_all_deps=true
-          outputs: type=image,push-by-digest=true,push=true
+          outputs: type=image,push-by-digest=false,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
         env:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Building and image manually using the Github action works for 'preview', this fixes the build for 'redash'

```
 > exporting to image:
221
------
222
ERROR: failed to solve: failed to push eradman/redash:24.11.0-dev: can't push tagged ref docker.io/eradman/redash:24.11.0-dev by digest
223
Error: buildx failed with: ERROR: failed to solve: failed to push eradman/redash:24.11.0-dev: can't push tagged ref docker.io/eradman/redash:24.11.0-dev by digest
```

## How is this tested?

- [x] Manually

Tested on personal repo: https://hub.docker.com/repository/docker/eradman/redash/general