### PR TITLE
Block query results API when public URLs are disabled

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -249,6 +249,9 @@ class QueryResultResource(BaseResource):
                                 any cached result, or executes if not available. Set to zero to
                                 always execute.
         """
+        if self.current_user.is_api_user() and self.current_org.get_setting("disable_public_urls"):
+            abort(400, message="Public URLs are disabled.")
+
         params = request.get_json(force=True, silent=True) or {}
         parameter_values = params.get("parameters", {})
 
@@ -301,6 +304,9 @@ class QueryResultResource(BaseResource):
         :<json number runtime: Length of execution time in seconds
         :<json string retrieved_at: Query retrieval date/time, in ISO format
         """
+        if self.current_user.is_api_user() and self.current_org.get_setting("disable_public_urls"):
+            abort(400, message="Public URLs are disabled.")
+
         # TODO:
         # This method handles two cases: retrieving result by id & retrieving result by query id.
         # They need to be split, as they have different logic (for example, retrieving by query id


### PR DESCRIPTION
Close: #7678

QueryResultResource did not check disable_public_urls, allowing API key holders to retrieve query results even after the setting was enabled. This adds the same guard used in PublicDashboardResource.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
- REDASH_DISABLE_PUBLIC_URLS=false
```sh
$ curl -s "http://localhost:5000/api/queries/1/results?api_key=<api key>"
{"query_result": {"id": 3, "query_hash": "c65c5f7abb67917dd98fedad6f6d850f", "query": "SELECT * FROM t LIMIT 1000", "data": {"columns": [{"name": "id", "friendly_name": "id", "type": "integer"}, {"name": "name", "friendly_name": "name", "type": "string"}], "rows": [{"id": 1, "name": "hello"}, {"id": 2, "name": "redash"}]}, "data_source_id": 1, "runtime": 0.010477542877197266, "retrieved_at": "2026-03-27T09:24:34.266Z"}}
```

- REDASH_DISABLE_PUBLIC_URLS=true
```sh
$ curl -s "http://localhost:5000/api/queries/1/results?api_key=<api key>"
{"message": "Public URLs are disabled."}
```


## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
