### PR TITLE
Fix 12-column layout migration crash on widgets with empty options

### DIFF
--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -20,22 +20,24 @@ def upgrade():
     # Guard against widgets whose options lack the position keys (e.g. rows written
     # through the API with options = '{}'): jsonb_set() with a NULL new_value returns
     # NULL, which would violate the NOT NULL constraint on widgets.options.
+    # The 9-digit bound also keeps the ::int cast and the doubling within int4 range.
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
+    WHERE options->'position'->>'col' ~ '^-?[0-9]{1,9}$';
     UPDATE widgets
     SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int * 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]{1,9}$';
     """)
 
 
 def downgrade():
+    # The 10-digit bound and bigint cast cover everything upgrade() can produce.
     op.execute("""
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int / 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
+    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::bigint / 2)::jsonb)
+    WHERE options->'position'->>'col' ~ '^-?[0-9]{1,10}$';
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int / 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
+    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::bigint / 2)::jsonb)
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]{1,10}$';
     """)

--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -17,34 +17,26 @@ depends_on = None
 
 
 def upgrade():
-    # Guard against widgets whose options lack the position keys (e.g. rows written
-    # through the API with options = '{}'): jsonb_set() with a NULL new_value returns
-    # NULL, which would violate the NOT NULL constraint on widgets.options.
-    # The 9-digit bound also keeps the ::int cast and the doubling within int4 range.
+    # Skip widgets whose position values are missing or not numeric, e.g. rows
+    # written through the API with options = '{}'. Without the filter the cast
+    # yields NULL, jsonb_set() returns NULL for a NULL new_value, and the update
+    # fails the NOT NULL constraint on widgets.options.
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]{1,9}$';
+    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
     UPDATE widgets
     SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int * 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]{1,9}$';
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
     """)
 
 
 def downgrade():
-    # Halve exactly the values the original statement could halve (anything in
-    # int4 range, which also covers everything upgrade() can produce) and skip
-    # the rest instead of aborting on the cast. The CASE guarantees the regex is
-    # checked before the cast (AND operands have no defined evaluation order).
     op.execute("""
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::bigint / 2)::jsonb)
-    WHERE CASE WHEN options->'position'->>'col' ~ '^-?[0-9]{1,10}$'
-               THEN (options->'position'->>'col')::bigint BETWEEN -2147483648 AND 2147483647
-               ELSE false END;
+    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int / 2)::jsonb)
+    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::bigint / 2)::jsonb)
-    WHERE CASE WHEN options->'position'->>'sizeX' ~ '^-?[0-9]{1,10}$'
-               THEN (options->'position'->>'sizeX')::bigint BETWEEN -2147483648 AND 2147483647
-               ELSE false END;
+    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int / 2)::jsonb)
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
     """)

--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -17,17 +17,17 @@ depends_on = None
 
 
 def upgrade():
-    # Skip widgets whose position values are missing or not numeric, e.g. rows
-    # written through the API with options = '{}'. Without the filter the cast
-    # yields NULL, jsonb_set() returns NULL for a NULL new_value, and the update
-    # fails the NOT NULL constraint on widgets.options.
+    # Skip widgets that have no position values, e.g. rows written through the
+    # API with options = '{}'. Without the filter the cast yields NULL,
+    # jsonb_set() returns NULL for a NULL new_value, and the update fails the
+    # NOT NULL constraint on widgets.options.
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
+    WHERE options->'position'->>'col' IS NOT NULL;
     UPDATE widgets
     SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int * 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
+    WHERE options->'position'->>'sizeX' IS NOT NULL;
     """)
 
 
@@ -35,8 +35,8 @@ def downgrade():
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int / 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
+    WHERE options->'position'->>'col' IS NOT NULL;
     UPDATE widgets
     SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int / 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
+    WHERE options->'position'->>'sizeX' IS NOT NULL;
     """)

--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -17,18 +17,25 @@ depends_on = None
 
 
 def upgrade():
+    # Guard against widgets whose options lack the position keys (e.g. rows written
+    # through the API with options = '{}'): jsonb_set() with a NULL new_value returns
+    # NULL, which would violate the NOT NULL constraint on widgets.options.
     op.execute("""
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb);
+    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb)
+    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int * 2)::jsonb);
+    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int * 2)::jsonb)
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
     """)
 
 
 def downgrade():
     op.execute("""
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int / 2)::jsonb);
+    SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int / 2)::jsonb)
+    WHERE options->'position'->>'col' ~ '^-?[0-9]+$';
     UPDATE widgets
-    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int / 2)::jsonb);
+    SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::int / 2)::jsonb)
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]+$';
     """)

