### PR TITLE
build: add core-js for frontend build compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "copy-webpack-plugin": "^13.0.1",
+    "core-js": "^2.6.12",
     "css-loader": "^7.1.4",
     "cypress": "^11.2.0",
     "dayjs": "^1.11.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       copy-webpack-plugin:
         specifier: ^13.0.1
         version: 13.0.1(webpack@5.105.3)
+      core-js:
+        specifier: ^2.6.12
+        version: 2.6.12
       css-loader:
         specifier: ^7.1.4
         version: 7.1.4(webpack@5.105.3)


### PR DESCRIPTION
## Summary
Add `core-js` as a devDependency to resolve Babel polyfill requirements for `@babel/preset-env` under pnpm.

## Changes
- Add `core-js: ^2.6.12` to devDependencies
- Regenerate `pnpm-lock.yaml`

## Why
- `@babel/preset-env` requires `core-js` for polyfill resolution
- Without it, frontend builds may fail with module resolution errors like:
  ```
  Cannot find module 'core-js/modules/es6.symbol.js'
  Cannot find module 'core-js/modules/es7.array.includes.js'
  ```
- This is a build-time dependency only (not shipped to production)

## CVEs Addressed
None - this is a build fix

## Testing
- ✅ Python tests pass (frontend-only change)
- ✅ Frontend tests pass
- ✅ `pnpm install` succeeds

## Note
- core-js 2.x is used (not 3.x) for compatibility with existing Babel configuration
- Deprecation warning is expected but acceptable for this version
- This is consistent with how other projects using similar Babel setups handle core-js

## Dependencies
None - independent frontend build fix

Made with [Cursor](https://cursor.com)