### PR TITLE
build: upgrade base images to Debian trixie and Poetry 2.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-bookworm AS frontend-builder
+FROM node:24-trixie AS frontend-builder
 
 RUN npm install --global pnpm@10.30.3
 
@@ -39,14 +39,29 @@ RUN --mount=type=cache,id=pnpm-store,target=/frontend/.cache/pnpm,uid=1001,gid=1
   fi
 EOF
 
-FROM python:3.13-slim-bookworm
+FROM python:3.13-slim-trixie
 
 EXPOSE 5000
 
 RUN useradd --create-home redash
 
-# Ubuntu packages
+# Add Debian trixie-security and trixie-updates repositories so we get the latest
+# security fixes and stable point updates at build time.
+# trixie-proposed-updates is kept for opt-in pre-release fixes already in flight.
+RUN set -eux; \
+  printf 'deb http://deb.debian.org/debian-security trixie-security main\n' \
+    > /etc/apt/sources.list.d/trixie-security.list; \
+  printf 'deb http://deb.debian.org/debian trixie-updates main\n' \
+    > /etc/apt/sources.list.d/trixie-updates.list; \
+  printf 'deb http://deb.debian.org/debian trixie-proposed-updates main\n' \
+    > /etc/apt/sources.list.d/trixie-proposed-updates.list
+
+# Apply security archive first (forces -t trixie-security so the security pocket wins),
+# then a general upgrade for stable point updates, then install build dependencies.
 RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y -t trixie-security upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y -t trixie-updates upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
   apt-get install -y --no-install-recommends \
   pkg-config \
   curl \
@@ -80,7 +95,7 @@ ARG databricks_odbc_driver_url=https://databricks-bi-artifacts.s3.us-east-2.amaz
 RUN <<EOF
   if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-    curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list
+    curl https://packages.microsoft.com/config/debian/13/prod.list > /etc/apt/sources.list.d/mssql-release.list
     apt-get update
     ACCEPT_EULA=Y apt-get install  -y --no-install-recommends msodbcsql18
     apt-get clean
@@ -97,10 +112,12 @@ EOF
 
 WORKDIR /app
 
-ENV POETRY_VERSION=2.1.4
+ENV POETRY_VERSION=2.4.1
 ENV POETRY_HOME=/etc/poetry
 ENV POETRY_VIRTUALENVS_CREATE=false
-RUN curl -sSL --retry 3 --retry-delay 5 https://install.python-poetry.org | python3 -
+
+RUN python3 -m pip install --no-cache-dir --upgrade "pip>=26.1" "setuptools>=78.1.1" "wheel>=0.46.2" \
+  && curl -sSL --retry 3 --retry-delay 5 https://install.python-poetry.org | python3 -
 
 # Avoid crashes, including corrupted cache artifacts, when building multi-platform images with GitHub Actions.
 RUN /etc/poetry/bin/poetry cache clear pypi --all

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "copy-webpack-plugin": "^13.0.1",
+    "core-js": "^2.6.12",
     "css-loader": "^7.1.4",
     "cypress": "^11.2.0",
     "dayjs": "^1.11.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       copy-webpack-plugin:
         specifier: ^13.0.1
         version: 13.0.1(webpack@5.105.3)
+      core-js:
+        specifier: ^2.6.12
+        version: 2.6.12
       css-loader:
         specifier: ^7.1.4
         version: 7.1.4(webpack@5.105.3)


### PR DESCRIPTION
- Node base: node:24-bookworm → node:24-trixie
- Python base: python:3.13-slim-bookworm → python:3.13-slim-trixie
- Add trixie-security, trixie-updates, and trixie-proposed-updates repos
- Apply targeted security upgrades before installing packages
- MSSQL packages repo: debian/12 → debian/13
- POETRY_VERSION: 2.1.4 → 2.4.1
- Upgrade pip/setuptools/wheel before Poetry install

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [x] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
