### PR TITLE
fix: match double-quoted __version__ in .ci/update_version

### DIFF
--- a/.ci/update_version
+++ b/.ci/update_version
@@ -2,5 +2,5 @@
 VERSION=$(jq -r .version package.json)
 FULL_VERSION=${VERSION}+b${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}
 
-sed -ri "s/^__version__ = '([A-Za-z0-9.-]*)'/__version__ = '${FULL_VERSION}'/" redash/__init__.py
+sed -ri "s/^__version__ = \"([A-Za-z0-9.-]*)\"/__version__ = \"${FULL_VERSION}\"/" redash/__init__.py
 sed -i "s/dev/${GITHUB_SHA}/" client/app/version.json


### PR DESCRIPTION
## What & why

Fixes #7598.

`.ci/update_version` stamps the build version into `redash/__init__.py` during release CI:

```sh
sed -ri "s/^__version__ = '([A-Za-z0-9.-]*)'/__version__ = '${FULL_VERSION}'/" redash/__init__.py
```

The pattern matches a **single-quoted** value, but the file declares the version with **double quotes**:

```python
__version__ = "26.06.0-dev"
```

So the substitution never matches and the version is silently left as the `-dev` placeholder in built images — `FULL_VERSION` (`<version>+b<run_id>.<run_number>`) is never applied.

## Fix

One line — match (and emit) the double-quoted form.

## Testing

Verified end-to-end by running the **actual script** against temp copies with CI-like env (`GITHUB_RUN_ID`/`GITHUB_RUN_NUMBER`/`GITHUB_SHA`, real `package.json` version via `jq`):

- **Old script**: `__version__` left unchanged — reproduces the bug.
- **New script**: `__version__` becomes `26.06.0-dev+b12345.67`; exactly one line changes; the `client/app/version.json` `dev → SHA` step is unaffected.

5/5 assertions pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

