### PR TITLE
Update mssql_odbc.py schema query to use QUOTENAME

### DIFF
--- a/redash/query_runner/mssql_odbc.py
+++ b/redash/query_runner/mssql_odbc.py
@@ -84,7 +84,7 @@ class SQLServerODBC(BaseSQLQueryRunner):
 
     def _get_tables(self, schema):
         query = """
-        SELECT table_schema, table_name, column_name
+        SELECT QUOTENAME(table_schema) AS table_schema, QUOTENAME(table_name) AS table_name, QUOTENAME(column_name) AS column_name
         FROM INFORMATION_SCHEMA.COLUMNS
         WHERE table_schema NOT IN ('guest','INFORMATION_SCHEMA','sys','db_owner','db_accessadmin'
                                   ,'db_securityadmin','db_ddladmin','db_backupoperator','db_datareader'


### PR DESCRIPTION
QUOTENAME will add [] around the values and this will lead to correctly handling database names, schema names and table names with spaces and other SQL syntax problematic characters.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
SQL query in MS SQL 2022 server with previous and new query

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->
Other pull about mssql.py about the same thing.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
