### PR TITLE
Use requests_or_advocate in alert destination modules

### DIFF
--- a/redash/destinations/asana.py
+++ b/redash/destinations/asana.py
@@ -1,10 +1,9 @@
 import logging
 import textwrap
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.models import Alert
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class Asana(BaseDestination):

--- a/redash/destinations/asana.py
+++ b/redash/destinations/asana.py
@@ -1,7 +1,7 @@
 import logging
 import textwrap
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.models import Alert

--- a/redash/destinations/chatwork.py
+++ b/redash/destinations/chatwork.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 

--- a/redash/destinations/chatwork.py
+++ b/redash/destinations/chatwork.py
@@ -1,8 +1,7 @@
 import logging
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class ChatWork(BaseDestination):

--- a/redash/destinations/datadog.py
+++ b/redash/destinations/datadog.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps

--- a/redash/destinations/datadog.py
+++ b/redash/destinations/datadog.py
@@ -1,10 +1,9 @@
 import logging
 import os
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class Datadog(BaseDestination):

--- a/redash/destinations/discord.py
+++ b/redash/destinations/discord.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.models import Alert

--- a/redash/destinations/discord.py
+++ b/redash/destinations/discord.py
@@ -1,10 +1,9 @@
 import logging
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.models import Alert
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 colors = {
     # Colors are in a Decimal format as Discord requires them to be Decimals for embeds

--- a/redash/destinations/hangoutschat.py
+++ b/redash/destinations/hangoutschat.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps

--- a/redash/destinations/hangoutschat.py
+++ b/redash/destinations/hangoutschat.py
@@ -1,9 +1,8 @@
 import logging
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class HangoutsChat(BaseDestination):

--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps

--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -1,9 +1,8 @@
 import logging
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class Mattermost(BaseDestination):

--- a/redash/destinations/microsoft_teams_webhook.py
+++ b/redash/destinations/microsoft_teams_webhook.py
@@ -1,7 +1,7 @@
 import logging
 from string import Template
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps

--- a/redash/destinations/microsoft_teams_webhook.py
+++ b/redash/destinations/microsoft_teams_webhook.py
@@ -1,10 +1,9 @@
 import logging
 from string import Template
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 def json_string_substitute(j, substitutions):

--- a/redash/destinations/slack.py
+++ b/redash/destinations/slack.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps

--- a/redash/destinations/slack.py
+++ b/redash/destinations/slack.py
@@ -1,9 +1,8 @@
 import logging
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class Slack(BaseDestination):

--- a/redash/destinations/webex.py
+++ b/redash/destinations/webex.py
@@ -3,10 +3,9 @@ import json
 import logging
 from copy import deepcopy
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.models import Alert
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class Webex(BaseDestination):

--- a/redash/destinations/webex.py
+++ b/redash/destinations/webex.py
@@ -3,7 +3,7 @@ import json
 import logging
 from copy import deepcopy
 
-import requests
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.models import Alert

--- a/redash/destinations/webhook.py
+++ b/redash/destinations/webhook.py
@@ -1,7 +1,8 @@
 import logging
 
-import requests
 from requests.auth import HTTPBasicAuth
+
+from redash.utils.requests_session import requests_or_advocate as requests
 
 from redash.destinations import BaseDestination, register
 from redash.serializers import serialize_alert

--- a/redash/destinations/webhook.py
+++ b/redash/destinations/webhook.py
@@ -2,11 +2,10 @@ import logging
 
 from requests.auth import HTTPBasicAuth
 
-from redash.utils.requests_session import requests_or_advocate as requests
-
 from redash.destinations import BaseDestination, register
 from redash.serializers import serialize_alert
 from redash.utils import json_dumps
+from redash.utils.requests_session import requests_or_advocate as requests
 
 
 class Webhook(BaseDestination):


### PR DESCRIPTION
## What type of PR is this? 

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

Update all 10 alert destination modules to use `requests_or_advocate` from `redash.utils.requests_session` instead of bare `import requests`. This is a consistency update to ensure all outbound HTTP requests go through the same code path, matching what we already do in query runners.

Thanks to @morimori-dev for bringing this to our attention.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Verify alert destinations (webhook, Slack, Mattermost, Discord, etc.) continue to fire correctly and that `ENFORCE_PRIVATE_ADDRESS_BLOCK` applies to destination requests when enabled.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A