### PR TITLE
Bump snowflake-connector-python to 4.7.3 (CVE-2026-15925) and add query runner tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ all_ds = [
     "requests-aws-sign==0.1.5",
     "sasl>=0.4a1",
     "simple-salesforce==0.74.3",
-    "snowflake-connector-python==4.5.0",
+    "snowflake-connector-python==4.7.3",
     "td-client==1.5.0",
     "thrift>=0.8.0",
     "thrift-sasl>=0.1.0",

--- a/tests/query_runner/test_snowflake.py
+++ b/tests/query_runner/test_snowflake.py
@@ -1,0 +1,293 @@
+from base64 import b64encode
+from unittest import TestCase
+
+import mock
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+
+from redash.query_runner import (
+    TYPE_BOOLEAN,
+    TYPE_DATE,
+    TYPE_DATETIME,
+    TYPE_FLOAT,
+    TYPE_INTEGER,
+    TYPE_STRING,
+)
+from redash.query_runner.snowflake import Snowflake
+
+
+def generate_private_key_b64(password=None):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    encryption = BestAvailableEncryption(password) if password else NoEncryption()
+    pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, encryption)
+    return b64encode(pem).decode()
+
+
+class FakeCursor:
+    """Minimal stand-in for snowflake.connector's DB-API cursor."""
+
+    def __init__(self, description=None, rows=None):
+        self.description = description or []
+        self.rows = rows or []
+        self.executed = []
+        self.closed = False
+
+    def execute(self, query):
+        self.executed.append(query)
+
+    def __iter__(self):
+        return iter(self.rows)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        self.closed = True
+
+
+class TestDetermineType(TestCase):
+    def test_maps_known_types(self):
+        self.assertEqual(TYPE_INTEGER, Snowflake.determine_type(0, 0))
+        self.assertEqual(TYPE_FLOAT, Snowflake.determine_type(1, 0))
+        self.assertEqual(TYPE_STRING, Snowflake.determine_type(2, 0))
+        self.assertEqual(TYPE_DATE, Snowflake.determine_type(3, 0))
+        self.assertEqual(TYPE_DATETIME, Snowflake.determine_type(4, 0))
+        self.assertEqual(TYPE_BOOLEAN, Snowflake.determine_type(13, 0))
+
+    def test_scaled_number_is_a_float(self):
+        self.assertEqual(TYPE_FLOAT, Snowflake.determine_type(0, 2))
+
+    def test_unknown_type_is_none(self):
+        self.assertIsNone(Snowflake.determine_type(999, 0))
+
+
+class TestConnectionParameters(TestCase):
+    def _connect_params(self, configuration):
+        with mock.patch("snowflake.connector.connect") as connect:
+            Snowflake(configuration)._get_connection()
+        return connect.call_args.kwargs
+
+    def test_us_west_does_not_pass_a_region(self):
+        params = self._connect_params(
+            {
+                "account": "acc",
+                "user": "user",
+                "password": "pwd",
+                "region": "us-west",
+                "database": "db",
+                "warehouse": "wh",
+            }
+        )
+
+        self.assertIsNone(params["region"])
+        self.assertEqual("acc.snowflakecomputing.com", params["host"])
+
+    def test_region_is_part_of_the_host(self):
+        params = self._connect_params(
+            {
+                "account": "acc",
+                "user": "user",
+                "password": "pwd",
+                "region": "eu-central-1",
+                "database": "db",
+                "warehouse": "wh",
+            }
+        )
+
+        self.assertEqual("eu-central-1", params["region"])
+        self.assertEqual("acc.eu-central-1.snowflakecomputing.com", params["host"])
+
+    def test_explicit_host_wins_over_the_derived_one(self):
+        params = self._connect_params(
+            {
+                "account": "acc",
+                "user": "user",
+                "password": "pwd",
+                "region": "eu-central-1",
+                "host": "custom.example.com",
+                "database": "db",
+                "warehouse": "wh",
+            }
+        )
+
+        self.assertEqual("custom.example.com", params["host"])
+
+    def test_password_authentication(self):
+        params = self._connect_params(
+            {
+                "account": "acc",
+                "user": "user",
+                "password": "pwd",
+                "database": "db",
+                "warehouse": "wh",
+            }
+        )
+
+        self.assertEqual("pwd", params["password"])
+        self.assertNotIn("private_key", params)
+
+    def test_key_pair_authentication(self):
+        params = self._connect_params(
+            {
+                "account": "acc",
+                "user": "user",
+                "private_key_File": generate_private_key_b64(),
+                "database": "db",
+                "warehouse": "wh",
+            }
+        )
+
+        self.assertIn("private_key", params)
+        self.assertNotIn("password", params)
+
+    def test_key_pair_authentication_with_an_encrypted_key(self):
+        params = self._connect_params(
+            {
+                "account": "acc",
+                "user": "user",
+                "private_key_File": generate_private_key_b64(b"secret"),
+                "private_key_pwd": "secret",
+                "database": "db",
+                "warehouse": "wh",
+            }
+        )
+
+        self.assertIn("private_key", params)
+
+    def test_missing_credentials_raise(self):
+        with self.assertRaises(Exception):
+            self._connect_params(
+                {
+                    "account": "acc",
+                    "user": "user",
+                    "database": "db",
+                    "warehouse": "wh",
+                }
+            )
+
+
+class TestRunQuery(TestCase):
+    def setUp(self):
+        self.configuration = {
+            "account": "acc",
+            "user": "user",
+            "password": "pwd",
+            "database": "db",
+            "warehouse": "wh",
+        }
+        self.cursor = FakeCursor(
+            description=[
+                ("ID", 0, None, None, None, 0, None),
+                ("NAME", 2, None, None, None, None, None),
+            ],
+            rows=[(1, "foo"), (2, "bar")],
+        )
+        self.connection = FakeConnection(self.cursor)
+        self.patcher = mock.patch("snowflake.connector.connect", return_value=self.connection)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+    def test_returns_columns_and_rows(self):
+        data, error = Snowflake(self.configuration).run_query("SELECT * FROM t", None)
+
+        self.assertIsNone(error)
+        self.assertEqual(
+            [
+                {"name": "ID", "friendly_name": "ID", "type": TYPE_INTEGER},
+                {"name": "NAME", "friendly_name": "NAME", "type": TYPE_STRING},
+            ],
+            data["columns"],
+        )
+        self.assertEqual([{"ID": 1, "NAME": "foo"}, {"ID": 2, "NAME": "bar"}], data["rows"])
+
+    def test_selects_warehouse_and_database_before_the_query(self):
+        Snowflake(self.configuration).run_query("SELECT * FROM t", None)
+
+        self.assertEqual(
+            ["USE WAREHOUSE wh", "USE db", "SELECT * FROM t"],
+            self.cursor.executed,
+        )
+
+    def test_closes_cursor_and_connection_on_failure(self):
+        self.cursor.execute = mock.Mock(side_effect=RuntimeError("boom"))
+
+        with self.assertRaises(RuntimeError):
+            Snowflake(self.configuration).run_query("SELECT * FROM t", None)
+
+        self.assertTrue(self.cursor.closed)
+        self.assertTrue(self.connection.closed)
+
+    def test_lower_case_columns_option(self):
+        configuration = dict(self.configuration, lower_case_columns=True)
+
+        data, _ = Snowflake(configuration).run_query("SELECT * FROM t", None)
+
+        self.assertEqual(["id", "name"], [column["name"] for column in data["columns"]])
+        self.assertEqual([{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}], data["rows"])
+
+
+class TestGetSchema(TestCase):
+    SHOW_COLUMNS_DESCRIPTION = [
+        ("schema_name", 2, None, None, None, None, None),
+        ("table_name", 2, None, None, None, None, None),
+        ("column_name", 2, None, None, None, None, None),
+        ("kind", 2, None, None, None, None, None),
+    ]
+
+    def _get_schema(self, database, rows):
+        cursor = FakeCursor(description=self.SHOW_COLUMNS_DESCRIPTION, rows=rows)
+        configuration = {
+            "account": "acc",
+            "user": "user",
+            "password": "pwd",
+            "database": database,
+            "warehouse": "wh",
+        }
+
+        with mock.patch("snowflake.connector.connect", return_value=FakeConnection(cursor)):
+            schema = Snowflake(configuration).get_schema()
+
+        return schema, cursor
+
+    def test_groups_columns_by_table_and_ignores_non_columns(self):
+        schema, cursor = self._get_schema(
+            "db",
+            [
+                ("public", "users", "id", "COLUMN"),
+                ("public", "users", "name", "COLUMN"),
+                ("public", "orders", "id", "COLUMN"),
+                ("public", "some_stage", "whatever", "STAGE"),
+            ],
+        )
+
+        self.assertEqual(
+            [
+                {"name": "public.users", "columns": ["id", "name"]},
+                {"name": "public.orders", "columns": ["id"]},
+            ],
+            schema,
+        )
+
+    def test_does_not_use_a_warehouse(self):
+        _, cursor = self._get_schema("db", [])
+
+        self.assertEqual(["USE db", "SHOW COLUMNS IN DATABASE"], cursor.executed)
+
+    def test_database_including_a_schema_narrows_the_scope(self):
+        _, cursor = self._get_schema("db.public", [])
+
+        self.assertEqual(["USE db.public", "SHOW COLUMNS"], cursor.executed)

