### PR TITLE
Show a clear error instead of a raw 500 while DB migrations are pending

### DIFF
--- a/redash/app.py
+++ b/redash/app.py
@@ -35,6 +35,7 @@ def create_app():
     from .handlers.webpack import configure_webpack
     from .metrics import request as request_metrics
     from .models import db, users
+    from .pending_migration import pending_migration_check
     from .utils import sentry
     from .version_check import reset_new_version_status
 
@@ -48,6 +49,7 @@ def create_app():
     request_metrics.init_app(app)
     db.init_app(app)
     migrate.init_app(app, db)
+    pending_migration_check.init_app(app, db)
     mail.init_app(app)
     authentication.init_app(app)
     limiter.init_app(app)

--- a/redash/pending_migration.py
+++ b/redash/pending_migration.py
@@ -1,0 +1,92 @@
+import logging
+import os
+import time
+
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from flask import render_template, request
+
+logger = logging.getLogger(__name__)
+
+# Don't hit the database on every single request while migrations are pending;
+# an admin running them will take at least a few seconds anyway.
+RECHECK_INTERVAL_SECONDS = 5
+
+# Requests that must keep working even while migrations are pending: health
+# checks used by orchestrators, and the static assets the error page itself needs.
+EXEMPT_PATH_PREFIXES = ("/ping", "/static/")
+
+
+def get_head_revision():
+    config = Config(os.path.join("migrations", "alembic.ini"))
+    config.set_main_option("script_location", "migrations")
+    return ScriptDirectory.from_config(config).get_current_head()
+
+
+def get_current_revision(db):
+    with db.engine.connect() as connection:
+        return MigrationContext.configure(connection).get_current_revision()
+
+
+def is_database_up_to_date(db):
+    return get_current_revision(db) == get_head_revision()
+
+
+class PendingMigrationCheck:
+    """
+    Blocks requests with a clear message while the database is behind the code's
+    migrations, instead of letting routes fail with a raw "column/table does not
+    exist" error that looks like an unrelated bug.
+    """
+
+    def __init__(self):
+        self._up_to_date = False
+        self._last_checked_at = 0.0
+
+    def init_app(self, app, db):
+        @app.before_request
+        def check_pending_migrations():
+            return self._check(app, db)
+
+    def _check(self, app, db):
+        if app.testing:
+            # Tests build the schema from the current models (db.create_all()) and
+            # never stamp an alembic revision, so this check would always fail.
+            # `app.testing` is read here (not in init_app) because tests only flip
+            # it on after create_app() has already registered this hook.
+            return None
+
+        if self._up_to_date or request.path.startswith(EXEMPT_PATH_PREFIXES):
+            return None
+
+        now = time.monotonic()
+        if now - self._last_checked_at < RECHECK_INTERVAL_SECONDS:
+            return self._pending_response()
+        self._last_checked_at = now
+
+        try:
+            self._up_to_date = is_database_up_to_date(db)
+        except Exception:
+            # If we can't tell, don't take down the whole app over it.
+            logger.exception("Unable to check migration status")
+            return None
+
+        return None if self._up_to_date else self._pending_response()
+
+    @staticmethod
+    def _pending_response():
+        return (
+            render_template(
+                "error.html",
+                error_message=(
+                    "This Redash instance's database schema is out of date. "
+                    "An administrator needs to run the pending migrations "
+                    "(e.g. `manage.py db upgrade`) before it can be used."
+                ),
+            ),
+            503,
+        )
+
+
+pending_migration_check = PendingMigrationCheck()

--- a/redash/pending_migration.py
+++ b/redash/pending_migration.py
@@ -95,7 +95,7 @@ class PendingMigrationCheck:
                 error_message=(
                     "This Redash instance's database schema is out of date. "
                     "An administrator needs to run the pending migrations "
-                    "(e.g. `manage.py db upgrade`) before it can be used."
+                    "(e.g. `docker-compose run --rm server manage db upgrade`) before it can be used."
                 ),
             ),
             503,

--- a/redash/pending_migration.py
+++ b/redash/pending_migration.py
@@ -6,12 +6,19 @@ from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from flask import render_template, request
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
 # Don't hit the database on every single request while migrations are pending;
 # an admin running them will take at least a few seconds anyway.
 RECHECK_INTERVAL_SECONDS = 5
+
+# A migration's DDL can briefly hold a lock covering the alembic_version table
+# (it's updated as the last step of each migration). Bound how long we'll wait
+# for it so a slow migration can't pile up stuck workers -- if we can't get an
+# answer quickly, the caller's fail-open handling takes over.
+STATEMENT_TIMEOUT_MS = 2000
 
 # Requests that must keep working even while migrations are pending: health
 # checks used by orchestrators, and the static assets the error page itself needs.
@@ -26,7 +33,13 @@ def get_head_revision():
 
 def get_current_revision(db):
     with db.engine.connect() as connection:
