### PR TITLE
Tolerate inaccessible datasets when loading BigQuery schema

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -333,47 +333,56 @@ class BigQuery(BaseSQLQueryRunner):
                 location_dataset_ids[location] = []
             location_dataset_ids[location].append(dataset_id)
 
-        for location, datasets in location_dataset_ids.items():
-            queries = []
-            for dataset_id in datasets:
-                query = query_base.format(dataset_id=dataset_id)
-                queries.append(query)
-
-            query = "\nUNION ALL\n".join(queries)
-            results, error = self.run_query(query, None)
-            if error is not None:
-                self._handle_run_query_error(error)
-
-            for row in results["rows"]:
-                table_name = "{0}.{1}".format(row["table_schema"], row["table_name"])
-                if table_name not in schema:
-                    schema[table_name] = {"name": table_name, "columns": []}
-                schema[table_name]["columns"].append(
-                    {
-                        "name": row["field_path"],
-                        "type": row["data_type"],
-                        "description": row["description"],
-                    }
-                )
-
-            table_queries = []
-            for dataset_id in datasets:
-                table_query = table_query_base.format(dataset_id=dataset_id)
-                table_queries.append(table_query)
-
-            table_query = "\nUNION ALL\n".join(table_queries)
-            results, error = self.run_query(table_query, None)
-            if error is not None:
-                self._handle_run_query_error(error)
-
-            for row in results["rows"]:
-                table_name = "{0}.{1}".format(row["table_schema"], row["table_name"])
-                if table_name not in schema:
-                    schema[table_name] = {"name": table_name, "columns": []}
-                if "table_description" in row:
-                    schema[table_name]["description"] = row["table_description"]
+        for location, dataset_ids in location_dataset_ids.items():
+            self._load_columns(dataset_ids, query_base, schema)
+            self._load_table_descriptions(dataset_ids, table_query_base, schema)
 
         return list(schema.values())
+
+    def _run_schema_query(self, dataset_ids, query_template):
+        """Fetch schema metadata for the given datasets, tolerating per-dataset errors.
+
+        Sends a single batched UNION ALL query first (fast path). If it fails -
+        e.g. the service account cannot access one of the datasets - falls back to
+        querying each dataset individually and skips the ones that error, so a
+        single inaccessible dataset doesn't wipe out the schema for the whole data
+        source.
+        """
+        query = "\nUNION ALL\n".join(query_template.format(dataset_id=dataset_id) for dataset_id in dataset_ids)
+        results, error = self.run_query(query, None)
+        if error is None:
+            return results["rows"]
+
+        logger.warning("Batched schema query failed, retrying per dataset. Error: %s", error)
+        rows = []
+        for dataset_id in dataset_ids:
+            results, error = self.run_query(query_template.format(dataset_id=dataset_id), None)
+            if error is not None:
+                logger.warning("Skipping dataset '%s' while loading schema: %s", dataset_id, error)
+                continue
+            rows.extend(results["rows"])
+        return rows
+
+    def _load_columns(self, dataset_ids, query_template, schema):
+        for row in self._run_schema_query(dataset_ids, query_template):
+            table_name = "{0}.{1}".format(row["table_schema"], row["table_name"])
+            if table_name not in schema:
+                schema[table_name] = {"name": table_name, "columns": []}
+            schema[table_name]["columns"].append(
+                {
+                    "name": row["field_path"],
+                    "type": row["data_type"],
+                    "description": row["description"],
+                }
+            )
+
+    def _load_table_descriptions(self, dataset_ids, query_template, schema):
+        for row in self._run_schema_query(dataset_ids, query_template):
+            table_name = "{0}.{1}".format(row["table_schema"], row["table_name"])
+            if table_name not in schema:
+                schema[table_name] = {"name": table_name, "columns": []}
+            if "table_description" in row:
+                schema[table_name]["description"] = row["table_description"]
 
     def run_query(self, query, user):
         logger.debug("BigQuery got query: %s", query)

--- a/tests/query_runner/test_bigquery.py
+++ b/tests/query_runner/test_bigquery.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from redash.query_runner.big_query import BigQuery
 
@@ -43,3 +44,78 @@ class TestBigQueryQueryRunner(unittest.TestCase):
         expect = query
 
         self.assertEqual(query_runner.annotate_query(query, metadata), expect)
