### PR TITLE
[fix]: thread RelayState through SAML login to preserve redirect

### DIFF
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -10,6 +10,7 @@ from saml2.sigver import get_xmlsec_binary
 from redash import settings
 from redash.authentication import (
     create_and_login_user,
+    get_next_path,
     logout_and_redirect_to_index,
 )
 from redash.authentication.org_resolving import current_org
@@ -141,9 +142,10 @@ def idp_initiated(org_slug=None):
         group_names = authn_response.ava.get("RedashGroups")
         user.update_group_assignments(group_names)
 
-    url = url_for("redash.index", org_slug=org_slug)
+    index_url = url_for("redash.index", org_slug=org_slug)
+    next_path = get_next_path(request.form.get("RelayState", index_url))
 
-    return redirect(url)
+    return redirect(next_path or index_url)
 
 
 @blueprint.route(org_scoped_rule("/saml/login"))
@@ -157,7 +159,10 @@ def sp_initiated(org_slug=None):
     if nameid_format is None or nameid_format == "":
         nameid_format = NAMEID_FORMAT_TRANSIENT
 
-    _, info = saml_client.prepare_for_authenticate(nameid_format=nameid_format)
+    index_url = url_for("redash.index", org_slug=org_slug)
+    next_path = get_next_path(request.args.get("next", index_url))
+
+    _, info = saml_client.prepare_for_authenticate(nameid_format=nameid_format, relay_state=next_path or index_url)
 
     redirect_url = None
     # Select the IdP URL to send the AuthN request to

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -295,6 +295,96 @@ class TestRedirectToUrlAfterLoggingIn(BaseTestCase):
         self.assertEqual(response.location, "/queries")
 
 
+class TestSAMLAuth(BaseTestCase):
+    def setUp(self):
+        super(TestSAMLAuth, self).setUp()
+        self.factory.org.set_setting("auth_saml_enabled", True)
+        models.db.session.commit()
+
+    def configure_saml_client_for_login(self, get_saml_client):
+        saml_client = Mock()
+        saml_client.prepare_for_authenticate.return_value = (
+            "request-id",
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        get_saml_client.return_value = saml_client
+        return saml_client
+
+    def configure_saml_client_for_callback(self, get_saml_client):
+        saml_client = Mock()
+        authn_response = Mock()
+        subject = Mock()
+        subject.text = "test@example.com"
+        authn_response.get_subject.return_value = subject
+        authn_response.ava = {"FirstName": ["Test"], "LastName": ["User"]}
+        saml_client.parse_authn_request_response.return_value = authn_response
+        get_saml_client.return_value = saml_client
+        return saml_client
+
+    @patch("redash.authentication.saml_auth.get_saml_client")
+    def test_sp_initiated_login_passes_next_as_relay_state(self, get_saml_client):
+        saml_client = self.configure_saml_client_for_login(get_saml_client)
+
+        response = self.get_request("/saml/login?next=/queries/1?p=abc", org=self.factory.org)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "https://idp.example.com/sso")
+        self.assertEqual(saml_client.prepare_for_authenticate.call_args[1]["relay_state"], "/queries/1?p=abc")
+
+    @patch("redash.authentication.saml_auth.get_saml_client")
+    def test_sp_initiated_login_sanitizes_relay_state(self, get_saml_client):
+        saml_client = self.configure_saml_client_for_login(get_saml_client)
+
+        self.get_request("/saml/login?next=https://example.com", org=self.factory.org)
+
+        self.assertEqual(saml_client.prepare_for_authenticate.call_args[1]["relay_state"], "./")
+
+    @patch("redash.authentication.saml_auth.create_and_login_user")
+    @patch("redash.authentication.saml_auth.get_saml_client")
+    def test_callback_redirects_to_relay_state(self, get_saml_client, create_and_login_user):
+        self.configure_saml_client_for_callback(get_saml_client)
+        create_and_login_user.return_value = self.factory.user
+
+        response = self.post_request(
+            "/saml/callback",
+            org=self.factory.org,
+            data={"SAMLResponse": "response", "RelayState": "/queries/1?p=abc"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/queries/1?p=abc")
+
+    @patch("redash.authentication.saml_auth.create_and_login_user")
+    @patch("redash.authentication.saml_auth.get_saml_client")
+    def test_callback_sanitizes_relay_state(self, get_saml_client, create_and_login_user):
+        self.configure_saml_client_for_callback(get_saml_client)
+        create_and_login_user.return_value = self.factory.user
+
+        response = self.post_request(
+            "/saml/callback",
+            org=self.factory.org,
+            data={"SAMLResponse": "response", "RelayState": "https://example.com"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "./")
+
+    @patch("redash.authentication.saml_auth.create_and_login_user")
+    @patch("redash.authentication.saml_auth.get_saml_client")
+    def test_callback_without_relay_state_redirects_to_index(self, get_saml_client, create_and_login_user):
+        self.configure_saml_client_for_callback(get_saml_client)
+        create_and_login_user.return_value = self.factory.user
+
+        response = self.post_request(
+            "/saml/callback",
+            org=self.factory.org,
+            data={"SAMLResponse": "response"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/{}/".format(self.factory.org.slug))
+
+
 class TestRemoteUserAuth(BaseTestCase):
     DEFAULT_SETTING_OVERRIDES = {"REDASH_REMOTE_USER_LOGIN_ENABLED": "true"}
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Bug Fix

## Description

When following a URL like `https://redash.<corp>.net/queries/123` and having to go through a SAML auth flow, the path is dropped upon completion of the flow and you land on the redash index instead of the URL of the link you clicked. This change attempts to fix this by propagating the "RelayState" across the auth flow.

## How is this tested?

- [x] Unit tests (pytest, jest)

I was unsure how to test this manually.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

