### PR TITLE
Configurable addition of Redash metadata as query tag

### DIFF
--- a/redash/query_runner/snowflake.py
+++ b/redash/query_runner/snowflake.py
@@ -17,6 +17,7 @@ from redash.query_runner import (
     BaseSQLQueryRunner,
     register,
 )
+from redash.utils import json_dumps
 
 TYPES_MAP = {
     0: TYPE_INTEGER,
@@ -33,7 +34,13 @@ TYPES_MAP = {
 
 
 class Snowflake(BaseSQLQueryRunner):
+    add_query_tags = False
+    metadata = None
     noop_query = "SELECT 1"
+
+    def __init__(self, configuration):
+        super().__init__(configuration)
+        self.add_query_tags = configuration.get("add_query_tags", False)
 
     @classmethod
     def configuration_schema(cls):
@@ -52,6 +59,11 @@ class Snowflake(BaseSQLQueryRunner):
                     "default": False,
                 },
                 "host": {"type": "string"},
+                "add_query_tags": {
+                    "type": "boolean",
+                    "title": "Add Redash metadata as query tag",
+                    "default": False,
+                },
             },
             "order": [
                 "account",
@@ -68,6 +80,11 @@ class Snowflake(BaseSQLQueryRunner):
                 "host",
             ],
         }
+
+    def annotate_query(self, query, metadata):
+        annotated = super(Snowflake, self).annotate_query(query, metadata)
+        self.metadata = metadata
+        return annotated
 
     @classmethod
     def enabled(cls):
@@ -129,6 +146,10 @@ class Snowflake(BaseSQLQueryRunner):
         try:
             cursor.execute("USE WAREHOUSE {}".format(self.configuration["warehouse"]))
             cursor.execute("USE {}".format(self.configuration["database"]))
+
+            if self.add_query_tags:
+                if self.metadata:
+                    cursor.execute(f"ALTER SESSION SET QUERY_TAG=$$'{json_dumps(self.metadata)}'$$")
 
             cursor.execute(query)
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [X] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

1. Enable "Add Redash metadata as query tag" in Data source connection options:
![image](https://github.com/user-attachments/assets/bbf173d2-e61f-473f-a0d7-38cf88590869)

2. Execute query
<img width="328" alt="image" src="https://github.com/user-attachments/assets/0aecc502-e00c-4911-b000-63a99b5c2e5c" />

3. Observe alter session set query_tag command in query history view:
![image](https://github.com/user-attachments/assets/9b9965b8-c5d7-48ec-b236-9e3c210eee05)

4. See query tag added to the query in query details:
![image](https://github.com/user-attachments/assets/666f7fae-6d19-475e-9adf-d7455a3b0b94)