--- a/uv.lock
+++ b/uv.lock
@@ -2259,7 +2259,7 @@ wheels = [
 
 [[package]]
 name = "redash"
-version = "26.7.0.dev0"
+version = "26.9.0.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "advocate" },
@@ -2524,7 +2524,7 @@ all-ds = [
     { name = "requests-aws-sign", specifier = "==0.1.5" },
     { name = "sasl", specifier = ">=0.4a1" },
     { name = "simple-salesforce", specifier = "==0.74.3" },
-    { name = "snowflake-connector-python", specifier = "==4.5.0" },
+    { name = "snowflake-connector-python", specifier = "==4.7.3" },
     { name = "td-client", specifier = "==1.5.0" },
     { name = "thrift", specifier = ">=0.8.0" },
     { name = "thrift-sasl", specifier = ">=0.1.0" },
@@ -2830,7 +2830,7 @@ wheels = [
 
 [[package]]
 name = "snowflake-connector-python"
-version = "4.5.0"
+version = "4.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asn1crypto" },
@@ -2851,12 +2851,13 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/e7/f0ab30895256c4d8e0b6e33857150d10d465bdfaef3f0ed471ba83b1444f/snowflake_connector_python-4.5.0.tar.gz", hash = "sha256:376eb9d956f6b9287df448e483ec862b94fb9ccb06cefc945b68ddac1c7d1c48", size = 932644, upload-time = "2026-05-12T11:57:10.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2c/bb5ecbd0af9f24b743de2d4a44497be2bdab0e4afcdcd23d96998a2f8d18/snowflake_connector_python-4.7.3.tar.gz", hash = "sha256:0f93139c3502c3d23139561b123492c09c33ab12a30956649a01e2cb04f06583", size = 968493, upload-time = "2026-09-03T14:13:37.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/30/f8a7161b62445aea45fd569522e998c9c718973afa7b10afa7a021a79fa8/snowflake_connector_python-4.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7badadc59d7e75550c7f35bdb9414895cae5898a4f9901b02231d0eaa694a4a0", size = 11935196, upload-time = "2026-05-12T11:57:21.76Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/dd/3f6c8196c1d906590eea2348c74ec307dd2f3ec479c548b864bb6f802856/snowflake_connector_python-4.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:64ec9b5dddf19c7f4ce4355d1b8e16239a26d1d161d92219919953510664269c", size = 2839990, upload-time = "2026-05-12T11:56:58.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/31/26d9614d67b374efa5248f4a9fc0280e57cc3dae34ec50ce0a52ad8ead74/snowflake_connector_python-4.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7f5e2ea42521c033c4ac0e60685c50a47082715eb57cdaf92b438d9bb44d220", size = 2874205, upload-time = "2026-05-12T11:57:00.866Z" },
-    { url = "https://files.pythonhosted.org/packages/25/58/4e6347760e93293126c28cbabc9711d7292c8eb7298fcf04765fa3627ba4/snowflake_connector_python-4.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:5f73f1b0ed24e01d9dd627b088cc83e62e81ea5b19bee679946941f6d1947ef9", size = 12073914, upload-time = "2026-05-12T11:57:44.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/38/3b206805b46defb638d02156746d21ba559937e93ca0f04a143dcd0aeceb/snowflake_connector_python-4.7.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7a4d325f39c1ae332b35f0238cb2aa6dfe4472a62a8c3b0956f0d96d8c15bec3", size = 1194303, upload-time = "2026-09-03T14:13:48.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d5/ba876a02bcf8f329d755bbee070de8df080ab3434cfef7bdbc2e7dc0de7f/snowflake_connector_python-4.7.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:95412cad64a7fafaabb87aee4120489dafcef767dc6ac853090b6f86b8ed6496", size = 1206774, upload-time = "2026-09-03T14:13:49.539Z" },
+    { url = "https://files.pythonhosted.org/packages/70/43/13cf1786f251129d0880f72e1185cc06c1833f27b3d973f913089ac7f431/snowflake_connector_python-4.7.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a101f32b1f2e0ed3d084503372d698e37290ef9ea211c29c916842802292dddb", size = 2919287, upload-time = "2026-09-03T14:13:27.391Z" },
+    { url = "https://files.pythonhosted.org/packages/04/de/2dfd370d4796510f2f5a6e0db7e1e7ed6cba9ae82fb0bf83a876bff2f828/snowflake_connector_python-4.7.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea6ebb8e2b782876210ed96535d95271cd3dee207f95f87f0ff3e80561bd24cc", size = 2951146, upload-time = "2026-09-03T14:13:29.267Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ae/8492cd097065a890f9e1085acb207917a7ddf7a07a8fef83097f80e3f149/snowflake_connector_python-4.7.3-cp313-cp313-win_amd64.whl", hash = "sha256:1217e3426c2df6713ba1518ce908b68b5aadcff4fc9ad6760a8947a7561b8c07", size = 5431806, upload-time = "2026-09-03T14:14:03.166Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What type of PR is this?

- [x] Other — security dependency bump, plus test coverage

## Description

`snowflake-connector-python` is currently pinned to `4.5.0`, which is affected by **CVE-2026-15925** (CRITICAL). This bumps the pin to **4.7.3** — past the `4.7.1` fixed version, and the current release at time of writing.

Compatible versions: the query runner uses only the DB-API surface of `snowflake.connector` (`connect`, `cursor`, `execute`, `description`, `close`), which is unchanged across `4.5.0` → `4.7.3`.

The Snowflake query runner had no test coverage at all, so this also adds `tests/query_runner/test_snowflake.py` covering the logic a connector upgrade could plausibly affect:

* `determine_type` / `TYPES_MAP`, including the `scale > 0` → float rule
* connection parameters — the `us-west` region special case, region-in-host derivation, explicit `host` override, password auth and key pair auth (plain and password-encrypted), and the missing-credentials error
* `run_query` — column and row parsing, the `USE WAREHOUSE` / `USE <db>` preamble, `lower_case_columns`, and cursor/connection cleanup when `execute` raises
* `get_schema` — grouping by `schema.table`, skipping non-`COLUMN` rows, and `SHOW COLUMNS` vs `SHOW COLUMNS IN DATABASE`

The tests patch `snowflake.connector.connect` and drive the runner through fake cursor/connection objects, following the existing style in `tests/query_runner/test_athena.py`. No new dependencies.

Note on the lockfile: re-running `uv lock` also picks up the `redash` version change from the `26.09.0-dev` snapshot, which the committed lockfile had not caught up with yet. That line is unrelated to this change.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

17 new tests, all passing against `4.7.3`. They also pass against the old `4.5.0`, confirming the bump is not a behaviour change on these paths.

Additionally, the type-code mapping was verified out-of-tree against a **real** connector `4.7.3` talking the actual Snowflake wire protocol to a [fakesnow](https://github.com/tekumara/fakesnow) server, feeding the resulting cursor to the runner's own `_parse_results`. Every code still maps as `TYPES_MAP` expects:

```
INT→0/scale 0→integer     NUMBER(10,2)→0/scale 2→float    FLOAT→1→float
VARCHAR→2→string          DATE→3→date                     BOOLEAN→13→boolean
TIMESTAMP_NTZ→8→datetime  TIMESTAMP_LTZ/TZ→7→datetime
```

That check is not included in the test suite: fakesnow requires `duckdb~=1.5.5` while this repo pins `duckdb==1.3.2` for the DuckDB runner, so the two cannot currently coexist. It also does not implement `USE WAREHOUSE`, bare `USE <db>`, or `SHOW COLUMNS IN DATABASE`, so it cannot drive `run_query` / `get_schema` end to end regardless.

## Related Tickets & Documents

CVE-2026-15925

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A — no UI changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

