### PR TITLE
SchemaBrowser: on column comment tooltip, show newlines correctly

### DIFF
--- a/client/app/components/queries/SchemaBrowser.jsx
+++ b/client/app/components/queries/SchemaBrowser.jsx
@@ -90,6 +90,7 @@ function SchemaItem({ item, expanded, onToggle, onSelect, ...props }) {
                   mouseEnterDelay={0}
                   mouseLeaveDelay={0}
                   placement="rightTop"
+                  overlayStyle={{ whiteSpace: "pre-line" }}
                 >
                   <PlainButton
                     key={columnName}


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
On Schema Browser, column comment tooltiop for newlines are not shown as newlines.
This PR fixes the issue by adding "white-space: pre-line" style to the tooltiop.

## How is this tested?
- [x] Manually

