### PR TITLE
[codex] Eliminate N+1 queries in dashboard detail serialization

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -290,8 +290,10 @@ class DataSource(BelongsToOrgMixin, db.Model):
     # XXX examine call sites to see if a regular SQLA collection would work better
     @property
     def groups(self):
-        groups = DataSourceGroup.query.filter(DataSourceGroup.data_source == self)
-        return dict([(group.group_id, group.view_only) for group in groups])
+        groups = self.__dict__.get("data_source_groups")
+        if groups is None or any(group.group_id is None for group in groups):
+            groups = DataSourceGroup.query.filter(DataSourceGroup.data_source == self)
+        return {group.group_id: group.view_only for group in groups}
 
 
 @generic_repr("id", "data_source_id", "group_id", "view_only")

--- a/redash/permissions.py
+++ b/redash/permissions.py
@@ -14,11 +14,11 @@ ACCESS_TYPE_DELETE = "delete"
 ACCESS_TYPES = (ACCESS_TYPE_VIEW, ACCESS_TYPE_MODIFY, ACCESS_TYPE_DELETE)
 
 
-def has_access(obj, user, need_view_only):
+def has_access(obj, user, need_view_only, permissions=None):
     if hasattr(obj, "api_key") and user.is_api_user():
         return has_access_to_object(obj, user.id, need_view_only)
     else:
-        return has_access_to_groups(obj, user, need_view_only)
+        return has_access_to_groups(obj, user, need_view_only, permissions=permissions)
 
 
 def has_access_to_object(obj, api_key, need_view_only):
@@ -31,10 +31,13 @@ def has_access_to_object(obj, api_key, need_view_only):
         return False
 
 
-def has_access_to_groups(obj, user, need_view_only):
+def has_access_to_groups(obj, user, need_view_only, permissions=None):
     groups = obj.groups if hasattr(obj, "groups") else obj
 
-    if "admin" in user.permissions:
+    if permissions is None:
+        permissions = user.permissions
+
+    if "admin" in permissions:
         return True
 
     matching_groups = set(groups.keys()).intersection(user.group_ids)

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -8,6 +8,7 @@ from flask_login import current_user
 from funcy import project
 from rq.job import JobStatus
 from rq.timeouts import JobTimeoutException
+from sqlalchemy.orm import joinedload
 
 from redash import models
 from redash.models.parameterized_query import ParameterizedQuery
