### PR TITLE
Bump vertica-python to 1.4.0 to restore the Vertica data source on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ all_ds = [
     "thrift>=0.8.0",
     "thrift-sasl>=0.1.0",
     "trino>=0.305,<1.0",
-    "vertica-python==1.1.1",
+    "vertica-python==1.4.0",
     "xlrd==2.0.1",
     "e6data-python-connector==2.2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2259,7 +2259,7 @@ wheels = [
 
 [[package]]
 name = "redash"
-version = "26.7.0.dev0"
+version = "26.9.0.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "advocate" },
@@ -2529,7 +2529,7 @@ all-ds = [
     { name = "thrift", specifier = ">=0.8.0" },
     { name = "thrift-sasl", specifier = ">=0.1.0" },
     { name = "trino", specifier = ">=0.305,<1.0" },
-    { name = "vertica-python", specifier = "==1.1.1" },
+    { name = "vertica-python", specifier = "==1.4.0" },
     { name = "xlrd", specifier = "==2.0.1" },
 ]
 dev = [
@@ -3093,15 +3093,15 @@ wheels = [
 
 [[package]]
 name = "vertica-python"
-version = "1.1.1"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/7d/b3bfd9f29c1621d85623e2988384d6767a72f9a4b0340eddf0699faa5ebe/vertica-python-1.1.1.tar.gz", hash = "sha256:dedf56d76b67673b4d57a13f7f96ebdc57b39ea650b93ebf0c05eb6d1d2c0c05", size = 88252, upload-time = "2022-07-08T09:19:57.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/25/a86f25e00bfeccf0cf22ac9a727d055d061d49e757dabadc37710f9b567c/vertica-python-1.4.0.tar.gz", hash = "sha256:542078ae2fedee694adedb04d81c6edc277b87ed7440302942107d86a0bcd445", size = 110416, upload-time = "2024-07-22T07:02:34.22Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/3d/647e5080a791ac4d5e6515e42f2ecf7931f3be0cbea85f833fb40e4dc858/vertica_python-1.1.1-py2.py3-none-any.whl", hash = "sha256:63d300832d6fe471987880f06a9590eafc46a1f896860881270f6b6645f3bec6", size = 175543, upload-time = "2022-07-08T09:19:54.563Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7e/adc6a46263a48e0270b0bc6ddab60c6a70766103f37ec4591ef78f0221db/vertica_python-1.4.0-py3-none-any.whl", hash = "sha256:50fecd7687f4b0b9f6dee6e2b35c195af2a4f702ece01bd12e080b51756e000b", size = 191824, upload-time = "2024-07-22T07:02:32.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

Fixes #7801.

Since #7636 the image is built on Python 3.13, but `vertica-python` is still pinned to 1.1.1 (2022). That version does an unconditional `import crypt` on non-Windows platforms ([password.py@1.1.1](https://github.com/vertica/vertica-python/blob/1.1.1/vertica_python/vertica/messages/frontend_messages/password.py#L46-L49)), and Python 3.13 removed the `crypt` module (PEP 594):

```
>>> import vertica_python
  File ".../vertica_python/vertica/messages/frontend_messages/password.py", line 49, in <module>
    import crypt
ModuleNotFoundError: No module named 'crypt'
```

`Vertica.enabled()` catches the `ImportError` and returns `False`, so the data source silently disappears from the "New Data Source" list and existing Vertica data sources stop working.

This PR bumps the pin to 1.4.0, the latest release on PyPI. vertica-python stopped depending on `crypt` in 1.3.0 (vertica/vertica-python#485, "deprecate crypt package"); since then the bundled pure-Python implementation is used on every platform, so the legacy `CRYPT_PASSWORD` auth method keeps working too (unlike the `v1.1.2`/`v1.1.3` git tags mentioned in the issue, which are not published on PyPI and only fall back to `cryptography.hashes`).

Nothing else in the runner needs to change:

- 1.4.0 has the same runtime dependencies as 1.1.1 (`python-dateutil`, `six`), both already locked, so the `uv.lock` diff is limited to the `vertica-python` entry.
- `cursor.description[i][1]` is still the data type OID (`Column.type_code = col['data_type_oid']`), and none of the OIDs used by `types_map` changed between the two versions (1.4.0 only adds new ROW/ARRAY/MAP/SET types).
- `connection_timeout` is still a supported `connect()` option, and extra options such as `read_timeout` are still accepted.

`uv lock` also refreshed the project version recorded in `uv.lock` (`26.7.0.dev0` → `26.9.0.dev0`), which had not been regenerated since the version bump in `pyproject.toml`.

## How is this tested?

- [x] Manually

- In a clean Python 3.13.14 virtualenv, `vertica-python==1.1.1` fails to import with the `ModuleNotFoundError` above, while `vertica-python==1.4.0` imports fine.
- Built the image with the CI settings (`docker compose build --build-arg install_groups="main,all_ds,dev" --build-arg skip_frontend_build=true` using `.ci/compose.ci.yaml`) and ran `manage ds list_types`: `Vertica` is now listed.
- Ran the backend test suite in that image (`docker compose run --rm redash tests tests/`): 932 passed, 1 skipped.

## Related Tickets & Documents

#7801

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/redash/pull/7808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

