### PR TITLE
Fix Trino parameterized type mapping

### DIFF
--- a/redash/query_runner/trino.py
+++ b/redash/query_runner/trino.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 from redash.models.users import ApiUser, User
 from redash.query_runner import (
@@ -62,16 +63,28 @@ TRINO_TYPES_MAPPING = {
 }
 
 
+_DECIMAL_SCALE_RE = re.compile(r"^decimal\(\d+,\s*(\d+)\)$")
+
+
 def _map_trino_type(type_name):
     """Map a Trino type name to a Redash column type.
 
     Handles parameterised types such as ``timestamp(3)`` or ``decimal(10,2)``
     by falling back to the base type when an exact match is not found.
     """
+    if not type_name:
+        return None
     mapped = TRINO_TYPES_MAPPING.get(type_name)
-    if mapped is None and type_name and "(" in type_name:
-        base = type_name.split("(", 1)[0]
-        mapped = TRINO_TYPES_MAPPING.get(base)
+    if mapped is not None:
+        return mapped
+    # Strip parameters: "timestamp(3)" -> "timestamp"
+    base = type_name.split("(", 1)[0]
+    mapped = TRINO_TYPES_MAPPING.get(base)
+    # decimal(p, s) with s > 0 has fractional digits
+    if base == "decimal":
+        m = _DECIMAL_SCALE_RE.match(type_name)
+        if m and int(m.group(1)) > 0:
+            mapped = TYPE_FLOAT
     return mapped
 
 

--- a/tests/query_runner/test_trino.py
+++ b/tests/query_runner/test_trino.py
@@ -110,10 +110,13 @@ class TestMapTrinoType(TestCase):
         self.assertEqual(_map_trino_type("timestamp(3)"), "datetime")
         self.assertEqual(_map_trino_type("timestamp(6)"), "datetime")
 
-    def test_parameterised_decimal(self):
-        # NOTE: upstream TRINO_TYPES_MAPPING maps "decimal" to TYPE_INTEGER,
-        # even though decimal(p,s) with s>0 would be better served by TYPE_FLOAT.
-        self.assertEqual(_map_trino_type("decimal(10,2)"), "integer")
+    def test_parameterised_decimal_with_scale(self):
+        self.assertEqual(_map_trino_type("decimal(10,2)"), "float")
+        self.assertEqual(_map_trino_type("decimal(18,6)"), "float")
+
+    def test_parameterised_decimal_without_scale(self):
+        self.assertEqual(_map_trino_type("decimal(10,0)"), "integer")
+        self.assertEqual(_map_trino_type("decimal"), "integer")
 
     def test_parameterised_varchar(self):
         self.assertEqual(_map_trino_type("varchar(255)"), "string")


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
Close: #7661

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
Trino columns with parameterized types such as timestamp(0), timestamp(3), decimal(10,2), varchar(255), etc. are not correctly mapped to Redash column types. This causes timestamp columns to be displayed as epoch milliseconds in the UI when the result set contains NULL values.


## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

The type determination for lines containing null is performed correctly.
<img width="1796" height="693" alt="スクリーンショット 2026-03-13 115906" src="https://github.com/user-attachments/assets/7ebe45f3-137b-4974-8e93-de22b3a1f0ae" />

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
