### PR TITLE
Add configurable tag sorting option (by name or usage count)

### DIFF
--- a/client/app/pages/settings/components/GeneralSettings/FeatureFlagsSettings.jsx
+++ b/client/app/pages/settings/components/GeneralSettings/FeatureFlagsSettings.jsx
@@ -15,7 +15,7 @@ export default function FeatureFlagsSettings(props) {
         {loading ? (
           <>
             <Row>
-              <Skeleton title={false} paragraph={{ width: [300, 300, 300], rows: 3 }} active />
+              <Skeleton title={false} paragraph={{ width: [300, 300, 300], rows: 4 }} active />
             </Row>
           </>
         ) : (
@@ -25,7 +25,8 @@ export default function FeatureFlagsSettings(props) {
                 <Checkbox
                   name="feature_show_permissions_control"
                   checked={values.feature_show_permissions_control}
-                  onChange={e => onChange({ feature_show_permissions_control: e.target.checked })}>
+                  onChange={(e) => onChange({ feature_show_permissions_control: e.target.checked })}
+                >
                   Enable experimental multiple owners support
                 </Checkbox>
               </Row>
@@ -34,7 +35,8 @@ export default function FeatureFlagsSettings(props) {
               <Checkbox
                 name="send_email_on_failed_scheduled_queries"
                 checked={values.send_email_on_failed_scheduled_queries}
-                onChange={e => onChange({ send_email_on_failed_scheduled_queries: e.target.checked })}>
+                onChange={(e) => onChange({ send_email_on_failed_scheduled_queries: e.target.checked })}
+              >
                 Email query owners when scheduled queries fail
               </Checkbox>
             </Row>
@@ -42,8 +44,18 @@ export default function FeatureFlagsSettings(props) {
               <Checkbox
                 name="multi_byte_search_enabled"
                 checked={values.multi_byte_search_enabled}
-                onChange={e => onChange({ multi_byte_search_enabled: e.target.checked })}>
+                onChange={(e) => onChange({ multi_byte_search_enabled: e.target.checked })}
+              >
                 Enable multi-byte (Chinese, Japanese, and Korean) search for query names and descriptions (slower)
+              </Checkbox>
+            </Row>
+            <Row>
+              <Checkbox
+                name="tags_sort_by"
+                checked={values.tags_sort_by === "count"}
+                onChange={(e) => onChange({ tags_sort_by: e.target.checked ? "count" : "name" })}
+              >
+                Sort tags by usage count (default: alphabetical)
               </Checkbox>
             </Row>
           </>

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -356,7 +356,11 @@ class DashboardTagsResource(BaseResource):
         """
         Lists all accessible dashboards.
         """
-        tags = models.Dashboard.all_tags(self.current_org, self.current_user)
+        tags = models.Dashboard.all_tags(
+            self.current_org,
+            self.current_user,
+            sort_by=self.current_org.get_setting("tags_sort_by"),
+        )
         return {"tags": [{"name": name, "count": count} for name, count in tags]}
 
 

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -474,7 +474,11 @@ class QueryTagsResource(BaseResource):
         """
         Returns all query tags including those for drafts.
         """
-        tags = models.Query.all_tags(self.current_user, include_drafts=True)
+        tags = models.Query.all_tags(
+            self.current_user,
+            include_drafts=True,
+            sort_by=current_org.get_setting("tags_sort_by"),
+        )
         return {"tags": [{"name": name, "count": count} for name, count in tags]}
 
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -555,17 +555,19 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         ).filter(Favorite.user_id == user.id)
 
     @classmethod
-    def all_tags(cls, user, include_drafts=False):
+    def all_tags(cls, user, include_drafts=False, sort_by="name"):
         queries = cls.all_queries(group_ids=user.group_ids, user_id=user.id, include_drafts=include_drafts)
 
         tag_column = func.unnest(cls.tags).label("tag")
         usage_count = func.count(1).label("usage_count")
 
+        order = tag_column.asc() if sort_by == "name" else usage_count.desc()
+
         query = (
             db.session.query(tag_column, usage_count)
             .group_by(tag_column)
             .filter(Query.id.in_(queries.options(load_only("id"))))
-            .order_by(tag_column)
+            .order_by(order)
         )
         return query
 
@@ -1171,17 +1173,19 @@ class Dashboard(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model
         return cls.by_user(user).filter(cls.name.ilike("%{}%".format(term))).limit(limit)
 
     @classmethod
-    def all_tags(cls, org, user):
+    def all_tags(cls, org, user, sort_by="name"):
         dashboards = cls.all(org, user.group_ids, user.id)
 
         tag_column = func.unnest(cls.tags).label("tag")
         usage_count = func.count(1).label("usage_count")
 
+        order = tag_column.asc() if sort_by == "name" else usage_count.desc()
+
         query = (
             db.session.query(tag_column, usage_count)
             .group_by(tag_column)
             .filter(Dashboard.id.in_(dashboards.options(load_only("id"))))
-            .order_by(tag_column)
+            .order_by(order)
         )
         return query
 

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -29,6 +29,7 @@ INTEGER_FORMAT = os.environ.get("REDASH_INTEGER_FORMAT", "0,0")
 FLOAT_FORMAT = os.environ.get("REDASH_FLOAT_FORMAT", "0,0.00")
 NULL_VALUE = os.environ.get("REDASH_NULL_VALUE", "null")
 MULTI_BYTE_SEARCH_ENABLED = parse_boolean(os.environ.get("MULTI_BYTE_SEARCH_ENABLED", "false"))
+TAGS_SORT_BY = os.environ.get("REDASH_TAGS_SORT_BY", "name")
 
 JWT_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_JWT_LOGIN_ENABLED", "false"))
 JWT_AUTH_ISSUER = os.environ.get("REDASH_JWT_AUTH_ISSUER", "")
@@ -62,6 +63,7 @@ settings = {
     "float_format": FLOAT_FORMAT,
     "null_value": NULL_VALUE,
     "multi_byte_search_enabled": MULTI_BYTE_SEARCH_ENABLED,
+    "tags_sort_by": TAGS_SORT_BY,
     "auth_jwt_login_enabled": JWT_LOGIN_ENABLED,
     "auth_jwt_auth_issuer": JWT_AUTH_ISSUER,
     "auth_jwt_auth_public_certs_url": JWT_AUTH_PUBLIC_CERTS_URL,


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

As a result of #7484, tags are now sorted by name (previously by usage count)

However, some users prefer the previous behavior of sorting by usage count.

This PR adds an organization-level setting to configure tag sorting order, accessible via General Settings > Feature Flags.

To respect the intent of #7484, the default sorting order remains alphabetical by name. Only when explicitly enabled in Feature Flags will tags be sorted by usage count.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="935" height="553" alt="스크린샷 2026-03-13 오전 9 24 25" src="https://github.com/user-attachments/assets/bdfdbaf0-1832-448f-84b8-76b1a0d49187" />


<img width="329" height="594" alt="스크린샷 2026-03-13 오전 9 24 49" src="https://github.com/user-attachments/assets/d9bb9c32-c440-489a-9337-647a99b77b29" />
