### PR TITLE
ci: replace sleep with healthchecks in compose.ci.yaml

### DIFF
--- a/.ci/compose.ci.yaml
+++ b/.ci/compose.ci.yaml
@@ -29,7 +29,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -h 127.0.0.1"]
       interval: 2s
       timeout: 5s
       retries: 15

--- a/.ci/compose.ci.yaml
+++ b/.ci/compose.ci.yaml
@@ -33,3 +33,4 @@ services:
       interval: 2s
       timeout: 5s
       retries: 15
+      start_period: 10s

--- a/.ci/compose.ci.yaml
+++ b/.ci/compose.ci.yaml
@@ -3,12 +3,12 @@ services:
     build: ../
     command: manage version
     depends_on:
-      - postgres
-      - redis
-    ports:
-      - "5000:5000"
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
-      PYTHONUNBUFFERED: 0
+      PYTHONUNBUFFERED: "1"
       REDASH_LOG_LEVEL: "INFO"
       REDASH_REDIS_URL: "redis://redis:6379/0"
       POSTGRES_PASSWORD: "FmTKs5vX52ufKR1rd8tn4MoSP7zvCJwb"
@@ -17,9 +17,19 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
   postgres:
     image: postgres:18-alpine
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,9 @@ jobs:
         run: |
           set -x
           docker compose build --build-arg install_groups="main,all_ds,dev" --build-arg skip_frontend_build=true
-          docker compose up -d
-          sleep 10
+          docker compose up -d --wait postgres redis
+      - name: Smoke Test Redash Image
+        run: docker compose -p redash run --rm redash manage version
       - name: Create Test Database
         run: docker compose -p redash run --rm postgres psql -h postgres -U postgres -c "create database tests;"
       - name: List Enabled Query Runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
         run: docker compose -p redash run --rm redash manage ds list_types
       - name: Run Tests
         run: docker compose -p redash run --name tests redash tests --junitxml=junit.xml --cov-report=xml --cov=redash --cov-config=.coveragerc tests/
+      - name: "Failure: output container logs"
+        if: failure()
+        run: docker compose logs
       - name: Copy Test Results
         run: |
           mkdir -p /tmp/test-results/unit-tests


### PR DESCRIPTION
## Summary

Replace the fragile `sleep 10` between `docker compose up -d` and the test steps with proper healthchecks + `--wait`, plus a few small cleanups in [.ci/compose.ci.yaml](.ci/compose.ci.yaml).

## Changes

**`.ci/compose.ci.yaml`**
- Add healthchecks to `postgres` (`pg_isready`) and `redis` (`redis-cli ping`).
- Switch the `redash` service's `depends_on` to `condition: service_healthy` for both, so any `docker compose run redash …` invocation also waits on real readiness.
- Drop the unused `ports: "5000:5000"` mapping. The CI compose only runs `manage version` and `tests`; neither binds port 5000, and the file [docker-compose.yml](docker-compose.yml) at the repo root is the right place for local dev port mapping.
- Fix `PYTHONUNBUFFERED: 0` → `"1"`. Python's `PYTHONUNBUFFERED` is presence-based — any non-empty value (including `"0"`) enables unbuffered mode, so the previous value did the opposite of what it read like.

**`.github/workflows/ci.yml`**
- Replace `docker compose up -d` + `sleep 10` with `docker compose up -d --wait postgres redis`. `--wait` blocks until the healthchecks pass (or fail), instead of a fixed 10s gamble.
- Promote the implicit `manage version` invocation (previously done by `up -d` against the redash service) to its own explicit `Smoke Test Redash Image` step, run via `docker compose run --rm`. Same coverage, clearer intent, no orphan exited container hanging around.

## Why

The `sleep 10` is both flaky and wasteful — too short on slow GitHub runners, longer than necessary on fast ones. Healthchecks remove the guesswork: dependents start the moment Postgres accepts connections, and the redash run steps no longer race against Postgres init.

## Test plan

- [x] `docker compose -f .ci/compose.ci.yaml config --quiet` passes.
- [ ] CI on this PR runs the unit-test job to completion (the real validation).
- [ ] Spot-check the workflow log: the new `Smoke Test Redash Image` step should print the version, and `up -d --wait` should return as soon as both healthchecks report healthy (typically a few seconds, vs. the old 10s sleep).