### PR TITLE
Fix unexpected /app shadowing in compose.yaml (#7433)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,8 +5,6 @@ x-redash-service: &redash-service
     context: .
     args:
       skip_frontend_build: "true"  # set to empty string to build
-  volumes:
-    - .:/app
   env_file:
     - .env
 x-redash-environment: &redash-environment


### PR DESCRIPTION
Paths within the container got overwritten by volume mount, which caused inconsistencies with the expected contents of directories populated on buid stage.

For example, CSS and graphics may not load — see issue getredash/redash#7433.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ X] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ X] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

```
make compose_build
make create_database
make up
```

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

#7433

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
