### PR TITLE
Push image using DOCKER_REPOSITORY

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -100,8 +100,8 @@ jobs:
         if: ${{ github.event.inputs.dockerRepository == 'preview' || !github.event.workflow_run }}
         with:
           tags: |
-            ${{ vars.DOCKER_USER }}/redash
-            ${{ vars.DOCKER_USER }}/preview
+            ${{ vars.DOCKER_REPOSITORY }}/redash
+            ${{ vars.DOCKER_REPOSITORY }}/preview
           context: .
           build-args: |
             test_all_deps=true
@@ -117,7 +117,7 @@ jobs:
         if: ${{ github.event.inputs.dockerRepository == 'redash' }}
         with:
           tags: |
-            ${{ vars.DOCKER_USER }}/redash:${{ steps.version.outputs.VERSION_TAG }}
+            ${{ vars.DOCKER_REPOSITORY }}/redash:${{ steps.version.outputs.VERSION_TAG }}
           context: .
           build-args: |
             test_all_deps=true


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

Preview images works for personal repositories, but we missed another variable when publishing official images:

```
  #34 [auth] arikfr/redash:pull,push token for registry-1.docker.io
  #34 DONE 0.0s
  #33 exporting to image
  #33 pushing layers 15.5s done
  #33 pushing manifest for docker.io/arikfr/redash
  #33 pushing manifest for docker.io/arikfr/redash 1.6s done
  #33 ...
  #35 [auth] arikfr/preview:pull,push token for registry-1.docker.io
  #35 DONE 0.0s
```

https://github.com/getredash/redash/actions/runs/14776025489/job/41484408477

## How is this tested?

- [x] Manually

Tested on personal repository (https://hub.docker.com/r/eradman/redash/)