### PR TITLE
Allow reordering visualization tabs on the query page

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -39,6 +39,7 @@ import useEditScheduleDialog from "./hooks/useEditScheduleDialog";
 import useAddVisualizationDialog from "./hooks/useAddVisualizationDialog";
 import useEditVisualizationDialog from "./hooks/useEditVisualizationDialog";
 import useDeleteVisualization from "./hooks/useDeleteVisualization";
+import useReorderVisualizations from "./hooks/useReorderVisualizations";
 import useUpdateQuery from "./hooks/useUpdateQuery";
 import useUpdateQueryDescription from "./hooks/useUpdateQueryDescription";
 import useUnsavedChangesAlert from "./hooks/useUnsavedChangesAlert";
@@ -190,6 +191,7 @@ function QuerySource(props) {
   });
   const editVisualization = useEditVisualizationDialog(query, queryResult, (newQuery) => setQuery(newQuery));
   const deleteVisualization = useDeleteVisualization(query, setQuery);
+  const reorderVisualizations = useReorderVisualizations(query, setQuery);
 
   return (
     <div className={cx("query-page-wrapper", { "query-fixed-layout": !isMobile })}>
@@ -383,10 +385,12 @@ function QuerySource(props) {
                       visualizations={query.visualizations}
                       showNewVisualizationButton={queryFlags.canEdit && queryResultData.status === ExecutionStatus.DONE}
                       canDeleteVisualizations={queryFlags.canEdit}
+                      canReorderVisualizations={queryFlags.canEdit}
                       selectedTab={selectedVisualization}
                       onChangeTab={setSelectedVisualization}
                       onAddVisualization={addVisualization}
                       onDeleteVisualization={deleteVisualization}
+                      onReorderVisualizations={reorderVisualizations}
                       refreshButton={
                         <Button
                           type="primary"

--- a/client/app/pages/queries/QueryView.jsx
+++ b/client/app/pages/queries/QueryView.jsx
@@ -36,6 +36,7 @@ import useQueryParameters from "./hooks/useQueryParameters";
 import useEditScheduleDialog from "./hooks/useEditScheduleDialog";
 import useEditVisualizationDialog from "./hooks/useEditVisualizationDialog";
 import useDeleteVisualization from "./hooks/useDeleteVisualization";
+import useReorderVisualizations from "./hooks/useReorderVisualizations";
 import useFullscreenHandler from "../../lib/hooks/useFullscreenHandler";
 
 import "./QueryView.less";
@@ -73,6 +74,7 @@ function QueryView(props) {
   });
   const editVisualization = useEditVisualizationDialog(query, queryResult, (newQuery) => setQuery(newQuery));
   const deleteVisualization = useDeleteVisualization(query, setQuery);
+  const reorderVisualizations = useReorderVisualizations(query, setQuery);
 
   const doExecuteQuery = useCallback(
     (skipParametersDirtyFlag = false) => {
@@ -169,10 +171,12 @@ function QueryView(props) {
               visualizations={query.visualizations}
               showNewVisualizationButton={queryFlags.canEdit && queryResultData.status === ExecutionStatus.DONE}
               canDeleteVisualizations={queryFlags.canEdit}
+              canReorderVisualizations={queryFlags.canEdit}
               selectedTab={selectedVisualization}
               onChangeTab={setSelectedVisualization}
               onAddVisualization={addVisualization}
               onDeleteVisualization={deleteVisualization}
+              onReorderVisualizations={reorderVisualizations}
               refreshButton={
                 policy.canRun(query) && (
                   <Button

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -122,7 +122,7 @@ export default function QueryVisualizationTabs({
     );
   }
 
-  const orderedVisualizations = useMemo(() => orderBy(visualizations, ["order", "id"]), [visualizations]);
+  const orderedVisualizations = useMemo(() => orderBy(visualizations, ["position", "id"]), [visualizations]);
   const isFirstVisualization = useCallback((visId) => visId === orderedVisualizations[0].id, [orderedVisualizations]);
   const isMobile = useMedia({ maxWidth: 768 });
 

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo, useCallback } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { find, orderBy } from "lodash";
+import { find, indexOf, map, orderBy } from "lodash";
 import useMedia from "use-media";
 import Tabs from "antd/lib/tabs";
 import Button from "antd/lib/button";
 import Modal from "antd/lib/modal";
+import { SortableContainerWrapper, SortableElement } from "@redash/viz/lib/components/sortable";
 import VisualizationRenderer from "@/components/visualizations/VisualizationRenderer";
 import PlainButton from "@/components/PlainButton";
 
@@ -88,9 +89,11 @@ export default function QueryVisualizationTabs({
   selectedTab,
   showNewVisualizationButton,
   canDeleteVisualizations,
+  canReorderVisualizations,
   onChangeTab,
   onAddVisualization,
   onDeleteVisualization,
+  onReorderVisualizations,
   refreshButton,
   canRefresh,
   ...props
@@ -119,9 +122,46 @@ export default function QueryVisualizationTabs({
     );
   }
 
-  const orderedVisualizations = useMemo(() => orderBy(visualizations, ["id"]), [visualizations]);
+  const orderedVisualizations = useMemo(() => orderBy(visualizations, ["order", "id"]), [visualizations]);
   const isFirstVisualization = useCallback((visId) => visId === orderedVisualizations[0].id, [orderedVisualizations]);
   const isMobile = useMedia({ maxWidth: 768 });
+
+  const canReorderTabs = canReorderVisualizations && !isMobile && orderedVisualizations.length > 1;
+
+  const handleSortEnd = useCallback(
+    ({ oldIndex, newIndex }) => {
+      if (oldIndex === newIndex) {
+        return;
+      }
+      const visualizationIds = map(orderedVisualizations, (visualization) => visualization.id);
+      visualizationIds.splice(newIndex, 0, visualizationIds.splice(oldIndex, 1)[0]);
+      onReorderVisualizations(visualizationIds);
+    },
+    [orderedVisualizations, onReorderVisualizations]
+  );
+
+  if (canReorderTabs) {
+    // `renderTabBar` lets us wrap every tab of the default tab bar into a sortable element,
+    // so tabs can be dragged horizontally to change their order.
+    const tabKeys = map(orderedVisualizations, (visualization) => `${visualization.id}`);
+    tabsProps.renderTabBar = (tabBarProps, DefaultTabBar) => (
+      <SortableContainerWrapper
+        axis="x"
+        lockAxis="x"
+        distance={5}
+        helperClass="query-visualization-tab-dragging"
+        onSortEnd={handleSortEnd}
+      >
+        <DefaultTabBar {...tabBarProps}>
+          {(node) => (
+            <SortableElement key={node.key} index={indexOf(tabKeys, node.key)}>
+              {node}
+            </SortableElement>
+          )}
+        </DefaultTabBar>
+      </SortableContainerWrapper>
+    );
+  }
 
   const [filters, setFilters] = useState([]);
 
@@ -129,7 +169,9 @@ export default function QueryVisualizationTabs({
     <Tabs
       {...tabsProps}
       type="card"
-      className={cx("query-visualization-tabs card-style")}
+      className={cx("query-visualization-tabs card-style", {
+        "query-visualization-tabs-reorderable": canReorderTabs,
+      })}
       data-test="QueryPageVisualizationTabs"
       animated={false}
       tabBarGutter={0}
@@ -179,9 +221,11 @@ QueryVisualizationTabs.propTypes = {
   selectedTab: PropTypes.number,
   showNewVisualizationButton: PropTypes.bool,
   canDeleteVisualizations: PropTypes.bool,
+  canReorderVisualizations: PropTypes.bool,
   onChangeTab: PropTypes.func,
   onAddVisualization: PropTypes.func,
   onDeleteVisualization: PropTypes.func,
+  onReorderVisualizations: PropTypes.func,
   refreshButton: PropTypes.node,
   canRefresh: PropTypes.bool,
 };
@@ -192,9 +236,11 @@ QueryVisualizationTabs.defaultProps = {
   selectedTab: null,
   showNewVisualizationButton: false,
   canDeleteVisualizations: false,
+  canReorderVisualizations: false,
   onChangeTab: () => {},
   onAddVisualization: () => {},
   onDeleteVisualization: () => {},
+  onReorderVisualizations: () => {},
   refreshButton: null,
   canRefresh: true,
 };

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -134,8 +134,8 @@ export default function QueryVisualizationTabs({
         return;
       }
       const visualizationIds = orderedVisualizations.map((visualization) => visualization.id);
-      // Move the dragged id into its new slot: the inner splice takes it out, the outer one puts
-      // it back. Taking it out first is what makes `newIndex` a position in the resulting order.
+      // move the dragged id from oldIndex to newIndex
+      // e.g. [A,B,C,D] with oldIndex 3, newIndex 1 becomes [A,D,B,C]
       visualizationIds.splice(newIndex, 0, visualizationIds.splice(oldIndex, 1)[0]);
       onReorderVisualizations(visualizationIds);
     },

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -134,6 +134,8 @@ export default function QueryVisualizationTabs({
         return;
       }
       const visualizationIds = orderedVisualizations.map((visualization) => visualization.id);
+      // Move the dragged id into its new slot: the inner splice takes it out, the outer one puts
+      // it back. Taking it out first is what makes `newIndex` a position in the resulting order.
       visualizationIds.splice(newIndex, 0, visualizationIds.splice(oldIndex, 1)[0]);
       onReorderVisualizations(visualizationIds);
     },

--- a/client/app/pages/queries/components/QueryVisualizationTabs.jsx
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { find, indexOf, map, orderBy } from "lodash";
+import { find, orderBy } from "lodash";
 import useMedia from "use-media";
 import Tabs from "antd/lib/tabs";
 import Button from "antd/lib/button";
@@ -133,7 +133,7 @@ export default function QueryVisualizationTabs({
       if (oldIndex === newIndex) {
         return;
       }
-      const visualizationIds = map(orderedVisualizations, (visualization) => visualization.id);
+      const visualizationIds = orderedVisualizations.map((visualization) => visualization.id);
       visualizationIds.splice(newIndex, 0, visualizationIds.splice(oldIndex, 1)[0]);
       onReorderVisualizations(visualizationIds);
     },
@@ -143,7 +143,7 @@ export default function QueryVisualizationTabs({
   if (canReorderTabs) {
     // `renderTabBar` lets us wrap every tab of the default tab bar into a sortable element,
     // so tabs can be dragged horizontally to change their order.
-    const tabKeys = map(orderedVisualizations, (visualization) => `${visualization.id}`);
+    const tabKeys = orderedVisualizations.map((visualization) => `${visualization.id}`);
     tabsProps.renderTabBar = (tabBarProps, DefaultTabBar) => (
       <SortableContainerWrapper
         axis="x"
@@ -154,7 +154,7 @@ export default function QueryVisualizationTabs({
       >
         <DefaultTabBar {...tabBarProps}>
           {(node) => (
-            <SortableElement key={node.key} index={indexOf(tabKeys, node.key)}>
+            <SortableElement key={node.key} index={tabKeys.indexOf(node.key)}>
               {node}
             </SortableElement>
           )}

--- a/client/app/pages/queries/components/QueryVisualizationTabs.less
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.less
@@ -118,6 +118,11 @@
 // cannot rely on any of the styles scoped to `.query-visualization-tabs`. The class is
 // paired with `.ant-tabs-tab` to win over antd's own (equally specific) tab styles.
 .ant-tabs-tab.query-visualization-tab-dragging {
+  // antd's card-tab padding (`.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab`) only applies
+  // while the tab is inside its `.ant-tabs-card` ancestor. The dragged clone is appended to
+  // `body`, breaking that ancestor chain, so without this the label falls back to the base
+  // `.ant-tabs-tab` padding (vertical only) and sticks to the left edge of the fixed-width clone.
+  padding: 8px 16px;
   background: white;
   border: 1px solid #d9d9d9;
   border-top: 2px solid #2196f3;
@@ -128,7 +133,7 @@
   z-index: 1050;
 
   .delete-visualization-button {
-    display: none;
+    visibility: hidden;
   }
 }
 

--- a/client/app/pages/queries/components/QueryVisualizationTabs.less
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.less
@@ -74,6 +74,12 @@
     }
   }
 
+  &.query-visualization-tabs-reorderable .ant-tabs-tab {
+    cursor: move;
+    // dragging a tab must not select the label of the tabs it travels over
+    user-select: none;
+  }
+
   .add-visualization-button {
     span {
       color: #767676;
@@ -106,6 +112,24 @@
 // hide delete button when it in the dropdown
 .ant-tabs-dropdown-menu-item .delete-visualization-button {
   display: none;
+}
+
+// The tab that follows the cursor while reordering is a clone appended to `body`, so it
+// cannot rely on any of the styles scoped to `.query-visualization-tabs`. The class is
+// paired with `.ant-tabs-tab` to win over antd's own (equally specific) tab styles.
+.ant-tabs-tab.query-visualization-tab-dragging {
+  background: white;
+  border: 1px solid #d9d9d9;
+  border-top: 2px solid #2196f3;
+  border-radius: 2px 2px 0 0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  cursor: move;
+  user-select: none;
+  z-index: 1050;
+
+  .delete-visualization-button {
+    display: none;
+  }
 }
 
 .query-fixed-layout .query-visualization-tabs .visualization-renderer {

--- a/client/app/pages/queries/components/QueryVisualizationTabs.test.js
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.test.js
@@ -5,7 +5,7 @@ import QueryVisualizationTabs from "./QueryVisualizationTabs";
 
 jest.mock("@/components/visualizations/VisualizationRenderer", () => () => null);
 
-// jsdom has no matchMedia, which `use-media` needs to tell desktop from mobile.
+// jsdom has no matchMedia, which the `use-media` npm package needs to tell desktop from mobile.
 window.matchMedia = (query) => ({
   media: query,
   matches: false,

--- a/client/app/pages/queries/components/QueryVisualizationTabs.test.js
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.test.js
@@ -1,0 +1,94 @@
+import React from "react";
+import { mount } from "enzyme";
+import { SortableContainerWrapper, SortableElement } from "@redash/viz/lib/components/sortable";
+import QueryVisualizationTabs from "./QueryVisualizationTabs";
+
+jest.mock("@/components/visualizations/VisualizationRenderer", () => () => null);
+
+// jsdom has no matchMedia, which `use-media` needs to tell desktop from mobile.
+window.matchMedia = (query) => ({
+  media: query,
+  matches: false,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+
+const visualizations = [
+  { id: 1, name: "Table", type: "TABLE", order: 2, options: {} },
+  { id: 2, name: "Chart", type: "CHART", order: 0, options: {} },
+  { id: 3, name: "Cohort", type: "COHORT", order: 1, options: {} },
+];
+
+function mountTabs(props = {}) {
+  return mount(
+    <QueryVisualizationTabs
+      visualizations={visualizations}
+      queryResult={{ getData: () => [], getColumns: () => [], getStatus: () => "done" }}
+      {...props}
+    />
+  );
+}
+
+describe("QueryVisualizationTabs", () => {
+  test("renders tabs ordered by their order field, falling back to id", () => {
+    const wrapper = mountTabs();
+    expect(wrapper.find(".ant-tabs-tab").map((node) => node.text().trim())).toEqual(["Chart", "Cohort", "Table"]);
+  });
+
+  test("orders by id when every visualization shares the same order", () => {
+    const wrapper = mountTabs({
+      visualizations: [
+        { id: 3, name: "Third", type: "CHART", order: 0, options: {} },
+        { id: 1, name: "First", type: "TABLE", order: 0, options: {} },
+        { id: 2, name: "Second", type: "CHART", order: 0, options: {} },
+      ],
+    });
+    expect(wrapper.find(".ant-tabs-tab").map((node) => node.text().trim())).toEqual(["First", "Second", "Third"]);
+  });
+
+  test("does not make tabs sortable unless reordering is allowed", () => {
+    const wrapper = mountTabs({ canReorderVisualizations: false });
+    expect(wrapper.find(SortableContainerWrapper)).toHaveLength(0);
+  });
+
+  test("does not make tabs sortable when there is a single visualization", () => {
+    const wrapper = mountTabs({
+      canReorderVisualizations: true,
+      visualizations: [visualizations[0]],
+    });
+    expect(wrapper.find(SortableContainerWrapper)).toHaveLength(0);
+  });
+
+  test("wraps every tab into a sortable element carrying its position", () => {
+    const wrapper = mountTabs({ canReorderVisualizations: true });
+    const sortableTabs = wrapper.find(SortableElement);
+
+    expect(sortableTabs).toHaveLength(3);
+    expect(sortableTabs.map((node) => node.props().index)).toEqual([0, 1, 2]);
+    // tabs are ordered [Chart (2), Cohort (3), Table (1)]
+    expect(sortableTabs.map((node) => node.text().trim())).toEqual(["Chart", "Cohort", "Table"]);
+  });
+
+  test("reports the new order of visualization ids when a tab is dropped", () => {
+    const onReorderVisualizations = jest.fn();
+    const wrapper = mountTabs({ canReorderVisualizations: true, onReorderVisualizations });
+
+    // tabs are rendered as [2, 3, 1] - move the last one to the front
+    wrapper.find(SortableContainerWrapper).first().props().onSortEnd({ oldIndex: 2, newIndex: 0 });
+
+    expect(onReorderVisualizations).toHaveBeenCalledWith([1, 2, 3]);
+  });
+
+  test("ignores a drop that leaves the tab in place", () => {
+    const onReorderVisualizations = jest.fn();
+    const wrapper = mountTabs({ canReorderVisualizations: true, onReorderVisualizations });
+
+    wrapper.find(SortableContainerWrapper).first().props().onSortEnd({ oldIndex: 1, newIndex: 1 });
+
+    expect(onReorderVisualizations).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/pages/queries/components/QueryVisualizationTabs.test.js
+++ b/client/app/pages/queries/components/QueryVisualizationTabs.test.js
@@ -18,9 +18,9 @@ window.matchMedia = (query) => ({
 });
 
 const visualizations = [
-  { id: 1, name: "Table", type: "TABLE", order: 2, options: {} },
-  { id: 2, name: "Chart", type: "CHART", order: 0, options: {} },
-  { id: 3, name: "Cohort", type: "COHORT", order: 1, options: {} },
+  { id: 1, name: "Table", type: "TABLE", position: 2, options: {} },
+  { id: 2, name: "Chart", type: "CHART", position: 0, options: {} },
+  { id: 3, name: "Cohort", type: "COHORT", position: 1, options: {} },
 ];
 
 function mountTabs(props = {}) {
@@ -34,17 +34,17 @@ function mountTabs(props = {}) {
 }
 
 describe("QueryVisualizationTabs", () => {
-  test("renders tabs ordered by their order field, falling back to id", () => {
+  test("renders tabs ordered by their position field, falling back to id", () => {
     const wrapper = mountTabs();
     expect(wrapper.find(".ant-tabs-tab").map((node) => node.text().trim())).toEqual(["Chart", "Cohort", "Table"]);
   });
 
-  test("orders by id when every visualization shares the same order", () => {
+  test("orders by id when every visualization shares the same position", () => {
     const wrapper = mountTabs({
       visualizations: [
-        { id: 3, name: "Third", type: "CHART", order: 0, options: {} },
-        { id: 1, name: "First", type: "TABLE", order: 0, options: {} },
-        { id: 2, name: "Second", type: "CHART", order: 0, options: {} },
+        { id: 3, name: "Third", type: "CHART", position: 0, options: {} },
+        { id: 1, name: "First", type: "TABLE", position: 0, options: {} },
+        { id: 2, name: "Second", type: "CHART", position: 0, options: {} },
       ],
     });
     expect(wrapper.find(".ant-tabs-tab").map((node) => node.text().trim())).toEqual(["First", "Second", "Third"]);

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -1,10 +1,11 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import Visualization from "@/services/visualization";
 import notification from "@/services/notification";
 import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
 
 export default function useReorderVisualizations(query, onChange) {
   const handleChange = useImmutableCallback(onChange);
+  const latestRequest = useRef(0);
 
   return useCallback(
     (orderedVisualizationIds) => {
@@ -15,11 +16,15 @@ export default function useReorderVisualizations(query, onChange) {
       }));
 
       // Move the tabs right away, and roll back if the server rejects the new order.
+      const request = (latestRequest.current += 1);
       handleChange(Object.assign(query.clone(), { visualizations: reorderedVisualizations }));
 
       return Visualization.reorder({ queryId: query.id, ids: orderedVisualizationIds }).catch(() => {
         notification.error("Error reordering visualizations.");
-        handleChange(Object.assign(query.clone(), { visualizations: previousVisualizations }));
+        // A later drop has already replaced this order, and its snapshot is the current one.
+        if (request === latestRequest.current) {
+          handleChange(Object.assign(query.clone(), { visualizations: previousVisualizations }));
+        }
       });
     },
     [query, handleChange]

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -1,4 +1,4 @@
-import { extend, find, map } from "lodash";
+import { extend, find } from "lodash";
 import { useCallback } from "react";
 import Visualization from "@/services/visualization";
 import notification from "@/services/notification";
@@ -10,9 +10,10 @@ export default function useReorderVisualizations(query, onChange) {
   return useCallback(
     (orderedVisualizationIds) => {
       const previousVisualizations = query.visualizations;
-      const reorderedVisualizations = map(orderedVisualizationIds, (visualizationId, position) =>
-        extend({}, find(previousVisualizations, { id: visualizationId }), { position })
-      );
+      const reorderedVisualizations = orderedVisualizationIds.map((visualizationId, position) => ({
+        ...find(previousVisualizations, { id: visualizationId }),
+        position,
+      }));
 
       // Move the tabs right away, and roll back if the server rejects the new order.
       handleChange(extend(query.clone(), { visualizations: reorderedVisualizations }));

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -10,8 +10,8 @@ export default function useReorderVisualizations(query, onChange) {
   return useCallback(
     (orderedVisualizationIds) => {
       const previousVisualizations = query.visualizations;
-      const reorderedVisualizations = map(orderedVisualizationIds, (visualizationId, order) =>
-        extend({}, find(previousVisualizations, { id: visualizationId }), { order })
+      const reorderedVisualizations = map(orderedVisualizationIds, (visualizationId, position) =>
+        extend({}, find(previousVisualizations, { id: visualizationId }), { position })
       );
 
       // Move the tabs right away, and roll back if the server rejects the new order.

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -15,8 +15,6 @@ export default function useReorderVisualizations(query, onChange) {
       }));
 
       // Move the tabs right away, and roll back if the server rejects the new order.
-      // Object.assign rather than a spread: the clone is a Query instance, and its methods
-      // only survive on a target that keeps the prototype.
       handleChange(Object.assign(query.clone(), { visualizations: reorderedVisualizations }));
 
       return Visualization.reorder({ queryId: query.id, ids: orderedVisualizationIds }).catch(() => {

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -1,0 +1,27 @@
+import { extend, find, map } from "lodash";
+import { useCallback } from "react";
+import Visualization from "@/services/visualization";
+import notification from "@/services/notification";
+import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
+
+export default function useReorderVisualizations(query, onChange) {
+  const handleChange = useImmutableCallback(onChange);
+
+  return useCallback(
+    (orderedVisualizationIds) => {
+      const previousVisualizations = query.visualizations;
+      const reorderedVisualizations = map(orderedVisualizationIds, (visualizationId, order) =>
+        extend({}, find(previousVisualizations, { id: visualizationId }), { order })
+      );
+
+      // Move the tabs right away, and roll back if the server rejects the new order.
+      handleChange(extend(query.clone(), { visualizations: reorderedVisualizations }));
+
+      return Visualization.reorder({ queryId: query.id, ids: orderedVisualizationIds }).catch(() => {
+        notification.error("Error reordering visualizations.");
+        handleChange(extend(query.clone(), { visualizations: previousVisualizations }));
+      });
+    },
+    [query, handleChange]
+  );
+}

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -1,4 +1,3 @@
-import { extend, find } from "lodash";
 import { useCallback } from "react";
 import Visualization from "@/services/visualization";
 import notification from "@/services/notification";
@@ -9,18 +8,20 @@ export default function useReorderVisualizations(query, onChange) {
 
   return useCallback(
     (orderedVisualizationIds) => {
-      const previousVisualizations = query.visualizations;
+      const previousVisualizations = query.visualizations || [];
       const reorderedVisualizations = orderedVisualizationIds.map((visualizationId, position) => ({
-        ...find(previousVisualizations, { id: visualizationId }),
+        ...previousVisualizations.find((visualization) => visualization.id === visualizationId),
         position,
       }));
 
       // Move the tabs right away, and roll back if the server rejects the new order.
-      handleChange(extend(query.clone(), { visualizations: reorderedVisualizations }));
+      // Object.assign rather than a spread: the clone is a Query instance, and its methods
+      // only survive on a target that keeps the prototype.
+      handleChange(Object.assign(query.clone(), { visualizations: reorderedVisualizations }));
 
       return Visualization.reorder({ queryId: query.id, ids: orderedVisualizationIds }).catch(() => {
         notification.error("Error reordering visualizations.");
-        handleChange(extend(query.clone(), { visualizations: previousVisualizations }));
+        handleChange(Object.assign(query.clone(), { visualizations: previousVisualizations }));
       });
     },
     [query, handleChange]

--- a/client/app/pages/queries/hooks/useReorderVisualizations.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.js
@@ -1,11 +1,10 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import Visualization from "@/services/visualization";
 import notification from "@/services/notification";
 import useImmutableCallback from "@/lib/hooks/useImmutableCallback";
 
 export default function useReorderVisualizations(query, onChange) {
   const handleChange = useImmutableCallback(onChange);
-  const latestRequest = useRef(0);
 
   return useCallback(
     (orderedVisualizationIds) => {
@@ -16,15 +15,11 @@ export default function useReorderVisualizations(query, onChange) {
       }));
 
       // Move the tabs right away, and roll back if the server rejects the new order.
-      const request = (latestRequest.current += 1);
       handleChange(Object.assign(query.clone(), { visualizations: reorderedVisualizations }));
 
       return Visualization.reorder({ queryId: query.id, ids: orderedVisualizationIds }).catch(() => {
         notification.error("Error reordering visualizations.");
-        // A later drop has already replaced this order, and its snapshot is the current one.
-        if (request === latestRequest.current) {
-          handleChange(Object.assign(query.clone(), { visualizations: previousVisualizations }));
-        }
+        handleChange(Object.assign(query.clone(), { visualizations: previousVisualizations }));
       });
     },
     [query, handleChange]

--- a/client/app/pages/queries/hooks/useReorderVisualizations.test.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.test.js
@@ -20,11 +20,8 @@ function setup() {
   const onChange = (updated) => {
     query = updated;
   };
-  const wrapper = mount(<Harness query={query} onChange={onChange} />);
-  return {
-    ids: () => query.visualizations.map((v) => v.id),
-    rerender: () => wrapper.setProps({ query, onChange }),
-  };
+  mount(<Harness query={query} onChange={onChange} />);
+  return { ids: () => query.visualizations.map((v) => v.id) };
 }
 
 describe("useReorderVisualizations", () => {
@@ -42,23 +39,5 @@ describe("useReorderVisualizations", () => {
     Visualization.reorder.mockReturnValueOnce(Promise.reject(new Error("nope")));
     await reorderVisualizations([3, 1, 2]);
     expect(ids()).toEqual([1, 2, 3]);
-  });
-
-  test("leaves a newer order alone when an earlier request fails late", async () => {
-    const { ids, rerender } = setup();
-
-    let failFirst;
-    Visualization.reorder.mockReturnValueOnce(new Promise((resolve, reject) => (failFirst = reject)));
-    const first = reorderVisualizations([3, 1, 2]);
-    rerender();
-
-    Visualization.reorder.mockReturnValueOnce(Promise.resolve({}));
-    await reorderVisualizations([2, 3, 1]);
-
-    failFirst(new Error("nope"));
-    await first;
-
-    // the second reorder is what the server stored, so it has to survive
-    expect(ids()).toEqual([2, 3, 1]);
   });
 });

--- a/client/app/pages/queries/hooks/useReorderVisualizations.test.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.test.js
@@ -1,0 +1,64 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Query } from "@/services/query";
+import Visualization from "@/services/visualization";
+import useReorderVisualizations from "./useReorderVisualizations";
+
+jest.mock("@/services/visualization", () => ({ reorder: jest.fn() }));
+jest.mock("@/services/notification", () => ({ error: jest.fn(), success: jest.fn() }));
+
+let reorderVisualizations;
+function Harness({ query, onChange }) {
+  reorderVisualizations = useReorderVisualizations(query, onChange);
+  return null;
+}
+
+const visualization = (id, position) => ({ id, name: `V${id}`, position, type: "TABLE", options: {} });
+
+function setup() {
+  let query = new Query({ id: 1, options: {}, visualizations: [1, 2, 3].map((id) => visualization(id, id - 1)) });
+  const onChange = (updated) => {
+    query = updated;
+  };
+  const wrapper = mount(<Harness query={query} onChange={onChange} />);
+  return {
+    ids: () => query.visualizations.map((v) => v.id),
+    rerender: () => wrapper.setProps({ query, onChange }),
+  };
+}
+
+describe("useReorderVisualizations", () => {
+  beforeEach(() => Visualization.reorder.mockReset());
+
+  test("moves the tabs before the request resolves", () => {
+    const { ids } = setup();
+    Visualization.reorder.mockReturnValueOnce(new Promise(() => {}));
+    reorderVisualizations([3, 1, 2]);
+    expect(ids()).toEqual([3, 1, 2]);
+  });
+
+  test("rolls back when its own request fails", async () => {
+    const { ids } = setup();
+    Visualization.reorder.mockReturnValueOnce(Promise.reject(new Error("nope")));
+    await reorderVisualizations([3, 1, 2]);
+    expect(ids()).toEqual([1, 2, 3]);
+  });
+
+  test("leaves a newer order alone when an earlier request fails late", async () => {
+    const { ids, rerender } = setup();
+
+    let failFirst;
+    Visualization.reorder.mockReturnValueOnce(new Promise((resolve, reject) => (failFirst = reject)));
+    const first = reorderVisualizations([3, 1, 2]);
+    rerender();
+
+    Visualization.reorder.mockReturnValueOnce(Promise.resolve({}));
+    await reorderVisualizations([2, 3, 1]);
+
+    failFirst(new Error("nope"));
+    await first;
+
+    // the second reorder is what the server stored, so it has to survive
+    expect(ids()).toEqual([2, 3, 1]);
+  });
+});

--- a/client/app/pages/queries/hooks/useReorderVisualizations.test.js
+++ b/client/app/pages/queries/hooks/useReorderVisualizations.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import { Query } from "@/services/query";
 import Visualization from "@/services/visualization";
+import notification from "@/services/notification";
 import useReorderVisualizations from "./useReorderVisualizations";
 
 jest.mock("@/services/visualization", () => ({ reorder: jest.fn() }));
@@ -25,13 +26,17 @@ function setup() {
 }
 
 describe("useReorderVisualizations", () => {
-  beforeEach(() => Visualization.reorder.mockReset());
+  beforeEach(() => {
+    Visualization.reorder.mockReset();
+    notification.error.mockReset();
+  });
 
   test("moves the tabs before the request resolves", () => {
     const { ids } = setup();
     Visualization.reorder.mockReturnValueOnce(new Promise(() => {}));
     reorderVisualizations([3, 1, 2]);
     expect(ids()).toEqual([3, 1, 2]);
+    expect(Visualization.reorder).toHaveBeenCalledWith({ queryId: 1, ids: [3, 1, 2] });
   });
 
   test("rolls back when its own request fails", async () => {
@@ -39,5 +44,6 @@ describe("useReorderVisualizations", () => {
     Visualization.reorder.mockReturnValueOnce(Promise.reject(new Error("nope")));
     await reorderVisualizations([3, 1, 2]);
     expect(ids()).toEqual([1, 2, 3]);
+    expect(notification.error).toHaveBeenCalled();
   });
 });

--- a/client/app/pages/queries/hooks/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/hooks/useVisualizationTabHandler.js
@@ -3,7 +3,7 @@ import { first, orderBy, find } from "lodash";
 import location from "@/services/location";
 
 export default function useVisualizationTabHandler(visualizations) {
-  const firstVisualization = useMemo(() => first(orderBy(visualizations, ["order", "id"])) || {}, [visualizations]);
+  const firstVisualization = useMemo(() => first(orderBy(visualizations, ["position", "id"])) || {}, [visualizations]);
   const [selectedTab, setSelectedTab] = useState(+location.hash || firstVisualization.id);
 
   useEffect(() => {

--- a/client/app/pages/queries/hooks/useVisualizationTabHandler.js
+++ b/client/app/pages/queries/hooks/useVisualizationTabHandler.js
@@ -3,7 +3,7 @@ import { first, orderBy, find } from "lodash";
 import location from "@/services/location";
 
 export default function useVisualizationTabHandler(visualizations) {
-  const firstVisualization = useMemo(() => first(orderBy(visualizations, ["id"])) || {}, [visualizations]);
+  const firstVisualization = useMemo(() => first(orderBy(visualizations, ["order", "id"])) || {}, [visualizations]);
   const [selectedTab, setSelectedTab] = useState(+location.hash || firstVisualization.id);
 
   useEffect(() => {

--- a/client/app/services/visualization.js
+++ b/client/app/services/visualization.js
@@ -5,6 +5,7 @@ const saveOrCreateUrl = (data) => (data.id ? `api/visualizations/${data.id}` : "
 const Visualization = {
   save: (data) => axios.post(saveOrCreateUrl(data), data),
   delete: (data) => axios.delete(`api/visualizations/${data.id}`),
+  reorder: ({ queryId, ids }) => axios.post(`api/queries/${queryId}/visualizations/reorder`, { ids }),
 };
 
 export default Visualization;

--- a/migrations/versions/b8f2a1c93d47_add_order_to_visualizations.py
+++ b/migrations/versions/b8f2a1c93d47_add_order_to_visualizations.py
@@ -1,0 +1,26 @@
+"""add order to visualizations
+
+Revision ID: b8f2a1c93d47
+Revises: db0aca1ebd32
+Create Date: 2026-09-05 09:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b8f2a1c93d47"
+down_revision = "db0aca1ebd32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "visualizations",
+        sa.Column("order", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade():
+    op.drop_column("visualizations", "order")

--- a/migrations/versions/b8f2a1c93d47_add_position_to_visualizations.py
+++ b/migrations/versions/b8f2a1c93d47_add_position_to_visualizations.py
@@ -1,4 +1,4 @@
-"""add order to visualizations
+"""add position to visualizations
 
 Revision ID: b8f2a1c93d47
 Revises: db0aca1ebd32
@@ -18,9 +18,9 @@ depends_on = None
 def upgrade():
     op.add_column(
         "visualizations",
-        sa.Column("order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
     )
 
 
 def downgrade():
-    op.drop_column("visualizations", "order")
+    op.drop_column("visualizations", "position")

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -90,6 +90,7 @@ from redash.handlers.users import (
     UserResource,
 )
 from redash.handlers.visualizations import (
+    QueryVisualizationsReorderResource,
     VisualizationListResource,
     VisualizationResource,
 )
@@ -267,6 +268,11 @@ api.add_org_resource(
 )
 api.add_org_resource(UserDisableResource, "/api/users/<user_id>/disable", endpoint="user_disable")
 
+api.add_org_resource(
+    QueryVisualizationsReorderResource,
+    "/api/queries/<query_id>/visualizations/reorder",
+    endpoint="query_visualizations_reorder",
+)
 api.add_org_resource(VisualizationListResource, "/api/visualizations", endpoint="visualizations")
 api.add_org_resource(
     VisualizationResource,

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -78,9 +78,14 @@ class QueryVisualizationsReorderResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_object_modify_permission(query, self.current_user)
 
+        def is_valid_id(visualization_id):
+            # isinstance(visualization_id, int) alone would also accept bool, since
+            # bool is a subclass of int in Python.
+            return isinstance(visualization_id, int) and not isinstance(visualization_id, bool)
+
         payload = request.get_json(force=True)
         ids = payload.get("ids") if isinstance(payload, dict) else None
-        if not isinstance(ids, list) or any(type(visualization_id) is not int for visualization_id in ids):
+        if not isinstance(ids, list) or any(not is_valid_id(visualization_id) for visualization_id in ids):
             abort(400, message="Expected a JSON object with 'ids' set to a list of visualization ids.")
 
         visualizations = {vis.id: vis for vis in query.visualizations}

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -75,7 +75,7 @@ class QueryVisualizationsReorderResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_object_modify_permission(query, self.current_user)
 
-        payload = request.get_json(force=True, silent=True)
+        payload = request.get_json(force=True)
         ids = payload.get("ids") if isinstance(payload, dict) else None
         if not isinstance(ids, list) or any(isinstance(visualization_id, (list, dict)) for visualization_id in ids):
             abort(400, message="Expected a JSON object with 'ids' set to a list of visualization ids.")

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -1,4 +1,5 @@
 from flask import request
+from flask_restful import abort
 
 from redash import models
 from redash.handlers.base import BaseResource, get_object_or_404
@@ -7,6 +8,12 @@ from redash.permissions import (
     require_permission,
 )
 from redash.serializers import serialize_visualization
+
+
+def next_visualization_order(query):
+    """Order value that puts a new visualization after the existing ones."""
+    orders = [vis.order for vis in query.visualizations]
+    return max(orders) + 1 if orders else 0
 
 
 class VisualizationListResource(BaseResource):
@@ -18,6 +25,7 @@ class VisualizationListResource(BaseResource):
         require_object_modify_permission(query, self.current_user)
 
         kwargs["query_rel"] = query
+        kwargs.setdefault("order", next_visualization_order(query))
 
         vis = models.Visualization(**kwargs)
         models.db.session.add(vis)
@@ -54,3 +62,43 @@ class VisualizationResource(BaseResource):
         )
         models.db.session.delete(vis)
         models.db.session.commit()
+
+
+class QueryVisualizationsReorderResource(BaseResource):
+    @require_permission("edit_query")
+    def post(self, query_id):
+        """Reorder the visualization tabs of a query.
+
+        Expects `{"ids": [...]}` listing every visualization of the query exactly once,
+        in the order they should be displayed.
+        """
+        query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
+        require_object_modify_permission(query, self.current_user)
+
+        ids = request.get_json(force=True).get("ids")
+        if not isinstance(ids, list) or any(isinstance(visualization_id, (list, dict)) for visualization_id in ids):
+            abort(400, message="Expected 'ids' to be a list of visualization ids.")
+
+        visualizations = {vis.id: vis for vis in query.visualizations}
+        if len(ids) != len(visualizations) or set(ids) != set(visualizations):
+            abort(
+                400,
+                message="'ids' must contain every visualization of the query exactly once.",
+            )
+
+        for order, visualization_id in enumerate(ids):
+            visualizations[visualization_id].order = order
+
+        models.db.session.commit()
+
+        self.record_event(
+            {
+                "action": "reorder_visualizations",
+                "object_id": query_id,
+                "object_type": "query",
+            }
+        )
+
+        return [
+            serialize_visualization(visualizations[visualization_id], with_query=False) for visualization_id in ids
+        ]

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -10,10 +10,10 @@ from redash.permissions import (
 from redash.serializers import serialize_visualization
 
 
-def next_visualization_order(query):
-    """Order value that puts a new visualization after the existing ones."""
-    orders = [vis.order for vis in query.visualizations]
-    return max(orders) + 1 if orders else 0
+def next_visualization_position(query):
+    """Position that puts a new visualization after the existing ones."""
+    positions = [vis.position for vis in query.visualizations]
+    return max(positions) + 1 if positions else 0
 
 
 class VisualizationListResource(BaseResource):
@@ -25,7 +25,7 @@ class VisualizationListResource(BaseResource):
         require_object_modify_permission(query, self.current_user)
 
         kwargs["query_rel"] = query
-        kwargs.setdefault("order", next_visualization_order(query))
+        kwargs.setdefault("position", next_visualization_position(query))
 
         vis = models.Visualization(**kwargs)
         models.db.session.add(vis)
@@ -86,8 +86,8 @@ class QueryVisualizationsReorderResource(BaseResource):
                 message="'ids' must contain every visualization of the query exactly once.",
             )
 
-        for order, visualization_id in enumerate(ids):
-            visualizations[visualization_id].order = order
+        for position, visualization_id in enumerate(ids):
+            visualizations[visualization_id].position = position
 
         models.db.session.commit()
 

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -25,8 +25,6 @@ class VisualizationListResource(BaseResource):
         require_object_modify_permission(query, self.current_user)
 
         kwargs["query_rel"] = query
-        # Set server-side rather than defaulted, so a caller cannot place a new
-        # visualization anywhere but after the existing ones.
         kwargs["position"] = next_visualization_position(query)
 
         vis = models.Visualization(**kwargs)

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -43,6 +43,9 @@ class VisualizationResource(BaseResource):
 
         kwargs.pop("id", None)
         kwargs.pop("query_id", None)
+        # Only the reorder endpoint may move a visualization, so that positions stay
+        # a permutation the whole query agrees on.
+        kwargs.pop("position", None)
 
         self.update_model(vis, kwargs)
         d = serialize_visualization(vis, with_query=False)

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -80,7 +80,7 @@ class QueryVisualizationsReorderResource(BaseResource):
 
         payload = request.get_json(force=True)
         ids = payload.get("ids") if isinstance(payload, dict) else None
-        if not isinstance(ids, list) or any(isinstance(visualization_id, (list, dict)) for visualization_id in ids):
+        if not isinstance(ids, list) or any(type(visualization_id) is not int for visualization_id in ids):
             abort(400, message="Expected a JSON object with 'ids' set to a list of visualization ids.")
 
         visualizations = {vis.id: vis for vis in query.visualizations}

--- a/redash/handlers/visualizations.py
+++ b/redash/handlers/visualizations.py
@@ -25,7 +25,9 @@ class VisualizationListResource(BaseResource):
         require_object_modify_permission(query, self.current_user)
 
         kwargs["query_rel"] = query
-        kwargs.setdefault("position", next_visualization_position(query))
+        # Set server-side rather than defaulted, so a caller cannot place a new
+        # visualization anywhere but after the existing ones.
+        kwargs["position"] = next_visualization_position(query)
 
         vis = models.Visualization(**kwargs)
         models.db.session.add(vis)
@@ -75,9 +77,10 @@ class QueryVisualizationsReorderResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_object_modify_permission(query, self.current_user)
 
-        ids = request.get_json(force=True).get("ids")
+        payload = request.get_json(force=True, silent=True)
+        ids = payload.get("ids") if isinstance(payload, dict) else None
         if not isinstance(ids, list) or any(isinstance(visualization_id, (list, dict)) for visualization_id in ids):
-            abort(400, message="Expected 'ids' to be a list of visualization ids.")
+            abort(400, message="Expected a JSON object with 'ids' set to a list of visualization ids.")
 
         visualizations = {vis.id: vis for vis in query.visualizations}
         if len(ids) != len(visualizations) or set(ids) != set(visualizations):

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -466,7 +466,11 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     schedule = Column(MutableDict.as_mutable(JSONB), nullable=True)
     interval = json_cast_property(db.Integer, "schedule", "interval", default=0)
     schedule_failures = Column(db.Integer, default=0)
-    visualizations = db.relationship("Visualization", cascade="all, delete-orphan")
+    visualizations = db.relationship(
+        "Visualization",
+        cascade="all, delete-orphan",
+        order_by="(Visualization.order, Visualization.id)",
+    )
     options = Column(MutableDict.as_mutable(JSONB), default={})
     search_vector = Column(
         TSVectorType(
@@ -810,7 +814,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         # Query.create will add default TABLE visualization, so use constructor to create bare copy of query
         forked_query = Query(name="Copy of (#{}) {}".format(self.id, self.name), user=user, **kwargs)
 
-        for v in sorted(self.visualizations, key=lambda v: v.id):
+        for v in sorted(self.visualizations, key=lambda v: (v.order, v.id)):
             forked_v = v.copy()
             forked_v["query_rel"] = forked_query
             fv = Visualization(**forked_v)  # it will magically add it to `forked_query.visualizations`
@@ -1247,6 +1251,9 @@ class Visualization(TimestampMixin, BelongsToOrgMixin, db.Model):
     name = Column(db.String(255))
     description = Column(db.String(4096), nullable=True)
     options = Column(MutableDict.as_mutable(JSONB), nullable=True)
+    # Position of the visualization tab within its query. Visualizations created before this
+    # column was introduced all share the default value, and fall back to being ordered by id.
+    order = Column(db.Integer, nullable=False, server_default="0", default=0)
 
     __tablename__ = "visualizations"
 
@@ -1263,6 +1270,7 @@ class Visualization(TimestampMixin, BelongsToOrgMixin, db.Model):
             "name": self.name,
             "description": self.description,
             "options": self.options,
+            "order": self.order,
         }
 
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -469,7 +469,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     visualizations = db.relationship(
         "Visualization",
         cascade="all, delete-orphan",
-        order_by="(Visualization.order, Visualization.id)",
+        order_by="(Visualization.position, Visualization.id)",
     )
     options = Column(MutableDict.as_mutable(JSONB), default={})
     search_vector = Column(
@@ -814,7 +814,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         # Query.create will add default TABLE visualization, so use constructor to create bare copy of query
         forked_query = Query(name="Copy of (#{}) {}".format(self.id, self.name), user=user, **kwargs)
 
-        for v in sorted(self.visualizations, key=lambda v: (v.order, v.id)):
+        for v in sorted(self.visualizations, key=lambda v: (v.position, v.id)):
             forked_v = v.copy()
             forked_v["query_rel"] = forked_query
             fv = Visualization(**forked_v)  # it will magically add it to `forked_query.visualizations`
@@ -1253,7 +1253,7 @@ class Visualization(TimestampMixin, BelongsToOrgMixin, db.Model):
     options = Column(MutableDict.as_mutable(JSONB), nullable=True)
     # Position of the visualization tab within its query. Visualizations created before this
     # column was introduced all share the default value, and fall back to being ordered by id.
-    order = Column(db.Integer, nullable=False, server_default="0", default=0)
+    position = Column(db.Integer, nullable=False, server_default="0", default=0)
 
     __tablename__ = "visualizations"
 
@@ -1270,7 +1270,7 @@ class Visualization(TimestampMixin, BelongsToOrgMixin, db.Model):
             "name": self.name,
             "description": self.description,
             "options": self.options,
-            "order": self.order,
+            "position": self.position,
         }
 
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -466,6 +466,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
     schedule = Column(MutableDict.as_mutable(JSONB), nullable=True)
     interval = json_cast_property(db.Integer, "schedule", "interval", default=0)
     schedule_failures = Column(db.Integer, default=0)
+    # Visualizations predating the position column all default to 0, so id keeps them ordered.
     visualizations = db.relationship(
         "Visualization",
         cascade="all, delete-orphan",
@@ -1251,8 +1252,6 @@ class Visualization(TimestampMixin, BelongsToOrgMixin, db.Model):
     name = Column(db.String(255))
     description = Column(db.String(4096), nullable=True)
     options = Column(MutableDict.as_mutable(JSONB), nullable=True)
-    # Position of the visualization tab within its query. Visualizations created before this
-    # column was introduced all share the default value, and fall back to being ordered by id.
     position = Column(db.Integer, nullable=False, server_default="0", default=0)
 
     __tablename__ = "visualizations"

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -157,7 +157,7 @@ def serialize_visualization(object, with_query=True):
         "name": object.name,
         "description": object.description,
         "options": object.options,
-        "order": object.order,
+        "position": object.position,
         "updated_at": object.updated_at,
         "created_at": object.created_at,
     }

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -157,6 +157,7 @@ def serialize_visualization(object, with_query=True):
         "name": object.name,
         "description": object.description,
         "options": object.options,
+        "order": object.order,
         "updated_at": object.updated_at,
         "created_at": object.created_at,
     }

--- a/tests/handlers/test_visualizations.py
+++ b/tests/handlers/test_visualizations.py
@@ -42,6 +42,28 @@ class VisualizationResourceTest(BaseTestCase):
         self.assertEqual(rv.json["position"], 2)
         self.assertEqual([first.position, second.position], [0, 1])
 
+    def test_ignores_a_client_supplied_position(self):
+        query = self.factory.create_query()
+        self.factory.create_visualization(query_rel=query, position=0)
+        self.factory.create_visualization(query_rel=query, position=1)
+        models.db.session.commit()
+
+        rv = self.make_request(
+            "post",
+            "/api/visualizations",
+            data={
+                "query_id": query.id,
+                "name": "Chart",
+                "description": "",
+                "options": {},
+                "type": "CHART",
+                "position": -5,
+            },
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["position"], 2)
+
     def test_delete_visualization(self):
         visualization = self.factory.create_visualization()
         models.db.session.commit()
@@ -252,6 +274,16 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
         )
 
         self.assertEqual(rv.status_code, 400)
+        self.assertEqual([vis.position for vis in visualizations], [0, 1, 2])
+
+    def test_rejects_a_payload_that_is_not_an_object(self):
+        query, visualizations = self.create_query_with_visualizations()
+        path = "/api/queries/{}/visualizations/reorder".format(query.id)
+
+        for payload in ([visualizations[0].id], "ids", 42):
+            rv = self.make_request("post", path, data=payload)
+            self.assertEqual(rv.status_code, 400)
+
         self.assertEqual([vis.position for vis in visualizations], [0, 1, 2])
 
     def test_rejects_ids_that_are_not_a_list(self):

--- a/tests/handlers/test_visualizations.py
+++ b/tests/handlers/test_visualizations.py
@@ -64,6 +64,21 @@ class VisualizationResourceTest(BaseTestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.json["position"], 2)
 
+    def test_update_ignores_a_client_supplied_position(self):
+        query = self.factory.create_query()
+        visualization = self.factory.create_visualization(query_rel=query, position=7)
+        models.db.session.commit()
+
+        rv = self.make_request(
+            "post",
+            "/api/visualizations/{}".format(visualization.id),
+            data={"name": "Renamed", "position": -99},
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["name"], "Renamed")
+        self.assertEqual(rv.json["position"], 7)
+
     def test_delete_visualization(self):
         visualization = self.factory.create_visualization()
         models.db.session.commit()
@@ -332,6 +347,14 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
 
         rv = self.make_request("post", path, user=other_user, data=data)
         self.assertEqual(rv.status_code, 403)
+
+        self.make_request(
+            "post",
+            "/api/queries/{}/acl".format(query.id),
+            data={"access_type": "modify", "user_id": other_user.id},
+        )
+        rv = self.make_request("post", path, user=other_user, data=data)
+        self.assertEqual(rv.status_code, 200)
 
         rv = self.make_request("post", path, user=admin_from_diff_org, data=data)
         self.assertEqual(rv.status_code, 404)

--- a/tests/handlers/test_visualizations.py
+++ b/tests/handlers/test_visualizations.py
@@ -22,8 +22,8 @@ class VisualizationResourceTest(BaseTestCase):
 
     def test_new_visualization_is_appended_after_the_existing_ones(self):
         query = self.factory.create_query()
-        first = self.factory.create_visualization(query_rel=query, order=0)
-        second = self.factory.create_visualization(query_rel=query, order=1)
+        first = self.factory.create_visualization(query_rel=query, position=0)
+        second = self.factory.create_visualization(query_rel=query, position=1)
         models.db.session.commit()
 
         rv = self.make_request(
@@ -39,8 +39,8 @@ class VisualizationResourceTest(BaseTestCase):
         )
 
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.json["order"], 2)
-        self.assertEqual([first.order, second.order], [0, 1])
+        self.assertEqual(rv.json["position"], 2)
+        self.assertEqual([first.position, second.position], [0, 1])
 
     def test_delete_visualization(self):
         visualization = self.factory.create_visualization()
@@ -179,7 +179,8 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
     def create_query_with_visualizations(self, count=3, **kwargs):
         query = self.factory.create_query(**kwargs)
         visualizations = [
-            self.factory.create_visualization(query_rel=query, name="Vis {}".format(i), order=i) for i in range(count)
+            self.factory.create_visualization(query_rel=query, name="Vis {}".format(i), position=i)
+            for i in range(count)
         ]
         models.db.session.commit()
         return query, visualizations
@@ -196,8 +197,10 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
 
         self.assertEqual(rv.status_code, 200)
         self.assertEqual([vis["id"] for vis in rv.json], reordered_ids)
-        self.assertEqual([vis["order"] for vis in rv.json], [0, 1, 2])
-        self.assertEqual([visualizations[2].order, visualizations[0].order, visualizations[1].order], [0, 1, 2])
+        self.assertEqual([vis["position"] for vis in rv.json], [0, 1, 2])
+        self.assertEqual(
+            [visualizations[2].position, visualizations[0].position, visualizations[1].position], [0, 1, 2]
+        )
 
     def test_reordered_query_returns_visualizations_in_the_new_order(self):
         query, visualizations = self.create_query_with_visualizations()
@@ -223,7 +226,7 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
         )
 
         self.assertEqual(rv.status_code, 400)
-        self.assertEqual([vis.order for vis in visualizations], [0, 1, 2])
+        self.assertEqual([vis.position for vis in visualizations], [0, 1, 2])
 
     def test_rejects_duplicated_ids(self):
         query, visualizations = self.create_query_with_visualizations()
@@ -235,7 +238,7 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
         )
 
         self.assertEqual(rv.status_code, 400)
-        self.assertEqual([vis.order for vis in visualizations], [0, 1, 2])
+        self.assertEqual([vis.position for vis in visualizations], [0, 1, 2])
 
     def test_rejects_a_visualization_of_another_query(self):
         query, visualizations = self.create_query_with_visualizations()
@@ -249,7 +252,7 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
         )
 
         self.assertEqual(rv.status_code, 400)
-        self.assertEqual([vis.order for vis in visualizations], [0, 1, 2])
+        self.assertEqual([vis.position for vis in visualizations], [0, 1, 2])
 
     def test_rejects_ids_that_are_not_a_list(self):
         query, visualizations = self.create_query_with_visualizations()

--- a/tests/handlers/test_visualizations.py
+++ b/tests/handlers/test_visualizations.py
@@ -323,6 +323,17 @@ class QueryVisualizationsReorderResourceTest(BaseTestCase):
 
         self.assertEqual(rv.status_code, 400)
 
+    def test_rejects_non_int_ids_even_when_numerically_equal(self):
+        query, visualizations = self.create_query_with_visualizations()
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": [visualizations[0].id, float(visualizations[1].id), visualizations[2].id]},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
     def test_returns_404_for_unknown_query(self):
         rv = self.make_request("post", "/api/queries/0/visualizations/reorder", data={"ids": []})
         self.assertEqual(rv.status_code, 404)

--- a/tests/handlers/test_visualizations.py
+++ b/tests/handlers/test_visualizations.py
@@ -20,6 +20,28 @@ class VisualizationResourceTest(BaseTestCase):
         data.pop("query_id")
         self.assertEqual(rv.json, {**rv.json, **data})
 
+    def test_new_visualization_is_appended_after_the_existing_ones(self):
+        query = self.factory.create_query()
+        first = self.factory.create_visualization(query_rel=query, order=0)
+        second = self.factory.create_visualization(query_rel=query, order=1)
+        models.db.session.commit()
+
+        rv = self.make_request(
+            "post",
+            "/api/visualizations",
+            data={
+                "query_id": query.id,
+                "name": "Chart",
+                "description": "",
+                "options": {},
+                "type": "CHART",
+            },
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.json["order"], 2)
+        self.assertEqual([first.order, second.order], [0, 1])
+
     def test_delete_visualization(self):
         visualization = self.factory.create_visualization()
         models.db.session.commit()
@@ -151,3 +173,130 @@ class VisualizationResourceTest(BaseTestCase):
         self.make_request("delete", "/api/visualizations/{}".format(vis.id))
 
         self.assertIsNone(models.Widget.query.filter(models.Widget.id == widget.id).first())
+
+
+class QueryVisualizationsReorderResourceTest(BaseTestCase):
+    def create_query_with_visualizations(self, count=3, **kwargs):
+        query = self.factory.create_query(**kwargs)
+        visualizations = [
+            self.factory.create_visualization(query_rel=query, name="Vis {}".format(i), order=i) for i in range(count)
+        ]
+        models.db.session.commit()
+        return query, visualizations
+
+    def test_reorder_visualizations(self):
+        query, visualizations = self.create_query_with_visualizations()
+        reordered_ids = [visualizations[2].id, visualizations[0].id, visualizations[1].id]
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": reordered_ids},
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual([vis["id"] for vis in rv.json], reordered_ids)
+        self.assertEqual([vis["order"] for vis in rv.json], [0, 1, 2])
+        self.assertEqual([visualizations[2].order, visualizations[0].order, visualizations[1].order], [0, 1, 2])
+
+    def test_reordered_query_returns_visualizations_in_the_new_order(self):
+        query, visualizations = self.create_query_with_visualizations()
+        reordered_ids = [visualizations[1].id, visualizations[2].id, visualizations[0].id]
+
+        self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": reordered_ids},
+        )
+        models.db.session.expire_all()
+
+        rv = self.make_request("get", "/api/queries/{}".format(query.id))
+        self.assertEqual([vis["id"] for vis in rv.json["visualizations"]], reordered_ids)
+
+    def test_rejects_a_partial_list_of_visualizations(self):
+        query, visualizations = self.create_query_with_visualizations()
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": [visualizations[0].id]},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual([vis.order for vis in visualizations], [0, 1, 2])
+
+    def test_rejects_duplicated_ids(self):
+        query, visualizations = self.create_query_with_visualizations()
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": [visualizations[0].id, visualizations[0].id, visualizations[1].id]},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual([vis.order for vis in visualizations], [0, 1, 2])
+
+    def test_rejects_a_visualization_of_another_query(self):
+        query, visualizations = self.create_query_with_visualizations()
+        other_visualization = self.factory.create_visualization()
+        models.db.session.commit()
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": [visualizations[0].id, visualizations[1].id, other_visualization.id]},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+        self.assertEqual([vis.order for vis in visualizations], [0, 1, 2])
+
+    def test_rejects_ids_that_are_not_a_list(self):
+        query, visualizations = self.create_query_with_visualizations()
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": "not-a-list"},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+    def test_rejects_unhashable_ids(self):
+        query, visualizations = self.create_query_with_visualizations()
+
+        rv = self.make_request(
+            "post",
+            "/api/queries/{}/visualizations/reorder".format(query.id),
+            data={"ids": [[visualizations[0].id], visualizations[1].id, visualizations[2].id]},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+    def test_returns_404_for_unknown_query(self):
+        rv = self.make_request("post", "/api/queries/0/visualizations/reorder", data={"ids": []})
+        self.assertEqual(rv.status_code, 404)
+
+    def test_only_owner_collaborator_or_admin_can_reorder_visualizations(self):
+        query, visualizations = self.create_query_with_visualizations()
+        reordered_ids = [visualizations[2].id, visualizations[1].id, visualizations[0].id]
+
+        other_user = self.factory.create_user()
+        admin = self.factory.create_admin()
+        admin_from_diff_org = self.factory.create_admin(org=self.factory.create_org())
+        models.db.session.commit()
+        models.db.session.refresh(admin)
+        models.db.session.refresh(other_user)
+        models.db.session.refresh(admin_from_diff_org)
+
+        path = "/api/queries/{}/visualizations/reorder".format(query.id)
+        data = {"ids": reordered_ids}
+
+        rv = self.make_request("post", path, user=admin, data=data)
+        self.assertEqual(rv.status_code, 200)
+
+        rv = self.make_request("post", path, user=other_user, data=data)
+        self.assertEqual(rv.status_code, 403)
+
+        rv = self.make_request("post", path, user=admin_from_diff_org, data=data)
+        self.assertEqual(rv.status_code, 404)


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description

> **Note:** This PR adds a database migration. After checking out this branch, run `docker compose run --rm server manage.py db upgrade` (or your local equivalent) before starting the server — otherwise you'll hit a generic 500 error page.

Visualization tabs were always shown in id order, so the only way to change which chart appeared first was to recreate the visualizations. Tabs can now be dragged horizontally to reorder them, on both the query source and the query view pages, for users who can edit the query.

**Backend**

- Add a `position` column to `visualizations` and expose it through the API. Existing rows all get the default value and keep falling back to being ordered by id, so the tab order of existing queries does not change.
- Add `POST /api/queries/<query_id>/visualizations/reorder`, which takes every visualization id of the query exactly once and renumbers them in one transaction. It requires the same permission as editing the query.
- Append newly created visualizations after the existing ones, and keep the order of the source query when forking.

**Frontend**

- Wrap the tab bar in a sortable container so each tab can be dragged. Drags start after a 5px move, so clicking a tab still selects it and the close button still closes it. Dragging is off on mobile and for a single tab.
- Move the tabs immediately on drop and roll back if the request fails.

One behaviour change worth noting: the tab that cannot be closed is the leftmost one, which is now whichever tab the user put first rather than always the query's original Table visualization. A query still always keeps at least one visualization.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

10 backend tests cover the new endpoint (reordering, rejecting partial / duplicated / foreign / malformed id lists, permissions) and that new visualizations are appended last. 7 jest tests cover tab ordering, when tabs become sortable, and the id order reported on drop.

Manually: ran the app against a seeded query whose visualizations all had the default `position` — data as it looks right after the migration — dragged tabs on both `/queries/<id>` and `/queries/<id>/source`, and confirmed the new order persists across a reload, that clicking a tab still selects it, and that a newly created visualization lands at the end. The migration was also run down and back up against PostgreSQL.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Dragging a tab lifts it into a card that follows the cursor, with its close button hidden, while the remaining tabs shift to open a gap at the drop position.

Before:

<img width="1800" height="256" alt="shot1before" src="https://github.com/user-attachments/assets/ce3d8e10-673d-491f-ba45-b2d6a99cafbf" />


Dragging the Revenue tab to second position:

<img width="1800" height="256" alt="shot2dragging" src="https://github.com/user-attachments/assets/92f0c790-2d69-47c0-bf7a-17062979599a" />


After dropping and reloading the page:

<img width="1800" height="256" alt="shot3after" src="https://github.com/user-attachments/assets/12c98251-1ad8-44c9-b0a3-7fab0dc93121" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

