### PR TITLE
Fix 500 when creating text widgets without visualization_id

### DIFF
--- a/redash/handlers/widgets.py
+++ b/redash/handlers/widgets.py
@@ -31,7 +31,7 @@ class WidgetListResource(BaseResource):
 
         widget_properties.pop("id", None)
 
-        visualization_id = widget_properties.pop("visualization_id")
+        visualization_id = widget_properties.pop("visualization_id", None)
         if visualization_id:
             visualization = models.Visualization.get_by_id_and_org(visualization_id, self.current_org)
             require_access(visualization.query_rel, self.current_user, view_only)

--- a/tests/handlers/test_widgets.py
+++ b/tests/handlers/test_widgets.py
@@ -56,6 +56,21 @@ class WidgetAPITest(BaseTestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.json["text"], "Sample text.")
 
+    def test_create_text_widget_without_visualization_id_key(self):
+        dashboard = self.factory.create_dashboard()
+
+        data = {
+            "text": "Sample text.",
+            "dashboard_id": dashboard.id,
+            "options": {},
+            "width": 2,
+        }
+
+        rv = self.make_request("post", "/api/widgets", data=data)
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["text"], "Sample text.")
+
     def test_delete_widget(self):
         widget = self.factory.create_widget()
 


### PR DESCRIPTION
## Summary
- `POST /api/widgets` no longer 500s when `visualization_id` is omitted (text widgets).
- Fixes https://github.com/getredash/redash/issues/7793

## Test plan
- [x] `POST /api/widgets` with `{dashboard_id, width, text}` (no `visualization_id`) returns 200
- [x] Same request with `"visualization_id": null` still returns 200
- [x] Creating a visualization widget still works

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

