### PR TITLE
Add NULLS LAST option for query list ordering

### DIFF
--- a/redash/utils/query_order.py
+++ b/redash/utils/query_order.py
@@ -33,7 +33,7 @@ from sqlalchemy.orm import mapperlib
 from sqlalchemy.orm.properties import ColumnProperty
 from sqlalchemy.orm.query import _ColumnEntity
 from sqlalchemy.orm.util import AliasedInsp
-from sqlalchemy.sql.expression import asc, desc
+from sqlalchemy.sql.expression import asc, desc, nullslast
 
 
 def get_query_descriptor(query, entity, attr):
@@ -225,7 +225,7 @@ class QuerySorter:
     def assign_order_by(self, entity, attr, func):
         expr = get_query_descriptor(self.query, entity, attr)
         if expr is not None:
-            return self.query.order_by(func(expr))
+            return self.query.order_by(nullslast(func(expr)))
         if not self.silent:
             raise QuerySorterException("Could not sort query with expression '%s'" % attr)
         return self.query


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
Before this PR, query list ordering does not have "NULLS LAST" option.

So, when I sort query list by "Last Executed At" in descendant order to see the recent active queries, I got bunch of queries that is not executed at all and "executed_at" is null in the beginning of the list.

This happens because PostgreSQL handles NULL as the "largest value" for ordering. 

I think the behavior does not make sense.

This PR fix the issue by adding "NULLS LAST" options for ordering so that the most recent query comes first, instead of query that was never run comes first.


## How is this tested?

- [x] Manually

Before this PR:
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/f8519d67-af7f-427d-8250-8d26ff01d3ef" />


After this PR:
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/b8b72a19-4e93-45f2-9ca7-2335ea32d848" />


