### PR TITLE
Encode Mattermost payloads as UTF-8

### DIFF
--- a/redash/destinations/mattermost.py
+++ b/redash/destinations/mattermost.py
@@ -44,7 +44,11 @@ class Mattermost(BaseDestination):
             payload["channel"] = options.get("channel")
 
         try:
-            resp = requests.post(options.get("url"), data=json_dumps(payload), timeout=5.0)
+            resp = requests.post(
+                options.get("url"),
+                data=json_dumps(payload).encode("utf-8"),
+                timeout=5.0,
+            )
             logging.warning(resp.text)
 
             if resp.status_code != 200:

--- a/tests/destinations/test_mattermost.py
+++ b/tests/destinations/test_mattermost.py
@@ -1,0 +1,39 @@
+import json
+from unittest import mock
+
+from redash.destinations.mattermost import Mattermost
+
+
+def test_mattermost_notify_sends_utf8_payload():
+    alert = mock.Mock()
+    alert.custom_subject = (
+        "Test Subject With Unicode: "
+        "\u041f\u0440\u0438\u0432\u0435\u0442"
+    )
+    alert.custom_body = None
+    alert.name = "Test Alert"
+
+    query = mock.Mock()
+    user = mock.Mock()
+    app = mock.Mock()
+    host = "http://redash.local"
+    metadata = {}
+    options = {"url": "https://example.com/mattermost"}
+    destination = Mattermost(options)
+
+    with mock.patch("redash.destinations.mattermost.requests.post") as mock_post:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        destination.notify(
+            alert, query, user, "triggered", app, host, metadata, options
+        )
+
+        sent_data = mock_post.call_args.kwargs["data"]
+
+    assert isinstance(sent_data, bytes)
+
+    decoded_data = json.loads(sent_data.decode("utf-8"))
+    assert decoded_data["text"] == alert.custom_subject
+    assert alert.custom_subject in sent_data.decode("utf-8")


### PR DESCRIPTION
## What type of PR is this?
Bug fix

## Description
Mattermost webhook payloads were passed to `requests.post` as a Python string, which lets Requests encode the body as latin-1. This matches the Slack destination by sending UTF-8 bytes so non-ASCII alert text is preserved.

Fixes #7775

## Validation
- `git diff --check`
- `python -m pytest tests\destinations\test_mattermost.py` (blocked locally: missing Redash runtime dependency `redis`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