+
+    def test_get_schema_skips_datasets_without_access(self):
+        query_runner = BigQuery({"projectId": "test-project", "loadSchema": True})
+
+        datasets = [
+            {"datasetReference": {"datasetId": "accessible"}, "location": "US"},
+            {"datasetReference": {"datasetId": "forbidden"}, "location": "US"},
+        ]
+
+        def fake_run_query(query, user):
+            if "forbidden" in query:
+                return None, "Access Denied: ... PERMISSION_DENIED"
+            if "COLUMN_FIELD_PATHS" in query:
+                return {
+                    "rows": [
+                        {
+                            "table_schema": "accessible",
+                            "table_name": "t1",
+                            "field_path": "id",
+                            "data_type": "INT64",
+                            "description": None,
+                        }
+                    ]
+                }, None
+            return {
+                "rows": [
+                    {
+                        "table_schema": "accessible",
+                        "table_name": "t1",
+                        "table_description": "desc",
+                    }
+                ]
+            }, None
+
+        with mock.patch.object(BigQuery, "_get_project_datasets", return_value=datasets), mock.patch.object(
+            BigQuery, "run_query", side_effect=fake_run_query
+        ):
+            schema = query_runner.get_schema()
+
+        self.assertEqual([table["name"] for table in schema], ["accessible.t1"])
+        self.assertEqual(schema[0]["columns"][0]["name"], "id")
+        self.assertEqual(schema[0]["description"], "desc")
+
+    def test_get_schema_uses_single_batched_query_when_all_accessible(self):
+        query_runner = BigQuery({"projectId": "test-project", "loadSchema": True})
+
+        datasets = [
+            {"datasetReference": {"datasetId": "ds_a"}, "location": "US"},
+            {"datasetReference": {"datasetId": "ds_b"}, "location": "US"},
+        ]
+
+        def fake_run_query(query, user):
+            if "COLUMN_FIELD_PATHS" in query:
+                return {
+                    "rows": [
+                        {
+                            "table_schema": "ds_a",
+                            "table_name": "t",
+                            "field_path": "id",
+                            "data_type": "INT64",
+                            "description": None,
+                        }
+                    ]
+                }, None
+            return {"rows": []}, None
+
+        with mock.patch.object(BigQuery, "_get_project_datasets", return_value=datasets), mock.patch.object(
+            BigQuery, "run_query", side_effect=fake_run_query
+        ) as run_query:
+            query_runner.get_schema()
+
+        # One batched columns query + one batched table-options query, no per-dataset fallback.
+        self.assertEqual(run_query.call_count, 2)
+        for call in run_query.call_args_list:
+            self.assertIn("UNION ALL", call.args[0])


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

`get_schema()` for BigQuery lists every dataset in the project and queries their `INFORMATION_SCHEMA` in a single `UNION ALL`. If any one dataset returns an error, `_handle_run_query_error()` raises and the whole schema refresh aborts, so the schema browser ends up empty.

This breaks environments that use dataset-level IAM (per-team isolation): a service account is granted only a subset of datasets, and the datasets it cannot read return `403 PERMISSION_DENIED` on `INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` / `TABLE_OPTIONS`. A single inaccessible dataset then hides the schema for the datasets the account *can* read.

The `location` filter (#7289) only helps when the inaccessible datasets live in a different location; when every dataset shares one location it excludes nothing.

This PR makes schema loading tolerant of per-dataset failures:

- Send the batched `UNION ALL` query first (fast path, unchanged for fully-accessible projects).
- If it fails, fall back to querying each dataset individually and skip the ones that error.

Per-dataset fallback queries are bounded by dataset count (not table count), so the performance win from #5632 is preserved for the common case.

Compatible with the existing BigQuery query runner; no configuration or schema changes.

## How is this tested?

- [x] Unit tests (pytest, jest)

Added `tests/query_runner/test_bigquery.py`:

- `test_get_schema_skips_datasets_without_access`: an inaccessible dataset is skipped and the accessible dataset's schema still loads.
- `test_get_schema_uses_single_batched_query_when_all_accessible`: when all datasets are accessible, only the batched queries run (no per-dataset fallback).

## Related Tickets & Documents

Closes #7760
Refs #5632, #7289

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