-        return MigrationContext.configure(connection).get_current_revision()
+        # `SET LOCAL` only reverts automatically at the end of a transaction. An
+        # explicit `begin()` guarantees that boundary, so the timeout can't leak
+        # onto whatever unrelated query reuses this connection once it's back in
+        # the pool (a plain `SET`, without a bounded transaction, would).
+        with connection.begin():
+            connection.execute(text("SET LOCAL statement_timeout = :timeout"), {"timeout": STATEMENT_TIMEOUT_MS})
+            return MigrationContext.configure(connection).get_current_revision()
 
 
 def is_database_up_to_date(db):

--- a/tests/test_pending_migration.py
+++ b/tests/test_pending_migration.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+from redash.pending_migration import pending_migration_check
+from tests import BaseTestCase
+
+
+class TestPendingMigrationCheck(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        # The hook is skipped while `app.testing` is set (see pending_migration.py),
+        # which is how every other test avoids it. Flip it off just for this class,
+        # and reset the checker's cached state so tests don't leak into each other.
+        self.app.config["TESTING"] = False
+        pending_migration_check._up_to_date = False
+        pending_migration_check._last_checked_at = 0.0
+        self.addCleanup(self._reset)
+
+    def _reset(self):
+        self.app.config["TESTING"] = True
+        pending_migration_check._up_to_date = False
+        pending_migration_check._last_checked_at = 0.0
+
+    @mock.patch("redash.pending_migration.is_database_up_to_date", return_value=False)
+    def test_blocks_requests_while_migrations_are_pending(self, _):
+        rv = self.client.get("/status.json")
+        self.assertEqual(rv.status_code, 503)
+
+    @mock.patch("redash.pending_migration.is_database_up_to_date", return_value=True)
+    def test_allows_requests_once_up_to_date(self, _):
+        rv = self.client.get("/status.json")
+        self.assertNotEqual(rv.status_code, 503)
+
+    @mock.patch("redash.pending_migration.is_database_up_to_date", return_value=False)
+    def test_exempts_the_health_check_endpoint(self, _):
+        rv = self.client.get("/ping")
+        self.assertEqual(rv.status_code, 200)
+
+    @mock.patch("redash.pending_migration.is_database_up_to_date")
+    def test_does_not_recheck_once_confirmed_up_to_date(self, mocked_check):
+        mocked_check.return_value = True
+        self.client.get("/status.json")
+        self.client.get("/status.json")
+        self.assertEqual(mocked_check.call_count, 1)
+
+    @mock.patch("redash.pending_migration.is_database_up_to_date")
+    def test_fails_open_when_the_check_itself_errors(self, mocked_check):
+        mocked_check.side_effect = Exception("boom")
+        rv = self.client.get("/status.json")
+        self.assertNotEqual(rv.status_code, 503)


### PR DESCRIPTION
## What type of PR is this? 
- [x] Feature

## What type of PR is this?

- [x] Bug fix

## Description

Follow-up to https://github.com/getredash/redash/pull/7802: while testing that PR, checking out the branch and hitting the app before running `manage.py db upgrade` produced a raw SQLAlchemy `UndefinedColumn` traceback, surfaced to the browser as a generic "It seems like we encountered an error" page — nothing hints that the fix is to run migrations. This isn't specific to that PR; any migration-adding change can hit it.

This adds a `before_request` check (`redash/pending_migration.py`) closer to Rails' approach: compare the DB's current alembic revision to the code's head revision, and if they don't match, render the existing `error.html` template with a specific message instead of letting the route fail.

- Skipped entirely once confirmed up to date — no per-request DB hit for the rest of the process's life.
- Throttled to once every 5s while pending, so it doesn't hammer the DB while someone's mid-`db upgrade`.
- Fails open (lets the request through) if the check itself errors, so a transient issue in the check can't take down the whole app.
- `/ping` and `/static/*` stay exempt so health checks and the error page's own assets keep working.
- Skipped whenever `app.testing` is set, since the test suite builds its schema with `db.create_all()` and never stamps a revision.

## How is this tested?

- [x] Unit tests (pytest)
- [x] Manually

5 new tests in `tests/test_pending_migration.py` cover: blocking while pending, allowing once up to date, exempting `/ping`, not re-checking once confirmed up to date, and failing open when the check itself raises.

Manually: ran the app against a DB whose current revision didn't match the code's head and confirmed `/status.json` returns 503 with the branded error page while `/ping` keeps returning 200; confirmed normal requests are unaffected once the revisions match.

## note

Looked at how other frameworks handle this:
- **Django**: only warns in the terminal at `runserver` startup, nothing shown to the browser.
- **Rails**: `ActiveRecord::Migration::CheckPending` middleware checks DB state on every request and renders a dedicated error page.
- **Apache Superset** (same stack: Flask + SQLAlchemy + Alembic): `_is_database_up_to_date()` compares the current revision to head, but only to skip one startup init step — it doesn't protect regular requests, so the same raw traceback can still happen there.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

