### PR TITLE
execute button shortcut: command+enter instead of mod+enter

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -297,7 +297,7 @@ function QuerySource(props) {
                       }
                       executeButtonProps={{
                         disabled: !queryFlags.canExecute || isQueryExecuting || areParametersDirty,
-                        shortcut: "mod+enter, alt+enter, ctrl+enter, shift+enter",
+                        shortcut: "command+enter, alt+enter, ctrl+enter, shift+enter",
                         onClick: doExecuteQuery,
                         text: (
                           <span className="hidden-xs">{selectedText === null ? "Execute" : "Execute Selected"}</span>

--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -47,8 +47,8 @@ import "./components/QuerySourceDropdown"; // register QuerySourceDropdown
 import "./QuerySource.less";
 
 function chooseDataSourceId(dataSourceIds, availableDataSources) {
-  availableDataSources = map(availableDataSources, ds => ds.id);
-  return find(dataSourceIds, id => includes(availableDataSources, id)) || null;
+  availableDataSources = map(availableDataSources, (ds) => ds.id);
+  return find(dataSourceIds, (id) => includes(availableDataSources, id)) || null;
 }
 
 function QuerySource(props) {
@@ -81,7 +81,7 @@ function QuerySource(props) {
   const [autocompleteAvailable, autocompleteEnabled, toggleAutocomplete] = useAutocompleteFlags(schema);
   const [autoLimitAvailable, autoLimitChecked, setAutoLimit] = useAutoLimitFlags(dataSource, query, setQuery);
 
-  const [handleQueryEditorChange] = useDebouncedCallback(queryText => {
+  const [handleQueryEditorChange] = useDebouncedCallback((queryText) => {
     setQuery(extend(query.clone(), { query: queryText }));
   }, 100);
 
@@ -108,7 +108,7 @@ function QuerySource(props) {
   };
 
   const handleDataSourceChange = useCallback(
-    dataSourceId => {
+    (dataSourceId) => {
       if (dataSourceId) {
         try {
           localStorage.setItem("lastSelectedDataSourceId", dataSourceId);
@@ -151,7 +151,7 @@ function QuerySource(props) {
     setQuery(newQuery);
   });
 
-  const handleSchemaItemSelect = useCallback(schemaItem => {
+  const handleSchemaItemSelect = useCallback((schemaItem) => {
     if (editorRef.current) {
       editorRef.current.paste(schemaItem);
     }
@@ -188,7 +188,7 @@ function QuerySource(props) {
     setQuery(newQuery);
     setSelectedVisualization(visualization.id);
   });
-  const editVisualization = useEditVisualizationDialog(query, queryResult, newQuery => setQuery(newQuery));
+  const editVisualization = useEditVisualizationDialog(query, queryResult, (newQuery) => setQuery(newQuery));
   const deleteVisualization = useDeleteVisualization(query, setQuery);
 
   return (
@@ -223,7 +223,7 @@ function QuerySource(props) {
               <SchemaBrowser
                 dataSource={dataSource}
                 options={query.options.schemaOptions}
-                onOptionsUpdate={schemaOptions =>
+                onOptionsUpdate={(schemaOptions) =>
                   setQuery(extend(query.clone(), { options: { ...query.options, schemaOptions } }))
                 }
                 onSchemaUpdate={setSchema}
@@ -253,7 +253,8 @@ function QuerySource(props) {
           <div className="flex-fill p-relative">
             <div
               className="p-absolute d-flex flex-column p-l-15 p-r-15"
-              style={{ left: 0, top: 0, right: 0, bottom: 0, overflow: "auto" }}>
+              style={{ left: 0, top: 0, right: 0, bottom: 0, overflow: "auto" }}
+            >
               <Resizable direction="vertical" sizeAttribute="flex-basis">
                 <div className="row editor">
                   <section className="query-editor-wrapper" data-test="QueryEditor">
@@ -319,7 +320,7 @@ function QuerySource(props) {
                               disabled: !queryFlags.canEdit,
                               value: dataSource.id,
                               onChange: handleDataSourceChange,
-                              options: map(dataSources, ds => ({ value: ds.id, label: ds.name })),
+                              options: map(dataSources, (ds) => ({ value: ds.id, label: ds.name })),
                             }
                           : false
                       }
@@ -391,7 +392,8 @@ function QuerySource(props) {
                           type="primary"
                           disabled={!queryFlags.canExecute || areParametersDirty}
                           loading={isQueryExecuting}
-                          onClick={doExecuteQuery}>
+                          onClick={doExecuteQuery}
+                        >
                           {!isQueryExecuting && <i className="zmdi zmdi-refresh m-r-5" aria-hidden="true" />}
                           Refresh Now
                         </Button>
@@ -430,7 +432,7 @@ routes.register(
   "Queries.New",
   routeWithUserSession({
     path: "/queries/new",
-    render: pageProps => <QuerySourcePage {...pageProps} />,
+    render: (pageProps) => <QuerySourcePage {...pageProps} />,
     bodyClass: "fixed-layout",
   })
 );
@@ -438,7 +440,7 @@ routes.register(
   "Queries.Edit",
   routeWithUserSession({
     path: "/queries/:queryId/source",
-    render: pageProps => <QuerySourcePage {...pageProps} />,
+    render: (pageProps) => <QuerySourcePage {...pageProps} />,
     bodyClass: "fixed-layout",
   })
 );

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -71,7 +71,7 @@ function QueryView(props) {
     setQuery(newQuery);
     setSelectedVisualization(visualization.id);
   });
-  const editVisualization = useEditVisualizationDialog(query, queryResult, newQuery => setQuery(newQuery));
+  const editVisualization = useEditVisualizationDialog(query, queryResult, (newQuery) => setQuery(newQuery));
   const deleteVisualization = useDeleteVisualization(query, setQuery);
 
   const doExecuteQuery = useCallback(
@@ -97,7 +97,8 @@ function QueryView(props) {
       className={cx("query-page-wrapper", {
         "query-view-fullscreen": fullscreen,
         "query-fixed-layout": isFixedLayout,
-      })}>
+      })}
+    >
       <div className="container w-100">
         <QueryPageHeader
           query={query}
@@ -112,7 +113,8 @@ function QueryView(props) {
                   type="primary"
                   shortcut="command+enter, alt+enter, ctrl+enter"
                   disabled={!queryFlags.canExecute || isExecuting || areParametersDirty}
-                  onClick={doExecuteQuery}>
+                  onClick={doExecuteQuery}
+                >
                   Refresh
                 </QueryViewButton>
               )}
@@ -177,7 +179,8 @@ function QueryView(props) {
                     type="primary"
                     disabled={!queryFlags.canExecute || areParametersDirty}
                     loading={isExecuting}
-                    onClick={doExecuteQuery}>
+                    onClick={doExecuteQuery}
+                  >
                     {!isExecuting && <i className="zmdi zmdi-refresh m-r-5" aria-hidden="true" />}
                     Refresh Now
                   </Button>
@@ -201,7 +204,8 @@ function QueryView(props) {
                     title="Toggle Fullscreen"
                     type="default"
                     shortcut="alt+f"
-                    onClick={toggleFullscreen}>
+                    onClick={toggleFullscreen}
+                  >
                     {fullscreen ? <FullscreenExitOutlinedIcon /> : <FullscreenOutlinedIcon />}
                   </QueryViewButton>
                 }
@@ -236,6 +240,6 @@ routes.register(
   "Queries.View",
   routeWithUserSession({
     path: "/queries/:queryId",
-    render: pageProps => <QueryViewPage {...pageProps} />,
+    render: (pageProps) => <QueryViewPage {...pageProps} />,
   })
 );

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -110,7 +110,7 @@ function QueryView(props) {
                 <QueryViewButton
                   className="m-r-5"
                   type="primary"
-                  shortcut="mod+enter, alt+enter, ctrl+enter"
+                  shortcut="command+enter, alt+enter, ctrl+enter"
                   disabled={!queryFlags.canExecute || isExecuting || areParametersDirty}
                   onClick={doExecuteQuery}>
                   Refresh


### PR DESCRIPTION
## What type of PR is this? 
On Windows, when ctrl-enter shortcut is used to execute the query, API is called twice. This happens because ctrl-enter handler is registered twice on Windows where mod+enter is mapped to ctrl+enter that is already exists.
This PR fixed the issue by using command+enter instead of mod+enter.

Related PR: https://github.com/getredash/redash/pull/7592

- [x] Bug Fix

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Manually

I tested on Mac that the query was run using command-enter, ctrl-enter, alt-enter, shift-enter.
(I haven't tested on Windows.)

<img width="187" height="107" alt="image" src="https://github.com/user-attachments/assets/b5b60840-b567-46c2-a324-69e8dc579324" />

