### PR TITLE
Make default group for new data sources configurable via env var

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -176,7 +176,19 @@ class DataSource(BelongsToOrgMixin, db.Model):
     @classmethod
     def create_with_group(cls, *args, **kwargs):
         data_source = cls(*args, **kwargs)
-        data_source_group = DataSourceGroup(data_source=data_source, group=data_source.org.default_group)
+
+        group_setting = settings.DATASOURCE_AUTO_ASSIGN_GROUP
+        if group_setting == "default":
+            group = data_source.org.default_group
+        elif group_setting == "admin":
+            group = data_source.org.admin_group
+        elif group_setting == "none":
+            db.session.add(data_source)
+            return data_source
+        else:
+            raise ValueError(f"Unexpected DATASOURCE_AUTO_ASSIGN_GROUP value: '{group_setting}'")
+
+        data_source_group = DataSourceGroup(data_source=data_source, group=group)
         db.session.add_all([data_source, data_source_group])
         return data_source
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -66,6 +66,19 @@ if SECRET_KEY is None:
 # The secret key to use when encrypting data source options
 DATASOURCE_SECRET_KEY = os.environ.get("REDASH_SECRET_KEY", SECRET_KEY)
 
+# Which group to automatically assign new data sources to.
+# Valid values: "admin", "default", "none"
+# "admin"   - add to admin group only (recommended, follows principle of least privilege)
+# "default" - add to default group (legacy behavior, all users can access)
+# "none"    - do not add to any group (manual assignment required)
+_DATASOURCE_AUTO_ASSIGN_GROUP_RAW = os.environ.get("REDASH_DATASOURCE_AUTO_ASSIGN_GROUP", "default").lower().strip()
+if _DATASOURCE_AUTO_ASSIGN_GROUP_RAW not in ("admin", "default", "none"):
+    raise ValueError(
+        f"Invalid value for REDASH_DATASOURCE_AUTO_ASSIGN_GROUP: '{_DATASOURCE_AUTO_ASSIGN_GROUP_RAW}'. "
+        "Valid values are: 'admin', 'default', 'none'."
+    )
+DATASOURCE_AUTO_ASSIGN_GROUP = _DATASOURCE_AUTO_ASSIGN_GROUP_RAW
+
 # Whether and how to redirect non-HTTP requests to HTTPS. Disabled by default.
 ENFORCE_HTTPS = parse_boolean(os.environ.get("REDASH_ENFORCE_HTTPS", "false"))
 ENFORCE_HTTPS_PERMANENT = parse_boolean(os.environ.get("REDASH_ENFORCE_HTTPS_PERMANENT", "false"))

--- a/tests/models/test_data_sources.py
+++ b/tests/models/test_data_sources.py
@@ -100,13 +100,53 @@ class DataSourceTest(BaseTestCase):
 
 class TestDataSourceCreate(BaseTestCase):
     def test_adds_data_source_to_default_group(self):
-        data_source = DataSource.create_with_group(
-            org=self.factory.org,
-            name="test",
-            options=ConfigurationContainer.from_json('{"dbname": "test"}'),
-            type="pg",
-        )
+        with patch("redash.settings.DATASOURCE_AUTO_ASSIGN_GROUP", "default"):
+            data_source = DataSource.create_with_group(
+                org=self.factory.org,
+                name="test",
+                options=ConfigurationContainer.from_json('{"dbname": "test"}'),
+                type="pg",
+            )
         self.assertIn(self.factory.org.default_group.id, data_source.groups)
+
+    def test_adds_data_source_to_admin_group(self):
+        with patch("redash.settings.DATASOURCE_AUTO_ASSIGN_GROUP", "admin"):
+            data_source = DataSource.create_with_group(
+                org=self.factory.org,
+                name="test",
+                options=ConfigurationContainer.from_json('{"dbname": "test"}'),
+                type="pg",
+            )
+        self.assertIn(self.factory.org.admin_group.id, data_source.groups)
+        self.assertNotIn(self.factory.org.default_group.id, data_source.groups)
+
+    def test_adds_data_source_to_no_group(self):
+        with patch("redash.settings.DATASOURCE_AUTO_ASSIGN_GROUP", "none"):
+            data_source = DataSource.create_with_group(
+                org=self.factory.org,
+                name="test",
+                options=ConfigurationContainer.from_json('{"dbname": "test"}'),
+                type="pg",
+            )
+        self.assertEqual(len(data_source.groups), 0)
+
+
+class TestDataSourceAutoAssignGroupValidation(BaseTestCase):
+    def test_rejects_invalid_value(self):
+        with self.assertRaises(ValueError):
+            self._validate("invalid")
+
+    def test_accepts_case_insensitive(self):
+        self.assertEqual(self._validate("Admin"), "admin")
+        self.assertEqual(self._validate("DEFAULT"), "default")
+        self.assertEqual(self._validate("None"), "none")
+
+    @staticmethod
+    def _validate(value):
+        normalized = value.lower().strip()
+        if normalized not in ("admin", "default", "none"):
+            raise ValueError(f"Invalid value for REDASH_DATASOURCE_AUTO_ASSIGN_GROUP: '{normalized}'.")
+        return normalized
 
 
 class TestDataSourceIsPaused(BaseTestCase):


### PR DESCRIPTION
Closes #7697

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Add a new environment variable `REDASH_DATASOURCE_AUTO_ASSIGN_GROUP` to control which group new data sources are assigned to.

| Value | Behavior |
|-------|----------|
| `default` | Add to default group (current behavior) |
| `admin` | Add to admin group only |
| `none` | Do not add to any group |

The default value would be `default` to preserve backward compatibility.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
