### PR TITLE
Require vars.DOCKER_REPOSITORY to publish image

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -32,6 +32,9 @@ jobs:
           elif [[ "${{ secrets.DOCKER_PASS }}" == '' ]]; then
             echo 'Docker password is empty. Skipping build+push'
             echo skip=true >> "$GITHUB_OUTPUT"
+          elif [[ "${{ vars.DOCKER_REPOSITORY }}" == '' ]]; then
+            echo 'Docker repository is empty. Skipping build+push'
+            echo skip=true >> "$GITHUB_OUTPUT"
           else
             echo 'Docker user and password are set and branch is `master`.'
             echo 'Building + pushing `preview` image.'
@@ -169,14 +172,14 @@ jobs:
         if: ${{ github.event.inputs.dockerRepository == 'preview' || !github.event.workflow_run }}
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create -t ${{ vars.DOCKER_USER }}/redash:preview \
-            $(printf '${{ vars.DOCKER_USER }}/redash:preview@sha256:%s ' *)
-          docker buildx imagetools create -t ${{ vars.DOCKER_USER }}/preview:${{ needs.build-docker-image.outputs.VERSION_TAG }} \
-            $(printf '${{ vars.DOCKER_USER }}/preview:${{ needs.build-docker-image.outputs.VERSION_TAG }}@sha256:%s ' *)
+          docker buildx imagetools create -t ${{ vars.DOCKER_REPOSITORY }}/redash:preview \
+            $(printf '${{ vars.DOCKER_REPOSITORY }}/redash:preview@sha256:%s ' *)
+          docker buildx imagetools create -t ${{ vars.DOCKER_REPOSITORY }}/preview:${{ needs.build-docker-image.outputs.VERSION_TAG }} \
+            $(printf '${{ vars.DOCKER_REPOSITORY }}/preview:${{ needs.build-docker-image.outputs.VERSION_TAG }}@sha256:%s ' *)
 
       - name: Create and push manifest for the release image
         if: ${{ github.event.inputs.dockerRepository == 'redash' }}
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create -t ${{ vars.DOCKER_USER }}/redash:${{ needs.build-docker-image.outputs.VERSION_TAG }} \
-            $(printf '${{ vars.DOCKER_USER }}/redash:${{ needs.build-docker-image.outputs.VERSION_TAG }}@sha256:%s ' *)
+          docker buildx imagetools create -t ${{ vars.DOCKER_REPOSITORY }}/redash:${{ needs.build-docker-image.outputs.VERSION_TAG }} \
+            $(printf '${{ vars.DOCKER_REPOSITORY }}/redash:${{ needs.build-docker-image.outputs.VERSION_TAG }}@sha256:%s ' *)


### PR DESCRIPTION
## What type of PR is this? 

- [x] Build Fix
- [x] Other

## Description

To allow user _arikfr_ to publish images to redash/redash and redash/preview. Only use `vars.DOCKER_USER` and `secrets.DOCKER_PASSWORD` for authorization.

2025.01 was the last preview image published at https://hub.docker.com/u/redash becuse the repository was assumed to be based on the docker username. (See https://github.com/getredash/redash/actions/runs/14184394211/job/39737590514)

## How is this tested?

- [x] Manually

https://github.com/eradman/redash/actions/runs/14250088861

## Related Tickets & Documents

## GitHub Settings

![action-vars](https://github.com/user-attachments/assets/e9f45eab-068f-4c9a-8867-35d3a0456aa9)
