### PR TITLE
Update mssql.py to use QUOTENAME in schema query

### DIFF
--- a/redash/query_runner/mssql.py
+++ b/redash/query_runner/mssql.py
@@ -77,7 +77,7 @@ class SqlServer(BaseSQLQueryRunner):
 
     def _get_tables(self, schema):
         query = """
-        SELECT table_schema, table_name, column_name
+        SELECT QUOTENAME(table_schema) AS table_schema, QUOTENAME(table_name) AS table_name, QUOTENAME(column_name) AS column_name
         FROM INFORMATION_SCHEMA.COLUMNS
         WHERE table_schema NOT IN ('guest','INFORMATION_SCHEMA','sys','db_owner','db_accessadmin'
                                   ,'db_securityadmin','db_ddladmin','db_backupoperator','db_datareader'


### PR DESCRIPTION
QUOTENAME adds [] around the values and handles eg. () in table names etc.  With this addition table names will be correct for queries SELECT * FROM [data base 1].[dbo 2].[table name 3]  will work

But the current 
SELECT * FROM data base 1.dbo 2.table name 3
does not, the spaces lead to error in query

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
SQL query with old and new version, on MS SQL 2022 server

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
I probably have suggested a change to this earlier. The issue has not gone away and QUOTENAME is probable the best solution for this; should work from MS SQL 1996 and up.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
