### PR TITLE
Fix error on pnpm install

### DIFF
--- a/viz-lib/src/visualizations/chart/Editor/DataLabelsSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/DataLabelsSettings.test.tsx
@@ -15,7 +15,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={{ columns: [], rows: [] }}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}

--- a/viz-lib/src/visualizations/chart/Editor/GeneralSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/GeneralSettings.test.tsx
@@ -19,7 +19,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={{ columns: [], rows: [] }}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}
@@ -228,5 +228,5 @@ describe("Visualizations -> Chart -> Editor -> General Settings", () => {
       .simulate("change", { target: { checked: true } });
   });
 
-  
+
 });

--- a/viz-lib/src/visualizations/chart/Editor/SeriesSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/SeriesSettings.test.tsx
@@ -15,7 +15,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={{ columns: [{ name: "a", type: "string" }], rows: [{ a: "test" }] }}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}

--- a/viz-lib/src/visualizations/chart/Editor/XAxisSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/XAxisSettings.test.tsx
@@ -15,7 +15,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={{ columns: [], rows: [] }}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}

--- a/viz-lib/src/visualizations/chart/Editor/YAxisSettings.test.tsx
+++ b/viz-lib/src/visualizations/chart/Editor/YAxisSettings.test.tsx
@@ -19,7 +19,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={{ columns: [], rows: [] }}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}

--- a/viz-lib/src/visualizations/details/Editor/ColumnsSettings.test.tsx
+++ b/viz-lib/src/visualizations/details/Editor/ColumnsSettings.test.tsx
@@ -23,7 +23,7 @@ function mount(options: any, done: any) {
       visualizationName="Details"
       data={data}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}

--- a/viz-lib/src/visualizations/table/Editor/ColumnsSettings.test.tsx
+++ b/viz-lib/src/visualizations/table/Editor/ColumnsSettings.test.tsx
@@ -19,7 +19,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={data}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}

--- a/viz-lib/src/visualizations/table/Editor/GridSettings.test.tsx
+++ b/viz-lib/src/visualizations/table/Editor/GridSettings.test.tsx
@@ -16,7 +16,7 @@ function mount(options: any, done: any) {
       visualizationName="Test"
       data={data}
       options={options}
-      onOptionsChange={changedOptions => {
+      onOptionsChange={(changedOptions: any) => {
         expect(changedOptions).toMatchSnapshot();
         done();
       }}


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix

## Description

Before the PR, `pnpm install` causes following error. This PR fixes the error.

Related PR: https://github.com/getredash/redash/pull/7651


```
$ pnpm install
Scope: all 2 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. postinstall$ pnpm run build:viz
│ > redash-client@26.03.0-dev build:viz /Users/tsuneo/work/redash/redash
│ > pnpm --filter @redash/viz build:babel
│ > @redash/viz@1.0.0 build:babel /Users/tsuneo/work/redash/redash/viz-lib
│ > pnpm run type-gen && pnpm run build:babel:base
│ > @redash/viz@1.0.0 type-gen /Users/tsuneo/work/redash/redash/viz-lib
│ > tsc --emitDeclarationOnly
│ src/visualizations/chart/Editor/DataLabelsSettings.test.tsx(18,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/chart/Editor/GeneralSettings.test.tsx(22,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/chart/Editor/SeriesSettings.test.tsx(18,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/chart/Editor/XAxisSettings.test.tsx(18,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/chart/Editor/YAxisSettings.test.tsx(22,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/details/Editor/ColumnsSettings.test.tsx(26,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/table/Editor/ColumnsSettings.test.tsx(22,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│ src/visualizations/table/Editor/GridSettings.test.tsx(19,24): error TS7006: Parameter 'changedOptions' implicitly has an 'any' type.
│  ELIFECYCLE  Command failed with exit code 2.
│ /Users/tsuneo/work/redash/redash/viz-lib:
│  ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @redash/viz@1.0.0 build:babel: `pnpm run type-gen && pnpm run build:babel:base`
│ Exit status 2
│  ELIFECYCLE  Command failed with exit code 2.
└─ Failed in 2s at /Users/tsuneo/work/redash/redash
 ELIFECYCLE  Command failed with exit code 2.
```


## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

