### PR TITLE
feat: Add search term highlighting in table results

### DIFF
--- a/viz-lib/src/visualizations/table/Renderer.tsx
+++ b/viz-lib/src/visualizations/table/Renderer.tsx
@@ -92,13 +92,19 @@ export default function Renderer({ options, data }: any) {
         // @ts-expect-error ts-migrate(2322) FIXME: Type '(event: any) => void' is not assignable to t... Remove this comment to see the full error message
         <SearchInput searchColumns={searchColumns} onChange={(event: any) => setSearchTerm(event.target.value)} />
       ) : null;
-    return prepareColumns(options.columns, searchInput, orderBy, (newOrderBy: any) => {
-      setOrderBy(newOrderBy);
-      // Remove text selection - may occur accidentally
-      // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-      document.getSelection().removeAllRanges();
-    });
-  }, [options.columns, searchColumns, orderBy]);
+    return prepareColumns(
+      options.columns,
+      searchInput,
+      orderBy,
+      (newOrderBy: any) => {
+          setOrderBy(newOrderBy);
+          // Remove text selection - may occur accidentally
+          // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+          document.getSelection().removeAllRanges();
+      },
+      searchTerm
+    );
+  }, [options.columns, searchColumns, orderBy, searchTerm]);
 
   const preparedRows = useMemo(() => sortRows(filterRows(initRows(data.rows), searchTerm, searchColumns), orderBy), [
     data.rows,


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
When viewing large datasets, it's difficult to quickly locate search matches. I've added text highlighting for better readability, which currently applies to all searchable columns. I propose making this highlighting feature configurable. Looking for feedback on implementing this as an optional setting.

## UI
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/33945126-5013-49fd-8811-4151450cf3d3" />
