### PR TITLE
Clear latest_query_data if queryResult.quey is differenct from query.query

### DIFF
--- a/client/app/pages/queries/hooks/useQueryExecute.js
+++ b/client/app/pages/queries/hooks/useQueryExecute.js
@@ -61,7 +61,7 @@ export default function useQueryExecute(query) {
       },
     });
 
-    const onStatusChange = status => {
+    const onStatusChange = (status) => {
       if (queryResultInExecution.current === newQueryResult) {
         setExecutionState({ updatedAt: newQueryResult.getUpdatedAt(), executionStatus: status });
       }
@@ -69,7 +69,7 @@ export default function useQueryExecute(query) {
 
     newQueryResult
       .toPromise(onStatusChange)
-      .then(queryResult => {
+      .then((queryResult) => {
         if (queryResultInExecution.current === newQueryResult) {
           // TODO: this should probably belong in the QueryEditor page.
           if (queryResult && queryResult.query_result.query === query.query) {
@@ -94,7 +94,7 @@ export default function useQueryExecute(query) {
           });
         }
       })
-      .catch(queryResult => {
+      .catch((queryResult) => {
         if (queryResultInExecution.current === newQueryResult) {
           if (executionState.loadedInitialResults) {
             notifications.showNotification("Redash", `${query.name} failed to run: ${queryResult.getError()}`);


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description
Saving query always updates `queries.latest_query_data_id` sent from frontend. But, as the "latest_query_data_id" sent from frontend is not always up to date.
The outdated latest_query_data_id happens when the query string on the frontend and the query string on the query_results table is different, for example by adding LIMIT or annotation, parameter, etc...
As a result, saving query after executing can revert the "latest_query_data_id" to the older one that frontend remember.

This is quite annoying as the clicking "Save" actually "revert the saved latest query result".

This PR fixes the issue by clearing the query.latest_query_data_id on the frontend when latest_query_data_id is not updated on the query execution so that frontend does not send the outdated latest_query_data_id to the backend.

Note that we need to set the`latest_query_data_id` not to `null` but to `undefined`, as sending `null` to backend set NULL value instead of ignoring the value.


## How is this tested?

- [x] Manually

