### PR TITLE
Use standard PostgreSQL image and drop clean-all target

### DIFF
--- a/.ci/compose.ci.yaml
+++ b/.ci/compose.ci.yaml
@@ -18,7 +18,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: pgautoupgrade/pgautoupgrade:latest
+    image: postgres:18-alpine
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
     environment:

--- a/.ci/compose.cypress.yaml
+++ b/.ci/compose.cypress.yaml
@@ -66,7 +66,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: pgautoupgrade/pgautoupgrade:latest
+    image: postgres:18-alpine
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
     environment:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compose_build up test_db create_database clean clean-all down tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
+.PHONY: compose_build up test_db create_database clean down tests lint backend-unit-tests frontend-unit-tests test build watch start redis-cli bash
 
 compose_build: .env
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose build
@@ -31,11 +31,6 @@ clean:
 	docker container prune --force
 	docker image prune --force
 	docker volume prune --force
-
-clean-all: clean
-	docker image rm --force \
-		redash/redash:latest redis:7-alpine maildev/maildev:latest \
-		pgautoupgrade/pgautoupgrade:15-alpine3.8 pgautoupgrade/pgautoupgrade:latest
 
 down:
 	docker compose down

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,7 +53,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
   postgres:
-    image: pgautoupgrade/pgautoupgrade:latest
+    image: postgres:18-alpine
     ports:
       - "15432:5432"
     # The following turns the DB into less durable, but gains significant performance improvements for the tests run (x3


### PR DESCRIPTION
## What type of PR is this? 

- [x] Other

## Description

Auto-upgrade of the database add unnecessary complication for a dev environment. This also solves a current problem with the pgautoupgrade image:

https://github.com/getredash/redash/actions/runs/18280518797/job/52042371707?pr=7532

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)