### PR TITLE
Reject leading backslash in post-login redirect target

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -316,6 +316,13 @@ def _is_safe_next_url(url):
     if unicodedata.category(url[0])[0] == "C":
         return False
 
+    # A leading backslash is never a valid on-site path. Browsers treat \ as /,
+    # so "\evil.com" or "\\evil.com" can be read as a path or a protocol-relative
+    # URL. A single leading backslash normalizes to a single-slash path (which is
+    # otherwise allowed), so reject any leading backslash outright.
+    if url.startswith("\\"):
+        return False
+
     # Chrome treats \ as / in URLs, so check both the original and
     # backslash-normalized versions to prevent bypasses like \/evil.com
     for test_url in (url, url.replace("\\", "/")):


### PR DESCRIPTION
## Problem

`_is_safe_next_url()` treats `\evil.com` as a safe post-login redirect target. It normalizes backslash to slash before validating, so `\evil.com` becomes `/evil.com` and passes as a relative path.

`test_backslash_redirect_rejected` (added in 9e66f81) expects `\evil.com` to be rejected. As a result, master's `backend-unit-tests` have been failing since that commit.

```
FAILED tests/test_authentication.py::TestRedirectToUrlAfterLoggingIn::test_backslash_redirect_rejected
>       self.assertEqual(response.location, "./")
E       AssertionError: '\\evil.com' != './'
```

## Fix

Reject any redirect target that starts with a backslash. A valid on-site path always starts with a forward slash or a path segment, never a backslash, so this does not affect legitimate redirects. It also covers `\\evil.com` and `\/evil.com`, which browsers read as `//evil.com`.

## Test

All redirect cases in `TestRedirectToUrlAfterLoggingIn` pass, including the previously failing `\evil.com`, with no change to valid paths such as `//localhost/queries` -> `/queries`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

