### PR TITLE
Mattermost: Fix UnicodeEncodeError for non-latin characters

### DIFF
--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -44,7 +44,7 @@ class Mattermost(BaseDestination):
             payload["channel"] = options.get("channel")
 
         try:
-            resp = requests.post(options.get("url"), data=json_dumps(payload), timeout=5.0)
+            resp = requests.post(options.get("url"), data=json_dumps(payload).encode("utf-8"), timeout=5.0)
             logging.warning(resp.text)
 
             if resp.status_code != 200:


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

This PR fixes an error that occurs when Redash tries to send a Mattermost notification that contains non-latin characters.

```
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 116-119: 
Body ('📉📊📈🚀') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Rebuilt the Docker image and ran the app locally.

## Related Tickets & Documents

- Similar issue for Slack destination: #6710