### PR TITLE
Fix displaying the "Name" field value for X and Y axes

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -20,7 +20,7 @@ function getAxisScaleType(axis: any) {
 function prepareXAxis(axisOptions: any, additionalOptions: any) {
   const titleText = getAxisTitleText(axisOptions);
   const axis: any = {
-    title: titleText ? { text: titleText } : undefined,
+    title: titleText ? { text: titleText } : null,
     type: getAxisScaleType(axisOptions),
     automargin: true,
     tickformat: axisOptions.tickFormat ?? null,
@@ -44,7 +44,7 @@ function prepareXAxis(axisOptions: any, additionalOptions: any) {
 function prepareYAxis(axisOptions: any) {
   const titleText = getAxisTitleText(axisOptions);
   return {
-    title: titleText ? { text: titleText } : undefined,
+    title: titleText ? { text: titleText } : null,
     type: getAxisScaleType(axisOptions),
     automargin: true,
     autorange: true,

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -1,8 +1,9 @@
 import { isObject, isUndefined, filter, map } from "lodash";
 import { getPieDimensions } from "./preparePieData";
 
-function getAxisTitle(axis: any) {
-  return isObject(axis.title) ? axis.title.text : null;
+function getAxisTitleText(axis: any): string | null {
+  if (!axis || !axis.title) return null;
+  return isObject(axis.title) ? axis.title.text : axis.title;
 }
 
 function getAxisScaleType(axis: any) {
@@ -17,8 +18,9 @@ function getAxisScaleType(axis: any) {
 }
 
 function prepareXAxis(axisOptions: any, additionalOptions: any) {
-  const axis = {
-    title: getAxisTitle(axisOptions),
+  const titleText = getAxisTitleText(axisOptions);
+  const axis: any = {
+    title: titleText ? { text: titleText } : undefined,
     type: getAxisScaleType(axisOptions),
     automargin: true,
     tickformat: axisOptions.tickFormat ?? null,
@@ -26,16 +28,13 @@ function prepareXAxis(axisOptions: any, additionalOptions: any) {
 
   if (additionalOptions.sortX && axis.type === "category") {
     if (additionalOptions.reverseX) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoryorder' does not exist on type '{... Remove this comment to see the full error message
       axis.categoryorder = "category descending";
     } else {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'categoryorder' does not exist on type '{... Remove this comment to see the full error message
       axis.categoryorder = "category ascending";
     }
   }
 
   if (!isUndefined(axisOptions.labels)) {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'showticklabels' does not exist on type '... Remove this comment to see the full error message
     axis.showticklabels = axisOptions.labels.enabled;
   }
 
@@ -43,8 +42,9 @@ function prepareXAxis(axisOptions: any, additionalOptions: any) {
 }
 
 function prepareYAxis(axisOptions: any) {
+  const titleText = getAxisTitleText(axisOptions);
   return {
-    title: getAxisTitle(axisOptions),
+    title: titleText ? { text: titleText } : undefined,
     type: getAxisScaleType(axisOptions),
     automargin: true,
     autorange: true,


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

OS: Chrome/Ubuntu 24.04.4 LTS

Redash version: 26.3.0
___
Issue: https://github.com/getredash/redash/issues/7700

The issue is related to a breaking change that occurred when updating Plotly.js from version 2 to version 3. Version 3 no longer supports passing axis titles as plain strings. Now the title must be defined as an object with a `text` field.

Structure used in Redash 25.1.0 (Plotly.js v2):
```
"xaxis": {
  "title": "random string",
}
```

Structure required in Redash 26.3.0 (Plotly.js v3):
```
"xaxis": {
  "title": {
    "text": "random string",
  }
}
```

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

**1.** Create New Query. I'm using the script that was already used here for testing Charts:

```
select '2025-01-01' as t, 'apple' as grp1, 'tokyo' as grp2, 10 as value
union all
select '2025-01-01' as t, 'orange' as grp1, 'tokyo' as grp2, 20 as value
union all
select '2025-01-01' as t, 'apple' as grp1, 'osaka' as grp2, 30 as value
union all
select '2025-01-01' as t, 'orange' as grp1, 'osaka' as grp2, 40 as value
union all
select '2025-01-02' as t, 'apple' as grp1, 'tokyo' as grp2, 210 as value
union all
select '2025-01-02' as t, 'orange' as grp1, 'tokyo' as grp2, 220 as value
union all
select '2025-01-02' as t, 'apple' as grp1, 'osaka' as grp2, 230 as value
union all
select '2025-01-02' as t, 'orange' as grp1, 'osaka' as grp2, 240 as value
union all
select '2025-01-03' as t, 'apple' as grp1, 'tokyo' as grp2, 110 as value
union all
select '2025-01-03' as t, 'orange' as grp1, 'tokyo' as grp2, 120 as value
union all
select '2025-01-03' as t, 'apple' as grp1, 'osaka' as grp2, 130 as value
union all
select '2025-01-03' as t, 'orange' as grp1, 'osaka' as grp2, 140 as value
```

**2.** Add Visualization -> Chart -> Line/Bar/Area...

**3.** Settings:
 - X Column = "t"
 - Y Columns = "value"
 - Group by = "grp1
 - X Axis(tab):
   - Name = "random string"
 - Y Axis(tab):
   - Left Y Axis -> Name = "random string"

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**This is what it looks like now:**

<img width="3644" height="1244" alt="2630_1" src="https://github.com/user-attachments/assets/45570a7b-dc43-4880-822c-df87a209a68f" />


**After applying the changes:**

<img width="3668" height="1527" alt="2630_after" src="https://github.com/user-attachments/assets/b4e909df-982e-46dd-b2d1-df40e2801578" />