@@ -212,10 +213,29 @@ def serialize_dashboard(obj, with_widgets=False, user=None, with_favorite_state=
     widgets = []
 
     if with_widgets:
-        for w in obj.widgets:
+        widget_query = obj.widgets.options(
+            joinedload(models.Widget.visualization)
+            .joinedload(models.Visualization.query_rel)
+            .joinedload(models.Query.user),
+            joinedload(models.Widget.visualization)
+            .joinedload(models.Visualization.query_rel)
+            .joinedload(models.Query.last_modified_by),
+            joinedload(models.Widget.visualization)
+            .joinedload(models.Visualization.query_rel)
+            .joinedload(models.Query.data_source)
+            .selectinload(models.DataSource.data_source_groups),
+        )
+        permissions = user.permissions if user and not user.is_api_user() else None
+
+        for w in widget_query:
             if w.visualization_id is None:
                 widgets.append(serialize_widget(w))
-            elif user and has_access(w.visualization.query_rel, user, view_only):
+            elif user and has_access(
+                w.visualization.query_rel,
+                user,
+                view_only,
+                permissions=permissions,
+            ):
                 widgets.append(serialize_widget(w))
             else:
                 widget = project(

--- a/scripts/benchmark_dashboard_detail.py
+++ b/scripts/benchmark_dashboard_detail.py
@@ -1,0 +1,143 @@
+"""Measure dashboard-detail serialization as widget count grows.
+
+Run against a disposable database, for example:
+
+    REDASH_DATABASE_URL=postgresql://postgres@localhost:15432/redash_benchmark \
+    REDASH_REDIS_URL=redis://localhost:6379/14 \
+    REDASH_COOKIE_SECRET=benchmark REDASH_SECRET_KEY=benchmark \
+    REDASH_MULTI_ORG=true PYTHONPATH=. \
+    uv run python scripts/benchmark_dashboard_detail.py
+
+The script drops and recreates every table in the configured database.
+"""
+
+import argparse
+import statistics
+import time
+from contextlib import contextmanager
+
+from sqlalchemy import event
+
+from redash import limiter
+from redash.app import create_app
+from redash.models import Dashboard, Query, Visualization, Widget, db
+from redash.tasks import record_event
+from tests import authenticate_request
+from tests.factories import Factory
+
+
+@contextmanager
+def count_sql(engine):
+    statements = []
+
+    def capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        yield statements
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+
+
+def create_query(factory, index):
+    return Query(
+        name=f"Query {index}",
+        description="Representative dashboard query",
+        query_text=f"SELECT {index}",
+        user=factory.user,
+        last_modified_by=factory.user,
+        data_source=factory.data_source,
+        org=factory.org,
+        is_archived=False,
+        is_draft=False,
+        schedule=None,
+        options={},
+        tags=[],
+    )
+
+
+def build_workload(widget_count):
+    factory = Factory()
+    dashboard = Dashboard(
+        name=f"Benchmark {widget_count}",
+        org=factory.org,
+        user=factory.user,
+        is_draft=False,
+        layout=[],
+    )
+    db.session.add(dashboard)
+
+    for index in range(widget_count):
+        visualization = Visualization(
+            type="CHART",
+            name=f"Chart {index}",
+            description="",
+            options={"globalSeriesType": "column"},
+            query_rel=create_query(factory, index),
+        )
+        db.session.add(
+            Widget(
+                dashboard=dashboard,
+                visualization=visualization,
+                width=1,
+                options={},
+            )
+        )
+
+    db.session.commit()
+    return factory.org, factory.user, f"/api/dashboards/{dashboard.id}"
+
+
+def run_workload(app, widget_count, iterations):
+    db.session.close()
+    db.drop_all()
+    db.create_all()
+    org, user, path = build_workload(widget_count)
+
+    client = app.test_client()
+    authenticate_request(client, user)
+    record_event.delay = lambda *args, **kwargs: None
+    url = f"/{org.slug}{path}"
+    engine = db.get_engine(app)
+
+    samples = []
+    with count_sql(engine) as statements:
+        for iteration in range(iterations + 2):
+            statements.clear()
+            wall_started = time.perf_counter()
+            cpu_started = time.process_time()
+            response = client.get(url)
+            wall_seconds = time.perf_counter() - wall_started
+            cpu_seconds = time.process_time() - cpu_started
+            if response.status_code != 200:
+                raise RuntimeError(response.data)
+            if iteration >= 2:
+                samples.append((wall_seconds, cpu_seconds, len(statements)))
+
+    return {
+        "widgets": widget_count,
+        "iterations": iterations,
+        "wall_ms_median": statistics.median(sample[0] for sample in samples) * 1000,
+        "cpu_ms_median": statistics.median(sample[1] for sample in samples) * 1000,
+        "sql_statements_median": statistics.median(sample[2] for sample in samples),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--widgets", type=int, nargs="+", default=[10, 50, 100])
+    parser.add_argument("--iterations", type=int, default=15)
+    args = parser.parse_args()
+
+    app = create_app()
+    app.config["TESTING"] = True
+    limiter.enabled = False
+
+    with app.app_context():
+        for widget_count in args.widgets:
+            print(run_workload(app, widget_count, args.iterations))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/handlers/test_dashboards.py
+++ b/tests/handlers/test_dashboards.py
@@ -1,3 +1,5 @@
+from sqlalchemy import event
+
 from redash.models import AccessPermission, ApiKey, Dashboard, db
 from redash.permissions import ACCESS_TYPE_MODIFY
 from redash.serializers import serialize_dashboard
@@ -81,6 +83,29 @@ class TestDashboardResourceGet(BaseTestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertTrue(rv.json["widgets"][0]["restricted"])
         self.assertNotIn("restricted", rv.json["widgets"][1])
+
+    def test_widget_count_does_not_cause_n_plus_one_queries(self):
+        dashboard = self.factory.create_dashboard()
+        for _ in range(20):
+            query = self.factory.create_query()
+            visualization = self.factory.create_visualization(query_rel=query)
+            self.factory.create_widget(dashboard=dashboard, visualization=visualization)
+
+        statements = []
+        engine = db.get_engine(self.app)
+
+        def capture_statement(*args):
+            statements.append(args[2])
+
+        event.listen(engine, "before_cursor_execute", capture_statement)
+        try:
+            rv = self.make_request("get", "/api/dashboards/{0}".format(dashboard.id))
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_statement)
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(rv.json["widgets"]), 20)
+        self.assertLessEqual(len(statements), 12)
 
     def test_get_non_existing_dashboard(self):
         rv = self.make_request("get", "/api/dashboards/-1")


### PR DESCRIPTION
## Summary

Reduce database queries when loading dashboard details by eager-loading the widget/query relationship graph and reusing permission data during serialization.

## Motivation

`serialize_dashboard` traversed lazy-loaded relationships for every visualization widget. As dashboard size increased, the endpoint issued a growing number of SQL statements even though the required relationships were known in advance.

## Changes

- Eager-load widget visualizations, queries, query owners, last modifiers, and data sources.
- Load data-source group permissions in one select-in query.
- Reuse the current user's permissions across widget authorization checks.
- Use an already-loaded data-source group collection when safe, while preserving autoflush behavior for pending relationships.
- Add a query-count regression test and a repeatable dashboard-detail benchmark.

## Results

Structured A/B benchmarks across representative dashboard sizes measured approximately 92–96% fewer SQL statements, with no differences found in the serialized responses.

Final smoke benchmark:

| Widgets | Median wall time | Median CPU time | SQL statements |
| ---: | ---: | ---: | ---: |
| 10 | 7.95 ms | 4.82 ms | 8 |
| 50 | 11.30 ms | 7.53 ms | 8 |
| 100 | 15.79 ms | 11.68 ms | 8 |

The SQL count remains constant as widget count grows.

## Validation

- 29 dashboard, permission, and focused regression tests passed.
- 46 data-source and group tests passed.
- Ruff and diff checks passed.
- A follow-up defect-first review found no remaining actionable findings.

## Risk

Low. This changes relationship loading and permission-data reuse without changing the API schema. Focused tests cover restricted widgets, API-key access, mixed group permissions, and pending data-source group relationships.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

