### PR TITLE
feat(alerts): add opt-in "Allow HTML content" for custom templates

### DIFF
--- a/client/app/pages/alert/AlertEdit.jsx
+++ b/client/app/pages/alert/AlertEdit.jsx
@@ -103,6 +103,8 @@ export default class AlertEdit extends React.Component {
                       setSubject={subject => onNotificationTemplateChange({ custom_subject: subject })}
                       body={options.custom_body}
                       setBody={body => onNotificationTemplateChange({ custom_body: body })}
+                      allowHtml={options.allow_html}
+                      setAllowHtml={allowHtml => onNotificationTemplateChange({ allow_html: allowHtml })}
                     />
                   </HorizontalFormItem>
                 </>

--- a/client/app/pages/alert/AlertNew.jsx
+++ b/client/app/pages/alert/AlertNew.jsx
@@ -70,6 +70,8 @@ export default class AlertNew extends React.Component {
                       setSubject={subject => onNotificationTemplateChange({ custom_subject: subject })}
                       body={options.custom_body}
                       setBody={body => onNotificationTemplateChange({ custom_body: body })}
+                      allowHtml={options.allow_html}
+                      setAllowHtml={allowHtml => onNotificationTemplateChange({ allow_html: allowHtml })}
                     />
                   </HorizontalFormItem>
                 </>

--- a/client/app/pages/alert/components/NotificationTemplate.jsx
+++ b/client/app/pages/alert/components/NotificationTemplate.jsx
@@ -4,12 +4,14 @@ import { head, isEmpty, isNull, isUndefined } from "lodash";
 import Mustache from "mustache";
 
 import HelpTrigger from "@/components/HelpTrigger";
+import Tooltip from "@/components/Tooltip";
 import { Alert as AlertType, Query as QueryType } from "@/components/proptypes";
 
 import Input from "antd/lib/input";
 import Select from "antd/lib/select";
 import Modal from "antd/lib/modal";
 import Switch from "antd/lib/switch";
+import Checkbox from "antd/lib/checkbox";
 
 import "./NotificationTemplate.less";
 
@@ -30,7 +32,18 @@ function normalizeCustomTemplateData(alert, query, columnNames, resultValues) {
   };
 }
 
-function NotificationTemplate({ alert, query, columnNames, resultValues, subject, setSubject, body, setBody }) {
+function NotificationTemplate({
+  alert,
+  query,
+  columnNames,
+  resultValues,
+  subject,
+  setSubject,
+  body,
+  setBody,
+  allowHtml,
+  setAllowHtml,
+}) {
   const hasContent = !!(subject || body);
   const [enabled, setEnabled] = useState(hasContent ? 1 : 0);
   const [showPreview, setShowPreview] = useState(false);
@@ -49,6 +62,7 @@ function NotificationTemplate({ alert, query, columnNames, resultValues, subject
         onOk: () => {
           setSubject(null);
           setBody(null);
+          setAllowHtml(false);
           setEnabled(value);
           setShowPreview(false);
         },
@@ -100,6 +114,16 @@ function NotificationTemplate({ alert, query, columnNames, resultValues, subject
             <i className="fa fa-question-circle" aria-hidden="true" /> Formatting guide{" "}
             <span className="sr-only">(help)</span>
           </HelpTrigger>
+          <Checkbox
+            className="alert-template-allow-html"
+            checked={allowHtml}
+            onChange={e => setAllowHtml(e.target.checked)}
+            data-test="AlertTemplateAllowHTML">
+            Allow HTML content
+            <Tooltip title="Renders query values without escaping, so destination formatting comes through instead of appearing as literal text. Only enable for queries you trust.">
+              <i className="fa fa-question-circle" aria-hidden="true" />
+            </Tooltip>
+          </Checkbox>
         </div>
       )}
     </div>
@@ -115,11 +139,14 @@ NotificationTemplate.propTypes = {
   setSubject: PropTypes.func.isRequired,
   body: PropTypes.string,
   setBody: PropTypes.func.isRequired,
+  allowHtml: PropTypes.bool,
+  setAllowHtml: PropTypes.func.isRequired,
 };
 
 NotificationTemplate.defaultProps = {
   subject: "",
   body: "",
+  allowHtml: false,
 };
 
 export default NotificationTemplate;

--- a/client/app/pages/alert/components/NotificationTemplate.less
+++ b/client/app/pages/alert/components/NotificationTemplate.less
@@ -33,4 +33,15 @@
   .alert-template-preview {
       margin: 0 0 0 5px !important;
   }
+
+  .alert-template-allow-html {
+      display: block;
+      margin-top: 8px;
+
+      .fa-question-circle {
+          margin-left: 5px;
+          color: rgba(0, 0, 0, 0.45);
+          cursor: help;
+      }
+  }
 }

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1087,12 +1087,12 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
     @property
     def custom_body(self):
         template = self.options.get("custom_body", self.options.get("template"))
-        return self.render_template(template, escape=not self.options.get("allow_html"))
+        return self.render_template(template, escape=self.options.get("allow_html") is not True)
 
     @property
     def custom_subject(self):
         template = self.options.get("custom_subject")
-        return self.render_template(template, escape=not self.options.get("allow_html"))
+        return self.render_template(template, escape=self.options.get("allow_html") is not True)
 
     @property
     def groups(self):

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1051,7 +1051,7 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
     def subscribers(self):
         return User.query.join(AlertSubscription).filter(AlertSubscription.alert == self)
 
-    def render_template(self, template):
+    def render_template(self, template, escape=True):
         if template is None:
             return ""
 
@@ -1081,17 +1081,18 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
             "QUERY_RESULT_COLS": data["columns"],
             "QUERY_RESULT_TABLE": result_table,
         }
-        return mustache_render_escape(template, context)
+        render = mustache_render_escape if escape else mustache_render
+        return render(template, context)
 
     @property
     def custom_body(self):
         template = self.options.get("custom_body", self.options.get("template"))
-        return self.render_template(template)
+        return self.render_template(template, escape=not self.options.get("allow_html"))
 
     @property
     def custom_subject(self):
         template = self.options.get("custom_subject")
-        return self.render_template(template)
+        return self.render_template(template, escape=not self.options.get("allow_html"))
 
     @property
     def groups(self):

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -216,3 +216,26 @@ class TestAlertRenderTemplate(BaseTestCase):
         """
         result = alert.render_template(textwrap.dedent(custom_alert))
         self.assertMultiLineEqual(result, textwrap.dedent(expected))
+
+    def test_custom_body_escapes_html_by_default(self):
+        alert = self.create_alert(get_results("<b>bold</b>"))
+        alert.options["custom_body"] = "Value: {{QUERY_RESULT_VALUE}}"
+        self.assertEqual(alert.custom_body, "Value: &lt;b&gt;bold&lt;/b&gt;")
+
+    def test_custom_body_renders_html_when_allow_html_enabled(self):
+        alert = self.create_alert(get_results("<b>bold</b>"))
+        alert.options["custom_body"] = "Value: {{QUERY_RESULT_VALUE}}"
+        alert.options["allow_html"] = True
+        self.assertEqual(alert.custom_body, "Value: <b>bold</b>")
+
+    def test_custom_subject_respects_allow_html(self):
+        alert = self.create_alert(get_results("<b>bold</b>"))
+        alert.options["custom_subject"] = "{{QUERY_RESULT_VALUE}}"
+        self.assertEqual(alert.custom_subject, "&lt;b&gt;bold&lt;/b&gt;")
+        alert.options["allow_html"] = True
+        self.assertEqual(alert.custom_subject, "<b>bold</b>")
+
+    def test_allow_html_does_not_affect_default_render_template(self):
+        alert = self.create_alert(get_results("<b>bold</b>"))
+        alert.options["allow_html"] = True
+        self.assertEqual(alert.render_template("{{QUERY_RESULT_VALUE}}"), "&lt;b&gt;bold&lt;/b&gt;")

--- a/tests/models/test_alerts.py
+++ b/tests/models/test_alerts.py
@@ -239,3 +239,9 @@ class TestAlertRenderTemplate(BaseTestCase):
         alert = self.create_alert(get_results("<b>bold</b>"))
         alert.options["allow_html"] = True
         self.assertEqual(alert.render_template("{{QUERY_RESULT_VALUE}}"), "&lt;b&gt;bold&lt;/b&gt;")
+
+    def test_allow_html_requires_boolean_true(self):
+        alert = self.create_alert(get_results("<b>bold</b>"))
+        alert.options["custom_body"] = "Value: {{QUERY_RESULT_VALUE}}"
+        alert.options["allow_html"] = "false"
+        self.assertEqual(alert.custom_body, "Value: &lt;b&gt;bold&lt;/b&gt;")


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description

In a custom alert subject/body, values interpolated from query results (`{{QUERY_RESULT_VALUE}}`, table rows, and other `{{...}}` variables) are HTML-escaped by default. This prevents dynamic injection of HTML content into Alert bodies. 

This adds an "Allow HTML content" checkbox to the alert template editor (Inspired by the table visualization per-column toggle) that renders the custom template without escaping. 

For our purposes, this gives Slack destined alerts `mrkdwn` embedding allowing dynamic user tagging and hyperlinking.

## How is this tested?

- [x] Unit tests (pytest)
- [x] Manually

Added `tests/models/test_alerts.py` cases: escape-by-default, raw rendering when enabled
(subject + body), and that a direct `render_template()` call stays escaped. Manually
verified in the alert editor and against a rendered alert.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="849" height="721" alt="image" src="https://github.com/user-attachments/assets/9810f5cf-12a5-4603-b2e1-c0aea7f9d95e" />
<img width="648" height="659" alt="image" src="https://github.com/user-attachments/assets/ee6205c4-0fb8-40d4-a8d9-f2db96beae54" />
<img width="919" height="189" alt="image" src="https://github.com/user-attachments/assets/6076922b-f27a-41ab-92b5-73cda6d94da6" />




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

