### PR TITLE
Resolve dynamic date parameters on the backend so scheduled queries can use them

### DIFF
--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -1,12 +1,136 @@
+import datetime
 import re
 from functools import partial
 from numbers import Number
 
 import pystache
 from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
 from funcy import distinct
 
-from redash.utils import mustache_render
+from redash.utils import mustache_render, utcnow
+
+# Dynamic ("d_*") values offered by the frontend for date and date range
+# parameters. The browser resolves them right before running a query, so they
+# have to be resolved here as well for everything that doesn't go through the
+# browser: scheduled refreshes, API calls and the query hash. The definitions
+# mirror client/app/services/parameters/DateParameter.js and
+# DateRangeParameter.js (with moment's default locale, weeks start on Sunday).
+# They are evaluated in UTC.
+DYNAMIC_PREFIX = "d_"
+
+DATE_TYPES = ("date", "datetime-local", "datetime-with-seconds")
+DATE_RANGE_TYPES = ("date-range", "datetime-range", "datetime-range-with-seconds")
+
+DATETIME_FORMATS = {
+    "date": "%Y-%m-%d",
+    "datetime-local": "%Y-%m-%d %H:%M",
+    "datetime-with-seconds": "%Y-%m-%d %H:%M:%S",
+    "date-range": "%Y-%m-%d",
+    "datetime-range": "%Y-%m-%d %H:%M",
+    "datetime-range-with-seconds": "%Y-%m-%d %H:%M:%S",
+}
+
+
+def _start_of_day(dt):
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _end_of_day(dt):
+    return dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+
+def _start_of_week(dt):
+    return _start_of_day(dt - datetime.timedelta(days=(dt.weekday() + 1) % 7))
+
+
+def _end_of_week(dt):
+    return _end_of_day(_start_of_week(dt) + datetime.timedelta(days=6))
+
+
+def _start_of_month(dt):
+    return _start_of_day(dt.replace(day=1))
+
+
+def _end_of_month(dt):
+    return _end_of_day(_start_of_month(dt) + relativedelta(months=1, days=-1))
+
+
+def _start_of_year(dt):
+    return _start_of_day(dt.replace(month=1, day=1))
+
+
+def _end_of_year(dt):
+    return _end_of_day(dt.replace(month=12, day=31))
+
+
+def _period(start_of, end_of, **ago):
+    """The whole day/week/month/year that contains ``now - ago``."""
+
+    def resolve(now):
+        reference = now - relativedelta(**ago)
+        return start_of(reference), end_of(reference)
+
+    return resolve
+
+
+def _until_now(start_of_day=True, **ago):
+    """From ``now - ago`` (the beginning of that day unless told otherwise) until now."""
+
+    def resolve(now):
+        start = now - relativedelta(**ago)
+        return (_start_of_day(start) if start_of_day else start), now
+
+    return resolve
+
+
+DYNAMIC_DATES = {
+    "d_now": lambda now: now,
+    "d_yesterday": lambda now: now - datetime.timedelta(days=1),
+}
+
+DYNAMIC_DATE_RANGES = {
+    "d_today": _period(_start_of_day, _end_of_day),
+    "d_yesterday": _period(_start_of_day, _end_of_day, days=1),
+    "d_this_week": _period(_start_of_week, _end_of_week),
+    "d_this_month": _period(_start_of_month, _end_of_month),
+    "d_this_year": _period(_start_of_year, _end_of_year),
+    "d_last_week": _period(_start_of_week, _end_of_week, weeks=1),
+    "d_last_month": _period(_start_of_month, _end_of_month, months=1),
+    "d_last_year": _period(_start_of_year, _end_of_year, years=1),
+    "d_last_hour": _until_now(start_of_day=False, hours=1),
+    "d_last_8_hours": _until_now(start_of_day=False, hours=8),
+    "d_last_24_hours": _until_now(start_of_day=False, hours=24),
+    "d_last_7_days": _until_now(days=7),
+    "d_last_14_days": _until_now(days=14),
+    "d_last_30_days": _until_now(days=30),
+    "d_last_60_days": _until_now(days=60),
+    "d_last_90_days": _until_now(days=90),
+    "d_last_12_months": _until_now(months=12),
+    "d_last_2_years": _until_now(years=2),
+    "d_last_3_years": _until_now(years=3),
+    "d_last_10_years": _until_now(years=10),
+}
+
+
+def resolve_dynamic_value(value, parameter_type, now=None):
+    """Replace a dynamic date or date range value with the concrete value the
+    frontend would send when running the query. Anything else is returned as is,
+    so unknown dynamic values are still rejected by the regular validation."""
+    if not isinstance(value, str) or not value.startswith(DYNAMIC_PREFIX):
+        return value
+
+    now = now or utcnow()
+    date_format = DATETIME_FORMATS.get(parameter_type)
+
+    if parameter_type in DATE_TYPES and value in DYNAMIC_DATES:
+        return DYNAMIC_DATES[value](now).strftime(date_format)
+
+    if parameter_type in DATE_RANGE_TYPES and value in DYNAMIC_DATE_RANGES:
+        start, end = DYNAMIC_DATE_RANGES[value](now)
+        return {"start": start.strftime(date_format), "end": end.strftime(date_format)}
+
+    return value
 
 
 def _pluck_name_and_value(default_column, row):
