### PR TITLE
fix: webpack missing source-map warning for @plotly/msgbox-gl

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,7 +151,10 @@ const config = {
         use: ["source-map-loader"],
         resolve: {
           fullySpecified: false
-        }
+        },
+        exclude: [
+          /node_modules\/@plotly\/mapbox-gl/,
+        ],
       },
       {
         test: /\.(t|j)sx?$/,


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
`yarn build` show following warning because of missing source-map for `@plotlyjs/msgbox-gl`.
This PR fixes the issue by excluding the package from source-map-loader.

```
WARNING in ./node_modules/@redash/viz/node_modules/@plotly/mapbox-gl/dist/mapbox-gl-unminified.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/tsuneo/work/redash/redash/node_modules/@redash/viz/node_modules/@plotly/mapbox-gl/dist/mapbox-gl-unminified.js.map' file: Error: ENOENT: no such file or directory, open '/Users/tsuneo/work/redash/redash/node_modules/@redash/viz/node_modules/@plotly/mapbox-gl/dist/mapbox-gl-unminified.js.map'
 @ ./node_modules/@redash/viz/node_modules/plotly.js/src/plots/mapbox/index.js 3:15-69
 @ ./node_modules/@redash/viz/node_modules/plotly.js/src/traces/scattermapbox/index.js 30:20-49
 @ ./node_modules/@redash/viz/node_modules/plotly.js/lib/scattermapbox.js 3:0-55
 @ ./node_modules/@redash/viz/node_modules/plotly.js/lib/index.js 37:4-30
 @ ./node_modules/@redash/viz/lib/visualizations/chart/plotly/index.js 49:37-57
 @ ./node_modules/@redash/viz/lib/visualizations/chart/Renderer/CustomPlotlyChart.js 11:14-34
 @ ./node_modules/@redash/viz/lib/visualizations/chart/Renderer/index.js 10:48-78
 @ ./node_modules/@redash/viz/lib/visualizations/chart/index.js 8:39-60
 @ ./node_modules/@redash/viz/lib/visualizations/registeredVisualizations.js 12:36-54
 @ ./node_modules/@redash/viz/lib/index.js 61:56-108
 @ ./client/app/config/index.js 11:0-25
 @ ./client/app/index.js 3:0-18

```

## How is this tested?

- [x] Manually

I run "yarn build", and confirmed that there is no warning.

