### PR TITLE
build: upgrade Poetry to 2.4.1 and pin pip/setuptools/wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,10 +97,12 @@ EOF
 
 WORKDIR /app
 
-ENV POETRY_VERSION=2.1.4
+ENV POETRY_VERSION=2.4.1
 ENV POETRY_HOME=/etc/poetry
 ENV POETRY_VIRTUALENVS_CREATE=false
-RUN curl -sSL --retry 3 --retry-delay 5 https://install.python-poetry.org | python3 -
+
+RUN python3 -m pip install --no-cache-dir --upgrade "pip>=26.1" "setuptools>=78.1.1" "wheel>=0.46.2" \
+  && curl -sSL --retry 3 --retry-delay 5 https://install.python-poetry.org | python3 -
 
 # Avoid crashes, including corrupted cache artifacts, when building multi-platform images with GitHub Actions.
 RUN /etc/poetry/bin/poetry cache clear pypi --all


### PR DESCRIPTION
## What type of PR is this?

* Refactor

## Description

Upgrades Python build toolchain in the Dockerfile:

- `POETRY_VERSION`: 2.1.4 → 2.4.1
- Upgrade `pip>=26.1`, `setuptools>=78.1.1`, `wheel>=0.46.2` before Poetry install

This ensures:
1. Poetry 2.4.1 is installed with current features and fixes
2. pip/setuptools/wheel are upgraded to versions with known security fixes:
   - `setuptools>=78.1.1` remediates **CVE-2025-47273** (path traversal in sdist extraction)
   - `pip>=26.1` and `wheel>=0.46.2` provide current patch levels

The pip/setuptools/wheel upgrade happens before the Poetry install to ensure Poetry itself is installed with secure build tooling.

## How is this tested?

* Manually (container rebuild with `make compose_build` required for full validation)

## Related Tickets & Documents

Split from #7718 per @zachliu's review feedback to separate build toolchain upgrades from base image changes.

Part of the security vulnerability remediation work tracked in #7711.

## Note

This PR is marked as **draft** until manual container testing is complete.

Made with [Cursor](https://cursor.com)