@@ -123,6 +247,7 @@ class ParameterizedQuery:
         self.parameters = {}
 
     def apply(self, parameters):
+        parameters = self._resolve_dynamic_values(parameters)
         invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value)]
         if invalid_parameter_names:
             raise InvalidParameterError(invalid_parameter_names)
@@ -131,6 +256,15 @@ class ParameterizedQuery:
             self.query = mustache_render(self.template, join_parameter_list_values(parameters, self.schema))
 
         return self
+
+    def _resolve_dynamic_values(self, parameters):
+        if not self.schema:
+            return parameters
+
+        types = {definition["name"]: definition.get("type") for definition in self.schema}
+        now = utcnow()
+
+        return {name: resolve_dynamic_value(value, types.get(name), now) for name, value in parameters.items()}
 
     def _valid(self, name, value):
         if not self.schema:

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -72,6 +72,22 @@ def _apply_default_parameters(query):
         return query.query_text
 
 
+def _sync_query_hash(query):
+    """
+    The rendered text of a query with dynamic parameter values (e.g. a "Last 7 days"
+    date range) changes over time, so the hash stored when the query was last saved
+    doesn't necessarily match the text that is about to run. Refresh it the same way
+    a save does; otherwise Query.update_latest_result() can't attach the result to
+    this query once the execution finishes.
+    """
+    previous_hash = query.query_hash
+    query.update_query_hash()
+    if query.query_hash != previous_hash:
+        query.skip_updated_at = True
+        models.db.session.add(query)
+        models.db.session.commit()
+
+
 class RefreshQueriesError(Exception):
     pass
 
@@ -92,6 +108,7 @@ def refresh_queries():
         try:
             query_text = _apply_default_parameters(query)
             query_text = _apply_auto_limit(query_text, query)
