### PR TITLE
ADD hour/minute granularity to dynamic date range option

### DIFF
--- a/client/app/components/dynamic-parameters/DateRangeParameter.jsx
+++ b/client/app/components/dynamic-parameters/DateRangeParameter.jsx
@@ -110,6 +110,26 @@ const DYNAMIC_DATE_OPTIONS = [
 
 const DYNAMIC_DATETIME_OPTIONS = [
   {
+    name: "Last 15 miniutes",
+    value: getDynamicDateRangeFromString("d_last_15_minutes"),
+    label: null
+  },
+  {
+    name: "Last 30 miniutes",
+    value: getDynamicDateRangeFromString("d_last_30_minutes"),
+    label: null
+  },
+  {
+    name: "Last Hour",
+    value: getDynamicDateRangeFromString("d_last_hour"),
+    label: null
+  },
+  {
+    name: "Last 8 Hours",
+    value: getDynamicDateRangeFromString("d_last_8_hours"),
+    label: null
+  },
+  {
     name: "Today",
     value: getDynamicDateRangeFromString("d_today"),
     label: () =>

--- a/client/app/services/parameters/DateRangeParameter.js
+++ b/client/app/services/parameters/DateRangeParameter.js
@@ -80,6 +80,14 @@ const DYNAMIC_DATE_RANGES = {
         .endOf("year"),
     ],
   },
+  last_30_minutes: {
+    name: "Last 30 minutes",
+    value: untilNow(() => moment().subtract(30, "minute")),
+  },
+  last_15_minutes: {
+    name: "Last 15 minutes",
+    value: untilNow(() => moment().subtract(15, "minute")),
+  },
   last_hour: {
     name: "Last hour",
     value: untilNow(() => moment().subtract(1, "hour")),


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Added finer time interval options to reduce database load when querying large datasets. Exposed existing "Last hour" and "Last 8 hours" options in the UI and implemented new granular options: "Last 15 minutes" and "Last 30 minutes" for more precise timeframe selections. 

```
const DYNAMIC_DATETIME_OPTIONS = [
  // new feaure
  {
    name: "Last 15 miniutes",
    value: getDynamicDateRangeFromString("d_last_15_minutes"),
    label: null
  },
  {
    name: "Last 30 miniutes",
    value: getDynamicDateRangeFromString("d_last_30_minutes"),
    label: null
  },
  {
    name: "Last Hour",
    value: getDynamicDateRangeFromString("d_last_hour"),
    label: null
  },
  {
    name: "Last 8 Hours",
    value: getDynamicDateRangeFromString("d_last_8_hours"),
    label: null
  },
```

<img width="255" alt="image" src="https://github.com/user-attachments/assets/b932fa49-157f-4317-979e-6963f29ac5f5" />


## Related Tickets & Documents
https://github.com/getredash/redash/issues/7418
