### PR TITLE
Correct custom chart help text: use newPlot()

### DIFF
--- a/viz-lib/src/visualizations/chart/Editor/CustomChartSettings.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/CustomChartSettings.tsx
@@ -6,7 +6,7 @@ import { EditorPropTypes } from "@/visualizations/prop-types";
 const defaultCustomCode = trimStart(`
 // Available variables are x, ys, element, and Plotly
 // Type console.log(x, ys); for more info about x and ys
-// To plot your graph call Plotly.plot(element, ...)
+// To plot your graph call Plotly.newPlot(element, ...)
 // Plotly examples and docs: https://plot.ly/javascript/
 `);
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

The Plotly JavaScript documentation shows `Plotly.newPlot` in all of the examples, but the incorrect comment in Redash will likely cause confusion.

## How is this tested?

- [x] Manually

<img width="506" height="803" alt="newplot" src="https://github.com/user-attachments/assets/c670d218-20a2-4601-867c-be64f962bc95" />