+            _sync_query_hash(query)
             enqueue_query(
                 query_text,
                 query.data_source,

--- a/tests/models/test_parameterized_query.py
+++ b/tests/models/test_parameterized_query.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from datetime import datetime, timezone
 from unittest import TestCase
 
 import pytest
@@ -307,3 +308,94 @@ class TestParameterizedQuery(TestCase):
     def test_dropdown_values_raises_when_query_is_detached_from_data_source(self, _):
         with pytest.raises(QueryDetachedFromDataSourceError):
             dropdown_values(1, None)
+
+
+NOW = datetime(2024, 3, 13, 15, 42, 7, tzinfo=timezone.utc)  # a Wednesday
+
+
+@patch("redash.models.parameterized_query.utcnow", return_value=NOW)
+class TestDynamicDateValues(TestCase):
+    """
+    Dynamic date and date range values ("d_*") are resolved the same way the
+    frontend resolves them before running a query.
+    """
+
+    def apply(self, parameter_type, value, template="{{p}}"):
+        schema = [{"name": "p", "type": parameter_type}]
+        return ParameterizedQuery(template, schema).apply({"p": value})
+
+    def test_resolves_dynamic_date(self, _):
+        query = self.apply("date", "d_now")
+
+        self.assertEqual("2024-03-13", query.text)
+        self.assertEqual({"p": "2024-03-13"}, query.parameters)
+
+    def test_resolves_dynamic_date_with_time(self, _):
+        self.assertEqual("2024-03-13 15:42", self.apply("datetime-local", "d_now").text)
+        self.assertEqual("2024-03-12 15:42:07", self.apply("datetime-with-seconds", "d_yesterday").text)
+
+    def test_resolves_dynamic_date_range(self, _):
+        query = self.apply("date-range", "d_last_7_days", "{{p.start}} to {{p.end}}")
+
+        self.assertEqual("2024-03-06 to 2024-03-13", query.text)
+        self.assertEqual({"p": {"start": "2024-03-06", "end": "2024-03-13"}}, query.parameters)
+        self.assertEqual(set(), query.missing_params)
+
+    def test_resolves_dynamic_date_range_with_time(self, _):
+        template = "{{p.start}} to {{p.end}}"
+
+        self.assertEqual(
+            "2024-03-06 00:00 to 2024-03-13 15:42",
+            self.apply("datetime-range", "d_last_7_days", template).text,
+        )
+        self.assertEqual(
+            "2024-03-13 14:42:07 to 2024-03-13 15:42:07",
+            self.apply("datetime-range-with-seconds", "d_last_hour", template).text,
+        )
+        self.assertEqual(
+            "2024-03-13 00:00:00 to 2024-03-13 23:59:59",
+            self.apply("datetime-range-with-seconds", "d_today", template).text,
+        )
+
+    def test_resolves_every_dynamic_date_range_preset(self, _):
+        expected = {
+            "d_today": ("2024-03-13", "2024-03-13"),
+            "d_yesterday": ("2024-03-12", "2024-03-12"),
+            "d_this_week": ("2024-03-10", "2024-03-16"),
+            "d_this_month": ("2024-03-01", "2024-03-31"),
+            "d_this_year": ("2024-01-01", "2024-12-31"),
+            "d_last_week": ("2024-03-03", "2024-03-09"),
+            "d_last_month": ("2024-02-01", "2024-02-29"),
+            "d_last_year": ("2023-01-01", "2023-12-31"),
+            "d_last_hour": ("2024-03-13", "2024-03-13"),
+            "d_last_8_hours": ("2024-03-13", "2024-03-13"),
+            "d_last_24_hours": ("2024-03-12", "2024-03-13"),
+            "d_last_7_days": ("2024-03-06", "2024-03-13"),
+            "d_last_14_days": ("2024-02-28", "2024-03-13"),
+            "d_last_30_days": ("2024-02-12", "2024-03-13"),
+            "d_last_60_days": ("2024-01-13", "2024-03-13"),
+            "d_last_90_days": ("2023-12-14", "2024-03-13"),
+            "d_last_12_months": ("2023-03-13", "2024-03-13"),
+            "d_last_2_years": ("2022-03-13", "2024-03-13"),
+            "d_last_3_years": ("2021-03-13", "2024-03-13"),
+            "d_last_10_years": ("2014-03-13", "2024-03-13"),
+        }
+
+        for value, (start, end) in expected.items():
+            query = self.apply("date-range", value, "{{p.start}} to {{p.end}}")
+            self.assertEqual("{} to {}".format(start, end), query.text, value)
+
+    def test_rejects_unknown_dynamic_values(self, _):
+        with pytest.raises(InvalidParameterError):
+            self.apply("date-range", "d_last_5_days")
+
+        with pytest.raises(InvalidParameterError):
+            self.apply("date", "d_last_7_days")
+
+    def test_leaves_other_parameter_types_alone(self, _):
+        self.assertEqual("d_today", self.apply("text", "d_today").text)
+
+    def test_leaves_concrete_values_alone(self, _):
+        query = self.apply("date-range", {"start": "2000-01-01", "end": "2000-12-31"}, "{{p.start}} {{p.end}}")
+
+        self.assertEqual("2000-01-01 2000-12-31", query.text)

--- a/tests/tasks/test_refresh_queries.py
+++ b/tests/tasks/test_refresh_queries.py
@@ -1,7 +1,10 @@
+from datetime import datetime, timezone
+
 from mock import ANY, call, patch
 
 from redash.models import Query
 from redash.tasks.queries.maintenance import refresh_queries
+from redash.utils import gen_query_hash
 from tests import BaseTestCase
 
 ENQUEUE_QUERY = "redash.tasks.queries.maintenance.enqueue_query"
@@ -189,6 +192,72 @@ class TestRefreshQuery(BaseTestCase):
                 scheduled_query=query,
                 metadata=ANY,
             )
