### PR TITLE
Fix: null is not shown for text with "Allow HTML content"

### DIFF
--- a/viz-lib/src/visualizations/table/columns/text.tsx
+++ b/viz-lib/src/visualizations/table/columns/text.tsx
@@ -52,7 +52,7 @@ export default function initTextColumn(column: any) {
   function TextColumn({ row }: any) {
     // eslint-disable-line react/prop-types
     const { text } = prepareData(row);
-    return column.allowHTML ? <HtmlContent>{text}</HtmlContent> : text;
+    return (column.allowHTML && typeof text === 'string') ? <HtmlContent>{text}</HtmlContent> : text;
   }
 
   TextColumn.prepareData = prepareData;


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
This PR fixes the issue that NULL value is not shown as "null" but shown as "[object Object]" for Text column with "Allow HTML content" checked.

## How is this tested?
- [x] Manually

1. Create a following query on QueryResult dataset, for example.

```sql
select null as col1, 'aa<b>bb</b>cc' as col2
```

2. Set Column type as Text(default), and check "Allow HTML content".

<img width="309" height="103" alt="image" src="https://github.com/user-attachments/assets/77d646d2-cb4a-46c7-94c7-c5cad73c7cd6" />


3. See the output for the NULL value.

Before this PR, NULL but is shown wrongly as "[object Object]".
<img width="252" height="146" alt="image" src="https://github.com/user-attachments/assets/e90e1c85-de5f-461b-94bc-e88caa1e7a3c" />



After this PR, NUL value is shown as "null" as intended.
<img width="210" height="127" alt="image" src="https://github.com/user-attachments/assets/c896923c-f93f-4bbd-9cef-e925a830e163" />

