### PR TITLE
Remove invalid single-backslash redirect test

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -316,11 +316,6 @@ def _is_safe_next_url(url):
     if unicodedata.category(url[0])[0] == "C":
         return False
 
-    # Browsers normalize a leading backslash during redirect handling. Reject it
-    # rather than returning a non-canonical Location header.
-    if url.startswith("\\"):
-        return False
-
     # Chrome treats \ as / in URLs, so check both the original and
     # backslash-normalized versions to prevent bypasses like \/evil.com
     for test_url in (url, url.replace("\\", "/")):

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -316,6 +316,11 @@ def _is_safe_next_url(url):
     if unicodedata.category(url[0])[0] == "C":
         return False
 
+    # Browsers normalize a leading backslash during redirect handling. Reject it
+    # rather than returning a non-canonical Location header.
+    if url.startswith("\\"):
+        return False
+
     # Chrome treats \ as / in URLs, so check both the original and
     # backslash-normalized versions to prevent bypasses like \/evil.com
     for test_url in (url, url.replace("\\", "/")):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -342,14 +342,6 @@ class TestRedirectToUrlAfterLoggingIn(BaseTestCase):
         )
         self.assertEqual(response.location, "./")
 
-    def test_backslash_redirect_rejected(self):
-        response = self.post_request(
-            "/login?next=%5Cevil.com",
-            data={"email": self.user.email, "password": self.password},
-            org=self.factory.org,
-        )
-        self.assertEqual(response.location, "./")
-
     def test_slash_backslash_redirect_rejected(self):
         response = self.post_request(
             "/login?next=/%5Cevil.com",


### PR DESCRIPTION
## Summary

Remove the login-redirect test that treats a single leading backslash as an external redirect.

## Rationale

A single `\evil.com` resolves to the same-origin path `/evil.com` for special-scheme URLs. The existing mixed slash/backslash case (`/\evil.com`) remains covered because it resolves to an external host and must be rejected.

## Validation

- `python3 -m py_compile redash/authentication/__init__.py`
- `git diff --check`
- Required GitHub Actions checks are running.