### PR TITLE
Keep query-based dropdown empty after clicking clear

### DIFF
--- a/client/app/components/QueryBasedParameterInput.jsx
+++ b/client/app/components/QueryBasedParameterInput.jsx
@@ -53,6 +53,10 @@ export default class QueryBasedParameterInput extends React.Component {
       this.setState({ value: validValues });
       return validValues;
     }
+    if (value == null || value === "") {
+      this.setState({ value: undefined });
+      return null;
+    }
     const found = find(options, (option) => option.value === this.props.value) !== undefined;
     value = found ? value : get(first(options), "value");
     this.setState({ value });


### PR DESCRIPTION
## Summary
- Query-based dropdowns no longer snap back to the first option after clicking X.
- Fixes https://github.com/getredash/redash/issues/7361

## Test plan
- [x] Query-based dropdown: select a value, click X, field stays empty
- [x] Selecting a value still works
- [x] After options reload, a valid existing value is kept

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

