### PR TITLE
TiDB: Exclude INFORMATION_SCHEMA

### DIFF
--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -152,7 +152,7 @@ class Mysql(BaseSQLQueryRunner):
                col.table_name as table_name,
                col.column_name as column_name
         FROM `information_schema`.`columns` col
-        WHERE col.table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
+        WHERE LOWER(col.table_schema) NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
         """
 
         results, error = self.run_query(query, None)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
https://github.com/getredash/redash/issues/7347
`INFORMATION_SCHEMA` is excluded in TiDB.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

### before change
- MySQL
```
mysql> SELECT col.table_schema as table_schema,
    ->                col.table_name as table_name,
    ->                col.column_name as column_name
    ->         FROM `information_schema`.`columns` col
    ->         WHERE col.table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
+--------------+------------+-------------+
| table_schema | table_name | column_name |
+--------------+------------+-------------+
| test         | t1         | x           |
+--------------+------------+-------------+
1 row in set (0.00 sec)
```

- TiDB
```
mysql> SELECT col.table_schema as table_schema,
    ->                col.table_name as table_name,
    ->                col.column_name as column_name
    ->         FROM `information_schema`.`columns` col
    ->         WHERE col.table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
+--------------------+---------------------------------------+-------------------------------------------+
| table_schema       | table_name                            | column_name                               |
+--------------------+---------------------------------------+-------------------------------------------+
| INFORMATION_SCHEMA | CLUSTER_DEADLOCKS                     | INSTANCE                                  |
| INFORMATION_SCHEMA | CLUSTER_DEADLOCKS                     | DEADLOCK_ID                               |
| INFORMATION_SCHEMA | CLUSTER_DEADLOCKS                     | OCCUR_TIME                                |
| INFORMATION_SCHEMA | CLUSTER_DEADLOCKS                     | RETRYABLE                                 |
...
| INFORMATION_SCHEMA | SEQUENCES                             | MIN_VALUE                                 |
| INFORMATION_SCHEMA | SEQUENCES                             | START                                     |
| INFORMATION_SCHEMA | SEQUENCES                             | COMMENT                                   |
| test               | t1                                    | x                                         |
+--------------------+---------------------------------------+-------------------------------------------+
1525 rows in set (0.02 sec)
```
### after change
- MySQL
```
mysql> SELECT col.table_schema as table_schema,
    ->                col.table_name as table_name,
    ->                col.column_name as column_name
    ->         FROM `information_schema`.`columns` col
    ->         WHERE LOWER(col.table_schema) NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
+--------------+------------+-------------+
| table_schema | table_name | column_name |
+--------------+------------+-------------+
| test         | t1         | x           |
+--------------+------------+-------------+
1 row in set (0.00 sec)
```

- TiDB
```
mysql> SELECT col.table_schema as table_schema,
    ->                col.table_name as table_name,
    ->                col.column_name as column_name
    ->         FROM `information_schema`.`columns` col
    ->         WHERE LOWER(col.table_schema) NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys');
+--------------+------------+-------------+
| table_schema | table_name | column_name |
+--------------+------------+-------------+
| test         | t1         | x           |
+--------------+------------+-------------+
1 row in set (0.01 sec)

mysql>
```


<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
