### PR TITLE
Make REDASH_DISABLE_PUBLIC_URLS the source of truth over stale org settings

### DIFF
--- a/redash/models/organizations.py
+++ b/redash/models/organizations.py
@@ -2,6 +2,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy_utils.models import generic_repr
 
+from redash.settings.organization import env_overrides as org_settings_env_overrides
 from redash.settings.organization import settings as org_settings
 
 from .base import Column, db, primary_key
@@ -66,7 +67,7 @@ class Organization(TimestampMixin, db.Model):
         flag_modified(self, "settings")
 
     def get_setting(self, key, raise_on_missing=True):
-        if key in self.settings.get("settings", {}):
+        if key in self.settings.get("settings", {}) and key not in org_settings_env_overrides:
             return self.settings["settings"][key]
 
         if key in org_settings:

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -81,3 +81,13 @@ settings = {
     "hide_plotly_mode_bar": HIDE_PLOTLY_MODE_BAR,
     "disable_public_urls": DISABLE_PUBLIC_URLS,
 }
+
+# Settings whose environment variable, when explicitly set, takes precedence over
+# a value stored in the organizations table. disable_public_urls is not editable
+# from the admin UI, but the admin settings form posts back every setting it
+# receives, so an env-derived value can end up persisted in the database; without
+# this override, that stored copy would silently shadow the environment variable
+# forever (#7630). When the environment variable is not set, the stored value
+# keeps working as before.
+_ENV_OVERRIDABLE = {"disable_public_urls": "REDASH_DISABLE_PUBLIC_URLS"}
+env_overrides = frozenset(key for key, var in _ENV_OVERRIDABLE.items() if var in os.environ)

--- a/tests/handlers/test_settings.py
+++ b/tests/handlers/test_settings.py
@@ -1,8 +1,34 @@
+from unittest import mock
+
 from redash.models import Organization
 from tests import BaseTestCase
 
 
 class TestOrganizationSettings(BaseTestCase):
+    def test_env_override_wins_over_stored_value(self):
+        # When REDASH_DISABLE_PUBLIC_URLS is explicitly set, a value persisted
+        # into the organizations table by an older version must not shadow it (#7630).
+        self.factory.org.settings["settings"] = {"disable_public_urls": True}
+
+        with mock.patch(
+            "redash.models.organizations.org_settings_env_overrides",
+            frozenset(["disable_public_urls"]),
+        ):
+            self.assertEqual(self.factory.org.get_setting("disable_public_urls"), False)
+
+    def test_stored_value_applies_without_env_override(self):
+        # Without the environment variable set, the stored value keeps working
+        # (e.g. the Cypress sharing specs toggle it through the API).
+        admin = self.factory.create_admin()
+        rv = self.make_request(
+            "post",
+            "/api/settings/organization",
+            data={"disable_public_urls": True},
+            user=admin,
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(self.factory.org.get_setting("disable_public_urls"), True)
+
     def test_post(self):
         admin = self.factory.create_admin()
         rv = self.make_request(


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

Fixes #7630.

`REDASH_DISABLE_PUBLIC_URLS=true` has no effect when the `organizations.settings` JSON already contains a `disable_public_urls` key, because `Organization.get_setting()` prefers the stored value.

How the stale value gets into the DB in the first place: `disable_public_urls` is not editable anywhere in the admin UI, but the General Settings form posts back **every** value it received from `GET /api/settings/organization` (see `useOrganizationSettings.jsx` — `OrgSettings.save(currentValues)`). So the first time an admin hits Save, the then-current env default is silently persisted, and from that point on the environment variable is dead for this key.

The fix: when `REDASH_DISABLE_PUBLIC_URLS` is **explicitly set in the environment**, it takes precedence over any value stored in the organizations table (`Organization.get_setting()` skips the stored value). This neutralizes stale rows written by older versions without any DB surgery, and matches the issue's expectation that a setting not editable via the UI follows the environment variable.

When the variable is **not** set, nothing changes: stored values keep working, `POST /api/settings/organization` persists them as before, and the audit trail is untouched. In particular the Cypress sharing/embed specs, which toggle `disable_public_urls` through the API at runtime (`cy.updateOrgSettings({ disable_public_urls: ... })`), are unaffected since CI doesn't set the variable.

The override set is computed in `redash/settings/organization.py` (`env_overrides`) and is easy to extend to other env-only settings if the need arises.

## How is this tested?

- [x] Unit tests (pytest, jest)

New tests in `tests/handlers/test_settings.py`:

- `test_env_override_wins_over_stored_value` — with the override active, a stored `disable_public_urls: true` no longer shadows the env value.
- `test_stored_value_applies_without_env_override` — without the env var, posting the setting through the API still works (guards the Cypress flows).

`pytest tests/handlers/test_settings.py tests/handlers/test_dashboards.py` passes locally; `ruff check` and `black --check` are clean.

## Related Tickets & Documents

#7630

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A (backend only; the Share button simply follows the env var again)
