### PR TITLE
Fix query create update json sanitize

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -348,6 +348,8 @@ class QueryResource(BaseResource):
                 "schedule",
                 "options",
                 "tags",
+                "version",
+                "latest_query_data_id",
             ),
         )
 

--- a/tests/handlers/test_queries.py
+++ b/tests/handlers/test_queries.py
@@ -81,7 +81,7 @@ class TestQueryResourcePost(BaseTestCase):
         owner = query.user
         owner_id = query.user.id
         query_id = query.id
-        data={"user_id": user.id, "name": "testing"}
+        data = {"user_id": user.id, "name": "testing"}
         db.session.expire_all()
         rv = self.make_request(
             "post",
@@ -99,18 +99,17 @@ class TestQueryResourcePost(BaseTestCase):
             "post",
             "/api/queries",
             data={"name": "Testing", "data_source_id": ds.id, "query": "test", "is_archived": True},
-            user=user
+            user=user,
         )
         self.assertEqual(rv.status_code, 200)
         self.assertNotEqual(rv.json["is_archived"], True)
 
     def test_pervents_update_query_skip_updated_at(self):
         query = self.factory.create_query()
-        user = self.factory.create_user()
         owner = query.user
         updated_at = query.updated_at
         query_id = query.id
-        data={"skip_updated_at": True}
+        data = {"skip_updated_at": True}
         db.session.expire_all()
         rv = self.make_request(
             "post",


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

The query `def post(self)` methods did not sanitize input correctly, any user with modify access can update query owner when `user_id` is set (bug present during update/create) also `updated_at` might be not updated when `skip_updated_at` is present and set to True. During update when `is_archived` is set to True, created query is both a draft and archived at the same time.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
