### PR TITLE
Make autocomplete always available

### DIFF
--- a/client/app/pages/queries/hooks/useAutocompleteFlags.js
+++ b/client/app/pages/queries/hooks/useAutocompleteFlags.js
@@ -1,13 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
-import { reduce } from "lodash";
 import localOptions from "@/lib/localOptions";
 
-function calculateTokensCount(schema) {
-  return reduce(schema, (totalLength, table) => totalLength + table.columns.length, 0);
-}
-
 export default function useAutocompleteFlags(schema) {
-  const isAvailable = useMemo(() => calculateTokensCount(schema) <= 5000, [schema]);
+  const isAvailable = true;
   const [isEnabled, setIsEnabled] = useState(localOptions.get("liveAutocomplete", true));
 
   const toggleAutocomplete = useCallback(state => {

--- a/client/app/pages/queries/hooks/useAutocompleteFlags.js
+++ b/client/app/pages/queries/hooks/useAutocompleteFlags.js
@@ -5,7 +5,7 @@ export default function useAutocompleteFlags(schema) {
   const isAvailable = true;
   const [isEnabled, setIsEnabled] = useState(localOptions.get("liveAutocomplete", true));
 
-  const toggleAutocomplete = useCallback(state => {
+  const toggleAutocomplete = useCallback((state) => {
     setIsEnabled(state);
     localOptions.set("liveAutocomplete", state);
   }, []);


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
Before this PR, autocomplete is not available if there are more than 5,000 tokens. The limit is too small for our data warehouse, and probably many data warehouse.

This PR removes the limit, and make autocomplete always available.

Anyway, if each user want to disable autocomplete, they can just disable by themselves, and I think it is better to make it user's choice instead of hard-coded limit.

Also, as tokens are stored on memory even if the autocomplete is disabled, amount of memory consumption does not change.

This PR is derived from the discussion on https://github.com/getredash/redash/pull/7319 .

## How is this tested?

- [x] Manually

I confirmed that the auto complete works smoothly for tokens more than 700,000.