--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -34,14 +34,17 @@ def upgrade():
 def downgrade():
     # Halve exactly the values the original statement could halve (anything in
     # int4 range, which also covers everything upgrade() can produce) and skip
-    # the rest instead of aborting on the cast.
+    # the rest instead of aborting on the cast. The CASE guarantees the regex is
+    # checked before the cast (AND operands have no defined evaluation order).
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::bigint / 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]{1,10}$'
-      AND (options->'position'->>'col')::bigint BETWEEN -2147483648 AND 2147483647;
+    WHERE CASE WHEN options->'position'->>'col' ~ '^-?[0-9]{1,10}$'
+               THEN (options->'position'->>'col')::bigint BETWEEN -2147483648 AND 2147483647
+               ELSE false END;
     UPDATE widgets
     SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::bigint / 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]{1,10}$'
-      AND (options->'position'->>'sizeX')::bigint BETWEEN -2147483648 AND 2147483647;
+    WHERE CASE WHEN options->'position'->>'sizeX' ~ '^-?[0-9]{1,10}$'
+               THEN (options->'position'->>'sizeX')::bigint BETWEEN -2147483648 AND 2147483647
+               ELSE false END;
     """)

--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -32,12 +32,16 @@ def upgrade():
 
 
 def downgrade():
-    # The 10-digit bound and bigint cast cover everything upgrade() can produce.
+    # Halve exactly the values the original statement could halve (anything in
+    # int4 range, which also covers everything upgrade() can produce) and skip
+    # the rest instead of aborting on the cast.
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::bigint / 2)::jsonb)
-    WHERE options->'position'->>'col' ~ '^-?[0-9]{1,10}$';
+    WHERE options->'position'->>'col' ~ '^-?[0-9]{1,10}$'
+      AND (options->'position'->>'col')::bigint BETWEEN -2147483648 AND 2147483647;
     UPDATE widgets
     SET options = jsonb_set(options, '{position,sizeX}', to_json((options->'position'->>'sizeX')::bigint / 2)::jsonb)
-    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]{1,10}$';
+    WHERE options->'position'->>'sizeX' ~ '^-?[0-9]{1,10}$'
+      AND (options->'position'->>'sizeX')::bigint BETWEEN -2147483648 AND 2147483647;
     """)

--- a/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
+++ b/migrations/versions/db0aca1ebd32_12_column_dashboard_layout.py
@@ -17,10 +17,6 @@ depends_on = None
 
 
 def upgrade():
-    # Skip widgets that have no position values, e.g. rows written through the
-    # API with options = '{}'. Without the filter the cast yields NULL,
-    # jsonb_set() returns NULL for a NULL new_value, and the update fails the
-    # NOT NULL constraint on widgets.options.
     op.execute("""
     UPDATE widgets
     SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb)


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

Fixes #7561.

Upgrading from v10 to a current release runs the `db0aca1ebd32` (12-column dashboard layout) migration, which rewrites every `widgets` row:

```sql
UPDATE widgets
SET options = jsonb_set(options, '{position,col}', to_json((options->'position'->>'col')::int * 2)::jsonb);
```

For widgets whose `options` don't contain the position keys — e.g. rows created through the API with `options = '{}'`, as reported in the issue — `(options->'position'->>'col')::int` evaluates to NULL, and since `jsonb_set()` is strict, the whole expression returns SQL `NULL`. The UPDATE then violates the `NOT NULL` constraint on `widgets.options` and the entire upgrade aborts:

```
psycopg2.errors.NotNullViolation: null value in column "options" of relation "widgets" violates not-null constraint
```

This PR restricts both UPDATE statements (and their `downgrade()` counterparts) to rows where the value being doubled/halved is actually a base-10 integer:

```sql
WHERE options->'position'->>'col' ~ '^-?[0-9]+$'
```

Degenerate rows (`{}`, missing `position`, non-numeric values) are left untouched instead of aborting the migration; they render the same as before the migration, and the layout of all valid widgets is converted as intended.

## How is this tested?

- [x] Manually

Against `postgres:18-alpine` with a table shaped like `widgets` (`options jsonb NOT NULL`) containing rows `{"position": {"col": 3, "sizeX": 2, "sizeY": 5}}`, `{}`, `{"isHidden": false}`, and `{"position": {"row": 1}}`:

- The current migration statement fails with `null value in column "options" ... violates not-null constraint` (reproducing the issue).
- With this change, the upgrade statements double `col`/`sizeX` on the valid row and leave the other rows untouched, and the downgrade statements round-trip back to the original values without errors.

## Related Tickets & Documents

#7561

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A (migration only)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

