### PR TITLE
Add "Last 10 years" option for dynamic date range

### DIFF
--- a/client/app/components/dynamic-parameters/DateRangeParameter.jsx
+++ b/client/app/components/dynamic-parameters/DateRangeParameter.jsx
@@ -106,6 +106,11 @@ const DYNAMIC_DATE_OPTIONS = [
     value: getDynamicDateRangeFromString("d_last_12_months"),
     label: null,
   },
+  {
+    name: "Last 10 years",
+    value: getDynamicDateRangeFromString("d_last_10_years"),
+    label: null,
+  },
 ];
 
 const DYNAMIC_DATETIME_OPTIONS = [

--- a/client/app/services/parameters/DateRangeParameter.js
+++ b/client/app/services/parameters/DateRangeParameter.js
@@ -152,6 +152,16 @@ const DYNAMIC_DATE_RANGES = {
       () => moment().endOf("day")
     ),
   },
+  last_10_years: {
+    name: "Last 10 years",
+    value: untilNow(
+      () =>
+        moment()
+          .subtract(10, "years")
+          .startOf("day"),
+      () => moment().endOf("day")
+    ),
+  },
 };
 
 export const DynamicDateRangeType = PropTypes.oneOf(values(DYNAMIC_DATE_RANGES));


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
At now, maximum date range option is "last 12 months".
But, it is quite convenient if I can view longer period like 10 years.

This PR add "Last 10 years" option to date range option.

## How is this tested?

- [x] Manually

I run following query with Date Range parameter.
```
select '{{DATE_RANGE.start}}', '{{DATE_RANGE.end}}'
```

And, I confirmed that output is correctly shown like below.
```
'2015-04-28' | '2025-04-28' |  
```


