### PR TITLE
Sanitize NaN, Infinite, -Infinite causing error when saving as PostgreSQL JSON #7339 (2nd try)

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -6,6 +6,7 @@ import decimal
 import hashlib
 import io
 import json
+import math
 import os
 import random
 import re
@@ -120,6 +121,17 @@ def json_loads(data, *args, **kwargs):
     return json.loads(data, *args, **kwargs)
 
 
+# Convert NaN, Inf, and -Inf to None, which PostgreSQL cannot handle.
+def _sanitize_data(data):
+    if isinstance(data, dict):
+        return {k: _sanitize_data(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_sanitize_data(v) for v in data]
+    if isinstance(data, float) and (math.isnan(data) or math.isinf(data)):
+        return None
+    return data
+
+
 def json_dumps(data, *args, **kwargs):
     """A custom JSON dumping function which passes all parameters to the
     json.dumps function."""
@@ -128,7 +140,7 @@ def json_dumps(data, *args, **kwargs):
     # Float value nan or inf in Python should be render to None or null in json.
     # Using allow_nan = True will make Python render nan as NaN, leading to parse error in front-end
     kwargs.setdefault("allow_nan", False)
-    return json.dumps(data, *args, **kwargs)
+    return json.dumps(_sanitize_data(data), *args, **kwargs)
 
 
 def mustache_render(template, context=None, **kwargs):


### PR DESCRIPTION
This PR is derived from #7339.
This PR changes json_dumps instead of QueryExecutor.run as suggested.

## What type of PR is this? 
- [x] Bug Fix

When running query that output NaN, Infinite, or -Infinite, redash executor crashes with the error "Out of range float values are not JSON compliant" like below. Redash does not output any rows when the error was occurred.

```
[2025-02-19 04:48:49,040][PID:593][ERROR][rq.worker] [Job 6cfa1d1c-2a32-48c6-8bf4-0cd8f8ba6f32]: exception raised while executing (redash.tasks.queries.execution.execute_query)
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.10/site-packages/rq/job.py", line 1280, in perform
    self._result = self._execute()
  File "/usr/local/lib/python3.10/site-packages/rq/job.py", line 1317, in _execute
    result = self.func(*self.args, **self.kwargs)
  File "/app/redash/tasks/queries/execution.py", line 309, in execute_query
    ).run()
  File "/app/redash/tasks/queries/execution.py", line 253, in run
    updated_query_ids = models.Query.update_latest_result(query_result)
  File "/app/redash/models/__init__.py", line 738, in update_latest_result
    for q in queries:
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 3534, in __iter__
    self.session._autoflush()
...
sqlalchemy.exc.StatementError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(builtins.ValueError) Out of range float values are not JSON compliant
[SQL: INSERT INTO query_results (org_id, data_source_id, query_hash, query, data, runtime, retrieved_at) VALUES (%(org_id)s, %(data_source_id)s, %(query_hash)s, %(query)s, %(data)s, %(runtime)s, %(retrieved_at)s) RETURNING query_results.id]
...
```

The error occurs because JSON(PostgreSQL JSON type) does not support NaN, Infinite, -Infinite.

This PR fixes the issue by sanitize NaN, Infinite, -Infinite value to None. This is the save behavior that JavaScript JSON.stringify() does.

We can reproduce the issue by running following query on BigQuery or PostgreSQL.

BigQuery:
```
select 1.0, cast('NaN' as float64), cast('Infinity' as float64), cast('-Infinity' as float64)
```

PostgreSQL:
```
select 1.0::float, 'NaN'::float, 'Infinity'::float, '-Infinity'::float
```

The issue was introduced by #6685 which removes simplejson. Before #6685 , NaN / Inf was converted to null by simplejson with ignore_nan=True. This PR change behavior for NaN/Inf as same as before #6685 .


## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

Unit test was added.
Also, we can confirm by running the query on the description. 

Before this PR:

<img width="793" alt="image" src="https://github.com/user-attachments/assets/8a929b4d-cde4-426a-af34-160091b0ad6b" />

After this PR:

<img width="709" alt="image" src="https://github.com/user-attachments/assets/d59e481f-26fa-4c51-8111-9861d8268251" />
