### PR TITLE
Add Use Query Annotation option to Databricks query runner

### DIFF
--- a/redash/query_runner/databricks.py
+++ b/redash/query_runner/databricks.py
@@ -44,7 +44,10 @@ def _build_odbc_connection_string(**kwargs):
 
 class Databricks(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
-    should_annotate_query = False
+
+    def __init__(self, configuration):
+        super().__init__(configuration)
+        self.should_annotate_query = configuration.get("useQueryAnnotation", False)
 
     @classmethod
     def type(cls):
@@ -63,11 +66,23 @@ class Databricks(BaseSQLQueryRunner):
                 "http_path": {"type": "string", "title": "HTTP Path"},
                 # We're using `http_password` here for legacy reasons
                 "http_password": {"type": "string", "title": "Access Token"},
+                "useQueryAnnotation": {
+                    "type": "boolean",
+                    "title": "Use Query Annotation",
+                    "default": False,
+                },
             },
-            "order": ["host", "http_path", "http_password"],
+            "order": ["host", "http_path", "http_password", "useQueryAnnotation"],
             "secret": ["http_password"],
             "required": ["host", "http_path", "http_password"],
         }
+
+    def annotate_query(self, query, metadata):
+        # Remove "Job ID" before annotating the query so repeated runs of the
+        # same query produce identical statements and can hit the Databricks
+        # SQL result cache.
+        metadata = {k: v for k, v in metadata.items() if k != "Job ID"}
+        return super().annotate_query(query, metadata)
 
     def _get_cursor(self):
         user_agent = "Redash/{} (Databricks)".format(__version__.split("-")[0])

--- a/tests/query_runner/test_databricks.py
+++ b/tests/query_runner/test_databricks.py
@@ -1,6 +1,48 @@
 from unittest import TestCase
 
 from redash.query_runner import split_sql_statements
+from redash.query_runner.databricks import Databricks
+
+
+class TestDatabricksQueryAnnotation(TestCase):
+    def test_annotate_query_with_use_query_annotation_option(self):
+        query_runner = Databricks({"useQueryAnnotation": True})
+
+        self.assertTrue(query_runner.should_annotate_query)
+
+        metadata = {
+            "Username": "username",
+            "query_id": "adhoc",
+            "Job ID": "job-id",
+            "Query Hash": "query-hash",
+            "Scheduled": False,
+        }
+
+        query = "SELECT a FROM tbl"
+        expect = (
+            "/* Username: username, query_id: adhoc, "
+            "Query Hash: query-hash, "
+            "Scheduled: False */ SELECT a FROM tbl"
+        )
+
+        self.assertEqual(query_runner.annotate_query(query, metadata), expect)
+
+    def test_annotate_query_without_use_query_annotation_option(self):
+        query_runner = Databricks({})
+
+        self.assertFalse(query_runner.should_annotate_query)
+
+        metadata = {
+            "Username": "username",
+            "query_id": "adhoc",
+            "Job ID": "job-id",
+            "Query Hash": "query-hash",
+            "Scheduled": False,
+        }
+
+        query = "SELECT a FROM tbl"
+
+        self.assertEqual(query_runner.annotate_query(query, metadata), query)
 
 
 class TestSplitMultipleSQLStatements(TestCase):


### PR DESCRIPTION
## What type of PR is this? 

- [x] Refactor

## Description

The Databricks query runner had `should_annotate_query` hardcoded to `False`, so queries sent to Databricks could never be annotated. This makes it impossible to trace a statement seen in Databricks query history (`system.query.history` / SQL Warehouse Query History) back to the Redash user and query that issued it — every statement just shows up under the shared service token.

This PR follows the existing BigQuery runner pattern (`useQueryAnnotation`):

- Adds a **"Use Query Annotation"** boolean to the Databricks data source configuration. It defaults to `False`, so existing data sources keep the current behavior unless the option is explicitly enabled.
- When enabled, queries are prefixed with the standard annotation comment, e.g.
  `/* Username: user@example.com, query_id: 42, Query Hash: ..., Queue: queries, Scheduled: False */ SELECT ...`
- `Job ID` is stripped from the annotation (same as the BigQuery runner) so repeated runs of the same query produce identical statements and can still hit the Databricks SQL result cache.

Compatible with any Databricks SQL warehouse / cluster reachable via the Simba Spark ODBC driver — block comments are part of standard Databricks SQL syntax, and the runner already sets `UseNativeQuery=1` so the query is passed through as-is.


## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually


Unit tests: added `TestDatabricksQueryAnnotation` in `tests/query_runner/test_databricks.py`, mirroring the existing BigQuery annotation tests (option enabled → annotated without `Job ID`; option omitted → query unchanged).

Manually: ran the local dev Docker setup, created a Databricks data source against a real workspace with **Use Query Annotation** enabled, executed a query, and confirmed the annotation comment appears in the Databricks query history. Also confirmed that with the option off (default) the statement is unchanged.



## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="560" height="236" alt="image" src="https://github.com/user-attachments/assets/0da1acc7-5227-4414-99a1-a4eba3c9feab" />

<img width="1116" height="103" alt="image" src="https://github.com/user-attachments/assets/9cb1071f-06c5-4054-8869-b7f42f8d2fe6" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

