### PR TITLE
fix(bug): added missing json=payload for the mattermost destination 

### DIFF
--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -44,7 +44,7 @@ class Mattermost(BaseDestination):
             payload["channel"] = options.get("channel")
 
         try:
-            resp = requests.post(options.get("url"), data=json_dumps(payload), timeout=5.0)
+            resp = requests.post(options.get("url"), data=json_dumps(payload).encode("utf-8"), timeout=5.0)
             logging.warning(resp.text)
 
             if resp.status_code != 200:

--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -44,7 +44,8 @@ class Mattermost(BaseDestination):
             payload["channel"] = options.get("channel")
 
         try:
-            resp = requests.post(options.get("url"), data=json_dumps(payload).encode("utf-8"), timeout=5.0)
+            resp = requests.post(options.get("url"), json=payload, timeout=5.0)
+            
             logging.warning(resp.text)
 
             if resp.status_code != 200:


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix
- [ ] 
## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [x] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

------
The PR fixes missing .encode("utf-8") in the mattermost.py file for the Mattermost class in line 47


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

