### PR TITLE
Fix DSV export for NUL bytes

### DIFF
--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -72,6 +72,13 @@ def _get_column_lists(columns):
     return fieldnames, special_columns
 
 
+def _sanitize_dsv_value(value):
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+
+    return value
+
+
 def serialize_query_result(query_result, is_api_user):
     if is_api_user:
         publicly_needed_keys = ["data", "retrieved_at"]
@@ -91,11 +98,14 @@ def serialize_query_result_to_dsv(query_result, delimiter):
     writer.writeheader()
 
     for row in query_data["rows"]:
+        serialized_row = dict(row)
         for col_name, converter in special_columns.items():
-            if col_name in row:
-                row[col_name] = converter(row[col_name])
+            if col_name in serialized_row:
+                serialized_row[col_name] = converter(serialized_row[col_name])
 
-        writer.writerow(row)
+        writer.writerow(
+            {key: _sanitize_dsv_value(value) for key, value in serialized_row.items()}
+        )
 
     return s.getvalue()
 

--- a/redash/serializers/query_result.py
+++ b/redash/serializers/query_result.py
@@ -103,9 +103,7 @@ def serialize_query_result_to_dsv(query_result, delimiter):
             if col_name in serialized_row:
                 serialized_row[col_name] = converter(serialized_row[col_name])
 
-        writer.writerow(
-            {key: _sanitize_dsv_value(value) for key, value in serialized_row.items()}
-        )
+        writer.writerow({key: _sanitize_dsv_value(value) for key, value in serialized_row.items()})
 
     return s.getvalue()
 

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -89,9 +89,7 @@ class DsvSerializationTest(BaseTestCase):
         )
 
         with self.app.test_request_context("/"):
-            parsed = csv.DictReader(
-                io.StringIO(serialize_query_result_to_dsv(query_result, ","))
-            )
+            parsed = csv.DictReader(io.StringIO(serialize_query_result_to_dsv(query_result, ",")))
         rows = list(parsed)
 
         self.assertEqual(rows[0]["message"], "helloworld")

--- a/tests/serializers/test_query_results.py
+++ b/tests/serializers/test_query_results.py
@@ -79,3 +79,19 @@ class DsvSerializationTest(BaseTestCase):
         self.assertEqual(rows[1]["bool"], "false")
         self.assertEqual(rows[2]["date"], "")
         self.assertEqual(rows[3]["datetime"], "459")
+
+    def test_removes_null_bytes_from_dsv_values(self):
+        query_result = self.factory.create_query_result(
+            data={
+                "rows": [{"message": "hello\x00world"}],
+                "columns": [{"friendly_name": "message", "type": "string", "name": "message"}],
+            }
+        )
+
+        with self.app.test_request_context("/"):
+            parsed = csv.DictReader(
+                io.StringIO(serialize_query_result_to_dsv(query_result, ","))
+            )
+        rows = list(parsed)
+
+        self.assertEqual(rows[0]["message"], "helloworld")


### PR DESCRIPTION
## What type of PR is this?
Bug fix

## Description
CSV and TSV export can fail when query results contain embedded NUL bytes because Python's CSV writer raises while trying to escape those values. This change removes NUL bytes from string fields before DSV serialization and avoids mutating the stored query result row during export.

Fixes #7758

## Validation
- `git diff --check`
- `python -m pytest tests\serializers\test_query_results.py` (blocked locally: missing Redash runtime dependency `redis`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

