### PR TITLE
BigQuery: Remove "Job ID" metadata on annotaton to avoid cache misses

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -156,6 +156,11 @@ class BigQuery(BaseSQLQueryRunner):
             "secret": ["jsonKeyFile"],
         }
 
+    def annotate_query(self, query, metadata):
+        # Remove "Job ID" before annotating the query to avoid cache misses
+        metadata = {k: v for k, v in metadata.items() if k != "Job ID"}
+        return super().annotate_query(query, metadata)
+
     def _get_bigquery_service(self):
         socket.setdefaulttimeout(settings.BIGQUERY_HTTP_TIMEOUT)
 

--- a/tests/query_runner/test_bigquery.py
+++ b/tests/query_runner/test_bigquery.py
@@ -20,7 +20,7 @@ class TestBigQueryQueryRunner(unittest.TestCase):
         query = "SELECT a FROM tbl"
         expect = (
             "/* Username: username, query_id: adhoc, "
-            "Job ID: job-id, Query Hash: query-hash, "
+            "Query Hash: query-hash, "
             "Scheduled: False */ SELECT a FROM tbl"
         )
 


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## Description
On BigQuery datasource, when "Use Query Annotation" is enabled, BigQuery's query result cache does not owkr because the query sent to BigQuery is always different because the annotation have different "Job ID" on the each query.

This PR fixes the BigQuery caching issue by removing "Job ID" from the query annotation so that the query sent to BigQuery is always the same and the BigQuery cache hits.


## How is this tested?

- [x] Manually

I run the same query twice for the BigQuery data source with Use Query Annotation enabled, and I confirmed that the "data scanned" for the second query is zero.

