### PR TITLE
Include Plotly.js localization

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/index.ts
+++ b/viz-lib/src/visualizations/chart/plotly/index.ts
@@ -1,5 +1,6 @@
 import * as Plotly from "plotly.js";
 
+import "./locales"
 import prepareData from "./prepareData";
 import prepareLayout from "./prepareLayout";
 import updateData from "./updateData";
@@ -11,6 +12,7 @@ import { prepareCustomChartData, createCustomChartRenderer } from "./customChart
 Plotly.setPlotConfig({
   modeBarButtonsToRemove: ["sendDataToCloud"],
   modeBarButtonsToAdd: ["togglespikelines", "v1hovermode"],
+  locale: window.navigator.language,
 });
 
 export {

--- a/viz-lib/src/visualizations/chart/plotly/locales.ts
+++ b/viz-lib/src/visualizations/chart/plotly/locales.ts
@@ -1,0 +1,230 @@
+import * as Plotly from "plotly.js";
+
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeAf from "plotly.js/lib/locales/af";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeAm from "plotly.js/lib/locales/am";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeAr_dz from "plotly.js/lib/locales/ar-dz";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeAr_eg from "plotly.js/lib/locales/ar-eg";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeAr from "plotly.js/lib/locales/ar";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeAz from "plotly.js/lib/locales/az";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeBg from "plotly.js/lib/locales/bg";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeBs from "plotly.js/lib/locales/bs";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeCa from "plotly.js/lib/locales/ca";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeCs from "plotly.js/lib/locales/cs";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeCy from "plotly.js/lib/locales/cy";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeDa from "plotly.js/lib/locales/da";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeDe_ch from "plotly.js/lib/locales/de-ch";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeDe from "plotly.js/lib/locales/de";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEl from "plotly.js/lib/locales/el";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEo from "plotly.js/lib/locales/eo";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEs_ar from "plotly.js/lib/locales/es-ar";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEs_pe from "plotly.js/lib/locales/es-pe";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEs from "plotly.js/lib/locales/es";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEt from "plotly.js/lib/locales/et";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeEu from "plotly.js/lib/locales/eu";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeFa from "plotly.js/lib/locales/fa";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeFi from "plotly.js/lib/locales/fi";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeFo from "plotly.js/lib/locales/fo";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeFr_ch from "plotly.js/lib/locales/fr-ch";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeFr from "plotly.js/lib/locales/fr";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeGl from "plotly.js/lib/locales/gl";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeGu from "plotly.js/lib/locales/gu";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeHe from "plotly.js/lib/locales/he";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeHi_in from "plotly.js/lib/locales/hi-in";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeHr from "plotly.js/lib/locales/hr";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeHu from "plotly.js/lib/locales/hu";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeHy from "plotly.js/lib/locales/hy";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeId from "plotly.js/lib/locales/id";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeIs from "plotly.js/lib/locales/is";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeIt from "plotly.js/lib/locales/it";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeJa from "plotly.js/lib/locales/ja";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeKa from "plotly.js/lib/locales/ka";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeKm from "plotly.js/lib/locales/km";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeKo from "plotly.js/lib/locales/ko";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeLt from "plotly.js/lib/locales/lt";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeLv from "plotly.js/lib/locales/lv";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeMe_me from "plotly.js/lib/locales/me-me";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeMe from "plotly.js/lib/locales/me";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeMk from "plotly.js/lib/locales/mk";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeMl from "plotly.js/lib/locales/ml";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeMs from "plotly.js/lib/locales/ms";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeMt from "plotly.js/lib/locales/mt";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeNl_be from "plotly.js/lib/locales/nl-be";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeNl from "plotly.js/lib/locales/nl";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeNo from "plotly.js/lib/locales/no";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localePa from "plotly.js/lib/locales/pa";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localePl from "plotly.js/lib/locales/pl";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localePt_br from "plotly.js/lib/locales/pt-br";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localePt_pt from "plotly.js/lib/locales/pt-pt";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeRm from "plotly.js/lib/locales/rm";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeRo from "plotly.js/lib/locales/ro";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeRu from "plotly.js/lib/locales/ru";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSk from "plotly.js/lib/locales/sk";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSl from "plotly.js/lib/locales/sl";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSq from "plotly.js/lib/locales/sq";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSr_sr from "plotly.js/lib/locales/sr-sr";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSr from "plotly.js/lib/locales/sr";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSv from "plotly.js/lib/locales/sv";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeSw from "plotly.js/lib/locales/sw";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeTa from "plotly.js/lib/locales/ta";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeTh from "plotly.js/lib/locales/th";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeTr from "plotly.js/lib/locales/tr";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeTt from "plotly.js/lib/locales/tt";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeUk from "plotly.js/lib/locales/uk";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeUr from "plotly.js/lib/locales/ur";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeVi from "plotly.js/lib/locales/vi";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeZh_cn from "plotly.js/lib/locales/zh-cn";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeZh_hk from "plotly.js/lib/locales/zh-hk";
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module
+import localeZh_tw from "plotly.js/lib/locales/zh-tw";
+
+(Plotly as any).register([
+    localeAf,
+    localeAm,
+    localeAr_dz,
+    localeAr_eg,
+    localeAr,
+    localeAz,
+    localeBg,
+    localeBs,
+    localeCa,
+    localeCs,
+    localeCy,
+    localeDa,
+    localeDe_ch,
+    localeDe,
+    localeEl,
+    localeEo,
+    localeEs_ar,
+    localeEs_pe,
+    localeEs,
+    localeEt,
+    localeEu,
+    localeFa,
+    localeFi,
+    localeFo,
+    localeFr_ch,
+    localeFr,
+    localeGl,
+    localeGu,
+    localeHe,
+    localeHi_in,
+    localeHr,
+    localeHu,
+    localeHy,
+    localeId,
+    localeIs,
+    localeIt,
+    localeJa,
+    localeKa,
+    localeKm,
+    localeKo,
+    localeLt,
+    localeLv,
+    localeMe_me,
+    localeMe,
+    localeMk,
+    localeMl,
+    localeMs,
+    localeMt,
+    localeNl_be,
+    localeNl,
+    localeNo,
+    localePa,
+    localePl,
+    localePt_br,
+    localePt_pt,
+    localeRm,
+    localeRo,
+    localeRu,
+    localeSk,
+    localeSl,
+    localeSq,
+    localeSr_sr,
+    localeSr,
+    localeSv,
+    localeSw,
+    localeTa,
+    localeTh,
+    localeTr,
+    localeTt,
+    localeUk,
+    localeUr,
+    localeVi,
+    localeZh_cn,
+    localeZh_hk,
+    localeZh_tw,
+]);


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
For now, the locale for the chat is English. It is not very intuitive for non-english people to show chart in English (ex: "January").

Make localized charts available by including and registering plotly.js localization definitions, and set locale based on browser language.

## How is this tested?

- [x] Manually

I confirmed that the "Month" and pop-up information is localized.

<img width="722" alt="image" src="https://github.com/user-attachments/assets/1d70ecf5-cb9f-4cff-8ea1-4ddb24b0c634" />
<img width="306" alt="image" src="https://github.com/user-attachments/assets/c179acbe-b198-4868-bc6a-c1e1edc476d9" />
