### PR TITLE
fix(destinations): Handle unicode characters in webhook notifications

### DIFF
--- a/tests/destinations/test_webhook.py
+++ b/tests/destinations/test_webhook.py
@@ -1,0 +1,50 @@
+import json
+from unittest import mock
+
+from redash.destinations.webhook import Webhook
+from redash.models import Alert
+
+
+def test_webhook_notify_handles_unicode():
+    # Create a mock alert with all the properties needed by serialize_alert
+    alert = mock.Mock()
+    alert.id = 1
+    alert.name = "Test Alert"
+    alert.custom_subject = "Test Subject With Unicode: 晨"
+    alert.custom_body = "Test Body"
+    alert.options = {}
+    alert.state = "ok"
+    alert.last_triggered_at = None
+    alert.updated_at = "2025-12-02T08:00:00Z"
+    alert.created_at = "2025-12-02T08:00:00Z"
+    alert.rearm = None
+    alert.query_id = 10
+    alert.user_id = 20
+
+    query = mock.Mock()
+    user = mock.Mock()
+    app = mock.Mock()
+    host = "http://redash.local"
+    options = {"url": "https://example.com/webhook", "username": "user", "password": "password"}
+    metadata = {}
+    new_state = Alert.TRIGGERED_STATE
+    destination = Webhook(options)
+
+    with mock.patch("redash.destinations.webhook.requests.post") as mock_post:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        destination.notify(alert, query, user, new_state, app, host, metadata, options)
+
+        # Get the data passed to the mock
+        call_args, call_kwargs = mock_post.call_args
+        sent_data = call_kwargs["data"]
+
+        # 1. Make sure we send bytes
+        assert isinstance(sent_data, bytes)
+
+        # 2. Make sure the bytes are the correct UTF-8 encoded JSON
+        decoded_data = json.loads(sent_data.decode("utf-8"))
+        assert decoded_data["alert"]["title"] == alert.custom_subject
+        assert "Test Subject With Unicode: 晨" in sent_data.decode("utf-8")

--- a/tests/handlers/test_destinations.py
+++ b/tests/handlers/test_destinations.py
@@ -7,7 +7,6 @@ from redash.destinations.datadog import Datadog
 from redash.destinations.discord import Discord
 from redash.destinations.slack import Slack
 from redash.destinations.webex import Webex
-from redash.destinations.webhook import Webhook
 from redash.models import Alert, NotificationDestination
 from tests import BaseTestCase
 
@@ -519,48 +518,3 @@ def test_datadog_notify_calls_requests_post():
         )
 
         assert mock_response.status_code == 202
-
-
-def test_webhook_notify_handles_unicode():
-    # Create a mock alert with all the properties needed by serialize_alert
-    alert = mock.Mock()
-    alert.id = 1
-    alert.name = "Test Alert"
-    alert.custom_subject = "Test Subject With Unicode: 晨"
-    alert.custom_body = "Test Body"
-    alert.options = {}
-    alert.state = "ok"
-    alert.last_triggered_at = None
-    alert.updated_at = "2025-12-02T08:00:00Z"
-    alert.created_at = "2025-12-02T08:00:00Z"
-    alert.rearm = None
-    alert.query_id = 10
-    alert.user_id = 20
-
-    query = mock.Mock()
-    user = mock.Mock()
-    app = mock.Mock()
-    host = "http://redash.local"
-    options = {"url": "https://example.com/webhook", "username": "user", "password": "password"}
-    metadata = {}
-    new_state = Alert.TRIGGERED_STATE
-    destination = Webhook(options)
-
-    with mock.patch("redash.destinations.webhook.requests.post") as mock_post:
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-        mock_post.return_value = mock_response
-
-        destination.notify(alert, query, user, new_state, app, host, metadata, options)
-
-        # Get the data passed to the mock
-        call_args, call_kwargs = mock_post.call_args
-        sent_data = call_kwargs["data"]
-
-        # 1. Make sure we send bytes
-        assert isinstance(sent_data, bytes)
-
-        # 2. Make sure the bytes are the correct UTF-8 encoded JSON
-        decoded_data = json.loads(sent_data.decode("utf-8"))
-        assert decoded_data["alert"]["title"] == alert.custom_subject
-        assert "Test Subject With Unicode: 晨" in sent_data.decode("utf-8")


### PR DESCRIPTION
Previously, webhook notifications would fail if they contained unicode characters in the alert data. This was because the JSON payload was not UTF-8 encoded before being sent.

This commit fixes the issue by explicitly encoding the JSON data to UTF-8 and adds a test to verify the fix.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
https://github.com/getredash/redash/issues/7468
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
