### PR TITLE
Add preferred_username support for Trino impersonation

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -197,6 +197,17 @@ def jwt_token_load_user_from_request(request):
     except models.NoResultFound:
         user = create_and_login_user(current_org, payload["email"], payload["email"])
 
+    preferred_username = payload.get("preferred_username")
+    if preferred_username:
+        user_details = user.details or {}
+
+        if user_details.get("preferred_username") != preferred_username:
+            user.details = {
+                **user_details,
+                "preferred_username": preferred_username,
+            }
+            models.db.session.commit()
+
     return user
 
 

--- a/redash/query_runner/trino.py
+++ b/redash/query_runner/trino.py
@@ -85,7 +85,11 @@ class Trino(BaseQueryRunner):
                     "type": "string",
                     "title": "Impersonation User Attribute",
                     "default": "email",
-                    "extendedEnum": [{"value": "email", "name": "Email"}, {"value": "name", "name": "Name"}],
+                    "extendedEnum": [
+                        {"value": "email", "name": "Email"},
+                        {"value": "name", "name": "Name"},
+                        {"value": "preferred_username", "name": "Preferred Username"},
+                    ],
                 },
             },
             "order": [
@@ -177,6 +181,8 @@ class Trino(BaseQueryRunner):
                 return user.email or default_user
             elif impersonation_field == "name":
                 return user.name or default_user
+            elif impersonation_field == "preferred_username":
+                return (user.details or {}).get("preferred_username") or default_user
         elif isinstance(user, ApiUser):
             return user.name or default_user
 

--- a/tests/query_runner/test_trino.py
+++ b/tests/query_runner/test_trino.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from trino.types import NamedRowTuple
 
+from redash.models.users import User
 from redash.query_runner.trino import Trino, _convert_row_types
 
 
@@ -68,6 +69,64 @@ class TestTrino(TestCase):
     def test_get_client_tags_returns_none_when_empty(self):
         runner = Trino({"client_tags": " ,  , "})
         self.assertIsNone(runner._get_client_tags())
+
+    def test_configuration_schema_supports_preferred_username_impersonation(self):
+        schema = Trino.configuration_schema()
+        enum_values = [
+            item["value"]
+            for item in schema["properties"]["impersonationField"]["extendedEnum"]
+        ]
+        self.assertIn("preferred_username", enum_values)
+
+    def test_get_trino_user_uses_preferred_username(self):
+        user = User(
+            name="Otter Gottaott",
+            email="otter@gotta.ott",
+            details={"preferred_username": "ottergottaott"},
+        )
+        runner = Trino(
+            {
+                "username": "redash",
+                "impersonation": True,
+                "impersonationField": "preferred_username",
+            }
+        )
+
+        self.assertEqual(runner._get_trino_user(user), "ottergottaott")
+
+    def test_get_trino_user_uses_selected_user_attribute(self):
+        user = User(
+            name="Otter Gottaott",
+            email="otter@gotta.ott",
+            details={"preferred_username": "ottergottaott"},
+        )
+
+        self.assertEqual(
+            Trino({"username": "redash", "impersonation": True, "impersonationField": "email"})._get_trino_user(user),
+            "otter@gotta.ott",
+        )
+        self.assertEqual(
+            Trino({"username": "redash", "impersonation": True, "impersonationField": "name"})._get_trino_user(user),
+            "Otter Gottaott",
+        )
+        self.assertEqual(
+            Trino(
+                {"username": "redash", "impersonation": True, "impersonationField": "preferred_username"}
+            )._get_trino_user(user),
+            "ottergottaott",
+        )
+
+    def test_get_trino_user_falls_back_when_preferred_username_missing(self):
+        user = User(name="Otter Gottaott", email="otter@gotta.ott", details={})
+        runner = Trino(
+            {
+                "username": "redash",
+                "impersonation": True,
+                "impersonationField": "preferred_username",
+            }
+        )
+
+        self.assertEqual(runner._get_trino_user(user), "redash")
 
 
 class TestConvertRowTypes(TestCase):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -530,13 +530,40 @@ class TestJWTAuthentication(BaseTestCase):
             "exp": expiration_timestamp,
             "iat": issued_at_timestamp,
             "iss": self.auth_issuer,
+            "preferred_username": "ottergottaott",
         }
         with open(self.rsa_private_key) as keyfile:
             sign_key = keyfile.read().strip()
         token_data = jwt.encode(data, sign_key, algorithm="RS256")
 
-        response = self.get_request("/data_sources", org=self.factory.org, headers={self.token_name: token_data})
+        response = self.get_request("/api/session", org=self.factory.org, headers={self.token_name: token_data})
         self.assertEqual(response.status_code, 200)
+
+        user = models.User.get_by_id(user.id)
+        self.assertEqual(user.details["preferred_username"], "ottergottaott")
+
+    def test_jwt_from_pem_file_stores_preferred_username_for_new_user(self):
+        issued_at_timestamp = time.time()
+        expiration_timestamp = issued_at_timestamp + 60
+
+        data = {
+            "aud": self.auth_audience,
+            "email": "otter@gotta.ott",
+            "exp": expiration_timestamp,
+            "iat": issued_at_timestamp,
+            "iss": self.auth_issuer,
+            "preferred_username": "ottergottaott",
+        }
+        with open(self.rsa_private_key) as keyfile:
+            sign_key = keyfile.read().strip()
+        token_data = jwt.encode(data, sign_key, algorithm="RS256")
+
+        response = self.get_request("/api/session", org=self.factory.org, headers={self.token_name: token_data})
+        self.assertEqual(response.status_code, 200)
+
+        user = models.User.get_by_email_and_org("otter@gotta.ott", self.factory.org)
+        self.assertEqual(user.name, "otter@gotta.ott")
+        self.assertEqual(user.details["preferred_username"], "ottergottaott")
 
     @patch.object(requests, "get")
     def test_jwk_decode(self, mock_get):


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Feature

## Description

Add support for using the JWT/OIDC `preferred_username` claim as the Trino impersonation user.

Redash already supports Trino impersonation using the Redash user's `email` or `name`. In SSO setups, those values are not always the identity expected by Trino access-control policies:

- `email` can be `otter@gotta.ott`
- `name` can be a display name like `Otter Gottaott`
- for newly auto-created JWT users, Redash sets `name` to the email
- `preferred_username` can be the actual login/short username, for example `ottergottaott`

This change stores `preferred_username` from a valid JWT payload in `User.details` and adds `Preferred Username` as a Trino impersonation attribute option. When selected, Trino receives `user.details["preferred_username"]`, with fallback to the configured datasource username if the claim is missing.

Expected compatible Trino versions: no Trino server-version dependency. This only changes the `user` value passed to the existing Python Trino client connection.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Manual testing:
Verified locally with Keycloak + oauth2-proxy + Redash JWT auth that:
Keycloak emits preferred_username
Redash stores it in users.details
Trino datasource UI exposes Preferred Username in Impersonation User Attribute

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

