### PR TITLE
Fix scheduling of forked queries

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -593,7 +593,8 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     def outdated_queries(cls):
         queries = (
             Query.query.options(joinedload(Query.latest_query_data).load_only("retrieved_at"))
-            .filter(func.jsonb_typeof(Query.schedule) != "null")
+            .filter(func.jsonb_typeof(Query.schedule) == "object")
+            .filter(cast(Query.schedule, db.Text) != "{}")
             .order_by(Query.id)
             .all()
         )
@@ -607,16 +608,31 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 if query.schedule.get("disabled"):
                     continue
 
+                interval = query.schedule.get("interval")
+                schedule_time = query.schedule.get("time")
+                day_of_week = query.schedule.get("day_of_week")
+                schedule_until = query.schedule.get("until")
+
+                # Parse `until` before interval checks so malformed date values are
+                # treated as faulty schedules and get disabled in the exception path.
+                if schedule_until:
+                    schedule_until = pytz.utc.localize(datetime.datetime.strptime(schedule_until, "%Y-%m-%d"))
+
+                    if schedule_until <= now:
+                        continue
+
+                # Missing interval means this isn't an actionable schedule.
+                if not interval:
+                    logger.warning(
+                        "Skipping schedule evaluation for query %s: interval is missing.",
+                        query.id,
+                    )
+                    continue
+
                 # Skip queries that have None for all schedule values. It's unclear whether this
                 # something that can happen in practice, but we have a test case for it.
                 if all(value is None for value in query.schedule.values()):
                     continue
-
-                if query.schedule["until"]:
-                    schedule_until = pytz.utc.localize(datetime.datetime.strptime(query.schedule["until"], "%Y-%m-%d"))
-
-                    if schedule_until <= now:
-                        continue
 
                 retrieved_at = scheduled_queries_executions.get(query.id) or (
                     query.latest_query_data and query.latest_query_data.retrieved_at
@@ -625,9 +641,9 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 if should_schedule_next(
                     retrieved_at,
                     now,
-                    query.schedule["interval"],
-                    query.schedule["time"],
-                    query.schedule["day_of_week"],
+                    interval,
+                    schedule_time,
+                    day_of_week,
                     query.schedule_failures,
                 ):
                     key = "{}:{}".format(query.query_hash, query.data_source_id)
@@ -808,7 +824,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         kwargs = {a: getattr(self, a) for a in forked_list}
 
         # Query.create will add default TABLE visualization, so use constructor to create bare copy of query
-        forked_query = Query(name="Copy of (#{}) {}".format(self.id, self.name), user=user, **kwargs)
+        forked_query = Query(name="Copy of (#{}) {}".format(self.id, self.name), user=user, schedule=None, **kwargs)
 
         for v in sorted(self.visualizations, key=lambda v: v.id):
             forked_v = v.copy()

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -458,6 +458,15 @@ class TestQueryFork(BaseTestCase):
 
         self.assertEqual(query.tags, forked_query.tags)
 
+    def test_fork_resets_query_schedule(self):
+        query = self.factory.create_query(
+            schedule={"interval": "60", "time": None, "until": None, "day_of_week": None}
+        )
+
+        forked_query = query.fork(self.factory.user)
+
+        self.assertIsNone(forked_query.schedule)
+
 
 class TestQueryUpdateLatestResult(BaseTestCase):
     def setUp(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,6 +163,16 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         self.assertNotIn(query, queries)
         self.assertNotIn(query_with_none, queries)
 
+    # Regression test: partial schedule objects (for example from forked queries)
+    # should be skipped instead of being auto-disabled by scheduler errors.
+    def test_outdated_queries_skips_schedule_without_interval(self):
+        query = self.factory.create_query(schedule={"time": None, "until": None, "day_of_week": None})
+
+        queries = models.Query.outdated_queries()
+
+        self.assertNotIn(query, queries)
+        self.assertIsNone(query.schedule.get("disabled"))
+
     def test_outdated_queries_works_with_ttl_based_schedule(self):
         query = self.create_scheduled_query(interval="3600")
         self.fake_previous_execution(query, hours=2)


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

When forking a query, redash would set the schedule to `{}`. This would trigger an exception which would cause the query to be unscheduled forever (even if a valid schedule was added later).

Update the code to be defensive against empty/invalid schedules (including tests) and also update the
fork code to explicitly set the schedule to `null` instead of `{}`.

(this bug is only present in ~recent versions of redash which use a jsonb column for the schedule)

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

Brought up an instance of redash, verified that forked queries were scheduled

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A