### PR TITLE
fix: Fall back to SVV_ALL_COLUMNS when Redshift schemas cannot be read

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -412,6 +412,24 @@ class Redshift(PostgreSQL):
 
         self._get_definitions(schema, query)
 
+        # Fall back to svv_all_columns when svv_columns does not return results.
+        # svv_all_columns already returns only accessible tables for regular users,
+        # so no additional permission filtering is needed.
+        # https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_ALL_COLUMNS.html
+        if not schema:
+            query_all = """
+            SELECT DISTINCT table_name,
+                            schema_name AS table_schema,
+                            column_name,
+                            data_type,
+                            ordinal_position AS pos
+            FROM svv_all_columns
+            WHERE schema_name NOT IN ('pg_internal','pg_catalog','information_schema')
+            AND schema_name NOT LIKE 'pg_temp_%'
+            ORDER BY table_name, pos
+            """
+            self._get_definitions(schema, query_all)
+
         return list(schema.values())
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

When using Redshift with data sharing (e.g. cross-database sharing on Redshift Serverless), `svv_columns` does not return shared tables/schemas, which prevents schema browsing in the query editor.

This change adds a fallback to `svv_all_columns` when `svv_columns` returns no results, enabling schema browsing for data-shared tables.

`svv_all_columns` already restricts visibility to accessible tables for regular users ([AWS docs](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_ALL_COLUMNS.html)), so no additional permission filtering is applied in the fallback query.

## How it works

1. The existing `svv_columns` query runs first with `HAS_SCHEMA_PRIVILEGE` / `HAS_TABLE_PRIVILEGE` / `SVV_EXTERNAL_SCHEMAS` filtering (unchanged).
2. If the result is empty, a second query against `svv_all_columns` is executed as a fallback.

## How has this been tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Tested manually on Redshift Serverless with data-shared tables:
- Confirmed `svv_columns` returns empty results for shared schemas
- Confirmed `svv_all_columns` fallback correctly loads shared table schemas
- Confirmed existing behavior on provisioned Redshift clusters is unchanged

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A