### PR TITLE
Fix Postgres JSON operator formatting

### DIFF
--- a/client/app/lib/queryFormat.test.js
+++ b/client/app/lib/queryFormat.test.js
@@ -39,6 +39,21 @@ describe("QueryFormat.formatQuery", () => {
       const formattedQueryParameters = new Query({ query: formattedQueryText }).getParameters().parseQuery();
       expect(formattedQueryParameters.sort()).toEqual(queryParameters.sort());
     });
+
+    test("preserves Postgres JSON containment operators", () => {
+      const queryText = `
+        select *
+        from example
+        where keywords @> '[{"keyword":{"id":12345}}]'
+          and '[{"keyword":{"id":12345}}]' <@ keywords
+      `;
+      const formattedQueryText = queryFormat.formatQuery(queryText, syntax);
+
+      expect(formattedQueryText).toContain('keywords @> \'[{"keyword":{"id":12345}}]\'');
+      expect(formattedQueryText).toContain('\'[{"keyword":{"id":12345}}]\' <@ keywords');
+      expect(formattedQueryText).not.toContain("@ >");
+      expect(formattedQueryText).not.toContain("< @");
+    });
   });
 
   describe("json", () => {

--- a/client/app/lib/queryFormat.test.js
+++ b/client/app/lib/queryFormat.test.js
@@ -54,6 +54,44 @@ describe("QueryFormat.formatQuery", () => {
       expect(formattedQueryText).not.toContain("@ >");
       expect(formattedQueryText).not.toContain("< @");
     });
+
+    test("preserves Postgres JSON path and key operators", () => {
+      const queryText = `
+        select
+          data #> '{a,b}' as path_json,
+          data #>> '{a,b}' as path_text,
+          data #- '{a,b}' as deleted_path
+        from example
+        where data ? 'key'
+          and data ?| array['key1', 'key2']
+          and data ?& array['key1', 'key2']
+      `;
+      const formattedQueryText = queryFormat.formatQuery(queryText, syntax);
+
+      expect(formattedQueryText).toContain("data #> '{a,b}'");
+      expect(formattedQueryText).toContain("data #>> '{a,b}'");
+      expect(formattedQueryText).toContain("data #- '{a,b}'");
+      expect(formattedQueryText).toContain("data ? 'key'");
+      expect(formattedQueryText).toContain("data ?| array");
+      expect(formattedQueryText).toContain("data ?& array");
+      expect(formattedQueryText).not.toContain("# >");
+      expect(formattedQueryText).not.toContain("# >>");
+      expect(formattedQueryText).not.toContain("# -");
+      expect(formattedQueryText).not.toContain("? |");
+      expect(formattedQueryText).not.toContain("? &");
+    });
+
+    test("does not replace user query text that looks like an operator placeholder", () => {
+      const queryText = `
+        select '__REDASH_POSTGRES_JSON_OPERATOR_0__' as placeholder_text,
+          data #>> '{a,b}' as path_text
+        from example
+      `;
+      const formattedQueryText = queryFormat.formatQuery(queryText, syntax);
+
+      expect(formattedQueryText).toContain("'__REDASH_POSTGRES_JSON_OPERATOR_0__'");
+      expect(formattedQueryText).toContain("data #>> '{a,b}'");
+    });
   });
 
   describe("json", () => {

--- a/client/app/lib/queryFormat.ts
+++ b/client/app/lib/queryFormat.ts
@@ -5,9 +5,32 @@ interface QueryFormatterMap {
   [syntax: string]: (queryText: string) => string;
 }
 
+const PostgreSqlJsonOperators = [
+  ["@>", "__REDASH_POSTGRES_JSON_CONTAINS__"],
+  ["<@", "__REDASH_POSTGRES_JSON_CONTAINED_BY__"],
+];
+
+function preservePostgreSqlJsonOperators(queryText: string) {
+  return PostgreSqlJsonOperators.reduce(
+    (text, [operator, replacement]) => text.split(operator).join(replacement),
+    queryText
+  );
+}
+
+function restorePostgreSqlJsonOperators(queryText: string) {
+  return PostgreSqlJsonOperators.reduce(
+    (text, [operator, replacement]) => text.split(replacement).join(operator),
+    queryText
+  );
+}
+
+function formatSqlQuery(queryText: string) {
+  return restorePostgreSqlJsonOperators(sqlFormatter.format(preservePostgreSqlJsonOperators(trim(queryText))));
+}
+
 const QueryFormatters: QueryFormatterMap = {
-  sql: queryText => sqlFormatter.format(trim(queryText)),
-  json: queryText => JSON.stringify(JSON.parse(queryText), null, 4),
+  sql: formatSqlQuery,
+  json: (queryText) => JSON.stringify(JSON.parse(queryText), null, 4),
 };
 
 export function isFormatQueryAvailable(syntax: string) {

--- a/client/app/lib/queryFormat.ts
+++ b/client/app/lib/queryFormat.ts
@@ -5,27 +5,39 @@ interface QueryFormatterMap {
   [syntax: string]: (queryText: string) => string;
 }
 
-const PostgreSqlJsonOperators = [
-  ["@>", "__REDASH_POSTGRES_JSON_CONTAINS__"],
-  ["<@", "__REDASH_POSTGRES_JSON_CONTAINED_BY__"],
-];
+const PostgreSqlJsonOperators = ["#>>", "#>", "#-", "?&", "?|", "@>", "<@", "?"];
 
-function preservePostgreSqlJsonOperators(queryText: string) {
-  return PostgreSqlJsonOperators.reduce(
-    (text, [operator, replacement]) => text.split(operator).join(replacement),
-    queryText
-  );
+function getPostgreSqlJsonOperatorPlaceholders(queryText: string) {
+  let suffix = 0;
+
+  return PostgreSqlJsonOperators.map((operator) => {
+    let replacement;
+
+    do {
+      replacement = `__REDASH_POSTGRES_JSON_OPERATOR_${suffix}__`;
+      suffix += 1;
+    } while (queryText.includes(replacement));
+
+    return [operator, replacement];
+  });
 }
 
-function restorePostgreSqlJsonOperators(queryText: string) {
-  return PostgreSqlJsonOperators.reduce(
-    (text, [operator, replacement]) => text.split(replacement).join(operator),
-    queryText
-  );
+function preservePostgreSqlJsonOperators(queryText: string, placeholders: string[][]) {
+  return placeholders.reduce((text, [operator, replacement]) => text.split(operator).join(replacement), queryText);
+}
+
+function restorePostgreSqlJsonOperators(queryText: string, placeholders: string[][]) {
+  return placeholders.reduce((text, [operator, replacement]) => text.split(replacement).join(operator), queryText);
 }
 
 function formatSqlQuery(queryText: string) {
-  return restorePostgreSqlJsonOperators(sqlFormatter.format(preservePostgreSqlJsonOperators(trim(queryText))));
+  const trimmedQueryText = trim(queryText);
+  const placeholders = getPostgreSqlJsonOperatorPlaceholders(trimmedQueryText);
+
+  return restorePostgreSqlJsonOperators(
+    sqlFormatter.format(preservePostgreSqlJsonOperators(trimmedQueryText, placeholders)),
+    placeholders
+  );
 }
 
 const QueryFormatters: QueryFormatterMap = {


### PR DESCRIPTION
## What changed

- Preserve Postgres JSON containment operators before SQL formatting.
- Restore the operators after formatting so `@>` and `<@` are not split into invalid SQL.
- Add regression coverage for both operators.

## Why

`sql-formatter` tokenizes `@>` and `<@` as separate characters, which produced invalid formatted Postgres queries such as `@ >` and `< @`.

Fixes #5644.

## Validation

- `pnpm.cmd --filter @redash/viz build:babel`
- `pnpm.cmd run type-check`
- `pnpm.cmd exec jest app/lib/queryFormat.test.js --runInBand`
- `$env:TZ='Africa/Khartoum'; pnpm.cmd exec jest --runInBand`
- `pnpm.cmd run lint`
- `pnpm.cmd exec prettier --check client/app/lib/queryFormat.ts client/app/lib/queryFormat.test.js`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

