### PR TITLE
Fix/too many history replace state

### DIFF
--- a/client/app/services/location.js
+++ b/client/app/services/location.js
@@ -9,7 +9,7 @@ function normalizeLocation(rawLocation) {
   const result = {};
 
   result.path = pathname;
-  result.search = mapValues(qs.parse(search), value => (isNil(value) ? true : value));
+  result.search = mapValues(qs.parse(search), (value) => (isNil(value) ? true : value));
   result.hash = trimStart(hash, "#");
   result.url = `${pathname}${search}${hash}`;
 
@@ -27,7 +27,7 @@ const location = {
 
   confirmChange(handler) {
     if (isFunction(handler)) {
-      return history.block(nextLocation => {
+      return history.block((nextLocation) => {
         return handler(normalizeLocation(nextLocation), location);
       });
     } else {
@@ -60,12 +60,16 @@ const location = {
       // serialize search and keep existing search parameters (!)
       if (isObject(newLocation.search)) {
         newLocation.search = omitBy(extend({}, location.search, newLocation.search), isNil);
-        newLocation.search = mapValues(newLocation.search, value => (value === true ? null : value));
+        newLocation.search = mapValues(newLocation.search, (value) => (value === true ? null : value));
         newLocation.search = qs.stringify(newLocation.search);
       }
     }
     if (replace) {
-      if (newLocation.pathname !== location.path || newLocation.search !== qs.stringify(location.search) || newLocation.hash !== location.hash) {
+      if (
+        newLocation.pathname !== location.path ||
+        newLocation.search !== qs.stringify(location.search) ||
+        newLocation.hash !== location.hash
+      ) {
         history.replace(newLocation);
       }
     } else {


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

On Safari, when a dashboard have many widgets, following error occurs because history.replaceState() is called many times.

```
Attempt to use history.replaceState() more than 100 times per 10 seconds
```
<img width="1332" height="945" alt="スクリーンショット 2025-09-12 1 16 00" src="https://github.com/user-attachments/assets/e6fd488d-c8ea-4ce2-bf0f-7297228a2491" />



This PR fixes the issue by calling history.replaceState() only when the url is really changed.

## How is this tested?
- [x] Manually

