### PR TITLE
Fix the issue that chart(scatter, bubble, line...) having data with same x-value have wrong y-value

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/prepareDefaultData.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareDefaultData.ts
@@ -99,8 +99,8 @@ function prepareSeries(series: any, options: any, numSeries: any, additionalOpti
       };
 
   const sourceData = new Map();
-
-  const labelsValuesMap = new Map();
+  const xValues: any[] = [];
+  const yValues: any[] = [];
 
   const yErrorValues: any = [];
   each(data, row => {
@@ -108,26 +108,19 @@ function prepareSeries(series: any, options: any, numSeries: any, additionalOpti
     const y = cleanYValue(row.y, seriesYAxis === "y2" ? options.yAxis[1].type : options.yAxis[0].type); // depends on series type!
     const yError = cleanNumber(row.yError); // always number
     const size = cleanNumber(row.size); // always number
-    if (labelsValuesMap.has(x)) {
-      labelsValuesMap.set(x, labelsValuesMap.get(x) + y);
-    } else {
-      labelsValuesMap.set(x, y);
-    }
-    const aggregatedY = labelsValuesMap.get(x);
 
     sourceData.set(x, {
       x,
-      y: aggregatedY,
+      y,
       yError,
       size,
       yPercent: null, // will be updated later
       row,
     });
+    xValues.push(x);
+    yValues.push(y);
     yErrorValues.push(yError);
   });
-
-  const xValues = Array.from(labelsValuesMap.keys());
-  const yValues = Array.from(labelsValuesMap.values());
 
   const plotlySeries = {
     visible: true,


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
Before this PR, the chart(scatter, line, bubble...) having same x-value have wrong y-value.
For example, before this PR, if the data is like (x,y) = (1,1), (2,1), (3,1), (3,1)  , the chart have y-value for x=3 is not 1 but 2 (So, the y-value for the same x-value is summed up.)

This PR fix the issue.
See issue: https://github.com/getredash/redash/issues/7329

This issue was introduced by following #6908 . #6908 is OK for pie chart written as example in PR. But not good for other charts. The pie chart is basically for categorical(nominal-level) x-value and ratio-scale y-value, so it is OK to sum up y-value. But other charts like scatter/bubble charts are normally for quantitative x-value and y-value can be interval-scale. So it is not good just summing up.

And, scatter chart can have multiple x-value as as scatter chart does not care x or y, and the issue is critical. But for pie chart, x-value can be(or should be) unique, anyway.

For example, when there is a scatter chart for physique and x-axis is for weight and y-axis is for height, summing up height for the same weight does not make sense at all.
For stock chart, summing up stock price for the same day does not make sense.

This PR does not change the behavior for pie chart.

## How is this tested?

- [x] Manually

I manually confirmed that the y-value is not summed up but shown as is.

Tested query:
```
select 1 as x, 1 as y
union all
select 2 as x, 1 as y
union all
select 3 as x, 1 as y
union all
select 3 as x, 1 as y
```

Scatter chart before this PR:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/13c216ed-9b3d-4fd8-91d2-9bbe06f7a2c7" />

Scatter chart after this PR:
<img width="914" alt="image" src="https://github.com/user-attachments/assets/cb585082-bddc-4382-91d5-658aa16209cb" />


