### PR TITLE
Avoid updating latest_query_data_id while saving the query

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -229,6 +229,7 @@ class QueryListResource(BaseQueryListResource):
             "api_key",
             "visualizations",
             "latest_query_data",
+            "latest_query_data_id",
             "last_modified_by",
         ]:
             query_def.pop(field, None)
@@ -337,6 +338,7 @@ class QueryResource(BaseResource):
             "api_key",
             "visualizations",
             "latest_query_data",
+            "latest_query_data_id",
             "user",
             "last_modified_by",
             "org",


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
Before this PR, saving query always update latest_query_data_id sent from frontend. But, as the "latest_query_data_id" sent from frontend is not always correct. 
Especially, after executing the query, the "latest_query_data_id" on the backend is updated, but the one on the frontend is not updated. As a result, saving query after executing reverts the "latest_query_data_id" to the older one that frontend remember.

This is quite annoying as the clicking "Save" actually "revert the saved latest query result".

This PR fixes the issue by filtering out the latest_query_data_id parameter on the backend.

## How is this tested?

- [x] Manually

