### PR TITLE
Add admin-managed custom choropleth maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .venv
 venv/
+.pr-assets/
 .cache
 .coverage.*
 .coveralls.yml

--- a/client/app/components/visualizations/visualizationComponents.jsx
+++ b/client/app/components/visualizations/visualizationComponents.jsx
@@ -1,59 +1,89 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { pick } from "lodash";
 import HelpTrigger from "@/components/HelpTrigger";
 import Link from "@/components/Link";
 import { Renderer as VisRenderer, Editor as VisEditor, updateVisualizationsSettings } from "@redash/viz/lib";
 import { clientConfig } from "@/services/auth";
+import CustomMap from "@/services/custom-map";
 
 import countriesDataUrl from "@redash/viz/lib/visualizations/choropleth/maps/countries.geo.json";
 import usaDataUrl from "@redash/viz/lib/visualizations/choropleth/maps/usa-albers.geo.json";
 import subdivJapanDataUrl from "@redash/viz/lib/visualizations/choropleth/maps/japan.prefectures.geo.json";
 
+const builtInMaps = {
+  countries: {
+    name: "Countries",
+    url: countriesDataUrl,
+    fieldNames: {
+      name: "Short name",
+      name_long: "Full name",
+      abbrev: "Abbreviated name",
+      iso_a2: "ISO code (2 letters)",
+      iso_a3: "ISO code (3 letters)",
+      iso_n3: "ISO code (3 digits)",
+    },
+  },
+  usa: {
+    name: "USA",
+    url: usaDataUrl,
+    fieldNames: {
+      name: "Name",
+      ns_code: "National Standard ANSI Code (8-character)",
+      geoid: "Geographic ID",
+      usps_abbrev: "USPS Abbreviation",
+      fips_code: "FIPS Code (2-character)",
+    },
+  },
+  subdiv_japan: {
+    name: "Japan/Prefectures",
+    url: subdivJapanDataUrl,
+    fieldNames: {
+      name: "Name",
+      name_alt: "Name (alternative)",
+      name_local: "Name (local)",
+      iso_3166_2: "ISO-3166-2",
+      postal: "Postal Code",
+      type: "Type",
+      type_en: "Type (EN)",
+      region: "Region",
+      region_code: "Region Code",
+    },
+  },
+};
+
+let customMapsRequested = false;
+let customMapsResolved = false;
+
+function loadCustomMaps() {
+  if (customMapsRequested) return;
+  customMapsRequested = true;
+
+  CustomMap.query().then((maps) => {
+    const customMaps = {};
+    maps.forEach((m) => {
+      customMaps[`custom_map_${m.id}`] = {
+        name: m.name,
+        url: `/api/custom_maps/${m.id}/geojson`,
+      };
+    });
+    customMapsResolved = true;
+    updateVisualizationsSettings({
+      choroplethAvailableMaps: { ...builtInMaps, ...customMaps },
+    });
+  }).catch(() => {
+    customMapsRequested = false; // allow retry on next render
+  });
+}
+
 function wrapComponentWithSettings(WrappedComponent) {
   return function VisualizationComponent(props) {
-    updateVisualizationsSettings({
+    useEffect(() => {
+      loadCustomMaps();
+    }, []);
+
+    const settings = {
       HelpTriggerComponent: HelpTrigger,
       LinkComponent: Link,
-      choroplethAvailableMaps: {
-        countries: {
-          name: "Countries",
-          url: countriesDataUrl,
-          fieldNames: {
-            name: "Short name",
-            name_long: "Full name",
-            abbrev: "Abbreviated name",
-            iso_a2: "ISO code (2 letters)",
-            iso_a3: "ISO code (3 letters)",
-            iso_n3: "ISO code (3 digits)",
-          },
-        },
-        usa: {
-          name: "USA",
-          url: usaDataUrl,
-          fieldNames: {
-            name: "Name",
-            ns_code: "National Standard ANSI Code (8-character)",
-            geoid: "Geographic ID",
-            usps_abbrev: "USPS Abbreviation",
-            fips_code: "FIPS Code (2-character)",
-          },
-        },
-        subdiv_japan: {
-          name: "Japan/Prefectures",
-          url: subdivJapanDataUrl,
-          fieldNames: {
-            name: "Name",
-            name_alt: "Name (alternative)",
-            name_local: "Name (local)",
-            iso_3166_2: "ISO-3166-2",
-            postal: "Postal Code",
-            type: "Type",
-            type_en: "Type (EN)",
-            region: "Region",
-            region_code: "Region Code",
-          },
-        },
-      },
       ...pick(clientConfig, [
         "dateFormat",
         "dateTimeFormat",
@@ -65,7 +95,15 @@ function wrapComponentWithSettings(WrappedComponent) {
         "allowCustomJSVisualizations",
         "hidePlotlyModeBar",
       ]),
-    });
+    };
+
+    // Only set builtInMaps if custom maps haven't resolved yet,
+    // otherwise we'd overwrite the merged map list on every render.
+    if (!customMapsResolved) {
+      settings.choroplethAvailableMaps = builtInMaps;
+    }
+
+    updateVisualizationsSettings(settings);
 
     return <WrappedComponent {...props} />;
   };

--- a/client/app/pages/custom-maps/CustomMapDialog.jsx
+++ b/client/app/pages/custom-maps/CustomMapDialog.jsx
@@ -1,0 +1,127 @@
+import { get } from "lodash";
+import React, { useCallback, useState } from "react";
+import PropTypes from "prop-types";
+import Button from "antd/lib/button";
+import Modal from "antd/lib/modal";
+import Form from "antd/lib/form";
+import Input from "antd/lib/input";
+import Upload from "antd/lib/upload";
+import UploadOutlined from "@ant-design/icons/UploadOutlined";
+import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
+
+function CustomMapDialog({ customMap, dialog, readOnly }) {
+  const isEditing = !!get(customMap, "id");
+  const [name, setName] = useState(get(customMap, "name", ""));
+  const [geojson, setGeojson] = useState(null);
+  const [fileName, setFileName] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleFileSelect = useCallback((file) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setGeojson(e.target.result);
+      setFileName(file.name);
+      setError(null);
+    };
+    reader.readAsText(file);
+    return false; // prevent default upload
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+
+    if (!isEditing && !geojson) {
+      setError("Please select a GeoJSON file.");
+      return;
+    }
+
+    setSubmitting(true);
+    const customMapId = get(customMap, "id");
+    const values = { name: name.trim() };
+    if (geojson) {
+      values.geojson = geojson;
+    }
+
+    dialog
+      .close(customMapId ? { id: customMapId, ...values } : values)
+      .then(() => setSubmitting(false))
+      .catch((err) => {
+        setSubmitting(false);
+        setError(get(err, "response.data.message", "Failed saving custom map."));
+      });
+  }, [dialog, customMap, name, geojson, isEditing]);
+
+  return (
+    <Modal
+      {...dialog.props}
+      title={isEditing ? customMap.name : "Create Custom Map"}
+      footer={[
+        <Button key="cancel" {...dialog.props.cancelButtonProps} onClick={dialog.dismiss}>
+          {readOnly ? "Close" : "Cancel"}
+        </Button>,
+        !readOnly && (
+          <Button
+            key="submit"
+            {...dialog.props.okButtonProps}
+            disabled={readOnly || submitting || dialog.props.okButtonProps.disabled}
+            onClick={handleSubmit}
+            type="primary"
+            loading={submitting}
+            data-test="SaveCustomMapButton"
+          >
+            {isEditing ? "Save" : "Create"}
+          </Button>
+        ),
+      ]}
+      wrapProps={{
+        "data-test": "CustomMapDialog",
+      }}
+    >
+      <Form layout="vertical">
+        <Form.Item label="Name" required>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={readOnly}
+            autoFocus={!isEditing}
+            data-test="CustomMapName"
+          />
+        </Form.Item>
+        <Form.Item label="GeoJSON File" required={!isEditing}>
+          <Upload
+            accept=".geojson,.json"
+            beforeUpload={handleFileSelect}
+            showUploadList={false}
+            disabled={readOnly}
+          >
+            <Button icon={<UploadOutlined />} disabled={readOnly} data-test="CustomMapFileUpload">
+              {fileName || "Select File"}
+            </Button>
+          </Upload>
+          {fileName && <span className="m-l-10">{fileName}</span>}
+          {isEditing && !fileName && (
+            <span className="text-muted m-l-10">Leave empty to keep current map data.</span>
+          )}
+        </Form.Item>
+        {error && <div className="text-danger">{error}</div>}
+      </Form>
+    </Modal>
+  );
+}
+
+CustomMapDialog.propTypes = {
+  dialog: DialogPropType.isRequired,
+  customMap: PropTypes.object,
+  readOnly: PropTypes.bool,
+};
+
+CustomMapDialog.defaultProps = {
+  customMap: null,
+  readOnly: false,
+};
+
+export default wrapDialog(CustomMapDialog);

