### PR TITLE
Handle NUL bytes in CSV query result export

### DIFF
--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -44,6 +44,12 @@ def _convert_datetime(value, fmt):
     return ret
 
 
+def _sanitize_dsv_value(value):
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+
+    return value
+
 def _get_column_lists(columns):
     date_format = _convert_format(current_org.get_setting("date_format"))
     datetime_format = _convert_format(
@@ -91,10 +97,13 @@ def serialize_query_result_to_dsv(query_result, delimiter):
     writer.writeheader()
 
     for row in query_data["rows"]:
+        row = row.copy()
+
         for col_name, converter in special_columns.items():
             if col_name in row:
                 row[col_name] = converter(row[col_name])
 
+        row = {key: _sanitize_dsv_value(value) for key, value in row.items()}
         writer.writerow(row)
 
     return s.getvalue()

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -79,3 +79,25 @@ class DsvSerializationTest(BaseTestCase):
         self.assertEqual(rows[1]["bool"], "false")
         self.assertEqual(rows[2]["date"], "")
         self.assertEqual(rows[3]["datetime"], "459")
+
+    def test_serializes_string_values_with_nul_bytes(self):
+        query_result = self.factory.create_query_result(
+            data={
+                "rows": [
+                    {"id": 1, "address": "123 Main St\x00Apt 4"},
+                ],
+                "columns": [
+                    {"friendly_name": "id", "type": "integer", "name": "id"},
+                    {"friendly_name": "address", "type": "string", "name": "address"},
+                ],
+            }
+        )
+
+        with self.app.test_request_context("/"):
+            parsed = csv.DictReader(
+                io.StringIO(serialize_query_result_to_dsv(query_result, ","))
+            )
+
+        rows = list(parsed)
+
+        self.assertEqual(rows[0]["address"], "123 Main StApt 4")


### PR DESCRIPTION
- [x] Bug Fix

## Description

Fixes CSV export failure when query result string values contain embedded NUL bytes (`\x00`).

Previously, `serialize_query_result_to_dsv()` passed row values directly to `csv.DictWriter.writerow()`. If a string field contained a NUL byte, CSV export could fail with:

```text
_csv.Error: need to escape, but no escapechar set

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

