### PR TITLE
Return 400 instead of 500 when query name/description exceed column limits

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -30,6 +30,16 @@ from redash.permissions import (
 from redash.serializers import QuerySerializer
 from redash.utils import collect_parameters_from_request
 
+
+def require_valid_field_lengths(query_def):
+    """Reject values that would overflow the query's varchar columns with a 400 instead of a 500."""
+    for field in ("name", "description"):
+        value = query_def.get(field)
+        max_length = models.Query.__table__.c[field].type.length
+        if isinstance(value, str) and len(value) > max_length:
+            abort(400, message="Query {} must be at most {} characters long.".format(field, max_length))
+
+
 # Ordering map for relationships
 order_map = {
     "name": "lowercase_name",
@@ -222,6 +232,7 @@ class QueryListResource(BaseQueryListResource):
         data_source = models.DataSource.get_by_id_and_org(query_def.pop("data_source_id"), self.current_org)
         require_access(data_source, self.current_user, not_view_only)
         require_access_to_dropdown_queries(self.current_user, query_def)
+        require_valid_field_lengths(query_def)
 
         for field in [
             "id",
@@ -332,6 +343,7 @@ class QueryResource(BaseResource):
 
         require_object_modify_permission(query, self.current_user)
         require_access_to_dropdown_queries(self.current_user, query_def)
+        require_valid_field_lengths(query_def)
 
         for field in [
             "id",

--- a/tests/handlers/test_queries.py
+++ b/tests/handlers/test_queries.py
@@ -97,6 +97,14 @@ class TestQueryResourcePost(BaseTestCase):
         self.assertEqual(rv.json["data_source_id"], data["data_source_id"])
         self.assertEqual(rv.json["latest_query_data_id"], data["latest_query_data_id"])
 
+    def test_update_query_rejects_too_long_name(self):
+        query = self.factory.create_query()
+
+        rv = self.make_request("post", "/api/queries/{0}".format(query.id), data={"name": "x" * 256})
+
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("name", rv.json["message"])
+
     def test_raises_error_in_case_of_conflict(self):
         q = self.factory.create_query()
         q.name = "Another Name"
@@ -272,6 +280,31 @@ class TestQueryListResourcePost(BaseTestCase):
         query = models.Query.query.get(rv.json["id"])
         self.assertEqual(len(list(query.visualizations)), 1)
         self.assertTrue(query.is_draft)
+
+    def test_rejects_too_long_name(self):
+        query_data = {
+            "name": "x" * 256,
+            "query": "SELECT 1",
+            "data_source_id": self.factory.data_source.id,
+        }
+
+        rv = self.make_request("post", "/api/queries", data=query_data)
+
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("name", rv.json["message"])
+
+    def test_rejects_too_long_description(self):
+        query_data = {
+            "name": "Testing",
+            "description": "x" * 4097,
+            "query": "SELECT 1",
+            "data_source_id": self.factory.data_source.id,
+        }
+
+        rv = self.make_request("post", "/api/queries", data=query_data)
+
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn("description", rv.json["message"])
 
     def test_allows_association_with_authorized_dropdown_queries(self):
         data_source = self.factory.create_data_source(group=self.factory.default_group)


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

Fixes #7478.

Creating (or updating) a query with a name longer than 255 characters returned a 500: the handler passed the value straight through to the database, where the insert failed with `psycopg2.errors.StringDataRightTruncation` (`value too long for type character varying(255)`). The same applies to `description` (varchar(4096)).

This adds a small `require_valid_field_lengths()` check in `redash/handlers/queries.py`, used by both `QueryListResource.post` (create) and `QueryResource.post` (update). It reads the maximum lengths from the model's column definitions (no duplicated magic numbers) and aborts with `400` and a message like `Query name must be at most 255 characters long.`

## How is this tested?

- [x] Unit tests (pytest, jest)

New tests in `tests/handlers/test_queries.py`:

- `TestQueryListResourcePost::test_rejects_too_long_name`
- `TestQueryListResourcePost::test_rejects_too_long_description`
- `TestQueryResourcePost::test_update_query_rejects_too_long_name`

Before the fix these fail with `sqlalchemy.exc.DataError` (the 500 from the issue); with the fix `pytest tests/handlers/test_queries.py` passes (37 passed). `ruff check` and `black --check` are clean.

## Related Tickets & Documents

#7478

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A (backend only)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