--- a/client/app/pages/custom-maps/CustomMapsList.jsx
+++ b/client/app/pages/custom-maps/CustomMapsList.jsx
@@ -1,0 +1,215 @@
+import { get } from "lodash";
+import React from "react";
+
+import Button from "antd/lib/button";
+import Modal from "antd/lib/modal";
+import routeWithUserSession from "@/components/ApplicationArea/routeWithUserSession";
+import navigateTo from "@/components/ApplicationArea/navigateTo";
+import Paginator from "@/components/Paginator";
+import CustomMapDialog from "@/pages/custom-maps/CustomMapDialog";
+
+import { wrap as itemsList, ControllerType } from "@/components/items-list/ItemsList";
+import { ResourceItemsSource } from "@/components/items-list/classes/ItemsSource";
+import { StateStorage } from "@/components/items-list/classes/StateStorage";
+
+import LoadingState from "@/components/items-list/components/LoadingState";
+import ItemsTable, { Columns } from "@/components/items-list/components/ItemsTable";
+import wrapSettingsTab from "@/components/SettingsWrapper";
+import PlainButton from "@/components/PlainButton";
+
+import CustomMap from "@/services/custom-map";
+import { currentUser } from "@/services/auth";
+import notification from "@/services/notification";
+import routes from "@/services/routes";
+
+class CustomMapsList extends React.Component {
+  static propTypes = {
+    controller: ControllerType.isRequired,
+  };
+
+  listColumns = [
+    Columns.custom.sortable(
+      (text, customMap) => (
+        <PlainButton type="link" className="table-main-title" onClick={() => this.showMapDialog(customMap)}>
+          {customMap.name}
+        </PlainButton>
+      ),
+      {
+        title: "Name",
+        field: "name",
+        className: "text-nowrap",
+      }
+    ),
+    Columns.avatar({ field: "user", className: "p-l-0 p-r-0" }, (name) => `Created by ${name}`),
+    Columns.date.sortable({
+      title: "Created At",
+      field: "created_at",
+      className: "text-nowrap",
+      width: "1%",
+    }),
+    Columns.custom(
+      (text, customMap) =>
+        currentUser.isAdmin && (
+          <Button type="danger" className="w-100" onClick={(e) => this.deleteCustomMap(e, customMap)}>
+            Delete
+          </Button>
+        ),
+      {
+        width: "1%",
+      }
+    ),
+  ];
+
+  componentDidMount() {
+    const { isNewOrEditPage, customMapId } = this.props.controller.params;
+
+    if (isNewOrEditPage) {
+      if (customMapId === "new") {
+        if (currentUser.isAdmin) {
+          this.showMapDialog();
+        } else {
+          navigateTo("custom_maps", true);
+        }
+      } else {
+        CustomMap.get({ id: customMapId })
+          .then(this.showMapDialog)
+          .catch((error) => {
+            this.props.controller.handleError(error);
+          });
+      }
+    }
+  }
+
+  saveCustomMap = (customMap) => {
+    const saveFn = customMap.id ? CustomMap.save : CustomMap.create;
+    return saveFn(customMap);
+  };
+
+  deleteCustomMap = (event, customMap) => {
+    Modal.confirm({
+      title: "Delete Custom Map",
+      content: "Are you sure you want to delete this custom map?",
+      okText: "Yes",
+      okType: "danger",
+      cancelText: "No",
+      onOk: () => {
+        CustomMap.delete(customMap)
+          .then(() => {
+            notification.success("Custom map deleted successfully.");
+            this.props.controller.update();
+          })
+          .catch(() => {
+            notification.error("Failed deleting custom map.");
+          });
+      },
+    });
+  };
+
+  showMapDialog = (customMap = null) => {
+    const canSave = !customMap || currentUser.isAdmin;
+    navigateTo("custom_maps/" + get(customMap, "id", "new"), true);
+    const goToMapsList = () => navigateTo("custom_maps", true);
+    CustomMapDialog.showModal({
+      customMap,
+      readOnly: !canSave,
+    })
+      .onClose((customMap) =>
+        this.saveCustomMap(customMap).then(() => {
+          this.props.controller.update();
+          goToMapsList();
+        })
+      )
+      .onDismiss(goToMapsList);
+  };
+
+  render() {
+    const { controller } = this.props;
+
+    return (
+      <div>
+        <div className="m-b-15">
+          <Button type="primary" onClick={() => this.showMapDialog()} disabled={!currentUser.isAdmin}>
+            <i className="fa fa-plus m-r-5" aria-hidden="true" />
+            New Custom Map
+          </Button>
+        </div>
+
+        {!controller.isLoaded && <LoadingState className="" />}
+        {controller.isLoaded && controller.isEmpty && (
+          <div className="text-center">
+            There are no custom maps yet.
+            {currentUser.isAdmin && (
+              <div className="m-t-5">
+                <PlainButton type="link" onClick={() => this.showMapDialog()}>
+                  Click here
+                </PlainButton>{" "}
+                to add one.
+              </div>
+            )}
+          </div>
+        )}
+        {controller.isLoaded && !controller.isEmpty && (
+          <div className="table-responsive">
+            <ItemsTable
+              items={controller.pageItems}
+              columns={this.listColumns}
+              context={this.actions}
+              orderByField={controller.orderByField}
+              orderByReverse={controller.orderByReverse}
+              toggleSorting={controller.toggleSorting}
+            />
+            <Paginator
+              showPageSizeSelect
+              totalCount={controller.totalItemsCount}
+              pageSize={controller.itemsPerPage}
+              onPageSizeChange={(itemsPerPage) => controller.updatePagination({ itemsPerPage })}
+              page={controller.page}
+              onChange={(page) => controller.updatePagination({ page })}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+const CustomMapsListPage = wrapSettingsTab(
+  "CustomMaps.List",
+  {
+    permission: "admin",
+    title: "Custom Maps",
+    path: "custom_maps",
+    order: 6,
+  },
+  itemsList(
+    CustomMapsList,
+    () =>
+      new ResourceItemsSource({
+        isPlainList: true,
+        getRequest() {
+          return {};
+        },
+        getResource() {
+          return CustomMap.query.bind(CustomMap);
+        },
+      }),
+    () => new StateStorage({ orderByField: "name", itemsPerPage: 10 })
+  )
+);
+
+routes.register(
+  "CustomMaps.List",
+  routeWithUserSession({
+    path: "/custom_maps",
+    title: "Custom Maps",
+    render: (pageProps) => <CustomMapsListPage {...pageProps} currentPage="custom_maps" />,
+  })
+);
+routes.register(
+  "CustomMaps.NewOrEdit",
+  routeWithUserSession({
+    path: "/custom_maps/:customMapId",
+    title: "Custom Maps",
+    render: (pageProps) => <CustomMapsListPage {...pageProps} currentPage="custom_maps" isNewOrEditPage />,
+  })
+);

--- a/client/app/pages/index.js
+++ b/client/app/pages/index.js
@@ -26,6 +26,7 @@ import "./queries/QuerySource";
 import "./queries/QueryView";
 import "./queries/VisualizationEmbed";
 
+import "./custom-maps/CustomMapsList";
 import "./query-snippets/QuerySnippetsList";
 
 import "./settings/OrganizationSettings";

--- a/client/app/services/custom-map.js
+++ b/client/app/services/custom-map.js
@@ -1,0 +1,11 @@
+import { axios } from "@/services/axios";
+
+const CustomMap = {
+  query: () => axios.get("api/custom_maps"),
+  get: ({ id }) => axios.get(`api/custom_maps/${id}`),
+  create: (data) => axios.post("api/custom_maps", data),
+  save: (data) => axios.post(`api/custom_maps/${data.id}`, data),
+  delete: ({ id }) => axios.delete(`api/custom_maps/${id}`),
+};
+
+export default CustomMap;

--- a/client/cypress/integration/custom-maps/create_custom_map_spec.js
+++ b/client/cypress/integration/custom-maps/create_custom_map_spec.js
@@ -1,0 +1,49 @@
+describe("Create Custom Map", () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("creates a custom map via the settings page", () => {
+    // Clean up any existing test map
+    cy.request("GET", "api/custom_maps")
+      .then(({ body }) => body.filter((m) => m.name === "Test Counties"))
+      .each((m) => cy.request("DELETE", `api/custom_maps/${m.id}`));
+
+    // Intercept the create call
+    cy.intercept("POST", "api/custom_maps", (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          id: 999,
+          name: req.body.name,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          user: { id: 1, name: "Admin" },
+        },
+      });
+    }).as("createMap");
+
+    cy.visit("/custom_maps/new");
+
+    cy.getByTestId("CustomMapDialog").within(() => {
+      cy.getByTestId("CustomMapName").type("Test Counties");
+    });
+
+    // Attach a minimal GeoJSON file
+    const geojson = JSON.stringify({ type: "FeatureCollection", features: [] });
+    const blob = new Blob([geojson], { type: "application/json" });
+    const file = new File([blob], "test.geojson", { type: "application/json" });
+
+    cy.getByTestId("CustomMapFileUpload").click();
+    cy.get("input[type=file]").selectFile(
+      { contents: Cypress.Buffer.from(geojson), fileName: "test.geojson", mimeType: "application/json" },
+      { force: true }
+    );
+
+    cy.getByTestId("SaveCustomMapButton").click();
+    cy.wait("@createMap");
+
+    // Verify dialog closes (back to list)
+    cy.url().should("include", "/custom_maps");
+  });
+});

--- a/client/cypress/integration/settings/settings_tabs_spec.js
+++ b/client/cypress/integration/settings/settings_tabs_spec.js
@@ -6,7 +6,7 @@ describe("Settings Tabs", () => {
   };
 
   const userTabs = ["Users", "Groups", "Query Snippets", "Account"];
-  const adminTabs = ["Data Sources", "Alert Destinations", "General"];
+  const adminTabs = ["Data Sources", "Alert Destinations", "Custom Maps", "General"];
 
   const expectSettingsTabsToBe = expectedTabs =>
     cy.getByTestId("SettingsScreenItem").then($list => {

--- a/migrations/versions/cf135a57edb3_add_custom_maps_table.py
+++ b/migrations/versions/cf135a57edb3_add_custom_maps_table.py
@@ -1,0 +1,31 @@
+"""Add custom_maps table
+
+Revision ID: cf135a57edb3
+Revises: db0aca1ebd32
+Create Date: 2026-03-16 10:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "cf135a57edb3"
+down_revision = "db0aca1ebd32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "custom_maps",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("org_id", sa.Integer, sa.ForeignKey("organizations.id"), nullable=False),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("geojson", sa.Text, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("custom_maps_org_id_name", "custom_maps", ["org_id", "name"], unique=True)
+
+
+def downgrade():
+    op.drop_table("custom_maps")

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -11,6 +11,11 @@ from redash.handlers.alerts import (
     AlertSubscriptionResource,
 )
 from redash.handlers.base import org_scoped_rule
+from redash.handlers.custom_maps import (
+    CustomMapGeoJsonResource,
+    CustomMapListResource,
+    CustomMapResource,
+)
 from redash.handlers.dashboards import (
     DashboardFavoriteListResource,
     DashboardForkResource,
@@ -283,5 +288,9 @@ api.add_org_resource(DestinationListResource, "/api/destinations", endpoint="des
 
 api.add_org_resource(QuerySnippetResource, "/api/query_snippets/<snippet_id>", endpoint="query_snippet")
 api.add_org_resource(QuerySnippetListResource, "/api/query_snippets", endpoint="query_snippets")
+
+api.add_org_resource(CustomMapListResource, "/api/custom_maps", endpoint="custom_maps")
+api.add_org_resource(CustomMapResource, "/api/custom_maps/<map_id>", endpoint="custom_map")
+api.add_org_resource(CustomMapGeoJsonResource, "/api/custom_maps/<map_id>/geojson", endpoint="custom_map_geojson")
 
 api.add_org_resource(OrganizationSettings, "/api/settings/organization", endpoint="organization_settings")

--- a/redash/handlers/custom_maps.py
+++ b/redash/handlers/custom_maps.py
@@ -1,0 +1,118 @@
+import json
+import logging
+
+from flask import make_response, request
+from funcy import project
+from sqlalchemy.exc import IntegrityError
+
+from redash import models
+from redash.handlers.base import BaseResource, get_object_or_404, require_fields
+from redash.permissions import require_admin
+
+logger = logging.getLogger(__name__)
+
+MAX_GEOJSON_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+def _validate_geojson(geojson_str):
+    """Validate an uploaded GeoJSON string.
+
+    Returns None on success, or a (error_dict, status_code) tuple on failure.
+    """
+    if not isinstance(geojson_str, str):
+        return {"message": "GeoJSON data must be a string."}, 400
+
+    try:
+        size = len(geojson_str.encode("utf-8"))
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return {"message": "GeoJSON contains invalid characters."}, 400
+
+    if size > MAX_GEOJSON_SIZE:
+        return {"message": "GeoJSON file is too large. Maximum size is 10 MB."}, 400
+
+    try:
+        data = json.loads(geojson_str)
+    except (json.JSONDecodeError, ValueError):
+        return {"message": "File does not contain valid JSON. Please upload a GeoJSON file."}, 400
+
+    if not isinstance(data, dict) or "features" not in data:
+        return {"message": "File is valid JSON but does not appear to be a GeoJSON FeatureCollection."}, 400
+
+    return None
+
+
+class CustomMapListResource(BaseResource):
+    def get(self):
+        self.record_event({"action": "list", "object_type": "custom_map"})
+        return [m.to_dict() for m in models.CustomMap.all(org=self.current_org)]
+
+    @require_admin
+    def post(self):
+        req = request.get_json(True)
+        require_fields(req, ("name", "geojson"))
+
+        error = _validate_geojson(req["geojson"])
+        if error:
+            return error
+
+        custom_map = models.CustomMap(
+            name=req["name"],
+            geojson=req["geojson"],
+            user=self.current_user,
+            org=self.current_org,
+        )
+        models.db.session.add(custom_map)
+        try:
+            models.db.session.commit()
+        except IntegrityError:
+            models.db.session.rollback()
+            return {"message": "A custom map with this name already exists."}, 400
+
+        self.record_event({"action": "create", "object_id": custom_map.id, "object_type": "custom_map"})
+        return custom_map.to_dict()
+
+
+class CustomMapResource(BaseResource):
+    def get(self, map_id):
+        custom_map = get_object_or_404(models.CustomMap.get_by_id_and_org, map_id, self.current_org)
+        return custom_map.to_dict()
+
+    @require_admin
+    def post(self, map_id):
+        custom_map = get_object_or_404(models.CustomMap.get_by_id_and_org, map_id, self.current_org)
+        req = request.get_json(True)
+        params = project(req, ("name", "geojson"))
+
+        if "geojson" in params:
+            error = _validate_geojson(params["geojson"])
+            if error:
+                return error
+
+        self.update_model(custom_map, params)
+        try:
+            models.db.session.commit()
+        except IntegrityError:
+            models.db.session.rollback()
+            return {"message": "A custom map with this name already exists."}, 400
+
+        self.record_event({"action": "edit", "object_id": custom_map.id, "object_type": "custom_map"})
+        return custom_map.to_dict()
+
+    @require_admin
+    def delete(self, map_id):
+        custom_map = get_object_or_404(models.CustomMap.get_by_id_and_org, map_id, self.current_org)
+        models.db.session.delete(custom_map)
+        models.db.session.commit()
+
+        self.record_event({"action": "delete", "object_id": custom_map.id, "object_type": "custom_map"})
+
+
+class CustomMapGeoJsonResource(BaseResource):
+    def get(self, map_id):
+        custom_map = get_object_or_404(models.CustomMap.get_by_id_and_org, map_id, self.current_org)
+
+        resp = make_response(custom_map.geojson)
+        resp.headers["Content-Type"] = "application/json"
+        resp.headers["Cache-Control"] = "private, max-age=3600"
+        resp.headers["X-Content-Type-Options"] = "nosniff"
+        return resp

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1517,6 +1517,35 @@ class QuerySnippet(TimestampMixin, db.Model, BelongsToOrgMixin):
         return d
 
 
+@generic_repr("id", "name", "org_id")
+class CustomMap(TimestampMixin, db.Model, BelongsToOrgMixin):
+    id = primary_key("CustomMap")
+    org_id = Column(key_type("Organization"), db.ForeignKey("organizations.id"))
+    org = db.relationship(Organization, backref="custom_maps")
+    user_id = Column(key_type("User"), db.ForeignKey("users.id"))
+    user = db.relationship(User, backref="custom_maps")
+    name = Column(db.String(255))
+    geojson = Column(db.Text)
+
+    __tablename__ = "custom_maps"
+    __table_args__ = (
+        db.Index("custom_maps_org_id_name", "org_id", "name", unique=True),
+    )
+
+    @classmethod
+    def all(cls, org):
+        return cls.query.filter(cls.org == org).order_by(cls.name.asc())
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "user": self.user.to_dict() if self.user else None,
+        }
+
+
 def init_db():
     default_org = Organization(name="Default", slug="default", settings={})
     admin_group = Group(

--- a/tests/handlers/test_custom_maps.py
+++ b/tests/handlers/test_custom_maps.py
@@ -1,0 +1,230 @@
+import json
+
+from redash.models import CustomMap
+from tests import BaseTestCase
+
+VALID_GEOJSON = json.dumps({"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"name": "Test"}, "geometry": {"type": "Point", "coordinates": [0, 0]}}]})
+INVALID_JSON = "not json at all"
+NO_FEATURES_JSON = json.dumps({"type": "Topology", "objects": {}})
+
+
+class TestCustomMapListResource(BaseTestCase):
+    def test_list_empty(self):
+        rv = self.make_request("get", "/api/custom_maps")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json, [])
+
+    def test_list_with_maps(self):
+        admin = self.factory.create_admin()
+        m1 = CustomMap(name="Map A", geojson=VALID_GEOJSON, user=admin, org=self.factory.org)
+        m2 = CustomMap(name="Map B", geojson=VALID_GEOJSON, user=admin, org=self.factory.org)
+        from redash.models import db
+
+        db.session.add_all([m1, m2])
+        db.session.commit()
+
+        rv = self.make_request("get", "/api/custom_maps")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(rv.json), 2)
+        names = [m["name"] for m in rv.json]
+        self.assertIn("Map A", names)
+        self.assertIn("Map B", names)
+
+    def test_list_scoped_to_org(self):
+        admin = self.factory.create_admin()
+        m1 = CustomMap(name="Map A", geojson=VALID_GEOJSON, user=admin, org=self.factory.org)
+        other_org = self.factory.create_org()
+        other_admin = self.factory.create_admin(org=other_org)
+        m2 = CustomMap(name="Map B", geojson=VALID_GEOJSON, user=other_admin, org=other_org)
+        from redash.models import db
+
+        db.session.add_all([m1, m2])
+        db.session.commit()
+
+        rv = self.make_request("get", "/api/custom_maps")
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["name"], "Map A")
+
+    def test_list_does_not_include_geojson(self):
+        """The list endpoint should not return the full geojson blob."""
+        admin = self.factory.create_admin()
+        m = CustomMap(name="Map A", geojson=VALID_GEOJSON, user=admin, org=self.factory.org)
+        from redash.models import db
+
+        db.session.add(m)
+        db.session.commit()
+
+        rv = self.make_request("get", "/api/custom_maps")
+        self.assertNotIn("geojson", rv.json[0])
+
+    def test_create_as_admin(self):
+        admin = self.factory.create_admin()
+        data = {"name": "Kenya Counties", "geojson": VALID_GEOJSON}
+        rv = self.make_request("post", "/api/custom_maps", data=data, user=admin)
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["name"], "Kenya Counties")
+        self.assertIsNotNone(rv.json["id"])
+
+    def test_create_rejected_for_non_admin(self):
+        data = {"name": "Kenya Counties", "geojson": VALID_GEOJSON}
+        rv = self.make_request("post", "/api/custom_maps", data=data)
+        self.assertEqual(rv.status_code, 403)
+
+    def test_create_missing_fields(self):
+        admin = self.factory.create_admin()
+        rv = self.make_request("post", "/api/custom_maps", data={"name": "Test"}, user=admin)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_rejects_oversized_geojson(self):
+        admin = self.factory.create_admin()
+        big_geojson = json.dumps({"type": "FeatureCollection", "features": [], "padding": "x" * (11 * 1024 * 1024)})
+        data = {"name": "Big Map", "geojson": big_geojson}
+        rv = self.make_request("post", "/api/custom_maps", data=data, user=admin)
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("too large", rv.json["message"])
+        self.assertEqual(CustomMap.query.count(), 0)
+
+    def test_create_rejects_invalid_json(self):
+        admin = self.factory.create_admin()
+        data = {"name": "Bad Map", "geojson": INVALID_JSON}
+        rv = self.make_request("post", "/api/custom_maps", data=data, user=admin)
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("valid JSON", rv.json["message"])
+
+    def test_create_rejects_non_featurecollection(self):
+        admin = self.factory.create_admin()
+        data = {"name": "Bad Map", "geojson": NO_FEATURES_JSON}
+        rv = self.make_request("post", "/api/custom_maps", data=data, user=admin)
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("FeatureCollection", rv.json["message"])
+
+    def test_create_duplicate_name_returns_400(self):
+        admin = self.factory.create_admin()
+        m = CustomMap(name="Kenya Counties", geojson=VALID_GEOJSON, user=admin, org=self.factory.org)
+        from redash.models import db
+
+        db.session.add(m)
+        db.session.commit()
+
+        data = {"name": "Kenya Counties", "geojson": VALID_GEOJSON}
+        rv = self.make_request("post", "/api/custom_maps", data=data, user=admin)
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("already exists", rv.json["message"])
+
+
+class TestCustomMapResource(BaseTestCase):
+    def _create_map(self, **kwargs):
+        admin = self.factory.create_admin()
+        defaults = {"name": "Test Map", "geojson": VALID_GEOJSON, "user": admin, "org": self.factory.org}
+        defaults.update(kwargs)
+        m = CustomMap(**defaults)
+        from redash.models import db
+
+        db.session.add(m)
+        db.session.commit()
+        return m, admin
+
+    def test_get_map(self):
+        m, _ = self._create_map()
+        rv = self.make_request("get", f"/api/custom_maps/{m.id}")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["name"], "Test Map")
+
+    def test_update_name_only(self):
+        m, admin = self._create_map()
+        rv = self.make_request("post", f"/api/custom_maps/{m.id}", data={"name": "Updated"}, user=admin)
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["name"], "Updated")
+
+    def test_update_geojson(self):
+        m, admin = self._create_map()
+        new_geojson = json.dumps({"type": "FeatureCollection", "features": []})
+        rv = self.make_request(
+            "post", f"/api/custom_maps/{m.id}",
+            data={"geojson": new_geojson},
+            user=admin,
+        )
+        self.assertEqual(rv.status_code, 200)
+        from redash.models import db
+        db.session.refresh(m)
+        self.assertEqual(m.geojson, new_geojson)
+
+    def test_update_rejects_invalid_geojson(self):
+        m, admin = self._create_map()
+        rv = self.make_request(
+            "post", f"/api/custom_maps/{m.id}",
+            data={"geojson": INVALID_JSON},
+            user=admin,
+        )
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("valid JSON", rv.json["message"])
+
+    def test_update_duplicate_name_returns_400(self):
+        m1, admin = self._create_map(name="Map One")
+        m2 = CustomMap(name="Map Two", geojson=VALID_GEOJSON, user=admin, org=self.factory.org)
+        from redash.models import db
+
+        db.session.add(m2)
+        db.session.commit()
+
+        rv = self.make_request("post", f"/api/custom_maps/{m2.id}", data={"name": "Map One"}, user=admin)
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("already exists", rv.json["message"])
+
+    def test_update_rejected_for_non_admin(self):
+        m, _ = self._create_map()
+        rv = self.make_request("post", f"/api/custom_maps/{m.id}", data={"name": "Updated"})
+        self.assertEqual(rv.status_code, 403)
+
+    def test_delete_as_admin(self):
+        m, admin = self._create_map()
+        rv = self.make_request("delete", f"/api/custom_maps/{m.id}", user=admin)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIsNone(CustomMap.query.get(m.id))
+
+    def test_delete_rejected_for_non_admin(self):
+        m, _ = self._create_map()
+        rv = self.make_request("delete", f"/api/custom_maps/{m.id}")
+        self.assertEqual(rv.status_code, 403)
+
+
+class TestCustomMapGeoJsonResource(BaseTestCase):
+    def _create_map(self, geojson=VALID_GEOJSON):
+        admin = self.factory.create_admin()
+        m = CustomMap(name="Test Map", geojson=geojson, user=admin, org=self.factory.org)
+        from redash.models import db
+
+        db.session.add(m)
+        db.session.commit()
+        return m
+
+    def test_geojson_endpoint_returns_stored_data(self):
+        m = self._create_map()
+        rv = self.make_request("get", f"/api/custom_maps/{m.id}/geojson")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(json.loads(rv.data), json.loads(VALID_GEOJSON))
+
+    def test_geojson_endpoint_headers(self):
+        m = self._create_map()
+        rv = self.make_request("get", f"/api/custom_maps/{m.id}/geojson")
+        self.assertEqual(rv.headers["Content-Type"], "application/json")
+        self.assertIn("private", rv.headers["Cache-Control"])
+        self.assertEqual(rv.headers["X-Content-Type-Options"], "nosniff")
+
+    def test_geojson_not_found(self):
+        rv = self.make_request("get", "/api/custom_maps/9999/geojson")
+        self.assertEqual(rv.status_code, 404)
+
+    def test_geojson_with_dashboard_api_key(self):
+        """GeoJSON endpoint must be accessible via a dashboard API key (public dashboards)."""
+        m = self._create_map()
+        dashboard = self.factory.create_dashboard()
+        api_key = self.factory.create_api_key(object=dashboard)
+
+        rv = self.make_request(
+            "get",
+            "/api/custom_maps/{}/geojson?api_key={}".format(m.id, api_key.api_key),
+            user=False,
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(json.loads(rv.data), json.loads(VALID_GEOJSON))

--- a/viz-lib/src/visualizations/choropleth/Editor/GeneralSettings.tsx
+++ b/viz-lib/src/visualizations/choropleth/Editor/GeneralSettings.tsx
@@ -7,18 +7,21 @@ import { visualizationsSettings } from "@/visualizations/visualizationsSettings"
 
 import useLoadGeoJson from "../hooks/useLoadGeoJson";
 import { getGeoJsonFields } from "./utils";
+import "./editor.less";
 
 export default function GeneralSettings({ options, data, onOptionsChange }: any) {
-  const [geoJson, isLoadingGeoJson] = useLoadGeoJson(options.mapType);
+  const [geoJson, isLoadingGeoJson, loadError] = useLoadGeoJson(options.mapType);
   const geoJsonFields = useMemo(() => getGeoJsonFields(geoJson), [geoJson]);
 
   // While geoJson is loading - show last selected field in select
   const targetFields = isLoadingGeoJson ? filter([options.targetField], isString) : geoJsonFields;
 
-  const fieldNames = get(visualizationsSettings, `choroplethAvailableMaps.${options.mapType}.fieldNames`, {});
+  const registeredFieldNames = get(visualizationsSettings, `choroplethAvailableMaps.${options.mapType}.fieldNames`, {});
+  const geoJsonFieldNames = get(geoJson, "fieldNames", {});
+  const fieldNames = { ...geoJsonFieldNames, ...registeredFieldNames };
 
   const handleMapChange = useCallback(
-    mapType => {
+    (mapType) => {
       onOptionsChange({ mapType: mapType || null });
     },
     [onOptionsChange]
@@ -32,7 +35,8 @@ export default function GeneralSettings({ options, data, onOptionsChange }: any)
           label="Map"
           data-test="Choropleth.Editor.MapType"
           defaultValue={options.mapType}
-          onChange={handleMapChange}>
+          onChange={handleMapChange}
+        >
           {map(visualizationsSettings.choroplethAvailableMaps, (_, mapType) => (
             // @ts-expect-error ts-migrate(2339) FIXME: Property 'Option' does not exist on type '({ class... Remove this comment to see the full error message
             <Select.Option key={mapType} data-test={`Choropleth.Editor.MapType.${mapType}`}>
@@ -41,6 +45,11 @@ export default function GeneralSettings({ options, data, onOptionsChange }: any)
             </Select.Option>
           ))}
         </Select>
+        {loadError && (
+          <div className="choropleth-custom-map-error" data-test="Choropleth.Editor.LoadError">
+            {loadError}
+          </div>
+        )}
       </Section>
 
       {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -53,7 +62,8 @@ export default function GeneralSettings({ options, data, onOptionsChange }: any)
               data-test="Choropleth.Editor.KeyColumn"
               disabled={data.columns.length === 0}
               defaultValue={options.keyColumn}
-              onChange={(keyColumn: any) => onOptionsChange({ keyColumn })}>
+              onChange={(keyColumn: any) => onOptionsChange({ keyColumn })}
+            >
               {map(data.columns, ({ name }) => (
                 // @ts-expect-error ts-migrate(2339) FIXME: Property 'Option' does not exist on type '({ class... Remove this comment to see the full error message
                 <Select.Option key={name} data-test={`Choropleth.Editor.KeyColumn.${name}`}>
@@ -71,8 +81,9 @@ export default function GeneralSettings({ options, data, onOptionsChange }: any)
               disabled={isLoadingGeoJson || targetFields.length === 0}
               loading={isLoadingGeoJson}
               value={options.targetField}
-              onChange={(targetField: any) => onOptionsChange({ targetField })}>
-              {map(targetFields, field => (
+              onChange={(targetField: any) => onOptionsChange({ targetField })}
+            >
+              {map(targetFields, (field) => (
                 // @ts-expect-error ts-migrate(2339) FIXME: Property 'Option' does not exist on type '({ class... Remove this comment to see the full error message
                 <Select.Option key={field} data-test={`Choropleth.Editor.TargetField.${field}`}>
                   {fieldNames[field] || field}
@@ -91,7 +102,8 @@ export default function GeneralSettings({ options, data, onOptionsChange }: any)
           data-test="Choropleth.Editor.ValueColumn"
           disabled={data.columns.length === 0}
           defaultValue={options.valueColumn}
-          onChange={(valueColumn: any) => onOptionsChange({ valueColumn })}>
+          onChange={(valueColumn: any) => onOptionsChange({ valueColumn })}
+        >
           {map(data.columns, ({ name }) => (
             // @ts-expect-error ts-migrate(2339) FIXME: Property 'Option' does not exist on type '({ class... Remove this comment to see the full error message
             <Select.Option key={name} data-test={`Choropleth.Editor.ValueColumn.${name}`}>

--- a/viz-lib/src/visualizations/choropleth/Editor/editor.less
+++ b/viz-lib/src/visualizations/choropleth/Editor/editor.less
@@ -1,0 +1,5 @@
+.choropleth-custom-map-error {
+  color: #ff4d4f;
+  font-size: 12px;
+  margin-top: 4px;
+}

--- a/viz-lib/src/visualizations/choropleth/Renderer/utils.ts
+++ b/viz-lib/src/visualizations/choropleth/Renderer/utils.ts
@@ -3,9 +3,7 @@ import chroma from "chroma-js";
 import { createNumberFormatter as createFormatter } from "@/lib/value-format";
 
 export function darkenColor(color: any) {
-  return chroma(color)
-    .darken()
-    .hex();
+  return chroma(color).darken().hex();
 }
 
 export function createNumberFormatter(format: any, placeholder: any) {
@@ -24,7 +22,7 @@ export function prepareData(data: any, keyColumn: any, valueColumn: any) {
   }
 
   const result = {};
-  each(data, item => {
+  each(data, (item) => {
     if (item[keyColumn]) {
       const value = parseFloat(item[valueColumn]);
       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -46,6 +44,12 @@ export function prepareFeatureProperties(feature: any, valueFormatted: any, data
   });
   // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   result["@@value"] = valueFormatted;
+  // Alias @@name to the target field so the default tooltip template works with any GeoJSON
+  // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+  if (targetField && feature.properties[targetField] != null && !result["@@name"]) {
+    // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+    result["@@name"] = feature.properties[targetField];
+  }
   const datum = data[feature.properties[targetField]] || {};
   return extend(result, datum.item);
 }
@@ -73,7 +77,7 @@ export function createScale(features: any, data: any, options: any) {
   // Calculate limits
   const values = uniq(
     filter(
-      map(features, feature => getValueForFeature(feature, data, options.targetField)),
+      map(features, (feature) => getValueForFeature(feature, data, options.targetField)),
       isFinite
     )
   );

--- a/viz-lib/src/visualizations/choropleth/__tests__/getOptions.test.ts
+++ b/viz-lib/src/visualizations/choropleth/__tests__/getOptions.test.ts
@@ -1,0 +1,65 @@
+import getOptions from "../getOptions";
+
+jest.mock("@/visualizations/visualizationsSettings", () => ({
+  visualizationsSettings: {
+    choroplethAvailableMaps: {
+      countries: { name: "Countries", url: "/countries.geo.json", fieldNames: {} },
+      usa: { name: "USA", url: "/usa.geo.json", fieldNames: {} },
+      custom_map_42: { name: "Kenya Counties", url: "/api/custom_maps/42/geojson" },
+    },
+  },
+}));
+
+describe("Choropleth getOptions", () => {
+  test("returns defaults when called with empty options", () => {
+    const result = getOptions({});
+    expect(result.mapType).toBe("countries");
+    expect(result.keyColumn).toBeNull();
+    expect(result.targetField).toBeNull();
+    expect(result.valueColumn).toBeNull();
+    expect(result.steps).toBe(5);
+  });
+
+  test("preserves valid built-in mapType", () => {
+    const result = getOptions({ mapType: "usa" });
+    expect(result.mapType).toBe("usa");
+  });
+
+  test("falls back to first map for invalid mapType", () => {
+    const result = getOptions({ mapType: "nonexistent" });
+    expect(result.mapType).toBe("countries");
+  });
+
+  test("preserves valid custom map key", () => {
+    const result = getOptions({ mapType: "custom_map_42" });
+    expect(result.mapType).toBe("custom_map_42");
+  });
+
+  test("backward compat: countryCodeColumn migrates to keyColumn", () => {
+    const result = getOptions({ countryCodeColumn: "iso" });
+    expect(result.keyColumn).toBe("iso");
+    expect(result.countryCodeColumn).toBeUndefined();
+  });
+
+  test("backward compat: countryCodeType migrates to targetField", () => {
+    const result = getOptions({ countryCodeType: "iso_a3" });
+    expect(result.targetField).toBe("iso_a3");
+    expect(result.countryCodeType).toBeUndefined();
+  });
+
+  test("merges color options with defaults", () => {
+    const result = getOptions({ colors: { min: "#ff0000" } });
+    expect(result.colors.min).toBe("#ff0000");
+    expect(result.colors.max).toBeDefined();
+    expect(result.colors.background).toBeDefined();
+  });
+
+  test("preserves bounds from options", () => {
+    const bounds = [
+      [1, 2],
+      [3, 4],
+    ];
+    const result = getOptions({ bounds });
+    expect(result.bounds).toBe(bounds);
+  });
+});

--- a/viz-lib/src/visualizations/choropleth/__tests__/utils.test.ts
+++ b/viz-lib/src/visualizations/choropleth/__tests__/utils.test.ts
@@ -1,0 +1,183 @@
+jest.mock("@/lib/value-format", () => ({
+  createNumberFormatter: () => (v: any) => String(v),
+}));
+
+import { get } from "lodash";
+import { prepareData, prepareFeatureProperties, getValueForFeature, getColorByValue } from "../Renderer/utils";
+import { getGeoJsonFields } from "../Editor/utils";
+
+describe("prepareData", () => {
+  test("returns empty object when keyColumn is null", () => {
+    expect(prepareData([{ a: 1 }], null, "a")).toEqual({});
+  });
+
+  test("returns empty object when valueColumn is null", () => {
+    expect(prepareData([{ a: 1 }], "a", null)).toEqual({});
+  });
+
+  test("creates lookup from rows", () => {
+    const rows = [
+      { region: "Region_A", value: 42 },
+      { region: "Region_B", value: 15 },
+    ];
+    const result = prepareData(rows, "region", "value");
+    expect(result).toHaveProperty("Region_A");
+    expect((result as any).Region_A.value).toBe(42);
+    expect((result as any).Region_A.code).toBe("Region_A");
+    expect((result as any).Region_B.value).toBe(15);
+  });
+
+  test("handles non-numeric values as undefined", () => {
+    const rows = [{ region: "Region_A", value: "not-a-number" }];
+    const result = prepareData(rows, "region", "value");
+    expect((result as any).Region_A.value).toBeUndefined();
+  });
+
+  test("skips rows with falsy key", () => {
+    const rows = [
+      { region: "", value: 10 },
+      { region: null, value: 20 },
+      { region: "Valid", value: 30 },
+    ];
+    const result = prepareData(rows, "region", "value");
+    expect(Object.keys(result)).toEqual(["Valid"]);
+  });
+});
+
+describe("getValueForFeature", () => {
+  const data = {
+    Region_A: { code: "Region_A", value: 42 },
+    Region_B: { code: "Region_B", value: 15 },
+  };
+
+  test("returns value for matching string property", () => {
+    const feature = { properties: { NAME_1: "Region_A" } };
+    expect(getValueForFeature(feature, data, "NAME_1")).toBe(42);
+  });
+
+  test("returns undefined for non-matching property", () => {
+    const feature = { properties: { NAME_1: "Unknown" } };
+    expect(getValueForFeature(feature, data, "NAME_1")).toBeUndefined();
+  });
+
+  test("returns undefined for numeric property (isString check)", () => {
+    const feature = { properties: { id: 123 } };
+    expect(getValueForFeature(feature, { 123: { value: 10 } }, "id")).toBeUndefined();
+  });
+
+  test("returns undefined for missing targetField", () => {
+    const feature = { properties: { NAME_1: "Region_A" } };
+    expect(getValueForFeature(feature, data, "nonexistent")).toBeUndefined();
+  });
+});
+
+describe("getGeoJsonFields", () => {
+  test("extracts unique property keys from features", () => {
+    const geoJson = {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", properties: { name: "A", iso_a2: "US" }, geometry: {} },
+        { type: "Feature", properties: { name: "B", code: "GB" }, geometry: {} },
+      ],
+    };
+    const fields = getGeoJsonFields(geoJson);
+    expect(fields).toContain("name");
+    expect(fields).toContain("iso_a2");
+    expect(fields).toContain("code");
+  });
+
+  test("returns empty array for null geoJson", () => {
+    expect(getGeoJsonFields(null)).toEqual([]);
+  });
+
+  test("returns empty array for geoJson without features", () => {
+    expect(getGeoJsonFields({ type: "FeatureCollection" })).toEqual([]);
+  });
+});
+
+describe("GeoJSON fieldNames mapping", () => {
+  test("optional top-level fieldNames provides human-readable labels", () => {
+    const geoJson = {
+      type: "FeatureCollection",
+      fieldNames: { iso_a2: "Country Code", name: "Country Name" },
+      features: [{ type: "Feature", properties: { name: "USA", iso_a2: "US" }, geometry: {} }],
+    };
+
+    const geoJsonFieldNames: Record<string, string> = get(geoJson, "fieldNames", {});
+    expect(geoJsonFieldNames).toEqual({ iso_a2: "Country Code", name: "Country Name" });
+
+    const fields = getGeoJsonFields(geoJson);
+    fields.forEach((field: string) => {
+      const label = geoJsonFieldNames[field] || field;
+      expect(label).toBeDefined();
+    });
+    expect(geoJsonFieldNames["iso_a2"]).toBe("Country Code");
+  });
+
+  test("missing fieldNames falls back to empty object", () => {
+    const geoJson = {
+      type: "FeatureCollection",
+      features: [{ type: "Feature", properties: { name: "A" }, geometry: {} }],
+    };
+    const geoJsonFieldNames: Record<string, string> = get(geoJson, "fieldNames", {});
+    expect(geoJsonFieldNames).toEqual({});
+
+    const fields = getGeoJsonFields(geoJson);
+    expect(fields).toContain("name");
+    expect(geoJsonFieldNames["name"] || "name").toBe("name");
+  });
+});
+
+describe("prepareFeatureProperties", () => {
+  const data = {
+    Baringo: { code: "Baringo", value: 73.6, item: { county: "Baringo", pct: 73.6 } },
+  };
+
+  test("aliases @@name to the target field value for custom GeoJSON", () => {
+    const feature = { properties: { NAME_1: "Baringo", ID_1: "1" } };
+    const result = prepareFeatureProperties(feature, "73.60", data, "NAME_1");
+    expect(result["@@NAME_1"]).toBe("Baringo");
+    expect(result["@@name"]).toBe("Baringo");
+    expect(result["@@value"]).toBe("73.60");
+  });
+
+  test("does not override existing @@name property", () => {
+    const feature = { properties: { name: "Kenya", NAME_1: "Baringo" } };
+    const result = prepareFeatureProperties(feature, "73.60", data, "NAME_1");
+    expect(result["@@name"]).toBe("Kenya");
+  });
+
+  test("sets @@value to formatted value", () => {
+    const feature = { properties: { NAME_1: "Baringo" } };
+    const result = prepareFeatureProperties(feature, "N/A", data, "NAME_1");
+    expect(result["@@value"]).toBe("N/A");
+  });
+
+  test("merges data item properties into result", () => {
+    const feature = { properties: { NAME_1: "Baringo" } };
+    const result = prepareFeatureProperties(feature, "73.60", data, "NAME_1");
+    expect(result["county"]).toBe("Baringo");
+    expect(result["pct"]).toBe(73.6);
+  });
+});
+
+describe("getColorByValue", () => {
+  const limits = [10, 20, 30];
+  const colors = ["#aaa", "#bbb", "#ccc"];
+
+  test("returns first color for values <= first limit", () => {
+    expect(getColorByValue(5, limits, colors, "#default")).toBe("#aaa");
+    expect(getColorByValue(10, limits, colors, "#default")).toBe("#aaa");
+  });
+
+  test("returns correct bucket color", () => {
+    expect(getColorByValue(15, limits, colors, "#default")).toBe("#bbb");
+    expect(getColorByValue(25, limits, colors, "#default")).toBe("#ccc");
+  });
+
+  test("returns default for non-finite values", () => {
+    expect(getColorByValue(undefined, limits, colors, "#default")).toBe("#default");
+    expect(getColorByValue(NaN, limits, colors, "#default")).toBe("#default");
+    expect(getColorByValue(null, limits, colors, "#default")).toBe("#default");
+  });
+});

--- a/viz-lib/src/visualizations/choropleth/hooks/useLoadGeoJson.ts
+++ b/viz-lib/src/visualizations/choropleth/hooks/useLoadGeoJson.ts
@@ -9,22 +9,36 @@ const cache = createReferenceCountingCache();
 export default function useLoadGeoJson(mapType: any) {
   const [geoJson, setGeoJson] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     const mapUrl = get(visualizationsSettings, `choroplethAvailableMaps.${mapType}.url`, undefined);
 
     if (isString(mapUrl)) {
       setIsLoading(true);
+      setLoadError(null);
       let cancelled = false;
 
-      const promise = cache.get(mapUrl, () => axios.get(mapUrl).catch(() => null));
-      promise.then(({ data }: any) => {
-        if (!cancelled) {
-          // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'object | null' is not assignable... Remove this comment to see the full error message
-          setGeoJson(isObject(data) ? data : null);
-          setIsLoading(false);
+      const promise = cache.get(mapUrl, () => axios.get(mapUrl));
+      promise.then(
+        (result: any) => {
+          if (!cancelled) {
+            const data = result ? result.data : null;
+            // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'object | null' is not assignable... Remove this comment to see the full error message
+            setGeoJson(isObject(data) ? data : null);
+            setLoadError(null);
+            setIsLoading(false);
+          }
+        },
+        () => {
+          if (!cancelled) {
+            setGeoJson(null);
+            setLoadError("Failed to load map data.");
+            setIsLoading(false);
+            cache.release(mapUrl);
+          }
         }
-      });
+      );
 
       return () => {
         cancelled = true;
@@ -32,9 +46,10 @@ export default function useLoadGeoJson(mapType: any) {
       };
     } else {
       setGeoJson(null);
+      setLoadError(null);
       setIsLoading(false);
     }
   }, [mapType]);
 
-  return [geoJson, isLoading];
+  return [geoJson, isLoading, loadError];
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

Adds admin-managed custom choropleth maps — the approach endorsed by @arikfr and @yoshiokatsuneo in #7639 (option 7). Admins upload GeoJSON files via Settings → Custom Maps, and they appear in the choropleth Map dropdown alongside built-in maps.

**How it works:**
1. Admin creates a map (name + uploaded GeoJSON file) in Settings → Custom Maps
2. GeoJSON is validated client-side (FileReader) and stored as a text blob in the database
3. The map appears in the choropleth editor dropdown for all users
4. GeoJSON is served via \`/api/custom_maps/<id>/geojson\` directly from the database
5. Admins can replace the GeoJSON by re-uploading, or rename/delete maps

**Backend**
- \`CustomMap\` model following the \`QuerySnippet\` pattern (TimestampMixin, BelongsToOrgMixin, unique org+name index)
- Alembic migration for the \`custom_maps\` table (\`geojson\` text column, no URL)
- CRUD handlers (admin-only writes) + GeoJSON endpoint (serves stored blob, 1hr cache, \`X-Content-Type-Options: nosniff\`)
- Duplicate name handling via IntegrityError catch on both create and update
- Custom maps lazy-loaded via API (not bundled in clientConfig)

**Frontend**
- Admin settings page + dialog following the Query Snippets pattern
- File upload via Ant Design Upload + FileReader (accepts .geojson/.json)
- Edit dialog: "Leave empty to keep current map data" for updates
- API service, route registration

**Viz-lib**
- Custom maps merged into \`choroplethAvailableMaps\` via async \`loadCustomMaps()\`
- \`@@name\` aliasing in \`prepareFeatureProperties\` — maps the selected target field to \`@@name\` so the default tooltip template works with any GeoJSON
- \`fieldNames\` merge from GeoJSON foreign member for human-readable field labels

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)
- [x] Manually

Backend pytest tests covering CRUD, org scoping, duplicate names, GeoJSON storage/retrieval, and validation. Viz-lib jest tests covering getOptions, prepareData, field extraction, @@name aliasing, and color mapping. Cypress E2E test for the create custom map flow.

Manual testing: created a custom map via file upload, verified it appears in choropleth Map dropdown, confirmed map renders with correct GeoJSON proxy and tooltip aliasing.

## Related Tickets & Documents

Implements "option 7" from #7639.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Admin Settings

| Custom Maps List | Create Dialog | Create Dialog (filled) |
|---|---|---|
| ![list](https://github.com/user-attachments/assets/51451065-e7cf-4a11-a606-8006861d0e49) | ![create](https://github.com/user-attachments/assets/f3744943-602d-4dfe-87d7-dc92c767f1e8) | ![filled](https://github.com/user-attachments/assets/554ec830-fc07-48ad-86cc-3da468778faf) |

| Edit Dialog | Choropleth Dropdown | Rendered Map + Tooltip |
|---|---|---|
| ![edit](https://github.com/user-attachments/assets/9987a698-00f1-44f5-a360-ea2d1d28a211) | ![dropdown](https://github.com/user-attachments/assets/0de7b600-2b21-4ba7-bfbd-9518a65ae7aa) | ![map](https://github.com/user-attachments/assets/cd13f1c7-cfe3-409b-a452-a224056406cf) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
