### PR TITLE
Remove dead Dashboard.recent client method

### DIFF
--- a/client/app/services/dashboard.js
+++ b/client/app/services/dashboard.js
@@ -170,7 +170,6 @@ const DashboardService = {
   save: (data) => axios.post(saveOrCreateUrl(data), data).then(transformResponse),
   delete: ({ id }) => axios.delete(`api/dashboards/${id}`).then(transformResponse),
   query: (params) => axios.get("api/dashboards", { params }).then(transformResponse),
-  recent: (params) => axios.get("api/dashboards/recent", { params }).then(transformResponse),
   myDashboards: (params) => axios.get("api/dashboards/my", { params }).then(transformResponse),
   favorites: (params) => axios.get("api/dashboards/favorites", { params }).then(transformResponse),
   favorite: ({ id }) => axios.post(`api/dashboards/${id}/favorite`),


### PR DESCRIPTION
## Summary
- Removes unused `Dashboard.recent`, which called `/api/dashboards/recent` (no backend route, no callers).
- Fixes https://github.com/getredash/redash/issues/7769

## Test plan
- [x] Grep shows no remaining `dashboards/recent` or `Dashboard.recent` usage
- [x] Dashboards list / my / favorites still load

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

