### PR TITLE
Change BigQuery super class from BaseQueryRunner to BaseSQLQueryRunner

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -12,7 +12,7 @@ from redash.query_runner import (
     TYPE_FLOAT,
     TYPE_INTEGER,
     TYPE_STRING,
-    BaseQueryRunner,
+    BaseSQLQueryRunner,
     InterruptException,
     JobTimeoutException,
     register,
@@ -98,7 +98,7 @@ def _get_total_bytes_processed_for_resp(bq_response):
     return int(bq_response.get("totalBytesProcessed", "0"))
 
 
-class BigQuery(BaseQueryRunner):
+class BigQuery(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
 
     def __init__(self, configuration):


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description
BigQuery is SQL.
So, the super class of BigQuery runner should be BaseSQLQueryRunner instead of BaseQueryRunner so that auto limit feature (LIMIT 1000) is available for BigQuery.

## How is this tested?
- [x] Manually

I confirmed that LIMIT 1000 feature is available on BigQuery.
Test Query:
```
select * from unnest(generate_array(1,2000))
```


<img width="798" alt="image" src="https://github.com/user-attachments/assets/f1476564-f71d-47e2-b60f-3db6cb9f51ae" />