+
+    def test_enqueues_parameterized_queries_with_dynamic_date_values(self):
+        """
+        Dynamic date values (e.g. "Last 7 days") are resolved before a scheduled query is enqueued.
+        """
+        query = self.factory.create_query(
+            query_text="select {{d.start}}, {{d.end}}",
+            options={
+                "parameters": [
+                    {
+                        "global": False,
+                        "type": "date-range",
+                        "name": "d",
+                        "value": "d_last_7_days",
+                        "title": "d",
+                    }
+                ],
+                "apply_auto_limit": False,
+            },
+        )
+        oq = staticmethod(lambda: [query])
+        now = datetime(2024, 3, 13, 15, 42, 7, tzinfo=timezone.utc)
+        with patch(ENQUEUE_QUERY) as add_job_mock, patch.object(Query, "outdated_queries", oq), patch(
+            "redash.models.parameterized_query.utcnow", return_value=now
+        ):
+            refresh_queries()
+            add_job_mock.assert_called_once_with(
+                "select 2024-03-06, 2024-03-13",
+                query.data_source,
+                query.user_id,
+                scheduled_query=query,
+                metadata=ANY,
+            )
+
+    def test_refreshes_query_hash_of_queries_with_dynamic_date_values(self):
+        """
+        The stored hash follows the resolved text, so the result of the scheduled
+        execution gets attached to the query (Query.update_latest_result).
+        """
+        query = self.factory.create_query(
+            query_text="select {{d.start}}, {{d.end}}",
+            options={
+                "parameters": [
+                    {
+                        "global": False,
+                        "type": "date-range",
+                        "name": "d",
+                        "value": "d_last_7_days",
+                        "title": "d",
+                    }
+                ],
+                "apply_auto_limit": False,
+            },
+        )
+        updated_at = query.updated_at
+        oq = staticmethod(lambda: [query])
+        now = datetime(2024, 3, 13, 15, 42, 7, tzinfo=timezone.utc)
+        with patch(ENQUEUE_QUERY), patch.object(Query, "outdated_queries", oq), patch(
+            "redash.models.parameterized_query.utcnow", return_value=now
+        ):
+            self.assertNotEqual(gen_query_hash("select 2024-03-06, 2024-03-13"), query.query_hash)
+            refresh_queries()
+
+        query = Query.get_by_id(query.id)
+        self.assertEqual(gen_query_hash("select 2024-03-06, 2024-03-13"), query.query_hash)
+        self.assertEqual(updated_at, query.updated_at)
 
     def test_doesnt_enqueue_parameterized_queries_with_invalid_parameters(self):
         """


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

Fixes #7710 and #4514.

Dynamic date and date range values (`d_last_7_days`, `d_this_month`, `d_now`, …) are only evaluated by the frontend, right before it runs a query ([DateRangeParameter.js](https://github.com/getredash/redash/blob/master/client/app/services/parameters/DateRangeParameter.js), [DateParameter.js](https://github.com/getredash/redash/blob/master/client/app/services/parameters/DateParameter.js)). Everything that runs a query without a browser gets the raw `d_*` string instead, so for a query whose parameter defaults to a dynamic value:

- `refresh_queries` fails validation on every cycle (`_is_date_range("d_last_7_days")` raises, which `_valid` turns into `InvalidParameterError`), logs `Could not enqueue query N due to InvalidParameterError(...)`, and `track_failure` bumps `schedule_failures` and sends a failure e-mail each time. The schedule never actually runs (#4514).
- Saving the query logs `Unable to update hash for query N because of invalid parameters` (#7710).

Just accepting the strings in `_is_date_range` (as tried in #7710) isn't enough: mustache then renders `{{ range.start }}` as an empty string and `missing_params` reports `range.start`.

### Changes

- `ParameterizedQuery.apply()` now resolves dynamic values into the same concrete values the frontend would send, based on each parameter's type from the schema (`YYYY-MM-DD`, `YYYY-MM-DD HH:mm` or `YYYY-MM-DD HH:mm:ss`, as `{start, end}` for ranges). The presets mirror the frontend definitions one to one, including the "until now" ranges and calendar periods (weeks start on Sunday, like moment's default locale). Values are evaluated in UTC. Unknown `d_*` values and presets used on the wrong parameter type are still rejected by the existing validation, and non-date parameters are untouched.
- Since the rendered text of such a query changes from one run to the next, the hash stored when the query was last saved doesn't necessarily match the text `refresh_queries` is about to run, and `Query.update_latest_result()` would leave the query's `latest_query_data` untouched even though the run succeeded. `refresh_queries` now refreshes the stored hash right before enqueueing (`Query.update_query_hash()`, the same thing a save does, without touching `updated_at`), so the result is attached through the existing hash match and dashboards and alerts on that query see the fresh data. Editing the query while a run is in flight keeps today's semantics: the hash changes with the edit, so the stale result isn't attached.

The presets are resolved wherever the parameter definitions are known: scheduled refreshes, the query hash, and API executions that go through the saved query (`/api/queries/<id>/results`). `/api/queries/<id>/refresh` intentionally builds its `ParameterizedQuery` without the schema (#3383), so it is unchanged. No change to how query hashes are calculated either, so this doesn't conflict with the larger rework proposed in #6960; it makes the existing scheduling path work for these queries in the meantime.

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

- New tests in `tests/models/test_parameterized_query.py` cover every preset against a fixed `now` (including leap-year month boundaries and week boundaries), each datetime format, unknown/mismatched presets and non-date parameters.
- `tests/tasks/test_refresh_queries.py`: a scheduled query with a `d_last_7_days` default is enqueued with the resolved dates, and its stored hash is refreshed to match that text without touching `updated_at`.
- Full backend suite run in the CI image (`docker compose build … && docker compose run redash tests tests/`): 942 passed, 1 skipped.

## Related Tickets & Documents

#7710, #4514, #6960

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
