### PR TITLE
fix: add core-js polyfill for babel preset-env useBuiltIns

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "copy-webpack-plugin": "^13.0.1",
+    "core-js": "^2.6.12",
     "css-loader": "^7.1.4",
     "cypress": "^11.2.0",
     "dayjs": "^1.11.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       copy-webpack-plugin:
         specifier: ^13.0.1
         version: 13.0.1(webpack@5.105.3)
+      core-js:
+        specifier: ^2.6.12
+        version: 2.6.12
       css-loader:
         specifier: ^7.1.4
         version: 7.1.4(webpack@5.105.3)


### PR DESCRIPTION
## What type of PR is this?

* Bug Fix

## Description

Add `core-js@^2.6.12` as a devDependency to satisfy `@babel/preset-env`'s `useBuiltIns: "usage"` configuration with `corejs: 2`.

This resolves build-time polyfill import errors where Babel injects `import 'core-js/modules/...'` statements but the package is not installed.

The babel config (`client/.babelrc.js`) uses:
- `useBuiltIns: "usage"` - automatically imports polyfills based on code usage
- `corejs: 2` - targets core-js version 2.x

Without core-js installed, the frontend build and Jest tests fail with "Cannot find module 'core-js/modules/es6.symbol.js'" errors.

**Note:** core-js@2 is EOL. A future migration to core-js@3 is recommended, but requires updating the babel config and is out of scope for this fix.

## How is this tested?

* Unit tests (Jest) - all 15 test suites pass with core-js installed

## Related Tickets & Documents

Split from #7718 per @zachliu's review feedback to separate frontend build dependency additions from Dockerfile infrastructure changes.

Part of the security vulnerability remediation work tracked in #7711.

## Note

This PR is marked as **draft** until manual container testing is complete.

Made with [Cursor](https://cursor.com)