### PR TITLE
Tolerate partial schedule dicts instead of silently disabling the schedule

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -400,8 +400,10 @@ def should_schedule_next(previous_iteration, now, interval, time=None, day_of_we
     else:
         # Accept both "HH:MM" (what the UI sends) and "HH:MM:SS" (common when the
         # schedule is written through the API); seconds are ignored.
-        hour, minute = time.split(":")[:2]
-        hour, minute = int(hour), int(minute)
+        time_parts = time.split(":")
+        if len(time_parts) not in (2, 3) or not all(part.isdigit() for part in time_parts):
+            raise ValueError("Invalid schedule time {!r}; expected HH:MM or HH:MM:SS".format(time))
+        hour, minute = int(time_parts[0]), int(time_parts[1])
 
         # The following logic is needed for cases like the following:
         # - The query scheduled to run at 23:59.

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -398,7 +398,9 @@ def should_schedule_next(previous_iteration, now, interval, time=None, day_of_we
         ttl = int(interval)
         next_iteration = previous_iteration + datetime.timedelta(seconds=ttl)
     else:
-        hour, minute = time.split(":")
+        # Accept both "HH:MM" (what the UI sends) and "HH:MM:SS" (common when the
+        # schedule is written through the API); seconds are ignored.
+        hour, minute = time.split(":")[:2]
         hour, minute = int(hour), int(minute)
 
         # The following logic is needed for cases like the following:
@@ -607,12 +609,15 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 if query.schedule.get("disabled"):
                     continue
 
-                # Skip queries that have None for all schedule values. It's unclear whether this
-                # something that can happen in practice, but we have a test case for it.
-                if all(value is None for value in query.schedule.values()):
+                # The schedule is free-form JSON that can also be written through the API,
+                # so optional keys may be missing entirely; treat a missing key like null.
+                # A schedule without an interval (e.g. one where all values are None) has
+                # nothing to run, so skip it rather than treating it as faulty.
+                interval = query.schedule.get("interval")
+                if interval is None:
                     continue
 
-                if query.schedule["until"]:
+                if query.schedule.get("until"):
                     schedule_until = pytz.utc.localize(datetime.datetime.strptime(query.schedule["until"], "%Y-%m-%d"))
 
                     if schedule_until <= now:
@@ -625,9 +630,9 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 if should_schedule_next(
                     retrieved_at,
                     now,
-                    query.schedule["interval"],
-                    query.schedule["time"],
-                    query.schedule["day_of_week"],
+                    interval,
+                    query.schedule.get("time"),
+                    query.schedule.get("day_of_week"),
                     query.schedule_failures,
                 ):
                     key = "{}:{}".format(query.query_hash, query.data_source_id)
@@ -640,7 +645,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                     "Could not determine if query %d is outdated due to %s. The schedule for this query has been disabled."
                     % (query.id, repr(e))
                 )
-                logging.info(message)
+                logging.warning(message)
                 sentry.capture_exception(type(e)(message).with_traceback(e.__traceback__))
 
         return list(outdated_queries.values())

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -399,10 +399,13 @@ def should_schedule_next(previous_iteration, now, interval, time=None, day_of_we
         next_iteration = previous_iteration + datetime.timedelta(seconds=ttl)
     else:
         # Accept both "HH:MM" (what the UI sends) and "HH:MM:SS" (common when the
-        # schedule is written through the API); seconds are ignored.
+        # schedule is written through the API); the seconds must be valid but are
+        # otherwise ignored.
         time_parts = time.split(":")
         if len(time_parts) not in (2, 3) or not all(part.isdigit() for part in time_parts):
             raise ValueError("Invalid schedule time {!r}; expected HH:MM or HH:MM:SS".format(time))
+        if len(time_parts) == 3 and int(time_parts[2]) > 59:
+            raise ValueError("Invalid schedule time {!r}; seconds must be between 0 and 59".format(time))
         hour, minute = int(time_parts[0]), int(time_parts[1])
 
         # The following logic is needed for cases like the following:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,6 +56,13 @@ class ShouldScheduleNextTest(TestCase):
         schedule = "23:59"
         self.assertTrue(models.should_schedule_next(previous, now, "86400", schedule))
 
+    def test_exact_time_with_seconds_component(self):
+        # "HH:MM:SS" is accepted as well as "HH:MM"; the seconds are ignored.
+        now = date_parse("2015-10-16 20:10")
+        yesterday = date_parse("2015-10-15 23:07")
+        self.assertFalse(models.should_schedule_next(yesterday, now, "86400", "23:00:00"))
+        self.assertTrue(models.should_schedule_next(yesterday, now, "86400", "17:00:00"))
+
     def test_exact_time_every_x_days_that_needs_reschedule(self):
         now = utcnow()
         four_days_ago = now - datetime.timedelta(days=4)
@@ -311,7 +318,7 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         self.assertIn(query, queries)
 
     def test_skips_and_disables_faulty_queries(self):
-        faulty_query = self.create_scheduled_query(until="pigs fly")
+        faulty_query = self.create_scheduled_query(interval="60", until="pigs fly")
         valid_query = self.create_scheduled_query(interval="60")
         self.fake_previous_execution(valid_query, minutes=10)
 
@@ -324,6 +331,34 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         query = self.create_scheduled_query(disabled=True)
         queries = models.Query.outdated_queries()
         self.assertNotIn(query, queries)
+
+    def test_partial_schedule_with_interval_only_is_not_disabled(self):
+        """
+        Schedules written through the API may omit optional keys (time, day_of_week, until).
+        They should still be scheduled rather than being treated as faulty and disabled.
+        """
+        query = self.factory.create_query(schedule={"interval": "3600"})
+        self.fake_previous_execution(query, hours=2)
+
+        self.assertEqual(list(models.Query.outdated_queries()), [query])
+        self.assertFalse(query.schedule.get("disabled"))
+
+    def test_partial_schedule_with_time_containing_seconds_is_not_disabled(self):
+        half_an_hour_ago = utcnow() - datetime.timedelta(minutes=30)
+        query = self.factory.create_query(
+            schedule={"interval": "86400", "time": half_an_hour_ago.strftime("%H:%M:%S")}
+        )
+        self.fake_previous_execution(query, hours=23)
+
+        self.assertEqual(list(models.Query.outdated_queries()), [query])
+        self.assertFalse(query.schedule.get("disabled"))
+
+    def test_schedule_without_interval_is_skipped_not_disabled(self):
+        query = self.factory.create_query(schedule={"until": "2050-01-01"})
+        self.fake_previous_execution(query, hours=2)
+
+        self.assertEqual(list(models.Query.outdated_queries()), [])
+        self.assertFalse(query.schedule.get("disabled"))
 
 
 class QueryArchiveTest(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,6 +63,13 @@ class ShouldScheduleNextTest(TestCase):
         self.assertFalse(models.should_schedule_next(yesterday, now, "86400", "23:00:00"))
         self.assertTrue(models.should_schedule_next(yesterday, now, "86400", "17:00:00"))
 
+    def test_exact_time_rejects_malformed_time(self):
+        now = date_parse("2015-10-16 20:10")
+        yesterday = date_parse("2015-10-15 23:07")
+        for malformed in ("23:00:garbage", "23:00:00:00", "23", "garbage:00"):
+            with self.assertRaises(ValueError):
+                models.should_schedule_next(yesterday, now, "86400", malformed)
+
     def test_exact_time_every_x_days_that_needs_reschedule(self):
         now = utcnow()
         four_days_ago = now - datetime.timedelta(days=4)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,7 +66,7 @@ class ShouldScheduleNextTest(TestCase):
     def test_exact_time_rejects_malformed_time(self):
         now = date_parse("2015-10-16 20:10")
         yesterday = date_parse("2015-10-15 23:07")
-        for malformed in ("23:00:garbage", "23:00:00:00", "23", "garbage:00"):
+        for malformed in ("23:00:garbage", "23:00:00:00", "23", "garbage:00", "23:00:60", "23:00:99"):
             with self.assertRaises(ValueError):
                 models.should_schedule_next(yesterday, now, "86400", malformed)
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

Fixes #7780.

A query's `schedule` JSON can be written through the API with only some of the keys the UI always sends (for example `{"interval": 86400}`), or with a `time` that carries a seconds component (`"07:00:00"`). `Query.outdated_queries()` indexed the dict directly (`query.schedule["until"]`, `["time"]`, `["day_of_week"]`) and `should_schedule_next()` unpacked the time strictly (`hour, minute = time.split(":")`), so on the first scheduler tick a `KeyError` / `ValueError` was raised, caught by the catch-all handler, and the schedule was flipped to `{"disabled": true}` with only an info-level log line. The only visible symptom was stale results.

Changes in `redash/models/__init__.py`:

- Read the optional schedule keys (`time`, `day_of_week`, `until`) with `.get()`, so a missing key behaves like `null`.
- Skip schedules with no `interval` (nothing to run) instead of treating them as faulty. This subsumes the previous "all values are None" check.
- Accept `"HH:MM:SS"` times in `should_schedule_next()` by ignoring the seconds.
- Log the auto-disable at `warning` level instead of `info`, so it shows up in default logs.

Genuinely unparseable values (e.g. `until: "pigs fly"`) still disable the schedule as before; the existing test for that was adjusted to include an `interval` so it still exercises that path.

This is the "use `.get()` with defaults" option from the issue. Validating the shape on `POST /api/queries/<id>` would be a reasonable follow-up but is a bigger behavior change, so I kept it out of this PR.

## How is this tested?

- [x] Unit tests (pytest, jest)

New tests in `tests/test_models.py`:

- `test_exact_time_with_seconds_component`
- `test_partial_schedule_with_interval_only_is_not_disabled`
- `test_partial_schedule_with_time_containing_seconds_is_not_disabled`
- `test_schedule_without_interval_is_skipped_not_disabled`

`pytest tests/test_models.py tests/tasks/test_refresh_queries.py` passes locally (66 passed). `ruff check` and `black --check` are clean.

## Related Tickets & Documents

#7780

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A (backend only)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

